### PR TITLE
fix(ci): mri-demo Test B timeout + bootstrap workflow fast-skip cache

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -20,20 +20,91 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # ---------------------------------------------------------------------
+      # Fast-skip cache.
+      #
+      # The bootstrap manifest is a deterministic function of:
+      #   - all .ts source under packages/*/src and examples/*/src (shave inputs)
+      #   - the committed bootstrap/expected-roots.json (verify target)
+      #   - the lockfile (transitive shave-pipeline deps)
+      #
+      # If we've previously verified the byte-equality of the manifest for
+      # this exact input hash, re-running the 30-60 minute shave produces a
+      # bit-identical result by construction. Cache a marker file keyed on
+      # the input hash; skip the verify step on cache hit.
+      #
+      # Cache miss = first time we've seen this source state OR the previous
+      # run failed (markers are only written after a successful verify).
+      # ---------------------------------------------------------------------
+      - name: Compute source hash
+        id: source-hash
+        run: |
+          # Hash every .ts file under packages/*/src and examples/*/src plus
+          # the verify target and lockfile. The bootstrap walker already
+          # filters test/fixture/dist files at runtime, so over-hashing here
+          # (e.g. including *.test.ts) only ever causes a benign cache miss
+          # — never a false hit. Under-hashing would be unsafe.
+          HASH=$(
+            { find packages/*/src examples/*/src -name '*.ts' -type f -print0 \
+                  | sort -z \
+                  | xargs -0 sha256sum
+              sha256sum bootstrap/expected-roots.json pnpm-lock.yaml
+            } | sha256sum | awk '{print $1}'
+          )
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+          echo "Computed input hash: $HASH"
+
+      - name: Restore verified-marker cache
+        id: verified-cache
+        uses: actions/cache@v4
+        with:
+          path: bootstrap/.verified-marker
+          key: bootstrap-verified-${{ steps.source-hash.outputs.hash }}
+
+      - name: Skip — already verified for this source state
+        if: steps.verified-cache.outputs.cache-hit == 'true'
+        run: |
+          echo "Cache hit — bootstrap was previously verified for this exact"
+          echo "source state. The manifest is a deterministic function of the"
+          echo "inputs that produced this cache entry; re-shaving would produce"
+          echo "a bit-identical result by construction."
+          echo
+          cat bootstrap/.verified-marker
+
+      # ---------------------------------------------------------------------
+      # Slow path — runs only on cache miss.
+      # ---------------------------------------------------------------------
       - name: Set up pnpm
+        if: steps.verified-cache.outputs.cache-hit != 'true'
         uses: pnpm/action-setup@v4
 
       - name: Set up Node.js
+        if: steps.verified-cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
 
       - name: Install dependencies
+        if: steps.verified-cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Build all packages
+        if: steps.verified-cache.outputs.cache-hit != 'true'
         run: pnpm -r build
 
       - name: Verify content-addressed manifest
+        if: steps.verified-cache.outputs.cache-hit != 'true'
         run: node packages/cli/dist/bin.js bootstrap --verify
+
+      - name: Write verified-marker
+        if: steps.verified-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p bootstrap
+          {
+            echo "input-hash: ${{ steps.source-hash.outputs.hash }}"
+            echo "verified-at: $(date -u +%FT%TZ)"
+            echo "commit: ${{ github.sha }}"
+            echo "ref: ${{ github.ref }}"
+          } > bootstrap/.verified-marker
+          cat bootstrap/.verified-marker

--- a/examples/v0.7-mri-demo/test/acceptance.test.ts
+++ b/examples/v0.7-mri-demo/test/acceptance.test.ts
@@ -91,7 +91,7 @@ describe("Test A: license refusal", () => {
 // ---------------------------------------------------------------------------
 
 describe("Test B: pipeline structural smoke test", () => {
-  it("universalize() decomposes MIT-licensed source without CanonicalAstParseError (static intent path, B-011 regression)", async () => {
+  it("universalize() decomposes MIT-licensed source without CanonicalAstParseError (static intent path, B-011 regression)", { timeout: 30_000 }, async () => {
     // Read the demo target itself — self-referential but deliberate: the parser
     // is the subject of the v0.7 demo and its source is well-typed MIT content.
     // @decision DEC-WI026-FILEURLTOPATH-001 — use fileURLToPath instead of URL.pathname.


### PR DESCRIPTION
## Summary

Two related CI-gate cleanups, both small and non-source.

## 1. mri-demo Test B timeout (closes #51)

`examples/v0.7-mri-demo/test/acceptance.test.ts` Test B reliably takes ~5s on the static-intent `universalize()` path. The default 5s vitest timeout was flaking. Bumped to 30s — same scale used by other slow integration tests in the workspace.

The test logic is correct; this is purely a timeout adjustment to match the test's actual cost.

## 2. Bootstrap workflow fast-skip cache

The bootstrap manifest is a deterministic function of:

- every `.ts` file under `packages/*/src` and `examples/*/src` (shave inputs + the shave pipeline itself)
- `bootstrap/expected-roots.json` (the verify target)
- `pnpm-lock.yaml` (transitive deps)

If we've already byte-verified the manifest for an exact input hash on a previous run, re-running the 30-60-minute shave produces a bit-identical result by construction. The new workflow:

1. Computes a SHA-256 hash of all those inputs.
2. Looks up `bootstrap/.verified-marker` in the GitHub Actions cache, keyed on that hash.
3. **On cache hit**: skips `pnpm install`, the full `-r build`, and the verify step entirely. Logs the cached marker (which run + commit produced the verification).
4. **On cache miss**: runs the existing slow path unchanged, then writes a marker recording the input hash, timestamp, commit, and ref.

### Correctness

- **Over-hashing is safe, under-hashing isn't.** The hash deliberately includes files the bootstrap walker would filter at runtime (test files, fixtures). Over-hashing → benign cache misses. Under-hashing → false hits → undetected drift, which is unacceptable.
- **Markers only written after success.** A failed verify never writes the marker, so a failed run never poisons the cache for future runs at the same input hash.
- **First-run-after-merge does the full work.** The first push to main with new sources is always a cache miss → full verify → marker written. Subsequent runs at that exact input state (e.g. PRs that don't touch source) hit the cache.

### Expected impact

- PRs that touch only docs/CI/test files (with no `.ts` source change): bootstrap workflow ~30s instead of 30-60min.
- PRs that touch source files: full verify still runs (correct behavior).
- Push to main after merging a source-changing PR: full verify on first run, then any rerun against the same source state hits the cache.

## Test plan

- [x] `pnpm --filter v0.7-mri-demo test` — 12/12 pass with the new 30s timeout
- [x] Hash computation tested locally — produces deterministic 64-hex digest covering 209 packages source files + 5 examples source files + lockfile + expected-roots.json
- [ ] Workflow fast-skip path will be exercised on the second push that doesn't touch source — first push to main lands the cache infrastructure itself, second push verifies the skip works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018RFmeHWE8TTDvzT8PeotLq)_