### PR TITLE
feat(ci): offline embedding seam + CI workflow (WI-CI-OFFLINE-01)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: pnpm -r build + test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm -r build
+
+      - run: pnpm -r test

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -49,12 +49,15 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
+import { createOfflineEmbeddingProvider } from "@yakcc/contracts";
 import type { BlockMerkleRoot, SpecYak } from "@yakcc/contracts";
 import { openRegistry } from "@yakcc/registry";
 import { seedRegistry } from "@yakcc/seeds";
 import ts from "typescript";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { CollectingLogger, runCli } from "./index.js";
+
+const OFFLINE_EMBEDDINGS = createOfflineEmbeddingProvider();
 
 // ---------------------------------------------------------------------------
 // Suite lifecycle — shared temp directories, seeded once
@@ -84,14 +87,14 @@ beforeAll(async () => {
 
   // Seed it once — all subsequent command tests reuse this seeded state.
   const seedLogger = new CollectingLogger();
-  const seedCode = await runCli(["seed", "--registry", registryPath], seedLogger);
+  const seedCode = await runCli(["seed", "--registry", registryPath], seedLogger, { embeddings: OFFLINE_EMBEDDINGS });
   if (seedCode !== 0) {
     throw new Error(`seed failed: ${seedLogger.errLines.join("\n")}`);
   }
 
   // Discover the list-of-ints BlockMerkleRoot from the seed corpus via a :memory: registry.
   // We open a separate handle here only for discovery; the CLI tests use registryPath.
-  const reg = await openRegistry(":memory:");
+  const reg = await openRegistry(":memory:", { embeddings: OFFLINE_EMBEDDINGS });
   const seedResult = await seedRegistry(reg);
   let found: BlockMerkleRoot | null = null;
   let foundSpec: SpecYak | null = null;
@@ -186,14 +189,14 @@ describe("seed", () => {
   it("ingested all 20 corpus blocks during beforeAll setup", async () => {
     // Re-run seed to verify idempotency and output format.
     const logger = new CollectingLogger();
-    const code = await runCli(["seed", "--registry", registryPath], logger);
+    const code = await runCli(["seed", "--registry", registryPath], logger, { embeddings: OFFLINE_EMBEDDINGS });
     expect(code).toBe(0);
     expect(logger.logLines.some((l) => l.includes("seeded 20 contracts"))).toBe(true);
   });
 
   it("is idempotent — repeated seed exits 0 with consistent count", async () => {
     const logger = new CollectingLogger();
-    const code = await runCli(["seed", "--registry", registryPath], logger);
+    const code = await runCli(["seed", "--registry", registryPath], logger, { embeddings: OFFLINE_EMBEDDINGS });
     expect(code).toBe(0);
     expect(logger.logLines.some((l) => l.includes("seeded"))).toBe(true);
   });
@@ -279,7 +282,7 @@ describe("search", () => {
     writeFileSync(searchSpecPath, JSON.stringify(listOfIntsSpec), "utf-8");
 
     const logger = new CollectingLogger();
-    const code = await runCli(["search", searchSpecPath, "--registry", registryPath], logger);
+    const code = await runCli(["search", searchSpecPath, "--registry", registryPath], logger, { embeddings: OFFLINE_EMBEDDINGS });
     expect(code).toBe(0);
     const resultLines = logger.logLines.filter((l) => l.includes("score="));
     expect(resultLines.length).toBeGreaterThanOrEqual(1);
@@ -302,6 +305,7 @@ describe("search", () => {
         registryPath,
       ],
       logger,
+      { embeddings: OFFLINE_EMBEDDINGS },
     );
     expect(code).toBe(0);
   });
@@ -334,6 +338,7 @@ describe("compile", () => {
     const code = await runCli(
       ["compile", fakeRoot, "--registry", emptyRegPath, "--out", join(suiteDir, "unused-out2")],
       logger,
+      { embeddings: OFFLINE_EMBEDDINGS },
     );
     expect(code).toBe(1);
     expect(logger.errLines.some((l) => l.includes("error"))).toBe(true);
@@ -345,6 +350,7 @@ describe("compile", () => {
     const code = await runCli(
       ["compile", listOfIntsRoot, "--registry", registryPath, "--out", outDir],
       logger,
+      { embeddings: OFFLINE_EMBEDDINGS },
     );
     expect(code).toBe(0);
     expect(existsSync(join(outDir, "module.ts"))).toBe(true);
@@ -357,6 +363,7 @@ describe("compile", () => {
     await runCli(
       ["compile", listOfIntsRoot, "--registry", registryPath, "--out", outDir],
       logger,
+      { embeddings: OFFLINE_EMBEDDINGS },
     );
     const manifest = JSON.parse(readFileSync(join(outDir, "manifest.json"), "utf-8")) as {
       entries: unknown[];
@@ -370,6 +377,7 @@ describe("compile", () => {
     const code = await runCli(
       ["compile", listOfIntsRoot, "--registry", registryPath, "--out", outDir],
       logger,
+      { embeddings: OFFLINE_EMBEDDINGS },
     );
     expect(code).toBe(0);
 
@@ -529,6 +537,7 @@ describe("compile manifest determinism", () => {
     const code1 = await runCli(
       ["compile", listOfIntsRoot, "--registry", registryPath, "--out", outDir1],
       logger1,
+      { embeddings: OFFLINE_EMBEDDINGS },
     );
     expect(code1).toBe(0);
 
@@ -536,6 +545,7 @@ describe("compile manifest determinism", () => {
     const code2 = await runCli(
       ["compile", listOfIntsRoot, "--registry", registryPath, "--out", outDir2],
       logger2,
+      { embeddings: OFFLINE_EMBEDDINGS },
     );
     expect(code2).toBe(0);
 
@@ -560,6 +570,7 @@ describe("compile manifest determinism", () => {
       const codeDirect = await runCli(
         ["compile", listOfIntsRoot, "--registry", registryPath, "--out", outDirDirect],
         loggerDirect,
+        { embeddings: OFFLINE_EMBEDDINGS },
       );
       expect(codeDirect).toBe(0);
 
@@ -570,6 +581,7 @@ describe("compile manifest determinism", () => {
       const codeDir = await runCli(
         ["compile", exampleDir, "--registry", registryPath, "--out", outDirDir],
         loggerDir,
+        { embeddings: OFFLINE_EMBEDDINGS },
       );
       expect(codeDir).toBe(0);
 

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -19,7 +19,7 @@ import { join } from "node:path";
 import { parseArgs } from "node:util";
 import { type Artifact, assemble } from "@yakcc/compile";
 import { type BlockMerkleRoot, type SpecYak, specHash } from "@yakcc/contracts";
-import { type Registry, openRegistry } from "@yakcc/registry";
+import { type Registry, type RegistryOptions, openRegistry } from "@yakcc/registry";
 import { seedRegistry } from "@yakcc/seeds";
 import type { Logger } from "../index.js";
 import { DEFAULT_REGISTRY_PATH } from "./registry-init.js";
@@ -27,6 +27,11 @@ import { DEFAULT_REGISTRY_PATH } from "./registry-init.js";
 /** A 64-hex string that may be a BlockMerkleRoot. */
 function isHex64(s: string): boolean {
   return /^[0-9a-f]{64}$/i.test(s);
+}
+
+/** Internal options for compile. Tests inject embeddings to avoid network I/O. */
+export interface CompileOptions {
+  embeddings?: RegistryOptions["embeddings"];
 }
 
 /**
@@ -38,9 +43,10 @@ function isHex64(s: string): boolean {
  *
  * @param argv - Remaining argv after `compile` has been consumed (includes the positional).
  * @param logger - Output sink; defaults to console via the caller.
+ * @param opts - Internal options (embeddings for test injection).
  * @returns Process exit code (0 = success, 1 = error).
  */
-export async function compile(argv: readonly string[], logger: Logger): Promise<number> {
+export async function compile(argv: readonly string[], logger: Logger, opts?: CompileOptions): Promise<number> {
   const { values, positionals } = parseArgs({
     args: [...argv],
     options: {
@@ -90,7 +96,7 @@ export async function compile(argv: readonly string[], logger: Logger): Promise<
   // Open the registry.
   let registry: Registry;
   try {
-    registry = await openRegistry(registryPath);
+    registry = await openRegistry(registryPath, { embeddings: opts?.embeddings });
   } catch (err) {
     logger.error(`error: failed to open registry at ${registryPath}: ${String(err)}`);
     return 1;

--- a/packages/cli/src/commands/federation.test.ts
+++ b/packages/cli/src/commands/federation.test.ts
@@ -38,6 +38,7 @@ import { join } from "node:path";
 import {
   blockMerkleRoot,
   canonicalize,
+  createOfflineEmbeddingProvider,
   specHash as computeSpecHash,
   validateProofManifestL0,
 } from "@yakcc/contracts";
@@ -49,6 +50,10 @@ import { serializeWireBlockTriplet } from "@yakcc/federation";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { CollectingLogger, runCli } from "../index.js";
 import { runFederation, runFederationServe } from "./federation.js";
+
+// Offline provider shared across all test cases — avoids any network I/O when
+// openRegistry or storeBlock is exercised via runFederation/runFederationServe.
+const OFFLINE_EMBEDDINGS = createOfflineEmbeddingProvider();
 
 // ---------------------------------------------------------------------------
 // Spec/row fixtures shared across test suites
@@ -196,7 +201,7 @@ describe("federation mirror (stub transport)", () => {
     const code = await runFederation(
       ["mirror", "--remote", "https://peer.example.com", "--registry", registryPath],
       logger,
-      { transport },
+      { transport, embeddings: OFFLINE_EMBEDDINGS },
     );
 
     expect(code).toBe(0);
@@ -234,7 +239,7 @@ describe("federation mirror (stub transport)", () => {
     const code = await runFederation(
       ["mirror", "--remote", "https://peer.example.com", "--registry", registryPath],
       logger,
-      { transport },
+      { transport, embeddings: OFFLINE_EMBEDDINGS },
     );
 
     expect(code).toBe(0);
@@ -276,7 +281,7 @@ describe("federation pull (stub transport)", () => {
         registryPath,
       ],
       logger,
-      { transport },
+      { transport, embeddings: OFFLINE_EMBEDDINGS },
     );
 
     expect(code).toBe(0);
@@ -306,7 +311,7 @@ describe("federation pull (stub transport)", () => {
         registryPath,
       ],
       logger,
-      { transport },
+      { transport, embeddings: OFFLINE_EMBEDDINGS },
     );
 
     expect(code).toBe(1);
@@ -338,7 +343,7 @@ describe("federation serve (noBlock smoke test)", () => {
     const result = await runFederationServe(
       ["--registry", registryPath, "--port", "0"],
       logger,
-      { noBlock: true },
+      { noBlock: true, embeddings: OFFLINE_EMBEDDINGS },
     );
 
     expect(result.code).toBe(0);
@@ -503,7 +508,7 @@ describe("federation pull --registry persist (WI-030)", () => {
     const code = await runFederation(
       ["pull", "--remote", "https://peer.example.com", "--root", row.blockMerkleRoot, "--registry", dbPath],
       logger,
-      { transport },
+      { transport, embeddings: OFFLINE_EMBEDDINGS },
     );
 
     expect(code).toBe(0);
@@ -518,7 +523,7 @@ describe("federation pull --registry persist (WI-030)", () => {
 
     // Post-condition: open registry in a second call and verify the row is present
     // with every column byte-identical (DEC-TRIPLET-IDENTITY-020).
-    const reg = await openRegistry(dbPath);
+    const reg = await openRegistry(dbPath, { embeddings: OFFLINE_EMBEDDINGS });
     try {
       const stored = await reg.getBlock(row.blockMerkleRoot);
       expect(stored).not.toBeNull();
@@ -566,7 +571,7 @@ describe("federation pull --registry persist (WI-030)", () => {
     const code1 = await runFederation(
       ["pull", "--remote", "https://peer.example.com", "--root", row.blockMerkleRoot, "--registry", dbPath],
       logger1,
-      { transport },
+      { transport, embeddings: OFFLINE_EMBEDDINGS },
     );
     expect(code1).toBe(0);
     expect(logger1.errLines).toHaveLength(0);
@@ -576,13 +581,13 @@ describe("federation pull --registry persist (WI-030)", () => {
     const code2 = await runFederation(
       ["pull", "--remote", "https://peer.example.com", "--root", row.blockMerkleRoot, "--registry", dbPath],
       logger2,
-      { transport },
+      { transport, embeddings: OFFLINE_EMBEDDINGS },
     );
     expect(code2).toBe(0);
     expect(logger2.errLines).toHaveLength(0);
 
     // Post-condition: exactly one row in the registry for this root.
-    const reg = await openRegistry(dbPath);
+    const reg = await openRegistry(dbPath, { embeddings: OFFLINE_EMBEDDINGS });
     try {
       const stored = await reg.getBlock(row.blockMerkleRoot);
       expect(stored).not.toBeNull();
@@ -615,7 +620,7 @@ describe("federation pull --registry persist (WI-030)", () => {
     const code = await runFederation(
       ["pull", "--remote", "https://peer.example.com", "--root", row.blockMerkleRoot],
       logger,
-      { transport },
+      { transport, embeddings: OFFLINE_EMBEDDINGS },
     );
 
     expect(code).toBe(0);
@@ -648,7 +653,7 @@ describe("federation pull --registry persist (WI-030)", () => {
     expect(await runCli(["registry", "init", "--path", dbPath], initLogger)).toBe(0);
 
     // Pre-condition: registry is empty.
-    const regBefore = await openRegistry(dbPath);
+    const regBefore = await openRegistry(dbPath, { embeddings: OFFLINE_EMBEDDINGS });
     try {
       const before = await regBefore.getBlock(row.blockMerkleRoot);
       expect(before).toBeNull();
@@ -660,13 +665,13 @@ describe("federation pull --registry persist (WI-030)", () => {
     const code = await runFederation(
       ["pull", "--remote", "https://peer.example.com", "--root", row.blockMerkleRoot, "--registry", dbPath],
       logger,
-      { transport },
+      { transport, embeddings: OFFLINE_EMBEDDINGS },
     );
 
     expect(code).toBe(0);
 
     // Post-condition: row is now present.
-    const regAfter = await openRegistry(dbPath);
+    const regAfter = await openRegistry(dbPath, { embeddings: OFFLINE_EMBEDDINGS });
     try {
       const after = await regAfter.getBlock(row.blockMerkleRoot);
       expect(after).not.toBeNull();
@@ -696,7 +701,7 @@ describe("federation pull --registry persist (WI-030)", () => {
     expect(await runCli(["registry", "init", "--path", dbPath], initLogger)).toBe(0);
 
     // Pre-condition: insert the row directly via the registry.
-    const regPre = await openRegistry(dbPath);
+    const regPre = await openRegistry(dbPath, { embeddings: OFFLINE_EMBEDDINGS });
     try {
       await regPre.storeBlock(row);
     } finally {
@@ -707,14 +712,14 @@ describe("federation pull --registry persist (WI-030)", () => {
     const code = await runFederation(
       ["pull", "--remote", "https://peer.example.com", "--root", row.blockMerkleRoot, "--registry", dbPath],
       logger,
-      { transport },
+      { transport, embeddings: OFFLINE_EMBEDDINGS },
     );
 
     expect(code).toBe(0);
     expect(logger.errLines).toHaveLength(0);
 
     // Post-condition: registry still contains exactly one row (no double-insert).
-    const regPost = await openRegistry(dbPath);
+    const regPost = await openRegistry(dbPath, { embeddings: OFFLINE_EMBEDDINGS });
     try {
       const allRoots = await regPost.selectBlocks(row.specHash);
       const matching = allRoots.filter((r) => r === row.blockMerkleRoot);
@@ -750,7 +755,7 @@ describe("federation pull --registry persist (WI-030)", () => {
     const code = await runFederation(
       ["pull", "--remote", "https://peer.example.com", "--root", "a".repeat(64), "--registry", badPath],
       logger,
-      { transport },
+      { transport, embeddings: OFFLINE_EMBEDDINGS },
     );
 
     expect(code).toBe(1);
@@ -780,7 +785,7 @@ describe("federation pull --registry persist (WI-030)", () => {
     const code = await runFederation(
       ["pull", "--remote", "https://peer.example.com", "--root", "a".repeat(64), "--registry", dbPath],
       logger,
-      { transport },
+      { transport, embeddings: OFFLINE_EMBEDDINGS },
     );
 
     expect(code).toBe(1);
@@ -788,7 +793,7 @@ describe("federation pull --registry persist (WI-030)", () => {
     expect(logger.errLines.some((l) => l.includes("pull failed"))).toBe(true);
 
     // Post-condition: registry is unchanged (no row was inserted).
-    const reg = await openRegistry(dbPath);
+    const reg = await openRegistry(dbPath, { embeddings: OFFLINE_EMBEDDINGS });
     try {
       const allRoots = await reg.selectBlocks("a".repeat(64) as unknown as import("@yakcc/contracts").SpecHash);
       expect(allRoots).toHaveLength(0);
@@ -847,7 +852,7 @@ describe("federation pull --registry persist (WI-030)", () => {
     const code = await runFederation(
       ["pull", "--remote", "https://peer.example.com", "--root", row.blockMerkleRoot, "--registry", dbPath2],
       logger,
-      { transport },
+      { transport, embeddings: OFFLINE_EMBEDDINGS },
     );
 
     expect(code).toBe(1);
@@ -875,7 +880,7 @@ describe("federation pull --registry persist (WI-030)", () => {
     const code = await runFederation(
       ["pull", "--remote", "https://peer.example.com", "--root", "a".repeat(64), "--registry", ""],
       logger,
-      { transport },
+      { transport, embeddings: OFFLINE_EMBEDDINGS },
     );
 
     expect(code).toBe(1);
@@ -908,7 +913,7 @@ describe("federation pull --registry persist (WI-030)", () => {
     const code = await runFederation(
       ["pull", "--remote", "https://peer.example.com", "--root", row.blockMerkleRoot, "--registry", dbPath],
       logger,
-      { transport },
+      { transport, embeddings: OFFLINE_EMBEDDINGS },
     );
 
     expect(code).toBe(0);

--- a/packages/cli/src/commands/federation.ts
+++ b/packages/cli/src/commands/federation.ts
@@ -32,7 +32,7 @@ import {
   serveRegistry,
 } from "@yakcc/federation";
 import type { ServeHandle, Transport } from "@yakcc/federation";
-import type { Registry } from "@yakcc/registry";
+import type { Registry, RegistryOptions } from "@yakcc/registry";
 import { openRegistry } from "@yakcc/registry";
 import type { Logger } from "../index.js";
 
@@ -58,6 +58,11 @@ export interface FederationOptions {
    * Default: false (production — blocks until signal).
    */
   noBlock?: boolean;
+  /**
+   * Embedding provider for openRegistry. Default: createLocalEmbeddingProvider().
+   * Tests inject createOfflineEmbeddingProvider() to avoid network I/O.
+   */
+  embeddings?: RegistryOptions["embeddings"];
 }
 
 // ---------------------------------------------------------------------------
@@ -142,7 +147,7 @@ export async function runFederationServe(
 
   let registry: Registry;
   try {
-    registry = await openRegistry(registryPath);
+    registry = await openRegistry(registryPath, { embeddings: opts?.embeddings });
   } catch (err) {
     logger.error(`error: failed to open registry at ${registryPath}: ${String(err)}`);
     return { code: 1, handle: null };
@@ -234,7 +239,7 @@ async function runFederationMirror(
 
   let registry: Registry;
   try {
-    registry = await openRegistry(registryPath);
+    registry = await openRegistry(registryPath, { embeddings: opts?.embeddings });
   } catch (err) {
     logger.error(`error: failed to open registry at ${registryPath}: ${String(err)}`);
     return 1;
@@ -343,7 +348,7 @@ async function runFederationPull(
   let registry: Registry | null = null;
   if (hasRegistry) {
     try {
-      registry = await openRegistry(registryPath as string);
+      registry = await openRegistry(registryPath as string, { embeddings: opts?.embeddings });
     } catch (err) {
       logger.error(`error: failed to open registry at ${registryPath as string}: ${String(err)}`);
       return 1;

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -13,7 +13,7 @@
 import { readFileSync } from "node:fs";
 import { parseArgs } from "node:util";
 import type { SpecYak } from "@yakcc/contracts";
-import { openRegistry, structuralMatch } from "@yakcc/registry";
+import { type RegistryOptions, openRegistry, structuralMatch } from "@yakcc/registry";
 import { seedRegistry } from "@yakcc/seeds";
 import type { Logger } from "../index.js";
 import { DEFAULT_REGISTRY_PATH } from "./registry-init.js";
@@ -39,6 +39,11 @@ function truncate(s: string, max: number): string {
   return s.length <= max ? s : `${s.slice(0, max - 1)}…`;
 }
 
+/** Internal options for search. Tests inject embeddings to avoid network I/O. */
+export interface SearchOptions {
+  embeddings?: RegistryOptions["embeddings"];
+}
+
 /**
  * Handler for `yakcc search <query> [--registry <p>] [--top <k>]`.
  *
@@ -47,9 +52,10 @@ function truncate(s: string, max: number): string {
  *
  * @param argv - Remaining argv after `search` has been consumed (includes the positional).
  * @param logger - Output sink; defaults to console via the caller.
+ * @param opts - Internal options (embeddings for test injection).
  * @returns Process exit code (0 = success, 1 = error).
  */
-export async function search(argv: readonly string[], logger: Logger): Promise<number> {
+export async function search(argv: readonly string[], logger: Logger, opts?: SearchOptions): Promise<number> {
   const { values, positionals } = parseArgs({
     args: [...argv],
     options: {
@@ -105,7 +111,7 @@ export async function search(argv: readonly string[], logger: Logger): Promise<n
   }
 
   // Open the registry, seed it, then scan all corpus blocks for structural matches.
-  const registry = await openRegistry(registryPath).catch((err: unknown) => {
+  const registry = await openRegistry(registryPath, { embeddings: opts?.embeddings }).catch((err: unknown) => {
     logger.error(`error: failed to open registry at ${registryPath}: ${String(err)}`);
     return null;
   });

--- a/packages/cli/src/commands/seed.ts
+++ b/packages/cli/src/commands/seed.ts
@@ -9,13 +9,18 @@
 // No author/ownership fields touched — DEC-NO-OWNERSHIP-011.
 
 import { parseArgs } from "node:util";
-import { type Registry, openRegistry } from "@yakcc/registry";
+import { type Registry, type RegistryOptions, openRegistry } from "@yakcc/registry";
 import { seedRegistry } from "@yakcc/seeds";
 import type { Logger } from "../index.js";
 import { DEFAULT_REGISTRY_PATH } from "./registry-init.js";
 
 /** Maximum number of merkle roots to print in the summary line. */
 const MAX_ROOTS_SHOWN = 3;
+
+/** Internal options for seed. Tests inject embeddings to avoid network I/O. */
+export interface SeedOptions {
+  embeddings?: RegistryOptions["embeddings"];
+}
 
 /**
  * Handler for `yakcc seed [--registry <p>]`.
@@ -25,9 +30,10 @@ const MAX_ROOTS_SHOWN = 3;
  *
  * @param argv - Remaining argv after `seed` has been consumed.
  * @param logger - Output sink; defaults to console via the caller.
+ * @param opts - Internal options (embeddings for test injection).
  * @returns Process exit code (0 = success, 1 = error).
  */
-export async function seed(argv: readonly string[], logger: Logger): Promise<number> {
+export async function seed(argv: readonly string[], logger: Logger, opts?: SeedOptions): Promise<number> {
   const { values } = parseArgs({
     args: [...argv],
     options: {
@@ -41,7 +47,7 @@ export async function seed(argv: readonly string[], logger: Logger): Promise<num
 
   let registry: Registry;
   try {
-    registry = await openRegistry(registryPath);
+    registry = await openRegistry(registryPath, { embeddings: opts?.embeddings });
   } catch (err) {
     logger.error(`error: failed to open registry at ${registryPath}: ${String(err)}`);
     return 1;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,6 +29,7 @@ import { registryInit } from "./commands/registry-init.js";
 import { search } from "./commands/search.js";
 import { seed } from "./commands/seed.js";
 import { shave } from "./commands/shave.js";
+import type { RegistryOptions } from "@yakcc/registry";
 
 // Re-export ContractId for callers who import from @yakcc/cli.
 export type { ContractId } from "@yakcc/contracts";
@@ -125,6 +126,15 @@ EXIT CODES
 // ---------------------------------------------------------------------------
 
 /**
+ * Internal options for runCli. Tests inject these to avoid external I/O.
+ */
+export interface CliOptions {
+  /** Embedding provider forwarded to commands that open a registry. Tests inject
+   * createOfflineEmbeddingProvider() so no network I/O occurs. */
+  embeddings?: RegistryOptions["embeddings"];
+}
+
+/**
  * Run the yakcc CLI with the given argument vector.
  *
  * Dispatches on the first positional token (command) and, for multi-word
@@ -133,11 +143,13 @@ EXIT CODES
  *
  * @param argv - Arguments after the binary name (i.e. process.argv.slice(2)).
  * @param logger - Output sink; defaults to CONSOLE_LOGGER (the real console).
+ * @param opts - Internal options (embeddings for test injection).
  * @returns Promise<number> — 0 on success, non-zero on error.
  */
 export async function runCli(
   argv: ReadonlyArray<string>,
   logger: Logger = CONSOLE_LOGGER,
+  opts?: CliOptions,
 ): Promise<number> {
   const [command, subcommand, ...rest] = argv;
 
@@ -155,7 +167,7 @@ export async function runCli(
     case "compile": {
       // subcommand is the first positional for compile (the entry arg).
       const compileArgv = subcommand !== undefined ? [subcommand, ...rest] : rest;
-      return compile(compileArgv, logger);
+      return compile(compileArgv, logger, { embeddings: opts?.embeddings });
     }
 
     case "propose": {
@@ -170,13 +182,13 @@ export async function runCli(
 
     case "search": {
       const searchArgv = subcommand !== undefined ? [subcommand, ...rest] : rest;
-      return search(searchArgv, logger);
+      return search(searchArgv, logger, { embeddings: opts?.embeddings });
     }
 
     case "seed": {
       // seed has no positional; subcommand may be a flag like --registry.
       const seedArgv = subcommand !== undefined ? [subcommand, ...rest] : rest;
-      return seed(seedArgv, logger);
+      return seed(seedArgv, logger, { embeddings: opts?.embeddings });
     }
 
     case "bootstrap": {
@@ -193,7 +205,7 @@ export async function runCli(
     case "federation": {
       // Reassemble remaining args: subcommand (the federation verb) + rest.
       const fedArgv = subcommand !== undefined ? [subcommand, ...rest] : rest;
-      return runFederation(fedArgv, logger);
+      return runFederation(fedArgv, logger, { embeddings: opts?.embeddings });
     }
 
     case "hooks": {

--- a/packages/compile/src/assemble-candidate.test.ts
+++ b/packages/compile/src/assemble-candidate.test.ts
@@ -55,6 +55,7 @@ import {
   type SpecYak,
   blockMerkleRoot,
   canonicalAstHash,
+  createOfflineEmbeddingProvider,
   specHash,
 } from "@yakcc/contracts";
 import { openRegistry } from "@yakcc/registry";
@@ -87,7 +88,7 @@ beforeEach(async () => {
   await mkdir(cacheDir, { recursive: true });
   // biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
   delete process.env.ANTHROPIC_API_KEY;
-  registry = await openRegistry(":memory:");
+  registry = await openRegistry(":memory:", { embeddings: createOfflineEmbeddingProvider() });
 });
 
 afterEach(async () => {

--- a/packages/compile/src/assemble.test.ts
+++ b/packages/compile/src/assemble.test.ts
@@ -46,6 +46,7 @@ import {
   type SpecYak,
   blockMerkleRoot,
   canonicalAstHash,
+  createOfflineEmbeddingProvider,
   specHash,
 } from "@yakcc/contracts";
 import { openRegistry } from "@yakcc/registry";
@@ -178,7 +179,7 @@ let assembleOpts: AssembleOptions;
 let tempDir: string;
 
 beforeAll(async () => {
-  registry = await openRegistry(":memory:");
+  registry = await openRegistry(":memory:", { embeddings: createOfflineEmbeddingProvider() });
 
   const { row: doubleRow, merkleRoot: dr } = makeBlockRow(
     "double",

--- a/packages/compile/src/resolve.test.ts
+++ b/packages/compile/src/resolve.test.ts
@@ -22,6 +22,7 @@ import {
   type SpecYak,
   blockMerkleRoot,
   canonicalAstHash,
+  createOfflineEmbeddingProvider,
   specHash,
 } from "@yakcc/contracts";
 import { openRegistry } from "@yakcc/registry";
@@ -127,7 +128,7 @@ const nullResolver: SubBlockResolver = async () => null;
 let registry: Registry;
 
 beforeEach(async () => {
-  registry = await openRegistry(":memory:");
+  registry = await openRegistry(":memory:", { embeddings: createOfflineEmbeddingProvider() });
 });
 
 afterEach(async () => {

--- a/packages/contracts/src/embeddings.test.ts
+++ b/packages/contracts/src/embeddings.test.ts
@@ -6,15 +6,6 @@ import {
 } from "./embeddings.js";
 import type { ContractSpec } from "./index.js";
 
-// ---------------------------------------------------------------------------
-// Note on test duration
-// ---------------------------------------------------------------------------
-// These tests load the Xenova/all-MiniLM-L6-v2 ONNX model on first embed()
-// call (~25MB download on a cold cache, instant on a warm cache). They are
-// intentionally slow on a cold machine — the latency is a property of the
-// production path and must not be hidden. Subsequent runs in the same process
-// reuse the pipeline singleton and are fast.
-
 const SAMPLE_SPEC: ContractSpec = {
   inputs: [{ name: "s", type: "string" }],
   outputs: [{ name: "result", type: "number[]" }],
@@ -24,9 +15,6 @@ const SAMPLE_SPEC: ContractSpec = {
   nonFunctional: { purity: "pure", threadSafety: "safe" },
   propertyTests: [],
 };
-
-/** 2-minute timeout for tests that load the ONNX model. */
-const MODEL_TIMEOUT = 120_000;
 
 describe("EmbeddingProvider (local)", () => {
   describe("provider properties", () => {
@@ -42,100 +30,77 @@ describe("EmbeddingProvider (local)", () => {
   });
 
   describe("embed output shape", () => {
-    it("embed returns a Float32Array of length 384", { timeout: MODEL_TIMEOUT }, async () => {
-      const provider = createLocalEmbeddingProvider();
+    it("embed returns a Float32Array of length 384", async () => {
+      const provider = createOfflineEmbeddingProvider();
       const vec = await provider.embed("hello world");
       expect(vec).toBeInstanceOf(Float32Array);
       expect(vec.length).toBe(384);
     });
 
-    it(
-      "embed returns non-zero vector for non-trivial input",
-      { timeout: MODEL_TIMEOUT },
-      async () => {
-        const provider = createLocalEmbeddingProvider();
-        const vec = await provider.embed("parse a list of integers");
-        const allZero = Array.from(vec).every((v) => v === 0);
-        expect(allZero).toBe(false);
-      },
-    );
+    it("embed returns non-zero vector for non-trivial input", async () => {
+      const provider = createOfflineEmbeddingProvider();
+      const vec = await provider.embed("parse a list of integers");
+      const allZero = Array.from(vec).every((v) => v === 0);
+      expect(allZero).toBe(false);
+    });
   });
 
   describe("determinism (the critical v0 requirement)", () => {
-    it(
-      "two embed() calls on the same input return byte-equal Float32Arrays",
-      { timeout: MODEL_TIMEOUT },
-      async () => {
-        const provider = createLocalEmbeddingProvider();
-        const text = "parse a JSON array of integers";
-        const vec1 = await provider.embed(text);
-        const vec2 = await provider.embed(text);
-        // Compare element by element for exact bit equality
-        expect(vec1.length).toBe(vec2.length);
-        for (let i = 0; i < vec1.length; i++) {
-          // Use Object.is to distinguish +0/-0 and NaN
-          expect(Object.is(vec1[i], vec2[i])).toBe(true);
-        }
-      },
-    );
+    it("two embed() calls on the same input return byte-equal Float32Arrays", async () => {
+      const provider = createOfflineEmbeddingProvider();
+      const text = "parse a JSON array of integers";
+      const vec1 = await provider.embed(text);
+      const vec2 = await provider.embed(text);
+      expect(vec1.length).toBe(vec2.length);
+      for (let i = 0; i < vec1.length; i++) {
+        expect(Object.is(vec1[i], vec2[i])).toBe(true);
+      }
+    });
 
-    it(
-      "generateEmbedding with same spec returns byte-equal vectors on two calls",
-      { timeout: MODEL_TIMEOUT },
-      async () => {
-        const vec1 = await generateEmbedding(SAMPLE_SPEC);
-        const vec2 = await generateEmbedding(SAMPLE_SPEC);
-        expect(vec1.length).toBe(384);
-        expect(vec2.length).toBe(384);
-        for (let i = 0; i < vec1.length; i++) {
-          expect(Object.is(vec1[i], vec2[i])).toBe(true);
-        }
-      },
-    );
+    it("generateEmbedding with same spec returns byte-equal vectors on two calls", async () => {
+      const provider = createOfflineEmbeddingProvider();
+      const vec1 = await generateEmbedding(SAMPLE_SPEC, provider);
+      const vec2 = await generateEmbedding(SAMPLE_SPEC, provider);
+      expect(vec1.length).toBe(384);
+      expect(vec2.length).toBe(384);
+      for (let i = 0; i < vec1.length; i++) {
+        expect(Object.is(vec1[i], vec2[i])).toBe(true);
+      }
+    });
   });
 
   describe("generateEmbedding integration", () => {
-    it(
-      "uses canonical text as input (different spec insertion order → same embedding)",
-      { timeout: MODEL_TIMEOUT },
-      async () => {
-        const specA: ContractSpec = SAMPLE_SPEC;
-        // Same data as SAMPLE_SPEC but properties inserted in a different order.
-        // canonicalize() must normalize this so embeddings are identical.
-        const specB: ContractSpec = {
-          behavior: SAMPLE_SPEC.behavior,
-          errorConditions: SAMPLE_SPEC.errorConditions,
-          guarantees: SAMPLE_SPEC.guarantees,
-          inputs: SAMPLE_SPEC.inputs,
-          nonFunctional: SAMPLE_SPEC.nonFunctional,
-          outputs: SAMPLE_SPEC.outputs,
-          propertyTests: SAMPLE_SPEC.propertyTests,
-        };
-        const vecA = await generateEmbedding(specA);
-        const vecB = await generateEmbedding(specB);
-        // Both must produce the same embedding since canonicalize() normalizes order
-        for (let i = 0; i < vecA.length; i++) {
-          expect(Object.is(vecA[i], vecB[i])).toBe(true);
-        }
-      },
-    );
+    it("uses canonical text as input (different spec insertion order → same embedding)", async () => {
+      const provider = createOfflineEmbeddingProvider();
+      const specA: ContractSpec = SAMPLE_SPEC;
+      const specB: ContractSpec = {
+        behavior: SAMPLE_SPEC.behavior,
+        errorConditions: SAMPLE_SPEC.errorConditions,
+        guarantees: SAMPLE_SPEC.guarantees,
+        inputs: SAMPLE_SPEC.inputs,
+        nonFunctional: SAMPLE_SPEC.nonFunctional,
+        outputs: SAMPLE_SPEC.outputs,
+        propertyTests: SAMPLE_SPEC.propertyTests,
+      };
+      const vecA = await generateEmbedding(specA, provider);
+      const vecB = await generateEmbedding(specB, provider);
+      for (let i = 0; i < vecA.length; i++) {
+        expect(Object.is(vecA[i], vecB[i])).toBe(true);
+      }
+    });
 
-    it(
-      "different specs produce different embeddings",
-      { timeout: MODEL_TIMEOUT },
-      async () => {
-        const specA = SAMPLE_SPEC;
-        const specB: ContractSpec = {
-          ...SAMPLE_SPEC,
-          behavior: "Compute the SHA-256 hash of a byte array.",
-        };
-        const vecA = await generateEmbedding(specA);
-        const vecB = await generateEmbedding(specB);
-        // These should be semantically different embeddings
-        const identical = Array.from(vecA).every((v, i) => Object.is(v, vecB[i]));
-        expect(identical).toBe(false);
-      },
-    );
+    it("different specs produce different embeddings", async () => {
+      const provider = createOfflineEmbeddingProvider();
+      const specA = SAMPLE_SPEC;
+      const specB: ContractSpec = {
+        ...SAMPLE_SPEC,
+        behavior: "Compute the SHA-256 hash of a byte array.",
+      };
+      const vecA = await generateEmbedding(specA, provider);
+      const vecB = await generateEmbedding(specB, provider);
+      const identical = Array.from(vecA).every((v, i) => Object.is(v, vecB[i]));
+      expect(identical).toBe(false);
+    });
 
     it("custom provider is used when provided", { timeout: 5_000 }, async () => {
       let callCount = 0;
@@ -152,6 +117,28 @@ describe("EmbeddingProvider (local)", () => {
       expect(result).toEqual(new Float32Array([1.0, 2.0, 3.0]));
     });
   });
+
+  // One smoke test exercises the real local (transformers.js) provider.
+  // Skipped by default — requires network access to download the ONNX model.
+  // Run with: YAKCC_NETWORK_TESTS=1 pnpm --filter @yakcc/contracts test
+  describe.skipIf(process.env.YAKCC_NETWORK_TESTS !== "1")(
+    "local provider smoke test (YAKCC_NETWORK_TESTS=1 required)",
+    () => {
+      /** 2-minute timeout for the model download on a cold cache. */
+      const MODEL_TIMEOUT = 120_000;
+
+      it(
+        "embed returns a Float32Array of length 384 (real ONNX model)",
+        { timeout: MODEL_TIMEOUT },
+        async () => {
+          const provider = createLocalEmbeddingProvider();
+          const vec = await provider.embed("hello world");
+          expect(vec).toBeInstanceOf(Float32Array);
+          expect(vec.length).toBe(384);
+        },
+      );
+    },
+  );
 });
 
 describe("EmbeddingProvider (offline / BLAKE3 stub)", () => {

--- a/packages/seeds/src/seed.test.ts
+++ b/packages/seeds/src/seed.test.ts
@@ -12,6 +12,7 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { createOfflineEmbeddingProvider } from "@yakcc/contracts";
 import { validateStrictSubset } from "@yakcc/ir";
 import { openRegistry } from "@yakcc/registry";
 import { afterEach, describe, expect, it } from "vitest";
@@ -82,7 +83,7 @@ const BLOCK_DIRS = [
 
 describe("seedRegistry", () => {
   it("stores all 20 blocks and returns their merkleRoots", async () => {
-    const registry = await openRegistry(":memory:");
+    const registry = await openRegistry(":memory:", { embeddings: createOfflineEmbeddingProvider() });
     let result: SeedResult;
     try {
       result = await seedRegistry(registry);
@@ -94,7 +95,7 @@ describe("seedRegistry", () => {
   });
 
   it("is idempotent — calling seedRegistry twice does not throw or double-count", async () => {
-    const registry = await openRegistry(":memory:");
+    const registry = await openRegistry(":memory:", { embeddings: createOfflineEmbeddingProvider() });
     try {
       const r1 = await seedRegistry(registry);
       const r2 = await seedRegistry(registry);
@@ -108,8 +109,8 @@ describe("seedRegistry", () => {
 
   it("seedRegistry() re-runs deterministically — same BlockMerkleRoot for every block", async () => {
     // Run seedRegistry twice on separate in-memory DBs; merkleRoots must match.
-    const registry1 = await openRegistry(":memory:");
-    const registry2 = await openRegistry(":memory:");
+    const registry1 = await openRegistry(":memory:", { embeddings: createOfflineEmbeddingProvider() });
+    const registry2 = await openRegistry(":memory:", { embeddings: createOfflineEmbeddingProvider() });
     try {
       const r1 = await seedRegistry(registry1);
       const r2 = await seedRegistry(registry2);
@@ -123,7 +124,7 @@ describe("seedRegistry", () => {
   }, 30_000);
 
   it("registry.selectBlocks finds each block by its specHash after seeding", async () => {
-    const registry = await openRegistry(":memory:");
+    const registry = await openRegistry(":memory:", { embeddings: createOfflineEmbeddingProvider() });
     try {
       const { merkleRoots } = await seedRegistry(registry);
       const { parseBlockTriplet } = await import("@yakcc/ir");
@@ -612,7 +613,7 @@ describe("end-to-end: seed → selectBlocks → getBlock → parse → compose",
   });
 
   it("seeds registry, looks up list-of-ints by specHash, retrieves block, and parses '[1,2,3]'", async () => {
-    const registry = await openRegistry(":memory:");
+    const registry = await openRegistry(":memory:", { embeddings: createOfflineEmbeddingProvider() });
     registryInstance = registry;
 
     // Step 1: Seed the registry
@@ -646,7 +647,7 @@ describe("end-to-end: seed → selectBlocks → getBlock → parse → compose",
   });
 
   it("verifies all blocks parse successfully via parseBlockTriplet after migration", async () => {
-    const registry = await openRegistry(":memory:");
+    const registry = await openRegistry(":memory:", { embeddings: createOfflineEmbeddingProvider() });
     registryInstance = registry;
 
     const { parseBlockTriplet } = await import("@yakcc/ir");


### PR DESCRIPTION
## Summary

- **Part A — offline embedding injection seam**: adds `embeddings?: RegistryOptions["embeddings"]` to `FederationOptions`, `SeedOptions`, `CompileOptions`, `SearchOptions`, and the new `CliOptions` on `runCli()`. All three `openRegistry()` call sites in federation.ts, plus the ones in seed.ts, compile.ts, and search.ts, now forward the injected provider. Tests in contracts, seeds, compile, federation, and cli packages pass `createOfflineEmbeddingProvider()` (BLAKE3-based, zero network I/O) so `pnpm -r test` passes in network-blocked environments (no more `Forbidden access to file: "https://huggingface.co/…"`). One `createLocalEmbeddingProvider()` smoke test is kept and gated behind `YAKCC_NETWORK_TESTS=1`.

- **Part B — CI workflow**: adds `.github/workflows/test.yml` that runs `pnpm -r build` then `pnpm -r test` on every push/PR targeting `main`. Uses `pnpm/action-setup@v4` without a `with: version:` pin (the `packageManager` field in `package.json` is the source of truth, matching the existing `bootstrap.yml` pattern). Node 22, ubuntu-latest, 30-minute job timeout.

## Test plan

- [x] `pnpm -r build` — clean, zero TypeScript errors
- [x] `packages/contracts` — 110 passed, 1 skipped (local-provider smoke test behind gate)
- [x] `packages/seeds` — 158 passed
- [x] `packages/compile` — 87 passed
- [x] `packages/federation` — 109 passed
- [x] `packages/cli` — 66 passed (all seed/compile/search/federation integration tests green)
- [x] `packages/registry` — 92 passed; `storage.benchmark.test.ts` timeout is pre-existing (180 s beforeAll storing 1000 blocks, present before this branch)

Closes #37

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9S1CYKHE4onpwNEWRi2iN)_