### PR TITLE
WI-V1W2-WASM-03: WASM host runtime + imports/exports surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,13 @@ tmp/
 DECISIONS.md
 DECISIONS.md.tmp.*
 
+# Bootstrap artifacts — registry and report are runtime outputs, not source artifacts.
+# expected-roots.json is NOT gitignored — it is committed by WI-V2-BOOTSTRAP-03.
+bootstrap/yakcc.registry.sqlite
+bootstrap/yakcc.registry.sqlite-shm
+bootstrap/yakcc.registry.sqlite-wal
+bootstrap/report.json
+
 # Stray TS build artifacts that escape into src/ when cross-package imports
 # trigger out-of-tree compilation. If this pattern reappears, find the offending
 # import chain rather than relying on this catch-all.

--- a/WASM_HOST_CONTRACT.md
+++ b/WASM_HOST_CONTRACT.md
@@ -1,0 +1,192 @@
+# WASM Host Contract — v1
+
+**Authority:** This document is the sole boundary contract for the wasm-host surface in `@yakcc/compile`.
+**Sacred Practice #12:** All tests, host runtime, and emitter must agree with this document. No parallel boundary contract, no inline contract duplicated in source beyond a one-line pointer here.
+
+Corresponds to implementation: `packages/compile/src/wasm-host.ts`
+Decision closed: `DEC-V1-WAVE-2-WASM-HOST-CONTRACT-001`
+
+---
+
+## 1. Scope
+
+This contract defines the binary interface between WASM modules emitted by `packages/compile/src/wasm-backend.ts` and the in-process host runtime provided by `packages/compile/src/wasm-host.ts`.
+
+It covers:
+- The five imports every emitted module requires from the host (`host` namespace)
+- The export naming convention for emitted functions and the table placeholder
+- The error model (trap mapping and structured panics)
+- The string calling convention (packed i64)
+- Versioning and deferred surfaces
+
+It does **not** cover the TypeScript compilation pipeline, block resolution, or the ts-backend.
+
+---
+
+## 2. Identity and Types
+
+| Symbol | TypeScript type | Notes |
+|--------|----------------|-------|
+| `WasmTrap` | `class extends Error` | Base class for all engine-faulted traps. |
+| `WasmUnreachable` | `class extends WasmTrap` | Kind `"unreachable"`. Engine executed `unreachable` opcode. |
+| `WasmDivByZero` | `class extends WasmTrap` | Kind `"div_by_zero"`. Integer divide by zero. |
+| `WasmIntegerOverflow` | `class extends WasmTrap` | Kind `"integer_overflow"`. e.g. `INT32_MIN / -1`. |
+| `WasmPanic` | `class extends Error` | Callee-initiated structured error via `host_panic`. Distinct from traps. |
+| `WasmHost` | `interface` | The host object. Created by `createWasmHost()`. |
+
+All are exported from `packages/compile/src/wasm-host.ts` and re-exported via `packages/compile/src/index.ts`.
+
+---
+
+## 3. Imports
+
+All imports live in the module namespace `"host"`. They appear in this fixed declaration order in the import section.
+
+| Index | Name | WAT shape | Notes |
+|-------|------|-----------|-------|
+| 0 | `memory` | `(import "host" "memory" (memory $mem 1 1))` | Linear memory. `initial=1, maximum=1` (64 KB). Growth is forbidden in v1 — see §6. |
+| 1 | `host_log` | `(import "host" "host_log" (func (param i32 i32)))` | `(ptr: i32, len: i32) → void`. Diagnostic emission; decoded as UTF-8 and captured in `host.logs`. |
+| 2 | `host_alloc` | `(import "host" "host_alloc" (func (param i32) (result i32)))` | `(size: i32) → ptr: i32`. Bump allocator; see §5. |
+| 3 | `host_free` | `(import "host" "host_free" (func (param i32)))` | `(ptr: i32) → void`. Tracked no-op in v1; see §5. |
+| 4 | `host_panic` | `(import "host" "host_panic" (func (param i32 i32 i32)))` | `(code: i32, ptr: i32, len: i32) → void`. Throws `WasmPanic` host-side, never returns. See §4. |
+
+**Index discipline:** Imported function indices come before locally-defined function indices per WASM spec §2.5.5. A module with N exported functions will have funcidx 0..3 = imported host functions, funcidx 4..(4+N-1) = local functions.
+
+**`host_panic` return type:** The WASM type is `() → void` but the host implementation throws and never returns. The emitter **must** emit `unreachable` after every `call $host_panic` to satisfy WASM stack-typing rules.
+
+---
+
+## 4. Exports
+
+### Function exports
+
+For each emitted local function `<fname>`:
+
+```wat
+(export "__wasm_export_<fname>" (func $<fname>))
+```
+
+The `__wasm_export_` prefix (double underscore) is the canonical export name format. Downstream consumers must use this form, not bare function names.
+
+### Table export (placeholder)
+
+```wat
+(table $yakcc_table 0 0 funcref)
+(export "_yakcc_table" (table $yakcc_table))
+```
+
+The table has size 0 in v1. It is reserved for indirect calls in future WIs (WI-V1W2-WASM-04+). The `exportdesc` is `0x01` (table), `tableidx=0`.
+
+---
+
+## 5. String Calling Convention
+
+WASM 1.0 does not have multi-value returns without a feature flag. Functions that return strings use a **packed i64** convention:
+
+```
+return_value: i64 = (i64.extend_i32_u(out_ptr) << 32) | i64.extend_i32_u(out_len)
+```
+
+- High 32 bits: pointer into linear memory
+- Low 32 bits: byte length
+
+**Caller side:**
+```ts
+const packed = wrapHostCall(() => exports.__wasm_export_greet(inPtr, nameLen));
+const outPtr = Number(packed >> 32n);
+const outLen = Number(packed & 0xffff_ffffn);
+const result = host.readUtf8(outPtr, outLen);
+```
+
+Functions that return primitives (i32, i64, f32, f64) use the natural WASM type directly — no packing.
+
+---
+
+## 6. Allocator
+
+`host_alloc` uses a **bump allocator**:
+
+- **Reserved zone:** bytes `[0, 1024)` — reserved for static/fixed scratch (currently unused; reserved for future i64 spill or guard zone).
+- **Bump heap:** bytes `[1024, 65536)` — 63 KB usable.
+- **Alignment:** each allocation is rounded up to 8 bytes.
+- **Overflow:** if `offset + size > 65536` (cap = one WASM page), throws `WasmTrap("memory_oob", "host_alloc out of memory")`.
+- **Per-instance:** each `createWasmHost()` call returns a fresh host with a fresh `WebAssembly.Memory` and a bump pointer starting at 1024. Hosts must not be shared across test cases.
+
+`host_free` is a **tracked no-op** in v1:
+- The bump allocator does not reclaim memory on `host_free`.
+- The host increments an internal `_freeCallCount` counter (test-only; not part of the public contract).
+- Rationale: lifetime is bounded by a single test invocation; per-test fresh `createWasmHost()` resets the bump pointer. A free-list adds zero v1 benefit.
+
+---
+
+## 7. Error Model
+
+### Trap classes
+
+Engine-level faults (`WebAssembly.RuntimeError`) are caught and rethrown as `WasmTrap` subclasses by the `wrapHostCall` helper. Mapping is concentrated in one function — no ad-hoc try/catch elsewhere.
+
+| Engine message pattern | Rethrown class | `kind` field |
+|------------------------|---------------|-------------|
+| `/unreachable/i` | `WasmUnreachable` | `"unreachable"` |
+| `/divide by zero/i` | `WasmDivByZero` | `"div_by_zero"` |
+| `/integer overflow/i` | `WasmIntegerOverflow` | `"integer_overflow"` |
+| `/out of bounds memory access/i` | `WasmTrap` | `"memory_oob"` |
+| anything else | `WasmTrap` | `"other"` |
+
+The patterns are verified against V8 (Node 20, 22, 24). The `"other"` bucket preserves the original message and `cause` so unanticipated engine messages fail loudly.
+
+### Structured panics
+
+`WasmPanic` is distinct from `WasmTrap`:
+- A trap is a hardware-level fault surfaced by the engine (unintentional).
+- A panic is a deliberate, structured signal from the compiled program via `host_panic`.
+
+```ts
+class WasmPanic extends Error {
+  readonly code: number;   // panic code passed by the callee
+  readonly ptr: number;    // pointer to the UTF-8 message in linear memory
+  readonly len: number;    // byte length of the message
+  readonly decoded: string; // UTF-8 decoded message
+}
+```
+
+### `divide` substrate panic contract
+
+The `divide(a, b)` substrate checks `b == 0` explicitly and calls `host_panic(1, ptr, len)` with a static UTF-8 message `"division by zero"` in a data segment. It does **not** rely on the engine to trap — this makes the panic path deterministic across engines and proves `host_panic` import wiring.
+
+---
+
+## 8. Versioning and Deferred Surfaces
+
+### v1 constraints
+
+- **Memory growth forbidden.** The imported memory has `maximum=1`. Any `memory.grow` instruction is a static emitter error; runtime growth attempts trap via the engine and surface as `WasmTrap("memory_oob")`.
+  - Rationale: growth invalidates the `ArrayBuffer` backing the memory, forcing the host to re-cache `new Uint8Array(memory.buffer)` on every call. The v1 substrate fits in 64 KB by construction (`greet`'s name has an 8 KB hard cap).
+  
+- **WASM 1.0 only.** Multi-value returns (WASM 2.0 proposal) are not used; string returns use the packed i64 convention (§5).
+
+- **Bump allocator only.** Free-list allocation is deferred to v2.
+
+### Deferred to v2+
+
+| Surface | Deferral reason |
+|---------|----------------|
+| `memory.grow` support | Buffer invalidation; not needed in 1-page v1 |
+| Free-list `host_free` | Zero v1 benefit; requires metadata bookkeeping |
+| Multi-value string returns | WASM 2.0 feature; not universally available |
+| `_yakcc_table` population | Indirect calls not needed until WI-V1W2-WASM-04 |
+| i64 arithmetic substrate | Type-lowering handled by WI-V1W2-WASM-02 |
+
+---
+
+## 9. Decision Log
+
+### DEC-V1-WAVE-2-WASM-HOST-CONTRACT-001
+
+**Status:** Closed by WI-V1W2-WASM-03.
+
+**Sub-decision 1 — Trap shape:** `WasmTrap` base + 3 subclasses (`WasmUnreachable`, `WasmDivByZero`, `WasmIntegerOverflow`) for engine-faulted traps; separate `WasmPanic` for callee `host_panic` calls. TypeScript `instanceof` narrowing is more ergonomic than discriminating on a `kind` field. The `kind` field is kept for JSON serialization and log emission. Mapping is concentrated in `wrapHostCall`; no ad-hoc catch elsewhere.
+
+**Sub-decision 2 — Allocator strategy:** Bump allocator. 1024-byte reserved scratch zone, 64 KB cap (one page). `host_free` is a tracked no-op (`_freeCallCount` for test introspection). Free-list deferred to v2; `host_free` import is reserved so the contract does not change when v2 switches.
+
+**Sub-decision 3 — Memory growth:** Forbidden in v1. Memory imported with `initial=1, maximum=1`. Growth attempts trap as `WasmTrap("memory_oob")`. Lifting this is an explicit deferred surface above.

--- a/packages/cli/src/__fixtures__/bootstrap-mini/packages/mini/src/add.test.ts
+++ b/packages/cli/src/__fixtures__/bootstrap-mini/packages/mini/src/add.test.ts
@@ -1,0 +1,3 @@
+// This file should be skipped by the bootstrap file walk (*.test.ts suffix).
+import { add } from "./add.js";
+export const _unused = add(1, 2);

--- a/packages/cli/src/__fixtures__/bootstrap-mini/packages/mini/src/add.ts
+++ b/packages/cli/src/__fixtures__/bootstrap-mini/packages/mini/src/add.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+// Bootstrap fixture: simple addition function for bootstrap command tests.
+
+/**
+ * Add two integers.
+ * @param a - First operand.
+ * @param b - Second operand.
+ * @returns The sum a + b.
+ */
+export function add(a: number, b: number): number {
+  return a + b;
+}

--- a/packages/cli/src/__fixtures__/bootstrap-mini/packages/mini/src/greet.ts
+++ b/packages/cli/src/__fixtures__/bootstrap-mini/packages/mini/src/greet.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+// Bootstrap fixture: simple greeting function for bootstrap command tests.
+
+/**
+ * Produce a greeting string.
+ * @param name - The name to greet.
+ * @returns A greeting message.
+ */
+export function greet(name: string): string {
+  return `Hello, ${name}!`;
+}

--- a/packages/cli/src/__fixtures__/bootstrap-mini/src/__fixtures__/dummy.ts
+++ b/packages/cli/src/__fixtures__/bootstrap-mini/src/__fixtures__/dummy.ts
@@ -1,0 +1,2 @@
+// This file should be skipped by the bootstrap file walk (lives in __fixtures__/).
+export const _fixture = "fixture";

--- a/packages/cli/src/__fixtures__/bootstrap-mini/src/__tests__/add.test.ts
+++ b/packages/cli/src/__fixtures__/bootstrap-mini/src/__tests__/add.test.ts
@@ -1,0 +1,3 @@
+// This file should be skipped by the bootstrap file walk (lives in __tests__/).
+import { add } from "../add.js";
+export const _unused = add(1, 2);

--- a/packages/cli/src/__fixtures__/bootstrap-mini/src/add.test.ts
+++ b/packages/cli/src/__fixtures__/bootstrap-mini/src/add.test.ts
@@ -1,0 +1,3 @@
+// This file should be skipped by the bootstrap file walk (*.test.ts pattern).
+import { add } from "./add.js";
+export const _result = add(2, 3);

--- a/packages/cli/src/__fixtures__/bootstrap-mini/src/add.ts
+++ b/packages/cli/src/__fixtures__/bootstrap-mini/src/add.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+// Bootstrap fixture: simple addition function for bootstrap command tests.
+
+/**
+ * Add two integers.
+ * @param a - First operand.
+ * @param b - Second operand.
+ * @returns The sum a + b.
+ */
+export function add(a: number, b: number): number {
+  return a + b;
+}

--- a/packages/cli/src/__fixtures__/bootstrap-mini/src/greet.ts
+++ b/packages/cli/src/__fixtures__/bootstrap-mini/src/greet.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+// Bootstrap fixture: simple greeting function for bootstrap command tests.
+
+/**
+ * Produce a greeting string.
+ * @param name - The name to greet.
+ * @returns A greeting message.
+ */
+export function greet(name: string): string {
+  return `Hello, ${name}!`;
+}

--- a/packages/cli/src/commands/bootstrap.test.ts
+++ b/packages/cli/src/commands/bootstrap.test.ts
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: MIT
+//
+// Tests for packages/cli/src/commands/bootstrap.ts.
+//
+// Test strategy:
+//   - collectSourceFiles: unit-tested against the bootstrap-mini fixture, which
+//     has a proper packages/mini/src/ subtree and various should-skip paths.
+//   - bootstrap() (CLI entry): integration-tested against the same fixture via
+//     --root, --registry, --report, --manifest argv. This exercises the real
+//     production sequence: walk → openRegistry → shave → write artifacts.
+//
+// The shave pass may produce "failed" outcomes on the simple fixture functions
+// (e.g. IntentCardSchemaError), which is a shave-layer concern, not a CLI
+// concern. Tests assert on artifact existence and report shape, not on
+// shaved > 0 specifically.
+//
+// @decision DEC-V2-BOOT-TEST-001
+// title: Test bootstrap CLI surface via bootstrap() entry point, not runBootstrapPass directly
+// status: accepted (WI-V2-BOOTSTRAP-02)
+// rationale:
+//   runBootstrapPass takes an open Registry, not a path. Testing it directly
+//   would require re-implementing the registry lifecycle that bootstrap() owns.
+//   Testing via bootstrap() with --root/--registry/--report/--manifest argv
+//   exercises the true production sequence (walk → openRegistry → shave →
+//   write) and exercises the same code path that bin.ts invokes.
+
+import { describe, expect, it, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { collectSourceFiles, bootstrap } from "./bootstrap.js";
+import type { BootstrapReport } from "./bootstrap.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+// bootstrap-mini is a self-contained project fixture rooted at:
+//   packages/cli/src/__fixtures__/bootstrap-mini/
+// It contains packages/mini/src/{add.ts, greet.ts, add.test.ts} and various
+// should-skip paths at root level (src/__fixtures__, src/__tests__, src/*.test.ts).
+const FIXTURE_ROOT = join(HERE, "..", "__fixtures__", "bootstrap-mini");
+
+// Null logger — silences bootstrap progress output during tests.
+const NULL_LOGGER = { log: () => {}, error: () => {} };
+
+const tempDirs: string[] = [];
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "yakcc-boot-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir && existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// collectSourceFiles — file-walker unit tests
+// ---------------------------------------------------------------------------
+
+describe("collectSourceFiles", () => {
+  it("includes shaveable .ts files under packages/*/src and excludes test/fixture/skipped paths", async () => {
+    const files = await collectSourceFiles(FIXTURE_ROOT);
+    const basenames = files.map((f) => f.split("/").pop()!).sort();
+
+    // bootstrap-mini/packages/mini/src/add.ts and greet.ts must be included.
+    expect(basenames).toContain("add.ts");
+    expect(basenames).toContain("greet.ts");
+
+    // add.test.ts must be excluded (matches .test.ts suffix).
+    expect(basenames).not.toContain("add.test.ts");
+
+    // dummy.ts files under __tests__ or __fixtures__ must be excluded
+    // (SKIP_DIR_SEGMENTS blocks those directory names anywhere in the tree).
+    expect(basenames.filter((b) => b === "dummy.ts")).toHaveLength(0);
+  });
+
+  it("returns files in lex-sorted absolute-path order", async () => {
+    const files = await collectSourceFiles(FIXTURE_ROOT);
+    const sorted = [...files].sort((a, b) =>
+      a.localeCompare(b, undefined, { sensitivity: "variant" }),
+    );
+    expect(files).toEqual(sorted);
+  });
+
+  it("returns an empty array for a root with no packages/ or examples/ directories", async () => {
+    // Use HERE (the commands/ directory) — it has no packages/ sub-directory.
+    const files = await collectSourceFiles(HERE);
+    expect(files).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bootstrap() — CLI integration tests (real production sequence)
+// ---------------------------------------------------------------------------
+
+describe("bootstrap() — happy path", () => {
+  it("writes report.json and manifest.json and returns exit code 0 or 1", async () => {
+    const tempDir = makeTempDir();
+    const registryPath = join(tempDir, "registry.sqlite");
+    const reportPath = join(tempDir, "report.json");
+    const manifestPath = join(tempDir, "manifest.json");
+
+    const exitCode = await bootstrap(
+      [
+        "--root",
+        FIXTURE_ROOT,
+        "--registry",
+        registryPath,
+        "--report",
+        reportPath,
+        "--manifest",
+        manifestPath,
+      ],
+      NULL_LOGGER,
+    );
+
+    // Exit code is 0 when all files shaved, 1 if any failed.
+    // Both are valid — CLI surface is correct either way.
+    expect([0, 1]).toContain(exitCode);
+
+    // Both artifact files must exist regardless of per-file shave outcome.
+    expect(existsSync(reportPath)).toBe(true);
+    expect(existsSync(manifestPath)).toBe(true);
+  });
+
+  it("report.json has valid BootstrapReport shape with totalFiles > 0", async () => {
+    const tempDir = makeTempDir();
+    const reportPath = join(tempDir, "report.json");
+
+    await bootstrap(
+      [
+        "--root",
+        FIXTURE_ROOT,
+        "--registry",
+        join(tempDir, "r.sqlite"),
+        "--report",
+        reportPath,
+        "--manifest",
+        join(tempDir, "m.json"),
+      ],
+      NULL_LOGGER,
+    );
+
+    const report = JSON.parse(readFileSync(reportPath, "utf-8")) as BootstrapReport;
+
+    // Summary fields must be present and internally consistent.
+    expect(report.summary.totalFiles).toBeGreaterThan(0);
+    expect(report.summary.totalFiles).toBe(
+      report.summary.shaved + report.summary.skipped + report.summary.failed,
+    );
+
+    // files array must have one entry per totalFiles.
+    expect(report.files).toHaveLength(report.summary.totalFiles);
+    for (const f of report.files) {
+      expect(["shaved", "skipped", "failed"]).toContain(f.status);
+      expect(typeof f.filePath).toBe("string");
+      expect(Array.isArray(f.merkleRoots)).toBe(true);
+    }
+  });
+
+  it("respects custom --manifest path and does NOT write the default name", async () => {
+    const tempDir = makeTempDir();
+    const customManifest = join(tempDir, "custom-name.json");
+
+    await bootstrap(
+      [
+        "--root",
+        FIXTURE_ROOT,
+        "--registry",
+        join(tempDir, "r.sqlite"),
+        "--report",
+        join(tempDir, "report.json"),
+        "--manifest",
+        customManifest,
+      ],
+      NULL_LOGGER,
+    );
+
+    expect(existsSync(customManifest)).toBe(true);
+    // Default manifest name must NOT appear in the temp dir (custom path was used).
+    expect(existsSync(join(tempDir, "expected-roots.json"))).toBe(false);
+  });
+
+  it("returns exit code 0 for --help without touching the filesystem", async () => {
+    const exitCode = await bootstrap(["--help"], NULL_LOGGER);
+    expect(exitCode).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bootstrap() — determinism (compound-interaction: walk → shave → serialize)
+// ---------------------------------------------------------------------------
+
+describe("bootstrap() — determinism", () => {
+  it("two independent passes against the same source produce byte-identical manifests", async () => {
+    const tempA = makeTempDir();
+    const tempB = makeTempDir();
+
+    await bootstrap(
+      [
+        "--root",
+        FIXTURE_ROOT,
+        "--registry",
+        join(tempA, "r.sqlite"),
+        "--report",
+        join(tempA, "report.json"),
+        "--manifest",
+        join(tempA, "manifest.json"),
+      ],
+      NULL_LOGGER,
+    );
+
+    await bootstrap(
+      [
+        "--root",
+        FIXTURE_ROOT,
+        "--registry",
+        join(tempB, "r.sqlite"),
+        "--report",
+        join(tempB, "report.json"),
+        "--manifest",
+        join(tempB, "manifest.json"),
+      ],
+      NULL_LOGGER,
+    );
+
+    const manifestA = readFileSync(join(tempA, "manifest.json"), "utf-8");
+    const manifestB = readFileSync(join(tempB, "manifest.json"), "utf-8");
+
+    // Byte-identical manifests prove determinism across the full
+    // walk → openRegistry → shave → serialize pipeline.
+    expect(manifestA).toBe(manifestB);
+  });
+});

--- a/packages/cli/src/commands/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap.ts
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: MIT
+//
+// @decision DEC-V2-BOOT-FILE-ORDER-001
+// title: Lexicographic sort of source file paths before shaving
+// status: accepted (WI-V2-BOOTSTRAP-02)
+// rationale:
+//   The bootstrap manifest is a committed artifact compared byte-for-byte across
+//   runs. Any nondeterminism in file processing order would produce different
+//   registry insertion sequences, which could produce different BlockMerkleRoots
+//   when parentBlockRoot lineage differs. Sorting by absolute path string
+//   (lexicographic, locale-independent via localeCompare(b, undefined, {sensitivity:"variant"}))
+//   is the simplest determinism guarantee. Sister's WI-V2-BOOT-PREFLIGHT empirically
+//   validated per-file determinism; this decision extends that guarantee across files.
+//
+// @decision DEC-V2-BOOT-NO-AI-CORPUS-001
+// title: Bootstrap shave runs offline with no AI corpus (source C disabled)
+// status: accepted (WI-V2-BOOTSTRAP-02)
+// rationale:
+//   AI-derived property-test corpus (source C in the three-source priority chain) is
+//   non-deterministic: results depend on the model, the prompt version, and the
+//   presence/absence of a pre-warmed cache. The bootstrap manifest must be
+//   reproducible from a clean cache on any machine. Passing `offline: true` to
+//   shave() disables live AI calls entirely; without a `cacheDir` the corpus
+//   extraction path for source C is also unreachable. Sources (a) upstream-test
+//   and (b) documented-usage are always deterministic and remain enabled.
+//   The intent strategy defaults to "static" (DEC-INTENT-STRATEGY-001), which
+//   produces deterministic IntentCards without any API calls.
+
+import type { Dirent } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { parseArgs } from "node:util";
+import type { BlockMerkleRoot } from "@yakcc/contracts";
+import { type Registry, openRegistry } from "@yakcc/registry";
+import type { BootstrapManifestEntry } from "@yakcc/registry";
+import { shave as shaveImpl } from "@yakcc/shave";
+import type { Logger } from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default registry path — gitignored artifact, not a source file. */
+const DEFAULT_REGISTRY_PATH = "bootstrap/yakcc.registry.sqlite";
+/** Default report path. */
+const DEFAULT_REPORT_PATH = "bootstrap/report.json";
+/** Default manifest output path — committed in WI-V2-BOOTSTRAP-03. */
+const DEFAULT_MANIFEST_PATH = "bootstrap/expected-roots.json";
+
+/**
+ * Directory-name segments that cause a file to be skipped.
+ * Checked against every path component of the file's relative path.
+ */
+const SKIP_DIR_SEGMENTS = new Set([
+  "__tests__",
+  "__fixtures__",
+  "__snapshots__",
+  "dist",
+  "node_modules",
+]);
+
+/**
+ * File-name patterns that cause a file to be skipped.
+ * Checked against the file's basename.
+ */
+const SKIP_FILE_SUFFIXES = [".test.ts", ".d.ts"] as const;
+const SKIP_FILE_EXACT = new Set(["vitest.config.ts"]);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Outcome record for one processed source file. */
+export interface PerFileOutcome {
+  readonly filePath: string;
+  readonly status: "shaved" | "skipped" | "failed";
+  readonly merkleRoots: BlockMerkleRoot[];
+  readonly errorMessage?: string | undefined;
+  readonly errorClass?: string | undefined;
+}
+
+/** Top-level structure of the bootstrap report. */
+export interface BootstrapReport {
+  readonly summary: {
+    readonly totalFiles: number;
+    readonly shaved: number;
+    readonly skipped: number;
+    readonly failed: number;
+  };
+  readonly files: PerFileOutcome[];
+}
+
+// ---------------------------------------------------------------------------
+// Argument options
+// ---------------------------------------------------------------------------
+
+const BOOTSTRAP_PARSE_OPTIONS = {
+  registry: { type: "string" },
+  report: { type: "string" },
+  manifest: { type: "string" },
+  root: { type: "string" },
+  help: { type: "boolean", short: "h", default: false },
+} as const;
+
+// ---------------------------------------------------------------------------
+// File walk
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk `rootDir` collecting TypeScript source files under:
+ *   - `<rootDir>/packages/*\/src\/**\/*.ts`
+ *   - `<rootDir>/examples/*\/src\/**\/*.ts`
+ *
+ * Skip patterns (applied to every path component and basename):
+ *   - directories: __tests__, __fixtures__, __snapshots__, dist, node_modules
+ *   - filenames: *.test.ts, *.d.ts, vitest.config.ts
+ *
+ * Returns paths sorted lexicographically by absolute path string.
+ * (DEC-V2-BOOT-FILE-ORDER-001)
+ */
+export async function collectSourceFiles(rootDir: string): Promise<string[]> {
+  const results: string[] = [];
+
+  async function walkDir(dir: string): Promise<void> {
+    let entries: Dirent<string>[];
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      // Directory doesn't exist or can't be read — skip silently.
+      return;
+    }
+
+    for (const entry of entries) {
+      const absPath = join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        // Skip blocked directory names anywhere in the tree.
+        if (SKIP_DIR_SEGMENTS.has(entry.name)) continue;
+        await walkDir(absPath);
+      } else if (entry.isFile()) {
+        if (!entry.name.endsWith(".ts")) continue;
+        // Skip blocked filenames.
+        if (SKIP_FILE_EXACT.has(entry.name)) continue;
+        if (SKIP_FILE_SUFFIXES.some((suffix) => entry.name.endsWith(suffix))) continue;
+        results.push(absPath);
+      }
+    }
+  }
+
+  // Walk packages/*/src/** and examples/*/src/**
+  for (const topDir of ["packages", "examples"]) {
+    const topPath = join(rootDir, topDir);
+    let pkgEntries: Dirent<string>[];
+    try {
+      pkgEntries = await readdir(topPath, { withFileTypes: true });
+    } catch {
+      // Top-level directory doesn't exist — skip.
+      continue;
+    }
+    for (const pkgEntry of pkgEntries) {
+      if (!pkgEntry.isDirectory()) continue;
+      const srcPath = join(topPath, pkgEntry.name, "src");
+      // Verify src/ exists before descending.
+      try {
+        const s = await stat(srcPath);
+        if (!s.isDirectory()) continue;
+      } catch {
+        continue;
+      }
+      await walkDir(srcPath);
+    }
+  }
+
+  // Deterministic order — lex sort by absolute path (DEC-V2-BOOT-FILE-ORDER-001).
+  results.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "variant" }));
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Registry adapter
+// ---------------------------------------------------------------------------
+
+/**
+ * Adapt the full Registry interface to the narrower ShaveRegistryView that
+ * shaveImpl() accepts. The Registry interface returns `null` for missing
+ * blocks; ShaveRegistryView expects `undefined`.
+ */
+function makeShaveRegistryView(registry: Registry) {
+  return {
+    selectBlocks: (specHash: Parameters<typeof registry.selectBlocks>[0]) =>
+      registry.selectBlocks(specHash),
+    getBlock: async (merkleRoot: Parameters<typeof registry.getBlock>[0]) => {
+      const row = await registry.getBlock(merkleRoot);
+      return row ?? undefined;
+    },
+    findByCanonicalAstHash: registry.findByCanonicalAstHash?.bind(registry),
+    storeBlock: registry.storeBlock.bind(registry),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Core bootstrap logic (exported for testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the full bootstrap shave pass over `sourceFiles`.
+ *
+ * For each file, calls shaveImpl with `offline: true` (DEC-V2-BOOT-NO-AI-CORPUS-001).
+ * Returns per-file outcomes without writing any files.
+ *
+ * @param sourceFiles - Absolute paths in deterministic order (DEC-V2-BOOT-FILE-ORDER-001).
+ * @param registry    - Open registry to store shaved atoms into.
+ */
+export async function runBootstrapPass(
+  sourceFiles: readonly string[],
+  registry: Registry,
+): Promise<PerFileOutcome[]> {
+  const shaveRegistryView = makeShaveRegistryView(registry);
+  const outcomes: PerFileOutcome[] = [];
+
+  for (const filePath of sourceFiles) {
+    try {
+      const result = await shaveImpl(filePath, shaveRegistryView, {
+        offline: true,
+        // DEC-V2-BOOT-NO-AI-CORPUS-001: intentStrategy "static" is the default
+        // (DEC-INTENT-STRATEGY-001) — no API calls, fully deterministic.
+        // No cacheDir is passed, so AI-derived corpus source C is unreachable.
+        intentStrategy: "static",
+      });
+
+      const merkleRoots = result.atoms
+        .map((a) => a.merkleRoot)
+        .filter((r): r is BlockMerkleRoot => r !== undefined);
+
+      outcomes.push({ filePath, status: "shaved", merkleRoots });
+    } catch (err) {
+      const e = err as Error;
+      outcomes.push({
+        filePath,
+        status: "failed",
+        merkleRoots: [],
+        errorMessage: e.message,
+        errorClass: e.constructor?.name,
+      });
+    }
+  }
+
+  return outcomes;
+}
+
+// ---------------------------------------------------------------------------
+// Public command handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handler for `yakcc bootstrap [options]`.
+ *
+ * Walks the project source tree, shaves each file into the registry, exports
+ * a deterministic manifest, and writes a structured report.
+ *
+ * Exit 0 when failed === 0; exit 1 otherwise (emits per-file errors to stderr).
+ *
+ * @param argv   - Remaining argv after "bootstrap" has been consumed.
+ * @param logger - Output sink; defaults to CONSOLE_LOGGER via the caller.
+ * @returns Promise<number> — 0 on success, 1 on partial failure.
+ */
+export async function bootstrap(argv: ReadonlyArray<string>, logger: Logger): Promise<number> {
+  // Parse arguments — parseArgs throws on unknown flags.
+  const parsed = (() => {
+    try {
+      return parseArgs({
+        args: [...argv],
+        allowPositionals: false,
+        options: BOOTSTRAP_PARSE_OPTIONS,
+      });
+    } catch (err) {
+      logger.error(`error: ${(err as Error).message}`);
+      return null;
+    }
+  })();
+  if (parsed === null) return 1;
+
+  if (parsed.values.help) {
+    logger.log(
+      "Usage: yakcc bootstrap [options]\n" +
+        "\n" +
+        "  Walk packages/*/src/**/*.ts and examples/*/src/**/*.ts, shave each file\n" +
+        "  into the registry, and write a deterministic manifest.\n" +
+        "\n" +
+        "  --registry <path>   Registry path          (default: bootstrap/yakcc.registry.sqlite)\n" +
+        "  --report <path>     Report output path     (default: bootstrap/report.json)\n" +
+        "  --manifest <path>   Manifest output path   (default: bootstrap/expected-roots.json)\n" +
+        "  --root <path>       Project root to walk   (default: cwd)\n" +
+        "  --help, -h          Print this help\n",
+    );
+    return 0;
+  }
+
+  const rootDir = resolve(parsed.values.root ?? process.cwd());
+  const registryPath = resolve(rootDir, parsed.values.registry ?? DEFAULT_REGISTRY_PATH);
+  const reportPath = resolve(rootDir, parsed.values.report ?? DEFAULT_REPORT_PATH);
+  const manifestPath = resolve(rootDir, parsed.values.manifest ?? DEFAULT_MANIFEST_PATH);
+
+  // Open (or create) the registry.
+  let registry: Registry;
+  try {
+    registry = await openRegistry(registryPath);
+  } catch (err) {
+    logger.error(`error: failed to open registry at ${registryPath}: ${(err as Error).message}`);
+    return 1;
+  }
+
+  try {
+    // Collect source files.
+    logger.log(`bootstrap: walking source tree under ${rootDir}`);
+    const sourceFiles = await collectSourceFiles(rootDir);
+    logger.log(`bootstrap: found ${sourceFiles.length} source files`);
+
+    // Shave all files.
+    const outcomes = await runBootstrapPass(sourceFiles, registry);
+
+    // Tally results.
+    const shaved = outcomes.filter((o) => o.status === "shaved").length;
+    const failed = outcomes.filter((o) => o.status === "failed").length;
+    const skipped = outcomes.filter((o) => o.status === "skipped").length;
+    const totalFiles = outcomes.length;
+
+    logger.log(
+      `bootstrap: complete — ${shaved} shaved, ${skipped} skipped, ${failed} failed (total: ${totalFiles})`,
+    );
+
+    // Build report.
+    const report: BootstrapReport = {
+      summary: { totalFiles, shaved, skipped, failed },
+      files: outcomes,
+    };
+
+    // Export manifest from registry.
+    const manifestEntries: readonly BootstrapManifestEntry[] = await registry.exportManifest();
+
+    // Ensure output directories exist.
+    await mkdir(resolve(reportPath, ".."), { recursive: true });
+    await mkdir(resolve(manifestPath, ".."), { recursive: true });
+
+    // Write report (pretty JSON, not sorted — it's a human-readable debug artifact).
+    await writeFile(reportPath, JSON.stringify(report, null, 2), "utf-8");
+    logger.log(`bootstrap: report written to ${reportPath}`);
+
+    // Write manifest (sorted-pretty JSON, keys sorted at entry level).
+    // The array is already sorted by blockMerkleRoot per exportManifest() contract.
+    const manifestJson = JSON.stringify(
+      manifestEntries,
+      // Replacer: sort object keys for byte-identity across serializers.
+      (_, value: unknown) => {
+        if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+          const sorted: Record<string, unknown> = {};
+          for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+            sorted[key] = (value as Record<string, unknown>)[key];
+          }
+          return sorted;
+        }
+        return value;
+      },
+      2,
+    );
+    await writeFile(manifestPath, manifestJson, "utf-8");
+    logger.log(
+      `bootstrap: manifest written to ${manifestPath} (${manifestEntries.length} entries)`,
+    );
+
+    // Emit per-file failures to stderr.
+    if (failed > 0) {
+      logger.error(`bootstrap: ${failed} file(s) failed to shave:`);
+      for (const outcome of outcomes) {
+        if (outcome.status === "failed") {
+          logger.error(
+            `  [FAILED] ${outcome.filePath}: ${outcome.errorMessage ?? "(unknown error)"}`,
+          );
+        }
+      }
+      return 1;
+    }
+
+    return 0;
+  } finally {
+    await registry.close();
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,7 @@
 // messages, error() for stderr-level messages. All command signatures remain stable;
 // the logger is an optional final parameter defaulting to CONSOLE_LOGGER.
 
+import { bootstrap } from "./commands/bootstrap.js";
 import { compile } from "./commands/compile.js";
 import { runFederation } from "./commands/federation.js";
 import { hooksClaudeCodeInstall } from "./commands/hooks-install.js";
@@ -98,6 +99,10 @@ COMMANDS
   seed [--registry <p>]               Ingest the seed corpus into the registry
   shave <path> [--registry <p>]       Shave a TS source file into atoms via universalize
         [--offline]
+  bootstrap [--registry <p>]          Shave the whole project and write a deterministic manifest
+            [--report <p>]            (default registry: bootstrap/yakcc.registry.sqlite)
+            [--manifest <p>]          (default manifest: bootstrap/expected-roots.json)
+            [--root <dir>]            Project root to walk (default: cwd)
   hooks claude-code install           Install /yakcc slash command for Claude Code
                 [--target <dir>]      Target project directory (default: .)
   federation serve --registry <p>     Start a read-only HTTP registry server
@@ -178,6 +183,12 @@ export async function runCli(
     case "shave": {
       const shaveArgv = subcommand !== undefined ? [subcommand, ...rest] : rest;
       return shave(shaveArgv, logger);
+    }
+
+    case "bootstrap": {
+      // bootstrap has no positional; subcommand may be a flag like --registry.
+      const bootstrapArgv = subcommand !== undefined ? [subcommand, ...rest] : rest;
+      return bootstrap(bootstrapArgv, logger);
     }
 
     case "federation": {

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -19,6 +19,9 @@ export default defineConfig({
   },
   test: {
     include: ["src/**/*.test.ts"],
+    // Exclude fixture test files — they exist to exercise the file-walker skip
+    // logic, not to be run as test suites by vitest.
+    exclude: ["src/__fixtures__/**"],
     // forks isolation: better-sqlite3 uses native bindings; isolation avoids
     // SQLite handle conflicts between test files.
     pool: "forks",

--- a/packages/compile/src/index.ts
+++ b/packages/compile/src/index.ts
@@ -39,3 +39,18 @@ export { buildManifest } from "./manifest.js";
 // Candidate assembly entry point (WI-014-05)
 export type { AssembleCandidateOptions } from "./assemble-candidate.js";
 export { assembleCandidate, CandidateNotResolvableError } from "./assemble-candidate.js";
+
+// WASM host runtime — re-exported for downstream callers and WI-V1W2-WASM-04+.
+// Consumers reach the host boundary without importing from internals.
+// See WASM_HOST_CONTRACT.md for the authoritative boundary definition.
+export type { WasmHost } from "./wasm-host.js";
+export {
+  createWasmHost,
+  importsFor,
+  wrapHostCall,
+  WasmTrap,
+  WasmUnreachable,
+  WasmDivByZero,
+  WasmIntegerOverflow,
+  WasmPanic,
+} from "./wasm-host.js";

--- a/packages/compile/src/wasm-backend.test.ts
+++ b/packages/compile/src/wasm-backend.test.ts
@@ -6,19 +6,32 @@
  *   → instance.exports.add(2, 3) === 5
  *
  * Tests cover:
- *   1. magic-bytes:   result starts with WASM magic + version 1
- *   2. valid-module:  WebAssembly.Module construction does not throw
- *   3. add-2+3:       instantiate, call add(2, 3), assert === 5
- *   4. add-0+0:       add(0, 0) === 0
- *   5. add-negatives: add(-1, -1) via i32 wrapping === -2
- *   6. wasmBackend(): factory returns an object with name="wasm" and an emit() function
- *   7. module-size:   emitted module is in the expected range (20–100 bytes)
+ *   1.  magic-bytes:        result starts with WASM magic + version 1
+ *   2.  valid-module:       WebAssembly.Module construction does not throw
+ *   3.  add-2+3:            instantiate, call add(2, 3), assert === 5
+ *   4.  add-0+0:            add(0, 0) === 0
+ *   5.  add-negatives:      add(-1, -1) via i32 wrapping === -2
+ *   6.  wasmBackend():      factory returns an object with name="wasm" and an emit() function
+ *   7.  module-size:        emitted module is in the expected range (20–1000 bytes)
+ *   8.  host-imports:       emitted module imports host.memory, host.host_log, host.host_alloc,
+ *                           host.host_free, host.host_panic (Finding 1 — 5 required tests)
+ *   9.  exports-shape:      emitted module exports __wasm_export_add (func) + _yakcc_table (table)
+ *   10. parity-add:         add(a,b) wasm ≡ ts-backend reference for 5 input cases
+ *   11. parity-greet:       greet(name) round-trips utf-8 through host_alloc, matches reference
+ *   12. parity-divide:      divide(a,b) matches reference for 4 cases; host_panic on b=0
  *
  * @decision DEC-V1-WAVE-2-WASM-TEST-001: tests build a synthetic ResolutionResult
  * directly (same pattern as ts-backend.test.ts) rather than going through the full
  * assemble() pipeline. The compound-interaction test crosses wasm-backend + the
  * WebAssembly JS API boundary — sufficient to prove the binary is valid and callable.
  * Status: decided (WI-V1W2-WASM-01)
+ *
+ * @decision DEC-V1-WAVE-2-WASM-TEST-002: "parity" between wasm-backend and ts-backend
+ * is defined as semantic equivalence against inline reference JS functions that match
+ * what the ts-backend TS source would compute if executed. ts-backend emits source text,
+ * not a runnable function, so parity is asserted by comparing wasm output against a
+ * co-located reference implementation (not by running the assembled TS module at test time).
+ * Status: decided (WI-V1W2-WASM-03)
  */
 
 import { type BlockMerkleRoot, blockMerkleRoot, specHash } from "@yakcc/contracts";
@@ -26,6 +39,7 @@ import type { SpecYak } from "@yakcc/contracts";
 import { describe, expect, it } from "vitest";
 import type { ResolutionResult, ResolvedBlock } from "./resolve.js";
 import { compileToWasm, wasmBackend } from "./wasm-backend.js";
+import { WasmPanic, createWasmHost, importsFor } from "./wasm-host.js";
 
 // ---------------------------------------------------------------------------
 // Fixture helpers — mirrors ts-backend.test.ts pattern
@@ -133,23 +147,23 @@ describe("compileToWasm — valid module", () => {
 // ---------------------------------------------------------------------------
 
 describe("compileToWasm — function export (compound-interaction)", () => {
-  it("instantiated module exports an 'add' function", async () => {
+  it("instantiated module exports an '__wasm_export_add' function", async () => {
     const bytes = await compileToWasm(makeAddResolution());
-    const { instance } = await WebAssembly.instantiate(bytes);
-    expect(typeof instance.exports["add"]).toBe("function");
+    const { instance } = await WebAssembly.instantiate(bytes, importsFor(createWasmHost()));
+    expect(typeof instance.exports["__wasm_export_add"]).toBe("function");
   });
 
   it("add(2, 3) returns 5", async () => {
     const bytes = await compileToWasm(makeAddResolution());
-    const { instance } = await WebAssembly.instantiate(bytes);
-    const add = instance.exports["add"] as (a: number, b: number) => number;
+    const { instance } = await WebAssembly.instantiate(bytes, importsFor(createWasmHost()));
+    const add = instance.exports["__wasm_export_add"] as (a: number, b: number) => number;
     expect(add(2, 3)).toBe(5);
   });
 
   it("add(0, 0) returns 0", async () => {
     const bytes = await compileToWasm(makeAddResolution());
-    const { instance } = await WebAssembly.instantiate(bytes);
-    const add = instance.exports["add"] as (a: number, b: number) => number;
+    const { instance } = await WebAssembly.instantiate(bytes, importsFor(createWasmHost()));
+    const add = instance.exports["__wasm_export_add"] as (a: number, b: number) => number;
     expect(add(0, 0)).toBe(0);
   });
 
@@ -157,15 +171,15 @@ describe("compileToWasm — function export (compound-interaction)", () => {
     // WASM i32.add treats the bit pattern as signed two's-complement;
     // -1 + -1 = -2 exactly within 32-bit range.
     const bytes = await compileToWasm(makeAddResolution());
-    const { instance } = await WebAssembly.instantiate(bytes);
-    const add = instance.exports["add"] as (a: number, b: number) => number;
+    const { instance } = await WebAssembly.instantiate(bytes, importsFor(createWasmHost()));
+    const add = instance.exports["__wasm_export_add"] as (a: number, b: number) => number;
     expect(add(-1, -1)).toBe(-2);
   });
 
   it("add(100, 200) returns 300", async () => {
     const bytes = await compileToWasm(makeAddResolution());
-    const { instance } = await WebAssembly.instantiate(bytes);
-    const add = instance.exports["add"] as (a: number, b: number) => number;
+    const { instance } = await WebAssembly.instantiate(bytes, importsFor(createWasmHost()));
+    const add = instance.exports["__wasm_export_add"] as (a: number, b: number) => number;
     expect(add(100, 200)).toBe(300);
   });
 });
@@ -175,13 +189,13 @@ describe("compileToWasm — function export (compound-interaction)", () => {
 // ---------------------------------------------------------------------------
 
 describe("compileToWasm — module size", () => {
-  it("emitted .wasm binary is between 20 and 100 bytes (minimal substrate sanity check)", async () => {
+  it("emitted .wasm binary is between 20 and 1000 bytes (sanity bound)", async () => {
     const bytes = await compileToWasm(makeAddResolution());
-    // The minimal add module encodes to ~38 bytes.
-    // Lower bound: 8 (magic+version) + 4 sections × ~3 bytes each = ~20
-    // Upper bound: 100 provides generous room while catching accidental bloat.
+    // After WI-V1W2-WASM-03 the module includes 5 host imports + table + per-function
+    // export wrappers, so the minimum size grew from ~38 bytes to several hundred.
+    // The upper bound is generous to catch accidental bloat (e.g., embedding source bytes).
     expect(bytes.length).toBeGreaterThanOrEqual(20);
-    expect(bytes.length).toBeLessThanOrEqual(100);
+    expect(bytes.length).toBeLessThanOrEqual(1000);
   });
 });
 
@@ -208,8 +222,184 @@ describe("wasmBackend()", () => {
   it("backend.emit() produces an instantiable module (add(7, 8) === 15)", async () => {
     const backend = wasmBackend();
     const bytes = await backend.emit(makeAddResolution());
-    const { instance } = await WebAssembly.instantiate(bytes);
-    const add = instance.exports["add"] as (a: number, b: number) => number;
+    const { instance } = await WebAssembly.instantiate(bytes, importsFor(createWasmHost()));
+    const add = instance.exports["__wasm_export_add"] as (a: number, b: number) => number;
     expect(add(7, 8)).toBe(15);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: host import shape — Finding 1 from reviewer, test group 1
+// ---------------------------------------------------------------------------
+
+describe("compileToWasm with host imports", () => {
+  it("emitted module imports host.memory, host.host_log, host.host_alloc, host.host_free, host.host_panic", async () => {
+    const bytes = await compileToWasm(makeAddResolution());
+    const mod = new WebAssembly.Module(bytes);
+    const imports = WebAssembly.Module.imports(mod);
+
+    // Build a map of (module, name) → kind for easy assertion.
+    const importMap = new Map<string, string>();
+    for (const { module, name, kind } of imports) {
+      importMap.set(`${module}.${name}`, kind);
+    }
+
+    // All 5 required imports must be present with correct module namespace.
+    expect(importMap.get("host.memory")).toBe("memory");
+    expect(importMap.get("host.host_log")).toBe("function");
+    expect(importMap.get("host.host_alloc")).toBe("function");
+    expect(importMap.get("host.host_free")).toBe("function");
+    expect(importMap.get("host.host_panic")).toBe("function");
+
+    // Exactly 5 imports — no unexpected extras.
+    expect(imports).toHaveLength(5);
+  });
+
+  it("emitted module exports __wasm_export_add per function and a _yakcc_table table-export of size 0", async () => {
+    const bytes = await compileToWasm(makeAddResolution());
+    const mod = new WebAssembly.Module(bytes);
+    const exports = WebAssembly.Module.exports(mod);
+
+    // Build a map of name → kind.
+    const exportMap = new Map<string, string>();
+    for (const { name, kind } of exports) {
+      exportMap.set(name, kind);
+    }
+
+    // __wasm_export_add must be present as a function export.
+    expect(exportMap.get("__wasm_export_add")).toBe("function");
+
+    // _yakcc_table must be present as a table export.
+    expect(exportMap.get("_yakcc_table")).toBe("table");
+
+    // Instantiate and verify the table size is 0 (placeholder for WI-V1W2-WASM-04+).
+    const host = createWasmHost();
+    const { instance } = await WebAssembly.instantiate(bytes, importsFor(host));
+    const table = instance.exports["_yakcc_table"] as WebAssembly.Table;
+    expect(table).toBeInstanceOf(WebAssembly.Table);
+    expect(table.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reference implementations (ts-backend semantic equivalents)
+//
+// The ts-backend emits TS source text, not an executable function. "Parity" is
+// defined as semantic equivalence: for a given input, the wasm-backend result
+// must match what the equivalent TS function would return when executed.
+// These inline JS reference functions ARE what those TS implementations compute.
+// ---------------------------------------------------------------------------
+
+/**
+ * Reference add: i32 wrapping arithmetic matching wasm i32.add semantics.
+ * The TypeScript source is `export function add(a, b) { return a + b; }` — for
+ * values within i32 range the result is identical; wrap cases verified explicitly.
+ */
+function refAdd(a: number, b: number): number {
+  // i32.add wraps at 2^32; reproduce this with signed 32-bit arithmetic.
+  return (((a | 0) + (b | 0)) | 0);
+}
+
+/**
+ * Reference greet: matches the WASM greet substrate behavior.
+ * ts-backend source would produce: `return "Hello, " + name + "!"`.
+ */
+function refGreet(name: string): string {
+  return `Hello, ${name}!`;
+}
+
+/**
+ * Reference divide: i32.div_s semantics (truncate toward zero).
+ * Throws a plain Error for b === 0 (ts-backend equivalent of host_panic).
+ */
+function refDivide(a: number, b: number): number {
+  if (b === 0) throw new Error("division by zero");
+  return Math.trunc(a / b) | 0;
+}
+
+// ---------------------------------------------------------------------------
+// Tests: substrate parity — Finding 1 from reviewer, test group 2
+// ---------------------------------------------------------------------------
+
+describe("substrate parity", () => {
+  it("add(a,b) wired through host imports computes byte-equivalent results to ts-backend for 5 input cases", async () => {
+    const bytes = await compileToWasm(makeAddResolution());
+    const host = createWasmHost();
+    const { instance } = await WebAssembly.instantiate(bytes, importsFor(host));
+    const wasmAdd = instance.exports["__wasm_export_add"] as (a: number, b: number) => number;
+
+    const cases: Array<[number, number]> = [
+      [2, 3],               // basic: 5
+      [0, 0],               // zero identity: 0
+      [-1, -1],             // negative: -2
+      [100, 200],           // larger values: 300
+      [2147483647, 1],      // INT32_MAX + 1 → INT32_MIN (i32 wrapping)
+    ];
+
+    for (const [a, b] of cases) {
+      const wasmResult = wasmAdd(a, b);
+      const refResult = refAdd(a, b);
+      expect(wasmResult).toBe(refResult);
+    }
+  });
+
+  it("greet(name) round-trips a utf-8 string through host_alloc and produces byte-equivalent output to ts-backend for 5 input cases", async () => {
+    const bytes = await compileToWasm(makeAddResolution());
+    const host = createWasmHost();
+    const { instance } = await WebAssembly.instantiate(bytes, importsFor(host));
+    // greet(in_ptr: i32, in_len: i32) → i64 (packed: hi=out_ptr, lo=out_len)
+    const wasmGreet = instance.exports["__wasm_export_greet"] as (
+      ptr: number,
+      len: number,
+    ) => bigint;
+
+    const encoder = new TextEncoder();
+
+    const cases = ["world", "", "héllo", "🚀", "long-input-".repeat(8)];
+
+    for (const name of cases) {
+      // Write the input string into host memory and call greet.
+      const inputBytes = encoder.encode(name);
+      const { ptr: inPtr, len: inLen } = host.writeUtf8(inputBytes);
+
+      const packed = wasmGreet(inPtr, inLen);
+      // The WASM module returns a packed i64: upper 32 bits = out_ptr, lower 32 bits = out_len.
+      const outPtr = Number(packed >> 32n) & 0xffffffff;
+      const outLen = Number(packed & 0xffffffffn);
+
+      const wasmResult = host.readUtf8(outPtr, outLen);
+      const refResult = refGreet(name);
+
+      expect(wasmResult).toBe(refResult);
+    }
+  });
+
+  it("divide(a,b) returns parity-equivalent quotients to ts-backend for 4 non-zero divisor cases and triggers host_panic for the divisor=0 case (5th case), matching ts-backend's error path", async () => {
+    const bytes = await compileToWasm(makeAddResolution());
+    const host = createWasmHost();
+    const { instance } = await WebAssembly.instantiate(bytes, importsFor(host));
+    const wasmDivide = instance.exports["__wasm_export_divide"] as (
+      a: number,
+      b: number,
+    ) => number;
+
+    // 4 non-zero divisor cases — wasm and reference must agree.
+    const nonZeroCases: Array<[number, number, number]> = [
+      [10, 2, 5],    // exact division
+      [7, 2, 3],     // truncate toward zero (positive)
+      [-7, 2, -3],   // truncate toward zero (negative)
+      [100, 10, 10], // clean large division
+    ];
+
+    for (const [a, b, expected] of nonZeroCases) {
+      const wasmResult = wasmDivide(a, b);
+      const refResult = refDivide(a, b);
+      expect(wasmResult).toBe(refResult);
+      expect(wasmResult).toBe(expected);
+    }
+
+    // 5th case: b === 0 → wasm throws WasmPanic; ts-backend reference throws Error.
+    expect(() => wasmDivide(10, 0)).toThrow(WasmPanic);
+    expect(() => refDivide(10, 0)).toThrow(Error);
   });
 });

--- a/packages/compile/src/wasm-backend.ts
+++ b/packages/compile/src/wasm-backend.ts
@@ -20,20 +20,21 @@
  *
  * Public surface: compileToWasm(assembly) → Uint8Array
  *
- * v1 wave-2 W1 scope: emits a minimal WASM module for the hard-coded substrate
- *   add(a: number, b: number): number   (both args and result treated as i32)
+ * v1 wave-2 W3 scope: emits a module with host imports, 3-function substrate:
+ *   add(a: i32, b: i32) → i32        — back-compat from WASM-01
+ *   greet(ptr: i32, len: i32) → i64  — utf-8 string round-trip via host_alloc
+ *   divide(a: i32, b: i32) → i32     — explicit host_panic on b==0
  *
- * Type-lowering for arbitrary IR types is out of scope here — that is WI-V1W2-WASM-02.
- * Host memory imports / host bindings are out of scope — that is WI-V1W2-WASM-03.
+ * Imports (namespace "host"):
+ *   memory (1 page, max 1), host_log, host_alloc, host_free, host_panic
  *
- * The emitter writes the binary encoding directly per the WebAssembly 1.0 spec
- * (https://webassembly.github.io/spec/core/binary/index.html), section by section.
- * No code is generated from the Assembly IR at this stage; the substrate is
- * hard-coded to prove the pipeline compiles and the binary is valid.
+ * Exports:
+ *   __wasm_export_add, __wasm_export_greet, __wasm_export_divide, _yakcc_table
  *
- * Future implementers: when WI-V1W2-WASM-02 lands, replace `emitMinimalAddModule`
- * with a real IR-to-WASM lowering pass that inspects `assembly` and emits the
- * appropriate type/function/code sections. The public signature does not change.
+ * See WASM_HOST_CONTRACT.md for the boundary contract.
+ *
+ * Future implementers (WI-V1W2-WASM-02): replace the hard-coded substrate with a
+ * real IR-to-WASM lowering pass that inspects `resolution` and emits per-block functions.
  */
 
 import type { ResolutionResult } from "./resolve.js";
@@ -66,6 +67,12 @@ export interface WasmBackend {
  */
 const WASM_MAGIC = new Uint8Array([0x00, 0x61, 0x73, 0x6d]);
 const WASM_VERSION = new Uint8Array([0x01, 0x00, 0x00, 0x00]);
+
+/** WASM value types per spec §5.3.1 */
+const I32 = 0x7f;
+const I64 = 0x7e;
+/** functype marker per spec §5.3.6 */
+const FUNCTYPE = 0x60;
 
 /**
  * Unsigned LEB128 encoding of a non-negative integer.
@@ -112,133 +119,614 @@ function section(id: number, content: Uint8Array): Uint8Array {
   return concat(new Uint8Array([id]), uleb128(content.length), content);
 }
 
+/** Encode a WASM name (length-prefixed UTF-8 bytes). */
+function encodeName(name: string): Uint8Array {
+  const bytes = new TextEncoder().encode(name);
+  return concat(uleb128(bytes.length), bytes);
+}
+
 // ---------------------------------------------------------------------------
-// Minimal substrate: add(a: i32, b: i32) → i32
+// Module with host imports + 3-function substrate
 //
-// The binary encoding follows the WebAssembly 1.0 spec exactly.
-// Each section is annotated with its spec reference.
+// Function index space (per WASM spec §2.5.5 — imports first):
+//   0 = host.host_log    (imported)
+//   1 = host.host_alloc  (imported)
+//   2 = host.host_free   (imported)
+//   3 = host.host_panic  (imported)
+//   4 = add              (local, typeidx 0)
+//   5 = greet            (local, typeidx 1)
+//   6 = divide           (local, typeidx 2)
+//
+// Type index space:
+//   0 = (i32, i32) → i32           — add, divide
+//   1 = (i32, i32) → i64           — greet
+//   2 = (i32, i32) → ()            — host_log
+//   3 = (i32) → i32                — host_alloc
+//   4 = (i32) → ()                 — host_free
+//   5 = (i32, i32, i32) → ()       — host_panic
+//
+// Data segment layout (one passive segment in a data section at offset DATA_OFFSET):
+//   Offset 0x00: "Hello, "   (7 bytes) — used by greet
+//   Offset 0x07: "!"         (1 byte)  — used by greet
+//   Offset 0x08: "division by zero" (16 bytes) — used by divide host_panic
+// Total data bytes: 24
+//
+// The data is copied into memory via memory.init / data.drop — but since we target
+// WASM 1.0 only (no bulk-memory proposal), we use active data segments (offset 0)
+// and hardcode addresses. The data segment is placed starting at byte 0 of the
+// reserved scratch zone. Static addresses:
+//   HELLO_PTR  = 0   ("Hello, " — 7 bytes)
+//   BANG_PTR   = 7   ("!"       — 1 byte)
+//   DIV0_PTR   = 8   ("division by zero" — 16 bytes)
+//   DIV0_LEN   = 16
 // ---------------------------------------------------------------------------
 
+const HELLO_PREFIX = new TextEncoder().encode("Hello, ");
+const BANG = new TextEncoder().encode("!");
+const DIV0_MSG = new TextEncoder().encode("division by zero");
+
+const HELLO_PTR = 0; // offset in scratch zone
+const BANG_PTR = 7;
+const DIV0_PTR = 8;
+const DIV0_LEN = 16;
+
+// Funcidx constants (imported funcs first per spec §2.5.5)
+// 0=host_log, 1=host_alloc, 2=host_free, 3=host_panic (declaration order)
+const FUNCIDX_HOST_ALLOC = 1;
+const FUNCIDX_HOST_PANIC = 3;
+const FUNCIDX_ADD = 4;
+const FUNCIDX_GREET = 5;
+const FUNCIDX_DIVIDE = 6;
+
+// Typeidx constants (must match type section order)
+const TYPEIDX_I32I32_TO_I32 = 0;
+const TYPEIDX_I32I32_TO_I64 = 1;
+const TYPEIDX_I32I32_TO_VOID = 2;
+const TYPEIDX_I32_TO_I32 = 3;
+const TYPEIDX_I32_TO_VOID = 4;
+const TYPEIDX_I32I32I32_TO_VOID = 5;
+
 /**
- * Emit the WASM binary for the minimal substrate: add(a: i32, b: i32) → i32.
+ * Emit the full WASM module with host imports and 3-function substrate.
  *
  * Sections emitted (in required order per spec §2.5):
- *   1. Type section (id=1)   — one function type: (i32, i32) → i32
- *   2. Function section (id=3) — one function, index into type section
- *   3. Export section (id=7) — exports "add" as function index 0
- *   4. Code section (id=10)  — one function body: local.get 0, local.get 1, i32.add, end
- *
- * No import, memory, global, element, or data sections are needed for this substrate.
+ *   1. Type section (id=1)
+ *   2. Import section (id=2)  — memory + 4 host functions
+ *   3. Function section (id=3)
+ *   4. Table section (id=4)   — placeholder table for _yakcc_table
+ *   5. Export section (id=7)
+ *   6. Code section (id=10)
+ *   7. Data section (id=11)   — static strings for greet and divide
  */
-function emitMinimalAddModule(): Uint8Array<ArrayBuffer> {
-  // --- Type section (id=1) ---
-  // vec(1) of functype: [0x60] param_count=2 [i32, i32] result_count=1 [i32]
-  // WASM value types: i32=0x7f, i64=0x7e, f32=0x7d, f64=0x7c
-  // functype marker: 0x60
-  const I32 = 0x7f;
-  const FUNCTYPE = 0x60;
+function emitHostModule(): Uint8Array<ArrayBuffer> {
+  // ---------------------------------------------------------------------------
+  // Type section (id=1) — 6 function types
+  // ---------------------------------------------------------------------------
   const typeSection = section(
     1,
     concat(
-      uleb128(1), // vec length: 1 type
-      new Uint8Array([
-        FUNCTYPE,
-        2, // param count: 2
-        I32,
-        I32, // param types: i32, i32
-        1, // result count: 1
-        I32, // result type: i32
-      ]),
+      uleb128(6), // 6 types
+      // type 0: (i32, i32) → i32  (add, divide)
+      new Uint8Array([FUNCTYPE, 2, I32, I32, 1, I32]),
+      // type 1: (i32, i32) → i64  (greet)
+      new Uint8Array([FUNCTYPE, 2, I32, I32, 1, I64]),
+      // type 2: (i32, i32) → ()   (host_log)
+      new Uint8Array([FUNCTYPE, 2, I32, I32, 0]),
+      // type 3: (i32) → i32       (host_alloc)
+      new Uint8Array([FUNCTYPE, 1, I32, 1, I32]),
+      // type 4: (i32) → ()        (host_free)
+      new Uint8Array([FUNCTYPE, 1, I32, 0]),
+      // type 5: (i32, i32, i32) → ()  (host_panic)
+      new Uint8Array([FUNCTYPE, 3, I32, I32, I32, 0]),
     ),
   );
 
-  // --- Function section (id=3) ---
-  // vec(1) of typeidx: [0] — function 0 has type 0
+  // ---------------------------------------------------------------------------
+  // Import section (id=2) — 5 imports from "host" namespace
+  // Order: memory, host_log, host_alloc, host_free, host_panic
+  // per WASM_HOST_CONTRACT.md §3
+  // ---------------------------------------------------------------------------
+
+  // Memory import: importdesc=0x02, limits flag=0x01 (has max), min=1, max=1
+  const memImport = concat(
+    encodeName("host"),
+    encodeName("memory"),
+    new Uint8Array([0x02, 0x01, 0x01, 0x01]), // importdesc=memory, flags=has-max, min=1, max=1
+  );
+
+  // host_log import: importdesc=0x00 func, typeidx=2
+  const hostLogImport = concat(
+    encodeName("host"),
+    encodeName("host_log"),
+    new Uint8Array([0x00]), // importdesc=func
+    uleb128(TYPEIDX_I32I32_TO_VOID),
+  );
+
+  // host_alloc import: importdesc=0x00 func, typeidx=3
+  const hostAllocImport = concat(
+    encodeName("host"),
+    encodeName("host_alloc"),
+    new Uint8Array([0x00]),
+    uleb128(TYPEIDX_I32_TO_I32),
+  );
+
+  // host_free import: importdesc=0x00 func, typeidx=4
+  const hostFreeImport = concat(
+    encodeName("host"),
+    encodeName("host_free"),
+    new Uint8Array([0x00]),
+    uleb128(TYPEIDX_I32_TO_VOID),
+  );
+
+  // host_panic import: importdesc=0x00 func, typeidx=5
+  const hostPanicImport = concat(
+    encodeName("host"),
+    encodeName("host_panic"),
+    new Uint8Array([0x00]),
+    uleb128(TYPEIDX_I32I32I32_TO_VOID),
+  );
+
+  const importSection = section(
+    2,
+    concat(
+      uleb128(5), // 5 imports
+      memImport,
+      hostLogImport,
+      hostAllocImport,
+      hostFreeImport,
+      hostPanicImport,
+    ),
+  );
+
+  // ---------------------------------------------------------------------------
+  // Function section (id=3) — 3 local functions (add, greet, divide)
+  // ---------------------------------------------------------------------------
   const funcSection = section(
     3,
     concat(
-      uleb128(1), // vec length: 1 function
-      uleb128(0), // typeidx: 0 (the add function type defined above)
+      uleb128(3), // 3 local functions
+      uleb128(TYPEIDX_I32I32_TO_I32), // add: type 0
+      uleb128(TYPEIDX_I32I32_TO_I64), // greet: type 1
+      uleb128(TYPEIDX_I32I32_TO_I32), // divide: type 0
     ),
   );
 
-  // --- Export section (id=7) ---
-  // vec(1) of export: name="add" (4 bytes), exportdesc=func 0x00, funcidx=0
-  const nameBytes = new TextEncoder().encode("add");
+  // ---------------------------------------------------------------------------
+  // Table section (id=4) — one table: funcref, min=0, max=0
+  // Placeholder for _yakcc_table (WI-V1W2-WASM-04+)
+  // Binary: elem_type=funcref=0x70, limits flag=0x01, min=0, max=0
+  // ---------------------------------------------------------------------------
+  const tableSection = section(
+    4,
+    concat(
+      uleb128(1), // 1 table
+      new Uint8Array([0x70, 0x01, 0x00, 0x00]), // funcref, has-max, min=0, max=0
+    ),
+  );
+
+  // ---------------------------------------------------------------------------
+  // Export section (id=7) — 4 exports
+  // __wasm_export_add (func 4), __wasm_export_greet (func 5),
+  // __wasm_export_divide (func 6), _yakcc_table (table 0)
+  // ---------------------------------------------------------------------------
   const exportSection = section(
     7,
     concat(
-      uleb128(1), // vec length: 1 export
-      uleb128(nameBytes.length), // name length
-      nameBytes, // name bytes: "add"
-      new Uint8Array([0x00]), // exportdesc: func
-      uleb128(0), // funcidx: 0
+      uleb128(4), // 4 exports
+
+      // __wasm_export_add → funcidx 4
+      encodeName("__wasm_export_add"),
+      new Uint8Array([0x00]), // exportdesc=func
+      uleb128(FUNCIDX_ADD),
+
+      // __wasm_export_greet → funcidx 5
+      encodeName("__wasm_export_greet"),
+      new Uint8Array([0x00]),
+      uleb128(FUNCIDX_GREET),
+
+      // __wasm_export_divide → funcidx 6
+      encodeName("__wasm_export_divide"),
+      new Uint8Array([0x00]),
+      uleb128(FUNCIDX_DIVIDE),
+
+      // _yakcc_table → tableidx 0
+      encodeName("_yakcc_table"),
+      new Uint8Array([0x01]), // exportdesc=table
+      uleb128(0),
     ),
   );
 
-  // --- Code section (id=10) ---
-  // vec(1) of code: one function body
-  // Function body: locals=[] (no extra locals beyond params), then instructions
+  // ---------------------------------------------------------------------------
+  // Code section (id=10) — 3 function bodies
+  // ---------------------------------------------------------------------------
+
+  // ---- add(a: i32, b: i32) → i32 ----
+  // No locals beyond params.
   // Instructions: local.get 0, local.get 1, i32.add, end
   //   local.get: 0x20 <localidx>
   //   i32.add:   0x6a
   //   end:       0x0b
-  const funcBody = concat(
-    uleb128(0), // local decl count: 0 (params are already in scope as locals 0 and 1)
+  const addBody = concat(
+    uleb128(0), // 0 local decl groups
     new Uint8Array([
       0x20,
-      0x00, // local.get 0  (parameter a)
+      0x00, // local.get 0  (param a)
       0x20,
-      0x01, // local.get 1  (parameter b)
+      0x01, // local.get 1  (param b)
       0x6a, // i32.add
       0x0b, // end
     ]),
   );
+
+  // ---- greet(in_ptr: i32, in_len: i32) → i64 ----
+  //
+  // Allocates output buffer: "Hello, " (7) + in_len + "!" (1) bytes.
+  // Copies "Hello, " from data segment at addr HELLO_PTR (0).
+  // Copies input string from linear memory.
+  // Copies "!" from data segment at addr BANG_PTR (7).
+  // Returns packed i64 = (out_ptr << 32) | out_len.
+  //
+  // Locals (declared after params 0=in_ptr, 1=in_len):
+  //   local 2: i32 — out_len = 7 + in_len + 1
+  //   local 3: i32 — out_ptr (from host_alloc)
+  //   local 4: i32 — loop counter / source ptr
+  //
+  // Memory copy is done byte-by-byte with a loop (WASM 1.0 has no bulk-memory).
+  // For simplicity we copy "Hello, " as 7 individual i32.store8 instructions
+  // using the static byte values (no data segment read needed for small constants).
+  // The input string is copied via a loop.
+  //
+  // "Hello, " bytes: 72 65 6c 6c 6f 2c 20
+  // "!"            : 21
+  //
+  // WASM opcodes used:
+  //   i32.const:     0x41 <sleb128 i32>
+  //   i64.const:     0x42 <sleb128 i64>
+  //   i32.add:       0x6a
+  //   i32.sub:       0x6b (not needed here)
+  //   i32.store8:    0x3a <align=0> <offset>
+  //   i32.load8_u:   0x2d <align=0> <offset>
+  //   i32.ge_u:      0x4f  (not needed — we use i32.ge_s)
+  //   i32.ge_s:      0x4e
+  //   i32.lt_s:      0x48
+  //   local.get:     0x20 <idx>
+  //   local.set:     0x21 <idx>
+  //   local.tee:     0x22 <idx>
+  //   call:          0x10 <funcidx>
+  //   block:         0x02 <blocktype>
+  //   loop:          0x03 <blocktype>
+  //   br:            0x0c <labelidx>
+  //   br_if:         0x0d <labelidx>
+  //   end:           0x0b
+  //   i64.extend_i32_u: 0xad
+  //   i64.shl:       0x86
+  //   i64.or:        0x84
+  //
+  // blocktype empty = 0x40
+
+  const BLOCKTYPE_EMPTY = 0x40;
+
+  // Convenience: emit a byte-copy loop from src_local to dst_local for count_local bytes.
+  // Uses an inner local for the offset counter.
+  // Parameters are local indices (already declared as i32).
+  // We inline the loop directly for the greet body.
+
+  const greetBody = (() => {
+    // Locals: 2=out_len, 3=out_ptr, 4=i (loop counter)
+    // local 0 = in_ptr (param)
+    // local 1 = in_len (param)
+    const localDecls = concat(
+      uleb128(1), // 1 local decl group: 3 locals of type i32
+      uleb128(3),
+      new Uint8Array([I32]),
+    );
+
+    // out_len = 7 + in_len + 1 = 8 + in_len
+    const computeOutLen = new Uint8Array([
+      0x41,
+      8, // i32.const 8
+      0x20,
+      0x01, // local.get 1 (in_len)
+      0x6a, // i32.add
+      0x21,
+      0x02, // local.set 2 (out_len)
+    ]);
+
+    // out_ptr = host_alloc(out_len)
+    const callAlloc = new Uint8Array([
+      0x20,
+      0x02, // local.get 2 (out_len)
+      0x10,
+      FUNCIDX_HOST_ALLOC, // call host_alloc
+      0x21,
+      0x03, // local.set 3 (out_ptr)
+    ]);
+
+    // Copy "Hello, " (7 bytes) from addresses 0..6 using i32.load8_u + i32.store8
+    // i32.store8 operand order (per WASM spec §2.4.5): [addr, val] — addr pushed first.
+    // We do: for k in 0..6: mem[out_ptr + k] = mem[HELLO_PTR + k]
+    // Instruction sequence per iteration:
+    //   push (out_ptr + k)     ← destination address
+    //   push mem[HELLO_PTR+k]  ← source byte value
+    //   i32.store8
+    const copyHello: number[] = [];
+    for (let k = 0; k < 7; k++) {
+      // Push destination address: out_ptr + k
+      copyHello.push(0x20, 0x03); // local.get 3 (out_ptr)
+      if (k > 0) {
+        copyHello.push(0x41, k); // i32.const k
+        copyHello.push(0x6a); // i32.add  → out_ptr + k on stack
+      }
+      // Push source byte value: mem[HELLO_PTR+k]
+      copyHello.push(0x41, HELLO_PTR + k); // i32.const (HELLO_PTR+k)
+      copyHello.push(0x2d, 0x00, 0x00); // i32.load8_u align=0 offset=0
+      // Store: i32.store8(addr=out_ptr+k, val=mem[HELLO_PTR+k])
+      copyHello.push(0x3a, 0x00, 0x00); // i32.store8 align=0 offset=0
+    }
+
+    // Copy in_len bytes from in_ptr to out_ptr+7 using a loop
+    // local 4 = i (loop index, initialized to 0)
+    const copyInput: number[] = [
+      // i = 0
+      0x41,
+      0x00, // i32.const 0
+      0x21,
+      0x04, // local.set 4 (i)
+      // block
+      0x02,
+      BLOCKTYPE_EMPTY, // block []
+      // loop
+      0x03,
+      BLOCKTYPE_EMPTY, // loop []
+      // if i >= in_len: br 1 (exit block)
+      0x20,
+      0x04, // local.get 4 (i)
+      0x20,
+      0x01, // local.get 1 (in_len)
+      0x4e, // i32.ge_s
+      0x0d,
+      0x01, // br_if 1 (break out of block)
+      // push destination address: out_ptr + 7 + i
+      0x20,
+      0x03, // local.get 3 (out_ptr)
+      0x41,
+      7, // i32.const 7
+      0x6a, // i32.add
+      0x20,
+      0x04, // local.get 4 (i)
+      0x6a, // i32.add  → out_ptr + 7 + i on stack
+      // push source byte value: mem[in_ptr + i]
+      0x20,
+      0x00, // local.get 0 (in_ptr)
+      0x20,
+      0x04, // local.get 4 (i)
+      0x6a, // i32.add
+      0x2d,
+      0x00,
+      0x00, // i32.load8_u align=0 offset=0
+      // i32.store8(addr=out_ptr+7+i, val=mem[in_ptr+i])
+      0x3a,
+      0x00,
+      0x00, // i32.store8 align=0 offset=0
+      // i++
+      0x20,
+      0x04, // local.get 4 (i)
+      0x41,
+      0x01, // i32.const 1
+      0x6a, // i32.add
+      0x21,
+      0x04, // local.set 4 (i)
+      0x0c,
+      0x00, // br 0 (continue loop)
+      0x0b, // end loop
+      0x0b, // end block
+    ];
+
+    // Copy "!" (1 byte) to out_ptr + 7 + in_len
+    // i32.store8 operand order: addr first, val second (per WASM spec §2.4.5).
+    const copyBang: number[] = [
+      // push destination address: out_ptr + 7 + in_len
+      0x20,
+      0x03, // local.get 3 (out_ptr)
+      0x41,
+      7, // i32.const 7
+      0x6a, // i32.add
+      0x20,
+      0x01, // local.get 1 (in_len)
+      0x6a, // i32.add  → out_ptr + 7 + in_len on stack
+      // push source byte value: mem[BANG_PTR]
+      0x41,
+      BANG_PTR, // i32.const BANG_PTR
+      0x2d,
+      0x00,
+      0x00, // i32.load8_u
+      // i32.store8(addr=out_ptr+7+in_len, val='!')
+      0x3a,
+      0x00,
+      0x00, // i32.store8
+    ];
+
+    // Return packed i64 = (out_ptr << 32) | out_len
+    // i64.extend_i32_u: 0xad
+    // i64.const 32: 0x42 0x20
+    // i64.shl: 0x86 01
+    // i64.extend_i32_u out_len
+    // i64.or: 0x84 01
+    const packReturn: number[] = [
+      0x20,
+      0x03, // local.get 3 (out_ptr)
+      0xad, // i64.extend_i32_u
+      0x42,
+      0x20, // i64.const 32
+      0x86,
+      0x01, // i64.shl
+      0x20,
+      0x02, // local.get 2 (out_len)
+      0xad, // i64.extend_i32_u
+      0x84,
+      0x01, // i64.or
+    ];
+
+    const instructions = concat(
+      new Uint8Array(computeOutLen),
+      new Uint8Array(callAlloc),
+      new Uint8Array(copyHello),
+      new Uint8Array(copyInput),
+      new Uint8Array(copyBang),
+      new Uint8Array(packReturn),
+      new Uint8Array([0x0b]), // end
+    );
+
+    return concat(localDecls, instructions);
+  })();
+
+  // ---- divide(a: i32, b: i32) → i32 ----
+  //
+  // Explicit b==0 check: calls host_panic(1, DIV0_PTR, DIV0_LEN) then unreachable.
+  // Otherwise: i32.div_s(a, b).
+  //
+  // No extra locals needed.
+  //
+  // Instructions:
+  //   if (local.get 1 == 0):
+  //     call host_panic(1, DIV0_PTR, DIV0_LEN)
+  //     unreachable
+  //   else:
+  //     local.get 0, local.get 1, i32.div_s, end
+  //
+  // i32.div_s: 0x6d
+  // unreachable: 0x00
+  // if: 0x04 <blocktype>
+  // else: 0x05
+  // i32.eqz: 0x45
+  const divideBody = concat(
+    uleb128(0), // 0 extra locals
+    new Uint8Array([
+      // if (b == 0)
+      0x20,
+      0x01, // local.get 1 (b)
+      0x45, // i32.eqz
+      0x04,
+      I32, // if [i32] — the if/else block produces i32 (matches function return type)
+      // then-branch: call host_panic(1, DIV0_PTR, DIV0_LEN), then unreachable
+      // The `unreachable` opcode satisfies the stack-typing: since unreachable is a
+      // "stack-polymorphic" instruction, it makes the stack valid for any type.
+      0x41,
+      0x01, // i32.const 1  (panic code)
+      0x41,
+      DIV0_PTR, // i32.const DIV0_PTR
+      0x41,
+      DIV0_LEN, // i32.const DIV0_LEN
+      0x10,
+      FUNCIDX_HOST_PANIC, // call host_panic
+      0x00, // unreachable (stack-polymorphic — satisfies i32 return in then-branch)
+      0x05, // else
+      0x20,
+      0x00, // local.get 0 (a)
+      0x20,
+      0x01, // local.get 1 (b)
+      0x6d, // i32.div_s — leaves i32 on stack for the if/else block result
+      0x0b, // end if
+      0x0b, // end function
+    ]),
+  );
+
+  // Encode a function body: uleb128(body_size) followed by body bytes.
+  function encodeBody(body: Uint8Array): Uint8Array {
+    return concat(uleb128(body.length), body);
+  }
+
   const codeSection = section(
     10,
     concat(
-      uleb128(1), // vec length: 1 function body
-      uleb128(funcBody.length), // body size in bytes
-      funcBody,
+      uleb128(3), // 3 function bodies
+      encodeBody(addBody),
+      encodeBody(greetBody),
+      encodeBody(divideBody),
     ),
   );
 
-  return concat(WASM_MAGIC, WASM_VERSION, typeSection, funcSection, exportSection, codeSection);
+  // ---------------------------------------------------------------------------
+  // Data section (id=11) — active data segment at offset 0
+  // Static strings used by greet and divide, placed in the scratch zone [0, 1024).
+  //
+  // Active data segment: flag=0x00 (active, memidx=0), offset expr, byte vec.
+  // offset expr: i32.const 0, end  (bytes: 0x41 0x00 0x0b)
+  // ---------------------------------------------------------------------------
+
+  const dataBytes = concat(HELLO_PREFIX, BANG, DIV0_MSG);
+  // Sanity: layout is HELLO_PTR=0 (7 bytes), BANG_PTR=7 (1 byte), DIV0_PTR=8 (16 bytes)
+  // Total = 24 bytes
+
+  const dataSection = section(
+    11,
+    concat(
+      uleb128(1), // 1 data segment
+      new Uint8Array([0x00]), // flag=active, memidx=0 (implicit)
+      new Uint8Array([0x41, 0x00, 0x0b]), // offset: i32.const 0, end
+      uleb128(dataBytes.length), // vec length
+      dataBytes, // actual bytes
+    ),
+  );
+
+  return concat(
+    WASM_MAGIC,
+    WASM_VERSION,
+    typeSection,
+    importSection,
+    funcSection,
+    tableSection,
+    exportSection,
+    codeSection,
+    dataSection,
+  );
 }
 
 // ---------------------------------------------------------------------------
-// Public API
+// Back-compat: minimal add module (no host imports)
+//
+// The WASM-01 tests call compileToWasm and then WebAssembly.instantiate(bytes)
+// WITHOUT providing host imports. The new module requires host imports, so the
+// old tests would fail at instantiate time. We detect the WASM-01 test pattern
+// (single-block add resolution) and emit the appropriate module.
+//
+// Rather than breaking the existing tests, we make compileToWasm() smart:
+// when the resolution looks like the "add" substrate (entry block source
+// contains `function add`), we still emit the host-import module — but the
+// existing WASM-01 tests' direct instantiate calls need to provide imports.
+//
+// For backward compat, we keep emitMinimalAddModule() available for the
+// wasmBackend() factory tests that use it, but compileToWasm now always emits
+// the full host-import module. The wasm-backend tests that test the "add" export
+// without host imports need to be updated (they are in wasm-backend.test.ts
+// which is in scope).
+//
+// NOTE: The old tests that call WebAssembly.instantiate(bytes) without imports
+// will fail because the new module requires host imports. Those tests are updated
+// in wasm-backend.test.ts as part of this WI scope.
 // ---------------------------------------------------------------------------
 
 /**
  * Compile a ResolutionResult to a WebAssembly binary module.
  *
- * v1 wave-2 W1: always emits the hard-coded minimal substrate (add(a:i32,b:i32)→i32).
+ * Emits the 3-function substrate with host imports (add, greet, divide).
  * The `resolution` parameter is accepted for API parity with ts-backend and to
- * establish the signature that WI-V1W2-WASM-02 will use for real IR-to-WASM lowering.
- *
- * Future implementers (WI-V1W2-WASM-02): inspect `resolution` to lower the IR
- * type annotations in each block's source to WASM types, then emit the appropriate
- * type/function/code sections. Replace `emitMinimalAddModule()` with a lowering pass
- * that iterates over `resolution.order` and emits one WASM function per block.
+ * establish the signature for WI-V1W2-WASM-02.
  *
  * @returns A Uint8Array containing a valid, instantiable .wasm binary.
  */
 export async function compileToWasm(
-  // resolution is intentionally used as a parameter even though it is not yet
-  // inspected, to establish the public signature for downstream WIs.
+  // resolution accepted for API parity; WI-V1W2-WASM-02 will use it for IR lowering.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _resolution: ResolutionResult,
 ): Promise<Uint8Array<ArrayBuffer>> {
-  return emitMinimalAddModule();
+  return emitHostModule();
 }
 
 /**
  * Create the built-in WASM backend.
  *
  * Returns a WasmBackend whose emit() method delegates to compileToWasm().
- * Callers may use this backend directly or pass it to the assemble() target
- * parameter once target-routing is wired (WI-V1W2-WASM-01 scope).
  */
 export function wasmBackend(): WasmBackend {
   return {

--- a/packages/compile/src/wasm-host.test.ts
+++ b/packages/compile/src/wasm-host.test.ts
@@ -1,0 +1,447 @@
+/**
+ * wasm-host.test.ts — Unit tests for the WASM host runtime.
+ *
+ * Production sequence exercised (compound-interaction test):
+ *   createWasmHost() → importsFor(host) → WebAssembly.instantiate(bytes, imports)
+ *   → exported call → result decoded via host.readUtf8 / caught as WasmPanic
+ *
+ * Tests cover:
+ *   1. createWasmHost — memory shape (1 page, max 1)
+ *   2. createWasmHost — host_alloc returns monotonically increasing offsets
+ *   3. createWasmHost — host_alloc traps at bump-pointer overflow (>64KB)
+ *   4. createWasmHost — host_log writes decoded UTF-8 to logs buffer
+ *   5. createWasmHost — host_panic throws WasmPanic with code, ptr, decoded message
+ *   6. createWasmHost — host_free is a no-op that increments _freeCallCount
+ *   7. createWasmHost — returns fresh instance per call (no shared state)
+ *   8. importsFor — produces WebAssembly.Imports with all 5 host keys
+ *   9. trap mapping — WebAssembly.RuntimeError(unreachable) → WasmUnreachable
+ *  10. trap mapping — i32.div_s / 0 → WasmDivByZero
+ *  11. trap mapping — i32.div_s INT32_MIN / -1 → WasmIntegerOverflow
+ *  12. compound interaction — compileToWasm + importsFor + instantiate end-to-end
+ *
+ * @decision DEC-V1-WAVE-2-WASM-HOST-CONTRACT-001: Trap classes use instanceof for
+ * narrowing. Tests exercise both unit-level (host API) and integration-level
+ * (host + wasm module) paths. All trap tests use real WebAssembly.instantiate —
+ * no monkey-patching.
+ * Status: decided (WI-V1W2-WASM-03)
+ */
+
+import { describe, expect, it } from "vitest";
+import { compileToWasm } from "./wasm-backend.js";
+import {
+  WasmDivByZero,
+  WasmIntegerOverflow,
+  WasmPanic,
+  WasmTrap,
+  WasmUnreachable,
+  createWasmHost,
+  importsFor,
+  wrapHostCall,
+} from "./wasm-host.js";
+
+// ---------------------------------------------------------------------------
+// Minimal WASM bytecode helpers for trap tests
+//
+// These are hand-rolled minimal modules that exercise specific engine traps.
+// They must be instantiated with host imports (memory, host_log, host_alloc,
+// host_free, host_panic) because all emitted modules import from "host".
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal WASM module that:
+ *   - imports the standard 5 host imports (required by our emitter format)
+ *   - exports one function "test_fn" that executes the given body instructions
+ *
+ * This is the canonical shape for trap-trigger test modules.
+ * Function indices: 0=host_log, 1=host_alloc, 2=host_free, 3=host_panic, 4=test_fn
+ *
+ * @param bodyInstructions - raw opcode bytes for the function body (no locals prefix,
+ *   no end byte — those are added here)
+ * @param typeidx - index into the type section for test_fn (default 0 = () → ())
+ */
+function makeTrapModule(
+  bodyInstructions: number[],
+  resultType: "void" | "i32" = "void",
+): Uint8Array<ArrayBuffer> {
+  const I32 = 0x7f;
+  const FUNCTYPE = 0x60;
+
+  function uleb128(n: number): number[] {
+    const bytes: number[] = [];
+    let v = n >>> 0;
+    do {
+      let byte = v & 0x7f;
+      v >>>= 7;
+      if (v !== 0) byte |= 0x80;
+      bytes.push(byte);
+    } while (v !== 0);
+    return bytes;
+  }
+
+  function nameBytes(s: string): number[] {
+    const enc = new TextEncoder().encode(s);
+    return [...uleb128(enc.length), ...enc];
+  }
+
+  // Types:
+  //   0 = () → void or () → i32 (test_fn)
+  //   1 = (i32, i32) → void   (host_log)
+  //   2 = (i32) → i32         (host_alloc)
+  //   3 = (i32) → void        (host_free)
+  //   4 = (i32, i32, i32) → void (host_panic)
+  const testFnType: number[] =
+    resultType === "void"
+      ? [FUNCTYPE, 0, 0] // () → void
+      : [FUNCTYPE, 0, 1, I32]; // () → i32
+
+  const typeSec = [
+    0x01, // section id = type
+    ...(() => {
+      const content = [
+        ...uleb128(5), // 5 types
+        ...testFnType,
+        FUNCTYPE, 2, I32, I32, 0, // (i32,i32) → void
+        FUNCTYPE, 1, I32, 1, I32, // (i32) → i32
+        FUNCTYPE, 1, I32, 0, // (i32) → void
+        FUNCTYPE, 3, I32, I32, I32, 0, // (i32,i32,i32) → void
+      ];
+      return [...uleb128(content.length), ...content];
+    })(),
+  ];
+
+  // Import section: memory, host_log, host_alloc, host_free, host_panic
+  const importSec = [
+    0x02, // section id = import
+    ...(() => {
+      const content = [
+        ...uleb128(5), // 5 imports
+        ...nameBytes("host"), ...nameBytes("memory"), 0x02, 0x01, 0x01, 0x01, // memory 1 1
+        ...nameBytes("host"), ...nameBytes("host_log"), 0x00, 1, // func typeidx=1
+        ...nameBytes("host"), ...nameBytes("host_alloc"), 0x00, 2, // func typeidx=2
+        ...nameBytes("host"), ...nameBytes("host_free"), 0x00, 3, // func typeidx=3
+        ...nameBytes("host"), ...nameBytes("host_panic"), 0x00, 4, // func typeidx=4
+      ];
+      return [...uleb128(content.length), ...content];
+    })(),
+  ];
+
+  // Function section: 1 local function (test_fn) with typeidx=0
+  const funcSec = [0x03, ...uleb128(2), ...uleb128(1), ...uleb128(0)];
+
+  // Export section: "test_fn" → func 4 (imported 0..3, local starts at 4)
+  const exportSec = [
+    0x07,
+    ...(() => {
+      const content = [
+        ...uleb128(1),
+        ...nameBytes("test_fn"),
+        0x00, // exportdesc=func
+        ...uleb128(4),
+      ];
+      return [...uleb128(content.length), ...content];
+    })(),
+  ];
+
+  // Code section: 1 function body
+  const body = [
+    ...uleb128(0), // 0 local decls
+    ...bodyInstructions,
+    0x0b, // end
+  ];
+  const codeSec = [
+    0x0a,
+    ...(() => {
+      const content = [...uleb128(1), ...uleb128(body.length), ...body];
+      return [...uleb128(content.length), ...content];
+    })(),
+  ];
+
+  const raw = [
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+    ...typeSec,
+    ...importSec,
+    ...funcSec,
+    ...exportSec,
+    ...codeSec,
+  ];
+  return new Uint8Array(raw) as Uint8Array<ArrayBuffer>;
+}
+
+// ---------------------------------------------------------------------------
+// createWasmHost tests
+// ---------------------------------------------------------------------------
+
+describe("createWasmHost", () => {
+  it("returns a host whose memory is a WebAssembly.Memory with initial=1 page and maximum=1 page", () => {
+    const host = createWasmHost();
+    expect(host.memory).toBeInstanceOf(WebAssembly.Memory);
+    // 1 page = 65536 bytes
+    expect(host.memory.buffer.byteLength).toBe(65536);
+  });
+
+  it("host_alloc returns monotonically increasing offsets and never overlaps prior allocations", () => {
+    const host = createWasmHost();
+    const ptr1 = host.host_alloc(1);
+    const ptr2 = host.host_alloc(1);
+    const ptr3 = host.host_alloc(100);
+
+    // All allocations start after the 1024-byte scratch zone
+    expect(ptr1).toBeGreaterThanOrEqual(1024);
+    expect(ptr2).toBeGreaterThan(ptr1);
+    expect(ptr3).toBeGreaterThan(ptr2);
+    // No overlap: ptr2 >= ptr1 + 8 (aligned to 8)
+    expect(ptr2).toBeGreaterThanOrEqual(ptr1 + 8);
+    // ptr3 >= ptr2 + 8 (alignment of size=1)
+    expect(ptr3).toBeGreaterThanOrEqual(ptr2 + 8);
+    // ptr3 + 100 aligned = ptr3 + 104 <= 65536
+    expect(ptr3 + 104).toBeLessThanOrEqual(65536);
+  });
+
+  it("host_alloc traps via WasmTrap when the bump pointer exceeds memory size (no growth in v1)", () => {
+    const host = createWasmHost();
+    // Allocate up to just under the limit — first alloc is at 1024, cap is 65536
+    // Usable space: 65536 - 1024 = 64512 bytes
+    // Allocate 64512 bytes in one go
+    const bigAlloc = host.host_alloc(64512);
+    expect(bigAlloc).toBeGreaterThanOrEqual(1024);
+
+    // Next allocation should exceed the cap
+    let caught: unknown;
+    try {
+      host.host_alloc(1);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(WasmTrap);
+    expect((caught as WasmTrap).kind).toBe("memory_oob");
+  });
+
+  it("host_log writes (ptr,len) into a captured log buffer decoded as utf-8", () => {
+    const host = createWasmHost();
+    const msg = "hello wasm";
+    const { ptr, len } = host.writeUtf8(new TextEncoder().encode(msg));
+    host.host_log(ptr, len);
+    expect(host.logs).toHaveLength(1);
+    expect(host.logs[0]).toBe(msg);
+
+    // Multiple log calls accumulate
+    const msg2 = "second log";
+    const w2 = host.writeUtf8(new TextEncoder().encode(msg2));
+    host.host_log(w2.ptr, w2.len);
+    expect(host.logs).toHaveLength(2);
+    expect(host.logs[1]).toBe(msg2);
+  });
+
+  it("host_panic throws a WasmPanic carrying code, ptr, and decoded utf-8 message", () => {
+    const host = createWasmHost();
+    const { ptr, len } = host.writeUtf8(new TextEncoder().encode("test panic"));
+    let caught: unknown;
+    try {
+      host.host_panic(42, ptr, len);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(WasmPanic);
+    const p = caught as WasmPanic;
+    expect(p.code).toBe(42);
+    expect(p.ptr).toBe(ptr);
+    expect(p.len).toBe(len);
+    expect(p.decoded).toBe("test panic");
+  });
+
+  it("host_free is a no-op (counter increments, freed memory not reclaimed)", () => {
+    const host = createWasmHost();
+    expect(host._freeCallCount).toBe(0);
+
+    const ptr = host.host_alloc(16);
+    host.host_free(ptr);
+    expect(host._freeCallCount).toBe(1);
+
+    // After free, bump pointer has not moved back — next alloc is still higher
+    const ptr2 = host.host_alloc(16);
+    expect(ptr2).toBeGreaterThan(ptr);
+
+    host.host_free(ptr2);
+    expect(host._freeCallCount).toBe(2);
+  });
+
+  it("createWasmHost returns fresh memory per instance (no shared state)", () => {
+    const h1 = createWasmHost();
+    const h2 = createWasmHost();
+
+    // Different memory objects
+    expect(h1.memory).not.toBe(h2.memory);
+
+    // Allocations on h1 don't affect h2
+    const p1 = h1.host_alloc(1024);
+    const p2 = h2.host_alloc(16);
+    expect(p1).toBe(1024); // fresh start at 1024
+    expect(p2).toBe(1024); // independent; also starts at 1024
+
+    // Log buffers are independent
+    h1.host_log(p1, 0);
+    expect(h1.logs).toHaveLength(1);
+    expect(h2.logs).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// importsFor tests
+// ---------------------------------------------------------------------------
+
+describe("importsFor", () => {
+  it("produces a WebAssembly.Imports object with host.memory, host.host_log, host.host_alloc, host.host_free, host.host_panic bound to the host instance", () => {
+    const host = createWasmHost();
+    const imports = importsFor(host);
+
+    expect(imports).toHaveProperty("host");
+    const h = imports["host"] as Record<string, unknown>;
+    expect(h["memory"]).toBe(host.memory);
+    expect(typeof h["host_log"]).toBe("function");
+    expect(typeof h["host_alloc"]).toBe("function");
+    expect(typeof h["host_free"]).toBe("function");
+    expect(typeof h["host_panic"]).toBe("function");
+  });
+
+  it("host_alloc via importsFor returns the same ptr as direct host.host_alloc", () => {
+    const h1 = createWasmHost();
+    const h2 = createWasmHost();
+    const imports = importsFor(h1);
+    const allocFn = (imports["host"] as Record<string, (n: number) => number>)["host_alloc"];
+    expect(allocFn).toBeDefined();
+
+    const ptrViaImport = allocFn!(16);
+    const ptrDirect = h2.host_alloc(16);
+    // Both fresh hosts start at 1024
+    expect(ptrViaImport).toBe(ptrDirect);
+    // And next alloc on h1 advances past the first
+    const ptrViaImport2 = allocFn!(16);
+    expect(ptrViaImport2).toBeGreaterThan(ptrViaImport);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trap mapping tests — use real WebAssembly.instantiate
+// ---------------------------------------------------------------------------
+
+describe("trap mapping", () => {
+  it("WebAssembly.RuntimeError from `unreachable` is rethrown as WasmUnreachable when invoked through a host-runtime call wrapper", async () => {
+    // Module: test_fn() { unreachable }
+    const bytes = makeTrapModule([0x00]); // 0x00 = unreachable
+    const host = createWasmHost();
+    const { instance } = await WebAssembly.instantiate(bytes, importsFor(host));
+    const testFn = instance.exports["test_fn"] as () => void;
+    expect(testFn).toBeDefined();
+
+    let caught: unknown;
+    try {
+      wrapHostCall(() => testFn());
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(WasmUnreachable);
+    expect((caught as WasmUnreachable).kind).toBe("unreachable");
+  });
+
+  it("WebAssembly.RuntimeError from i32.div_s of x/0 is rethrown as WasmDivByZero", async () => {
+    // Module: test_fn() → i32 { i32.const 5, i32.const 0, i32.div_s }
+    // i32.const: 0x41 <imm>; i32.div_s: 0x6d
+    const bytes = makeTrapModule([0x41, 5, 0x41, 0, 0x6d], "i32");
+    const host = createWasmHost();
+    const { instance } = await WebAssembly.instantiate(bytes, importsFor(host));
+    const testFn = instance.exports["test_fn"] as () => number;
+
+    let caught: unknown;
+    try {
+      wrapHostCall(() => testFn());
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(WasmDivByZero);
+    expect((caught as WasmDivByZero).kind).toBe("div_by_zero");
+  });
+
+  it("WebAssembly.RuntimeError from i32.div_s overflow (INT32_MIN / -1) is rethrown as WasmIntegerOverflow", async () => {
+    // INT32_MIN = -2147483648
+    // i32.const -2147483648 in signed LEB128: 0x80 0x80 0x80 0x80 0x78
+    // i32.const -1 in signed LEB128: 0x7f
+    // i32.div_s: 0x6d
+    const bytes = makeTrapModule(
+      [
+        0x41, 0x80, 0x80, 0x80, 0x80, 0x78, // i32.const INT32_MIN
+        0x41, 0x7f,                           // i32.const -1
+        0x6d,                                 // i32.div_s
+      ],
+      "i32",
+    );
+    const host = createWasmHost();
+    const { instance } = await WebAssembly.instantiate(bytes, importsFor(host));
+    const testFn = instance.exports["test_fn"] as () => number;
+
+    let caught: unknown;
+    try {
+      wrapHostCall(() => testFn());
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(WasmIntegerOverflow);
+    expect((caught as WasmIntegerOverflow).kind).toBe("integer_overflow");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WasmPanic via real wasm call (compound interaction)
+// ---------------------------------------------------------------------------
+
+describe("WasmPanic", () => {
+  it("host_panic call from inside compiled WASM surfaces with code and decoded message", async () => {
+    // Module: test_fn() { call host_panic(99, 0, 0) ; unreachable }
+    // host_panic is funcidx=3, call opcode=0x10
+    // i32.const 99 in signed LEB128: 0xe3 0x00
+    //   (99 = 0x63; bit 6 is set so single byte 0x63 would sign-extend to -29.
+    //    Use two-byte form: low 7 bits with continuation = 0xe3, high bits = 0x00)
+    // i32.const 0:  0x41 0x00
+    // call 3:       0x10 0x03
+    // unreachable:  0x00
+    const bytes = makeTrapModule([
+      0x41, 0xe3, 0x00, // i32.const 99 (code) — two-byte signed LEB128
+      0x41, 0x00,       // i32.const 0  (ptr — empty message at addr 0)
+      0x41, 0x00,       // i32.const 0  (len = 0)
+      0x10, 0x03,       // call funcidx=3 (host_panic)
+      0x00,             // unreachable (required after non-returning call)
+    ]);
+
+    const host = createWasmHost();
+    const { instance } = await WebAssembly.instantiate(bytes, importsFor(host));
+    const testFn = instance.exports["test_fn"] as () => void;
+
+    let caught: unknown;
+    try {
+      wrapHostCall(() => testFn());
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(WasmPanic);
+    const p = caught as WasmPanic;
+    expect(p.code).toBe(99);
+    expect(p.ptr).toBe(0);
+    expect(p.len).toBe(0);
+    // decoded is empty string for len=0
+    expect(p.decoded).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compound interaction: compileToWasm + createWasmHost + importsFor end-to-end
+// ---------------------------------------------------------------------------
+
+// NOTE: Compound integration test (compileToWasm + WasmHost end-to-end)
+// is covered by `wasm-backend.test.ts` which already exercises a real
+// resolution through `compileToWasm` and instantiates the resulting bytes
+// against a host. The unit tests above cover the WasmHost surface in
+// isolation (allocator, log, panic, traps, memory shape).

--- a/packages/compile/src/wasm-host.ts
+++ b/packages/compile/src/wasm-host.ts
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: MIT
+//
+// @decision DEC-V1-WAVE-2-WASM-HOST-CONTRACT-001 (closed) — see WASM_HOST_CONTRACT.md.
+// Status: decided (WI-V1W2-WASM-03)
+// Rationale: Three sub-decisions are resolved here:
+//
+//   Sub-decision 1 — Trap shape:
+//     WasmTrap base + 3 subclasses (WasmUnreachable, WasmDivByZero, WasmIntegerOverflow)
+//     for engine-faulted traps caught as WebAssembly.RuntimeError; separate WasmPanic
+//     for callee-initiated host_panic calls. TypeScript instanceof narrowing is more
+//     ergonomic than discriminating on a kind field. The kind field is kept for JSON
+//     serialization and log emission. Mapping is concentrated in wrapHostCall; no
+//     ad-hoc catch elsewhere.
+//
+//   Sub-decision 2 — Allocator strategy:
+//     Bump allocator. 1024-byte reserved scratch zone, 64 KB cap (one page). host_free
+//     is a tracked no-op (_freeCallCount exposed for test introspection). Free-list
+//     deferred to v2; host_free import is reserved so the contract does not change
+//     when v2 switches.
+//
+//   Sub-decision 3 — Memory growth:
+//     Forbidden in v1. Memory imported with initial=1, maximum=1. Growth attempts trap
+//     as WasmTrap("memory_oob"). Lifting this is an explicit deferred surface in
+//     WASM_HOST_CONTRACT.md §8.
+//
+// This file is the sole in-process host runtime authority. Downstream consumers and
+// tests import from here. No second host runtime elsewhere.
+
+/**
+ * wasm-host.ts — In-process host runtime for @yakcc/compile WASM modules.
+ *
+ * Public surface:
+ *   - WasmTrap (base), WasmUnreachable, WasmDivByZero, WasmIntegerOverflow — trap classes
+ *   - WasmPanic — structured callee-initiated panic
+ *   - WasmHost — interface for the host object
+ *   - createWasmHost() — factory; each call returns an independent instance
+ *   - importsFor(host) — builds WebAssembly.Imports keyed { host: { ... } }
+ *   - wrapHostCall(fn) — catches WebAssembly.RuntimeError and rethrows as WasmTrap subclass
+ *
+ * See WASM_HOST_CONTRACT.md for the boundary contract (authority for this surface).
+ */
+
+// ---------------------------------------------------------------------------
+// Trap classes — engine-faulted errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Base class for all WASM engine traps (WebAssembly.RuntimeError translated to host-side).
+ *
+ * A trap is an unintentional hardware-level fault surfaced by the WASM engine.
+ * The `kind` field is a stable discriminator for logging and JSON serialization;
+ * TypeScript callers should prefer instanceof for narrowing.
+ *
+ * @see WASM_HOST_CONTRACT.md §7
+ */
+export class WasmTrap extends Error {
+  readonly kind: "unreachable" | "div_by_zero" | "integer_overflow" | "memory_oob" | "other";
+
+  constructor(kind: WasmTrap["kind"], message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "WasmTrap";
+    this.kind = kind;
+    // Maintain correct prototype chain in environments that transpile class extends
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * WASM `unreachable` opcode was executed.
+ */
+export class WasmUnreachable extends WasmTrap {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super("unreachable", message, options);
+    this.name = "WasmUnreachable";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Integer divide by zero (i32.div_s or i32.div_u with divisor = 0).
+ */
+export class WasmDivByZero extends WasmTrap {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super("div_by_zero", message, options);
+    this.name = "WasmDivByZero";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Integer overflow — e.g. INT32_MIN / -1 with i32.div_s.
+ */
+export class WasmIntegerOverflow extends WasmTrap {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super("integer_overflow", message, options);
+    this.name = "WasmIntegerOverflow";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// WasmPanic — callee-initiated structured error
+// ---------------------------------------------------------------------------
+
+/**
+ * Structured error thrown when compiled WASM calls the `host_panic` import.
+ *
+ * Distinct from WasmTrap: a panic is a deliberate signal from the compiled program
+ * (carrying code, ptr, len, and a UTF-8 decoded message). Traps are unintentional
+ * engine-level faults.
+ *
+ * @see WASM_HOST_CONTRACT.md §7
+ */
+export class WasmPanic extends Error {
+  readonly code: number;
+  readonly ptr: number;
+  readonly len: number;
+  readonly decoded: string;
+
+  constructor(args: { code: number; ptr: number; len: number; decoded: string }) {
+    super(`WasmPanic(code=${args.code}): ${args.decoded}`);
+    this.name = "WasmPanic";
+    this.code = args.code;
+    this.ptr = args.ptr;
+    this.len = args.len;
+    this.decoded = args.decoded;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// WasmHost interface
+// ---------------------------------------------------------------------------
+
+/**
+ * The in-process host object provided to instantiated WASM modules.
+ *
+ * Each instance is independent: bump-allocator state, log buffer, and memory
+ * are all per-instance. Never share a host across test cases.
+ *
+ * @see WASM_HOST_CONTRACT.md §3 (imports), §6 (allocator)
+ */
+export interface WasmHost {
+  /** Linear memory exported to the WASM module. initial=1, maximum=1 (64 KB). */
+  readonly memory: WebAssembly.Memory;
+
+  /** Captured log lines (test/diagnostic surface). Each call to host_log appends one entry. */
+  readonly logs: ReadonlyArray<string>;
+
+  /**
+   * Test-only counter for emitted host_free calls.
+   * Not part of the public boundary contract; used to assert the emitter emits host_free.
+   */
+  readonly _freeCallCount: number;
+
+  /** Diagnostic emission: decodes (ptr, len) as UTF-8 and appends to `logs`. */
+  host_log(ptr: number, len: number): void;
+
+  /**
+   * Bump allocator: allocates `size` bytes (aligned to 8), returns pointer.
+   * Throws WasmTrap("memory_oob") if the bump pointer would exceed 64 KB.
+   */
+  host_alloc(size: number): number;
+
+  /**
+   * Tracked no-op in v1. Increments _freeCallCount. Does not reclaim memory.
+   * The bump allocator releases on host re-creation.
+   */
+  host_free(ptr: number): void;
+
+  /**
+   * Called by compiled WASM to signal an unrecoverable error.
+   * Throws WasmPanic and never returns.
+   */
+  host_panic(code: number, ptr: number, len: number): never;
+
+  /** Write UTF-8 bytes into linear memory, returning the pointer and length. */
+  writeUtf8(bytes: Uint8Array): { ptr: number; len: number };
+
+  /** Read UTF-8 bytes from linear memory at (ptr, len). */
+  readUtf8(ptr: number, len: number): string;
+}
+
+// ---------------------------------------------------------------------------
+// createWasmHost() — factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a fresh WasmHost instance.
+ *
+ * Each call produces an independent host with:
+ *   - a fresh WebAssembly.Memory(1, 1) (64 KB, no growth)
+ *   - a bump pointer starting at offset 1024 (bytes [0,1024) are reserved scratch)
+ *   - an empty log buffer
+ *   - a free-call counter at 0
+ *
+ * @see WASM_HOST_CONTRACT.md §6
+ */
+export function createWasmHost(): WasmHost {
+  // Memory: initial=1 page (64 KB), maximum=1 page (growth forbidden in v1).
+  const memory = new WebAssembly.Memory({ initial: 1, maximum: 1 });
+
+  // Bump allocator state.
+  // Bytes [0, SCRATCH_BASE) are reserved scratch (currently unused).
+  // Bytes [SCRATCH_BASE, MEM_CAP) are the bump heap.
+  const SCRATCH_BASE = 1024;
+  const MEM_CAP = 65536; // 64 KB = 1 WASM page
+  let bumpOffset = SCRATCH_BASE;
+
+  // Log buffer and free-call counter.
+  const logBuffer: string[] = [];
+  let freeCallCount = 0;
+
+  const decoder = new TextDecoder("utf-8");
+  const encoder = new TextEncoder();
+
+  const host: WasmHost = {
+    get memory(): WebAssembly.Memory {
+      return memory;
+    },
+
+    get logs(): ReadonlyArray<string> {
+      return logBuffer;
+    },
+
+    get _freeCallCount(): number {
+      return freeCallCount;
+    },
+
+    host_log(ptr: number, len: number): void {
+      const view = new Uint8Array(memory.buffer, ptr, len);
+      logBuffer.push(decoder.decode(view));
+    },
+
+    host_alloc(size: number): number {
+      // Align to 8 bytes.
+      const aligned = (size + 7) & ~7;
+      if (bumpOffset + aligned > MEM_CAP) {
+        throw new WasmTrap("memory_oob", "host_alloc out of memory");
+      }
+      const ptr = bumpOffset;
+      bumpOffset += aligned;
+      return ptr;
+    },
+
+    host_free(_ptr: number): void {
+      // Tracked no-op. See DEC-V1-WAVE-2-WASM-HOST-CONTRACT-001 sub-decision 2.
+      freeCallCount++;
+    },
+
+    host_panic(code: number, ptr: number, len: number): never {
+      const view = new Uint8Array(memory.buffer, ptr, len);
+      const decoded = decoder.decode(view);
+      throw new WasmPanic({ code, ptr, len, decoded });
+    },
+
+    writeUtf8(bytes: Uint8Array): { ptr: number; len: number } {
+      const ptr = host.host_alloc(bytes.length);
+      new Uint8Array(memory.buffer).set(bytes, ptr);
+      return { ptr, len: bytes.length };
+    },
+
+    readUtf8(ptr: number, len: number): string {
+      const view = new Uint8Array(memory.buffer, ptr, len);
+      return decoder.decode(view);
+    },
+  };
+
+  return host;
+}
+
+// ---------------------------------------------------------------------------
+// importsFor() — build WebAssembly.Imports from a WasmHost
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a WebAssembly.Imports object from a WasmHost instance.
+ *
+ * Returns `{ host: { memory, host_log, host_alloc, host_free, host_panic } }`
+ * matching the import namespace declared in the emitted module.
+ *
+ * @see WASM_HOST_CONTRACT.md §3
+ */
+export function importsFor(host: WasmHost): WebAssembly.Imports {
+  return {
+    host: {
+      memory: host.memory,
+      host_log: (ptr: number, len: number): void => host.host_log(ptr, len),
+      host_alloc: (size: number): number => host.host_alloc(size),
+      host_free: (ptr: number): void => host.host_free(ptr),
+      host_panic: (code: number, ptr: number, len: number): void => {
+        host.host_panic(code, ptr, len);
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// wrapHostCall() — engine RuntimeError → WasmTrap subclass translator
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap a thunk so that WebAssembly.RuntimeError instances are caught and
+ * rethrown as the appropriate WasmTrap subclass.
+ *
+ * This is the **only** place engine runtime errors are translated. All callers
+ * that invoke compiled WASM exports must funnel through this function.
+ *
+ * Mapping table (engine message pattern → rethrown class):
+ *   /unreachable/i               → WasmUnreachable
+ *   /divide by zero/i            → WasmDivByZero
+ *   /integer overflow/i          → WasmIntegerOverflow
+ *   /out of bounds memory access/i → WasmTrap("memory_oob")
+ *   anything else                → WasmTrap("other")
+ *
+ * WasmTrap and WasmPanic instances are re-thrown unchanged (they are already
+ * the correct type — host_panic throws WasmPanic before the engine sees anything).
+ *
+ * @see WASM_HOST_CONTRACT.md §7
+ */
+export function wrapHostCall<T>(fn: () => T): T {
+  try {
+    return fn();
+  } catch (err) {
+    // Re-throw already-translated errors unchanged.
+    if (err instanceof WasmPanic || err instanceof WasmTrap) throw err;
+
+    if (err instanceof WebAssembly.RuntimeError) {
+      const msg = err.message;
+      if (/unreachable/i.test(msg)) {
+        throw new WasmUnreachable("wasm 'unreachable' executed", { cause: err });
+      }
+      if (/divide by zero/i.test(msg)) {
+        throw new WasmDivByZero("integer divide by zero", { cause: err });
+      }
+      // V8 emits "integer overflow" for some engines, but "divide result unrepresentable"
+      // for INT32_MIN / -1 specifically. Both patterns map to WasmIntegerOverflow.
+      if (/integer overflow/i.test(msg) || /divide result unrepresentable/i.test(msg)) {
+        throw new WasmIntegerOverflow("integer overflow (e.g. INT32_MIN / -1)", { cause: err });
+      }
+      if (/out of bounds memory access/i.test(msg)) {
+        throw new WasmTrap("memory_oob", msg, { cause: err });
+      }
+      throw new WasmTrap("other", msg, { cause: err });
+    }
+
+    throw err;
+  }
+}


### PR DESCRIPTION
Closes #5

## Summary
- WASM_HOST_CONTRACT.md at repo root (sole authority for the wasm-host boundary).
- @yakcc/compile gains wasm-host.ts: WasmHost runtime, bump allocator (1024B scratch, 64KB cap, no growth in v1), trap classes (WasmTrap base + WasmUnreachable/WasmDivByZero/WasmIntegerOverflow + separate WasmPanic), wrapHostCall translator.
- wasm-backend.ts emits imports (memory + 4 host fns), exports (__wasm_export_<fn> + _yakcc_table table), and bodies for add, greet (utf-8 round-trip via host_alloc), divide (host_panic on b=0). i32.store8 operand-order fix per WASM spec section 2.4.5.
- DEC-V1-WAVE-2-WASM-HOST-CONTRACT-001 annotated.
- 5 substrate-parity tests (add x5, greet x5 utf-8 strings, divide x5 incl. panic case) + 2 imports/exports shape tests.

## Acceptance
- `pnpm --filter @yakcc/compile test` -> **77/77 pass** (7 files)
- `pnpm -r build` -> clean across all 17 packages
- WASM_HOST_CONTRACT.md committed at repo root
- Reviewer verdict round 2: ready_for_guardian (after addressing 5 missing tests + index.ts re-exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)