### PR TITLE
docs: refresh all READMEs to reflect v1 wave-2 closed + v2 bootstrap …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yakcc
 
-**Status: v1 wave-1 substantially landed (property-test corpus, parent-block lineage, federation protocol, registry artifact-bytes persistence, deterministic intent extraction). v1 wave-2 (live Claude Code intercept + WASM backend) planned, not started.**
+**Status: v1 fully closed. v1 wave-2 closed (live IDE hooks + WASM backend shipped). v2 bootstrap in progress (`yakcc bootstrap` one-shot mode landed; `--verify` mode in-flight).**
 
 Yakcc is a local-only TypeScript substrate for assembling programs from content-addressed
 basic blocks. A block is a triplet directory (`spec.yak` + `impl.ts` + `proof/`) stored
@@ -41,15 +41,19 @@ again. The double-c is a nod to the long lineage of terse compiler names.
 
 ```
 packages/
-  contracts/         @yakcc/contracts   — branded types: SpecYak, ContractId, BlockMerkleRoot, SpecHash
-  registry/          @yakcc/registry    — SQLite-backed registry, openRegistry()
-  ir/                @yakcc/ir          — strict-TS-subset IR and block types
-  compile/           @yakcc/compile     — TS backend, assembler, provenance manifest
-  seeds/             @yakcc/seeds       — hand-authored ~20-block seed corpus
-  hooks-claude-code/ @yakcc/hooks-claude-code — Claude Code hook integration facade
-  cli/               @yakcc/cli         — yakcc CLI (registry init, seed, shave, search, propose, compile, hooks claude-code install)
-  shave/             @yakcc/shave       — universalizer pipeline: intent extraction (static or LLM), atom decomposition, slicer, atom-persist
-  variance/          @yakcc/variance    — variance scoring + contract design rules (intersection/majority-vote/union per WI-011)
+  contracts/         @yakcc/contracts        — branded types: SpecYak, ContractId, BlockMerkleRoot, SpecHash
+  registry/          @yakcc/registry         — SQLite-backed registry, openRegistry(), exportManifest()
+  ir/                @yakcc/ir               — strict-TS-subset IR, validateStrictSubset(), validateStrictSubsetProject()
+  compile/           @yakcc/compile          — TS + WASM backends, assembler, provenance manifest
+  seeds/             @yakcc/seeds            — hand-authored ~20-block seed corpus
+  hooks-base/        @yakcc/hooks-base       — shared hook types: EmissionContext, HookResponse, executeRegistryQuery()
+  hooks-claude-code/ @yakcc/hooks-claude-code — Claude Code hook: registry-hit / synthesis-required / passthrough
+  hooks-cursor/      @yakcc/hooks-cursor     — Cursor hook (same contract as hooks-claude-code)
+  hooks-codex/       @yakcc/hooks-codex      — Codex CLI hook (same contract as hooks-claude-code)
+  federation/        @yakcc/federation       — F1 read-only block mirror: serveRegistry(), mirrorRegistry(), pullBlock()
+  cli/               @yakcc/cli              — yakcc CLI (registry init, seed, shave, search, query, propose, compile, bootstrap, federation, hooks install)
+  shave/             @yakcc/shave            — universalizer pipeline: intent extraction (static or LLM), atom decomposition, slicer, atom-persist
+  variance/          @yakcc/variance         — variance scoring + contract design rules (intersection/majority-vote/union per WI-011)
 
 examples/
   parse-int-list/    target demo: assemble a JSON-integer-list parser from ~10 sub-blocks
@@ -240,15 +244,10 @@ yakcc query "parse a JSON array of integers" --top 5
 
 Honest list of capabilities that are planned but not yet shipped:
 
-- **Live Claude Code hook intercept**: the `hooks-claude-code` package is a passthrough
-  stub today. Real intercept that reroutes AI emission through the registry is planned
-  as WI-026 (v1 wave-2).
-- **WASM compilation backend**: planned as WI-027 (AssemblyScript-style emit). The
-  current backend emits TypeScript only. Native binary portability via wasm2c → clang
-  is deferred until after the WASM backend ships.
-- **Federation publishing path (F2+)**: the F1 read-only mirror (`@yakcc/federation`)
-  covers F1 only (content-addressed pull, no push/auth). F2+ (block submission,
-  dispute adjudication) is deferred. See `FEDERATION.md` for the F0..F4 axis.
+- **`yakcc bootstrap --verify`**: one-shot bootstrap mode (`yakcc bootstrap`) is live and produces a deterministic `bootstrap/expected-roots.json`. The `--verify` flag (byte-compare against committed manifest, structured diff on mismatch) is in-flight as WI-V2-BOOTSTRAP-03.
+- **v2 self-hosting (Phases B–I)**: IR subset extensions, foreign-block primitives, source refactor for shavability, property-test coverage, first shave pass, compile self-equivalence, two-pass bootstrap equivalence, and v2 CI demo are all gated on the v2 bootstrap chain closing. See `MASTER_PLAN.md` for the full v2 wave map.
+- **WASM string/mixed substrates**: the WASM backend (`compileToWasm`) handles numeric (i32/i64/f64) substrates today. String-handling and record/array lowering (type-lowering pass WI-V1W2-WASM-02) are deferred to a follow-on wave.
+- **Federation publishing path (F2+)**: the F1 read-only mirror (`@yakcc/federation`) covers content-addressed pull only. F2+ (block submission, dispute adjudication) is deferred. See `FEDERATION.md` for the F0..F4 axis.
 
 ## License
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,7 +2,7 @@
 
 The `yakcc` command-line interface.
 
-**Status: v0 substrate operational; v1 wave-1 federation work in progress.**
+**Status: v1 fully closed. v1 wave-2 closed (live IDE hooks + WASM backend). v2 bootstrap in progress.**
 
 ## Commands
 
@@ -18,7 +18,10 @@ The `yakcc` command-line interface.
 | `yakcc federation serve --registry <db> [--port n] [--host h]` | Start a read-only HTTP registry server that exposes the F1 federation wire protocol (WI-020). Blocks until SIGINT/SIGTERM. |
 | `yakcc federation mirror --remote <url> --registry <db>` | Mirror all blocks from a remote registry peer into the local registry. Prints a `MirrorReport` as JSON on completion. Exits 0 even when some blocks fail (recoverable); exits 1 on `SchemaVersionMismatchError`. |
 | `yakcc federation pull --remote <url> --root <merkleRoot> [--registry <db>]` | Pull a single block by its `BlockMerkleRoot` from a remote peer. Without `--registry`: diagnostic-only (prints root + specHash, no persistence). With `--registry <db>`: pulls and persists the block idempotently via `storeBlock` (WI-030). |
+| `yakcc bootstrap [--registry p] [--manifest p] [--report p]` | Walk all `packages/*/src` and `examples/*/src` TypeScript files, shave each into a `:memory:` registry, and write `bootstrap/expected-roots.json` (sorted deterministic manifest). Add `--verify` to byte-compare against the committed manifest; exits 1 with a structured diff on mismatch. |
 | `yakcc hooks claude-code install` | Install the Yakcc Claude Code hook into the current Claude Code project settings. |
+| `yakcc hooks cursor install` | Install the Yakcc Cursor hook marker file. |
+| `yakcc hooks codex install` | Install the Yakcc Codex CLI hook marker file. |
 
 ## Quickstart
 

--- a/packages/compile/README.md
+++ b/packages/compile/README.md
@@ -6,10 +6,11 @@ The backend interface and whole-program assembler for Yakcc.
 
 - **`Backend`** — the interface a code-emission backend must implement. A
   `Backend` receives a sequence of `Implementation` records (one per basic
-  block) and emits a single source artifact. The TypeScript backend (`TsBackend`)
-  is the production backend and the only target in v0/v1.
-- **`tsBackend()`** — factory for the TypeScript emission backend. Live in
-  `src/ts-backend.ts`. `yakcc compile <entry> --target ts` uses this backend.
+  block) and emits a single source artifact.
+- **`tsBackend()`** — factory for the TypeScript emission backend. `yakcc compile <entry> --target ts` uses this backend.
+- **`wasmBackend()`** — factory for the WASM binary emission backend (shipped WI-V1W2-WASM-01 through WI-V1W2-WASM-04). Emits a `Uint8Array` WAT-compiled binary for numeric substrates (i32/i64/f64). `compileToWasm(assembly)` is the convenience entry point.
+- **`WasmTrap` / `WasmTrapKind`** — discriminated union of 7 trap kinds (unreachable, div-by-zero, integer-overflow, out-of-bounds, stack-overflow, bad-alignment, panic) mirroring `ResolutionErrorKind` symmetry. Thrown by the host runtime on WASM trap conditions.
+- **`YakccHost` / `createHost()` / `instantiateAndRun()`** — the in-process WASM host runtime. `createHost()` returns a `YakccHost` implementing bump-allocator memory management and the 4 required host imports (`host_log`, `host_alloc`, `host_free`, `host_panic`). `instantiateAndRun(wasmBytes, host, fnName, args)` instantiates a WASM module against the host and invokes the named export. The host contract is documented in `WASM_HOST_CONTRACT.md` at repo root.
 - **`assemble(registry, entryContractId, backend)`** — the whole-program
   assembler. Starting from `entryContractId`, it traverses the registry,
   collects all referenced blocks in dependency order (cycle detection included),
@@ -65,10 +66,8 @@ change the selected blocks, which changes the artifact and manifest.
 
 ## What is not yet wired
 
-- **No WASM backend** — planned as WI-027 in `~/.claude/plans/v1-vision-wave-2.md`.
-  The TypeScript backend covers all current use cases.
-- **No native binary backend** — deferred; WASM serves the portability goal
-  without adding a native compilation dependency.
+- **WASM string/mixed substrates** — the WASM backend covers numeric (i32/i64/f64) substrates. String-handling (linear-memory string view + `host_alloc`/`host_free`) and record/array type-lowering are deferred to a follow-on wave (WI-V1W2-WASM-02). The parity demo marks these substrates as `todo` rather than skipping silently.
+- **No native binary backend** — deferred; WASM serves the portability goal without adding a native compilation dependency.
 
 ## License
 

--- a/packages/hooks-base/README.md
+++ b/packages/hooks-base/README.md
@@ -1,0 +1,36 @@
+# @yakcc/hooks-base
+
+Shared types and registry-query logic for all Yakcc IDE hooks.
+
+## What this package provides
+
+This package is a leaf shared by `@yakcc/hooks-claude-code`, `@yakcc/hooks-cursor`, and `@yakcc/hooks-codex`. It exists to satisfy Sacred Practice #12 (single source of truth): the hook contract and registry-query logic live in exactly one place.
+
+- **`EmissionContext`** — structured input describing a code-emission intent. Fields: `hookName`, `toolInput` (raw JSON), `sessionId`.
+- **`HookResponse`** — discriminated union of hook outcomes:
+  - `{ kind: "registry-hit", block: BlockTripletRow }` — existing block satisfies the intent.
+  - `{ kind: "synthesis-required", contractSpecSkeleton: ContractSpec }` — no registry hit; skeleton for downstream synthesis.
+  - `{ kind: "passthrough" }` — registry error path only; not a default-success path.
+- **`HookOptions`** — construction options for all `createHook()` factories. Fields: `threshold?: number` (cosine distance cutoff; default `DEFAULT_REGISTRY_HIT_THRESHOLD`).
+- **`DEFAULT_REGISTRY_HIT_THRESHOLD`** — `0.30`. A cosine distance below this value triggers `registry-hit`.
+- **`buildIntentCardQuery(ctx)`** — derive an intent query object from an `EmissionContext`. Used internally by `executeRegistryQuery`.
+- **`buildSkeletonSpec(intent)`** — build a minimal `ContractSpec` skeleton from a behavior string. Used to populate `synthesis-required` responses.
+- **`writeMarkerCommand(markerDir, filename, payload)`** — write a hook marker file to disk. Used by all three `registerXxxCommand()` implementations.
+- **`executeRegistryQuery(registry, ctx, options)`** — the load-bearing shared implementation. Runs `findCandidatesByIntent`, applies the threshold, and returns the appropriate `HookResponse`. All three IDE hooks delegate here.
+
+## Usage
+
+This package is consumed by the three IDE hook packages. Direct use is only needed when building a new hook implementation:
+
+```ts
+import {
+  executeRegistryQuery,
+  buildIntentCardQuery,
+  DEFAULT_REGISTRY_HIT_THRESHOLD,
+} from "@yakcc/hooks-base";
+import type { EmissionContext, HookResponse, HookOptions } from "@yakcc/hooks-base";
+```
+
+## License
+
+This package is dedicated to the public domain under [The Unlicense](../../LICENSE).

--- a/packages/hooks-claude-code/README.md
+++ b/packages/hooks-claude-code/README.md
@@ -4,56 +4,66 @@ Claude Code hook integration for Yakcc.
 
 ## What this package provides
 
-- **`EmissionContext`** — the structured input describing a code-emission
-  intent intercepted from a Claude Code hook call. Carries the hook name,
-  the tool input as a raw JSON value, and the session identifier.
-- **`HookResponse`** — the discriminated union of outcomes a hook handler
-  may return:
-  - `{ kind: "passthrough" }` — let Claude Code proceed normally with no
-    intervention.
-  - `{ kind: "substitute", content: string }` — replace the emission with
-    the provided content (a pre-assembled block or program from the registry).
-  - `{ kind: "block", reason: string }` — prevent the emission and report
-    the reason back to the caller.
-- **`handleEmission(ctx)`** — the primary hook entry point. Receives an
-  `EmissionContext` and returns a `Promise<HookResponse>`. v0 always returns
-  `{ kind: "passthrough" }` (see below).
+- **`ClaudeCodeHook`** — the hook interface:
+  - `registerSlashCommand()` — writes `~/.claude/yakcc-slash-command.json` as a marker file for the Claude Code slash-command extension API (the marker-file pattern avoids requiring a live CLI harness at registration time).
+  - `onCodeEmissionIntent(ctx)` — the load-bearing path. Queries the registry via `findCandidatesByIntent`, returning one of three outcomes:
+    - `{ kind: "registry-hit", block }` — top candidate's cosine distance is below threshold; an existing block satisfies the intent.
+    - `{ kind: "synthesis-required", contractSpecSkeleton }` — no candidate beats threshold; returns a `ContractSpec` skeleton derived from the emission context for downstream synthesis.
+    - `{ kind: "passthrough" }` — registry error path only (open failure, embedding failure). Not a default-success path.
+- **`createHook(registry, options?)`** — factory. Returns a `ClaudeCodeHook` backed by the given `Registry`.
+- **`DEFAULT_REGISTRY_HIT_THRESHOLD`** — `0.30` (cosine distance; lower = closer match). Override via `HookOptions.threshold`.
+- **`SLASH_COMMAND_MARKER_FILENAME`** — `"yakcc-slash-command.json"`.
+- Re-exports from `@yakcc/hooks-base`: `EmissionContext`, `HookResponse`, `HookOptions`.
 
-## v0 behavior
+## How it works
 
-v0 ships the command surface and the `EmissionContext`/`HookResponse` contract
-so that consumers can wire the hook and test the integration path. The default
-response is `passthrough`: all emission intents are forwarded to Claude Code
-unchanged. Registry-hit detection (substitute) and synthesis-required blocking
-(block) ship in v0.5 once the live registry is available.
+`onCodeEmissionIntent(ctx)` delegates to `executeRegistryQuery()` from `@yakcc/hooks-base` (DEC-HOOK-BASE-001). The shared implementation lives in exactly one place; all three IDE hooks consume it.
 
-The live-intercept plan (turning the passthrough stub into an active registry
-lookup) is tracked as WI-026 in `~/.claude/plans/v1-vision-wave-2.md`.
+Decision logic:
+1. Build an intent query from the emission context (behavior text + inferred input/output types).
+2. Call `registry.findCandidatesByIntent(query, { k: 5, rerank: "structural" })`.
+3. If the top candidate's `cosineDistance < threshold` → `registry-hit`.
+4. If no candidate beats threshold → `synthesis-required` with a skeleton `ContractSpec`.
+5. If the registry call itself throws → `passthrough`.
 
 ## How callers consume this package
 
 ```ts
-import { handleEmission } from "@yakcc/hooks-claude-code";
-import type { EmissionContext, HookResponse } from "@yakcc/hooks-claude-code";
+import { createHook } from "@yakcc/hooks-claude-code";
+import type { ClaudeCodeHook, EmissionContext, HookResponse } from "@yakcc/hooks-claude-code";
+import { openRegistry } from "@yakcc/registry";
 
-// In a Claude Code hook handler:
+const registry = await openRegistry(".yakcc/registry.db");
+const hook: ClaudeCodeHook = createHook(registry, { threshold: 0.25 });
+
+// Register the /yakcc slash command in Claude Code
+hook.registerSlashCommand();
+
+// In a Claude Code PreToolUse hook handler:
 const ctx: EmissionContext = {
   hookName: "PreToolUse",
   toolInput: rawInput,
   sessionId: sessionId,
 };
-const response: HookResponse = await handleEmission(ctx);
-if (response.kind === "substitute") {
-  return { content: [{ type: "text", text: response.content }] };
+const response: HookResponse = await hook.onCodeEmissionIntent(ctx);
+switch (response.kind) {
+  case "registry-hit":
+    // Use response.block — an existing atom satisfies this intent
+    break;
+  case "synthesis-required":
+    // Use response.contractSpecSkeleton — derive a new contract from it
+    break;
+  case "passthrough":
+    // Registry unavailable — let Claude Code proceed normally
+    break;
 }
 ```
 
-## What this package does not do (yet)
+## Related packages
 
-- **No registry lookup** — v0.5 connects `handleEmission` to the live
-  registry to detect existing blocks.
-- **No synthesis blocking** — v0.5 adds the `block` response path for
-  cases where a registry hit should suppress Claude Code's own generation.
+- `@yakcc/hooks-base` — shared `EmissionContext`, `HookResponse`, `HookOptions`, `executeRegistryQuery()`
+- `@yakcc/hooks-cursor` — same contract, Cursor-adapted surface
+- `@yakcc/hooks-codex` — same contract, Codex CLI-adapted surface
 
 ## License
 

--- a/packages/hooks-codex/README.md
+++ b/packages/hooks-codex/README.md
@@ -1,0 +1,37 @@
+# @yakcc/hooks-codex
+
+Codex CLI hook integration for Yakcc. Same contract as `@yakcc/hooks-claude-code`, adapted for OpenAI's Codex CLI extension surface.
+
+## What this package provides
+
+- **`CodexHook`** — the hook interface:
+  - `registerCommand()` — writes `~/.yakcc/yakcc-codex-command.json` as a marker file for the Codex CLI extension API (distinct directory from hooks-claude-code's `~/.claude/` per DEC-HOOK-CODEX-001).
+  - `onCodeEmissionIntent(ctx)` — delegates to `executeRegistryQuery()` from `@yakcc/hooks-base`. Returns `registry-hit`, `synthesis-required`, or `passthrough` (errors only). Identical semantics to `@yakcc/hooks-claude-code`.
+- **`createHook(registry, options?)`** — factory returning a `CodexHook`.
+- **`DEFAULT_REGISTRY_HIT_THRESHOLD`** — `0.30` (re-exported from `@yakcc/hooks-base`).
+- **`COMMAND_MARKER_FILENAME`** — `"yakcc-codex-command.json"`.
+- Re-exports from `@yakcc/hooks-base`: `EmissionContext`, `HookResponse`, `HookOptions`.
+
+## How callers consume this package
+
+```ts
+import { createHook } from "@yakcc/hooks-codex";
+import { openRegistry } from "@yakcc/registry";
+
+const registry = await openRegistry(".yakcc/registry.db");
+const hook = createHook(registry);
+hook.registerCommand();
+
+const response = await hook.onCodeEmissionIntent(ctx);
+// response.kind: "registry-hit" | "synthesis-required" | "passthrough"
+```
+
+## Related packages
+
+- `@yakcc/hooks-base` — shared logic (`executeRegistryQuery`, `EmissionContext`, `HookResponse`)
+- `@yakcc/hooks-claude-code` — Claude Code variant
+- `@yakcc/hooks-cursor` — Cursor variant
+
+## License
+
+This package is dedicated to the public domain under [The Unlicense](../../LICENSE).

--- a/packages/hooks-cursor/README.md
+++ b/packages/hooks-cursor/README.md
@@ -1,0 +1,37 @@
+# @yakcc/hooks-cursor
+
+Cursor hook integration for Yakcc. Same contract as `@yakcc/hooks-claude-code`, adapted for Cursor's command registration surface.
+
+## What this package provides
+
+- **`CursorHook`** — the hook interface:
+  - `registerCommand()` — writes `~/.cursor/yakcc-cursor-command.json` as a marker file for the Cursor extension API.
+  - `onCodeEmissionIntent(ctx)` — delegates to `executeRegistryQuery()` from `@yakcc/hooks-base`. Returns `registry-hit`, `synthesis-required`, or `passthrough` (errors only). Identical semantics to `@yakcc/hooks-claude-code`.
+- **`createHook(registry, options?)`** — factory returning a `CursorHook`.
+- **`DEFAULT_REGISTRY_HIT_THRESHOLD`** — `0.30` (re-exported from `@yakcc/hooks-base`).
+- **`CURSOR_COMMAND_MARKER_FILENAME`** — `"yakcc-cursor-command.json"`.
+- Re-exports from `@yakcc/hooks-base`: `EmissionContext`, `HookResponse`, `HookOptions`.
+
+## How callers consume this package
+
+```ts
+import { createHook } from "@yakcc/hooks-cursor";
+import { openRegistry } from "@yakcc/registry";
+
+const registry = await openRegistry(".yakcc/registry.db");
+const hook = createHook(registry);
+hook.registerCommand();
+
+const response = await hook.onCodeEmissionIntent(ctx);
+// response.kind: "registry-hit" | "synthesis-required" | "passthrough"
+```
+
+## Related packages
+
+- `@yakcc/hooks-base` — shared logic (`executeRegistryQuery`, `EmissionContext`, `HookResponse`)
+- `@yakcc/hooks-claude-code` — Claude Code variant
+- `@yakcc/hooks-codex` — Codex CLI variant
+
+## License
+
+This package is dedicated to the public domain under [The Unlicense](../../LICENSE).

--- a/packages/ir/README.md
+++ b/packages/ir/README.md
@@ -4,61 +4,50 @@ The intermediate representation for strict-TypeScript-subset basic blocks.
 
 ## What this package provides
 
-- **`BlockAst`** — an opaque AST type representing a parsed basic block. v0
-  carries the raw source as a string; WI-004 replaces this with a structured
-  node tree that encodes the strict-TS-subset grammar.
-- **`parseBlock(source)`** — parses a source string into a `BlockAst`. v0
-  accepts all input as valid (facade); WI-004 wires the real parser that
-  enforces the strict subset.
-- **`validateStrictSubset(ast)`** — validates that a `BlockAst` conforms to
-  the strict-TS-subset grammar. Returns a `ValidationResult` with any
-  violations. v0 always returns `{ valid: true }` (facade).
+- **`validateStrictSubset(source)`** — validate a single source string against the strict-TS-subset grammar. Returns a `ValidationResult` with any `ValidationError` violations. The strict subset bans: `any`, `eval`, untyped imports, runtime reflection, mutable globals, top-level side effects (with a documented `// @cli-entry` exemption for CLI entry points, DEC-IR-CLI-ENTRY-EXEMPTION-001), classes (outside an explicit class-allowlist), and dynamic `import()`.
+- **`validateStrictSubsetFile(filePath)`** — file-level variant; reads and validates a `.ts` source file in isolated mode.
+- **`validateStrictSubsetProject(tsconfigPath)`** — project-mode validation (WI-V2-01, DEC-V2-IR-PROJECT-MODE-001). Loads a real `tsconfig.json` via ts-morph's `tsConfigFilePath` constructor option, resolving cross-file relative imports, workspace `@yakcc/*` cross-package imports, and `node:*` builtin imports through the actual TypeScript resolver. Eliminates the ~98% false-positive `no-untyped-imports` rate seen in isolated mode against whole-package source. Both modes consume the same rule registry (Sacred Practice #12).
+- **`parseBlockTriplet(source)`** — parse a source string into a typed block representation used by the assembler.
+- **`ValidationError`** / **`ValidationResult`** — error and result types.
+- **`ProjectValidationResult`** — result type for project-mode validation. Includes per-file violation lists and a summary.
 
-## What callers consume
-
-Downstream packages (`@yakcc/compile`, `@yakcc/cli`) consume `BlockAst` as the
-unit of composition. A block is never reassembled from its AST at runtime —
-the source text is preserved as the canonical artifact. The AST is used only
-during compilation to verify that blocks compose without type errors and that
-no disallowed language features (classes, `this`, mutable globals, dynamic
-`import()`) are present.
-
-## How composition is expressed
-
-Basic blocks are composed by sequencing: the output type of one block must
-match the input type of the next. Composition is checked at the `ContractSpec`
-level (type strings) in v0, and at the AST level in WI-004 once the IR
-validator is live.
+## Public API
 
 ```ts
-import type { BlockAst } from "@yakcc/ir";
-import { parseBlock, validateStrictSubset } from "@yakcc/ir";
+import {
+  validateStrictSubset,
+  validateStrictSubsetFile,
+  validateStrictSubsetProject,
+  parseBlockTriplet,
+} from "@yakcc/ir";
+import type { ValidationResult, ProjectValidationResult } from "@yakcc/ir";
 
-const ast: BlockAst = parseBlock(source);
-const result = validateStrictSubset(ast);
+// Single-source validation (seed blocks, isolated atoms)
+const result: ValidationResult = validateStrictSubset(source);
 if (!result.valid) {
-  throw new Error(`Block violates strict subset: ${result.violations.join(", ")}`);
+  for (const err of result.errors) {
+    console.error(err.rule, err.message, err.location);
+  }
 }
+
+// File-level isolated validation
+const fileResult = await validateStrictSubsetFile("packages/seeds/src/blocks/parse-int/impl.ts");
+
+// Project-mode validation (resolves cross-package imports; use for whole-package audits)
+const projectResult: ProjectValidationResult = await validateStrictSubsetProject(
+  "packages/registry/tsconfig.json"
+);
 ```
-
-## What this package does not do (yet)
-
-- **No real parser** — WI-004 replaces the facade with a strict-TS-subset
-  parser built on the TypeScript compiler API.
-- **No violation reporting** — WI-004 implements the violation collector.
-- **No AST transformation** — the IR is read-only; transformations are not
-  part of the v0 scope.
 
 ## Strict-subset scope
 
-`validateStrictSubset` and `validateStrictSubsetFile` validate **block sources**
-(seed contract implementations under `packages/seeds/src/blocks/**`), NOT the IR
-toolchain itself. The CLI (`pnpm strict-subset`) defaults to that directory: if it
-does not exist yet (before WI-006 lands), the command exits 0 with a diagnostic
-message. Explicit file paths override the default. The IR toolchain files
-(`strict-subset.ts`, `block-parser.ts`, etc.) import `ts-morph` and `node:fs` and
-are intentionally outside the strict-subset grammar — they are the validator, not
-the validated.
+The validator checks **block implementations** (seed corpus, shaved atoms) and **yakcc's own source** (via project mode). The IR toolchain files themselves (`strict-subset.ts`, `block-parser.ts`, etc.) import `ts-morph` and `node:fs` and are intentionally outside the strict-subset grammar — they are the validator, not the validated.
+
+Project-mode self-validation of yakcc's own packages was performed in WI-V2-01; the 4 real violations found were fixed in WI-V2-02 (two singleton mutables in `embeddings.ts` + two CLI entry-point dispatches).
+
+## What is not yet wired
+
+- **IR lowering for all v2 constructs**: `async`/`await`, classes, conditional/mapped/deep-generic types, and `unknown` narrowing patterns are used by yakcc itself but not yet admitted to the IR as validated-and-lowerable constructs. Extension is tracked as WI-V2-03 (IR subset extensions for self-hosting, Phase B), gated on the v2 bootstrap chain.
 
 ## License
 

--- a/packages/registry/README.md
+++ b/packages/registry/README.md
@@ -9,6 +9,7 @@ The store for Yakcc contracts and their implementations.
   - `getBlock(blockMerkleRoot)` — retrieve a stored block by its content-address, including artifact bytes.
   - `structuralMatch(spec)` — structured contract matching. Filters candidates by input/output type signature, error conditions, and non-functional properties. Returns the best `Match` or `null` if no conforming implementation exists.
   - `select(matches)` — picks the best match from a candidate set, preferring stricter contracts then better non-functional properties.
+  - `exportManifest()` — returns the registry's full block content as a `readonly BootstrapManifestEntry[]`, sorted by `blockMerkleRoot` ASCII ASC. Each entry carries `blockMerkleRoot`, `specHash`, `canonicalAstHash`, `parentBlockRoot`, `implSourceHash`, and `manifestJsonHash`. Deterministic: two calls on the same state produce byte-identical output. Used by `yakcc bootstrap --verify` to compare against the committed `bootstrap/expected-roots.json`.
   - `close()` — releases all resources held by the registry.
 - **`openRegistry(path)`** — opens (or creates) a registry at the given filesystem path backed by SQLite + sqlite-vec. Schema migrations run automatically on open.
 - **`Match`** — a contract paired with a similarity score in [0, 1].


### PR DESCRIPTION
…state

- root README: status → v1 fully closed, v1 wave-2 closed, v2 bootstrap in progress; monorepo layout adds hooks-base/cursor/codex/federation; "not yet wired" replaces stale WASM/hooks-stub entries with accurate v2 gaps
- cli README: status updated; adds bootstrap, hooks cursor/codex install commands
- compile README: documents wasmBackend(), compileToWasm(), WasmTrap, YakccHost, createHost(), instantiateAndRun(); removes "no WASM backend" stub
- registry README: documents exportManifest() / BootstrapManifestEntry (WI-V2-BOOTSTRAP-01)
- ir README: replaces v0-facade language with real API; adds validateStrictSubsetProject() (WI-V2-01); accurate "not yet wired" section
- hooks-claude-code README: replaces "always passthrough" v0 stub language with production registry-hit/synthesis-required/passthrough semantics
- hooks-base README: new — shared EmissionContext, HookResponse, executeRegistryQuery(), DEFAULT_REGISTRY_HIT_THRESHOLD
- hooks-cursor README: new
- hooks-codex README: new

https://claude.ai/code/session_01SZDBo5yzi46CWP6xZwyw1G