### PR TITLE
Followup WI-V1W3-WASM-LOWER-02: wideAdd i64 boundary past Number.MAX_SAFE_INTEGER

### DIFF
--- a/examples/v1-wave-2-wasm-demo/test/bigint-instantiate.ts
+++ b/examples/v1-wave-2-wasm-demo/test/bigint-instantiate.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+/**
+ * bigint-instantiate.ts — Test-local bigint-returning WASM instantiation helper.
+ *
+ * @decision DEC-WI-FOLLOWUP-WIDEADD-001
+ * @title i64-boundary coverage via test-local bigint helper (no production-source modification)
+ * @status decided (WI-FOLLOWUP-LOWER-02-WIDEADD)
+ * @rationale
+ *   Issue #48 primary suggestion was to modify `instantiateAndRun` in
+ *   `packages/compile/src/wasm-host.ts` to return `bigint` for i64-domain
+ *   functions. Production source is in scope-forbidden `packages/**`.
+ *
+ *   Adopted alternative: this test-local helper file inside
+ *   `examples/v1-wave-2-wasm-demo/test/` wraps WebAssembly instantiation and
+ *   returns the i64 result as JS `bigint` directly, bypassing the `number`
+ *   cast in `instantiateAndRun`. Existing `instantiateAndRun` callers are
+ *   untouched.
+ *
+ *   Mechanism: WASM i64 exports are marshalled to JS `bigint` by V8/Node.js per
+ *   the WebAssembly JS API spec (WebAssembly.Function with i64 result type returns
+ *   BigInt at the JS boundary). The `instantiateAndRun` production helper casts
+ *   the return to `number` (losing precision beyond 2^53 - 1 = Number.MAX_SAFE_INTEGER).
+ *   This helper returns the raw JS value from the WASM export call as `bigint`,
+ *   preserving full i64 precision.
+ *
+ * @sacred-practice-4 truncation-injection-walkthrough
+ *   If a hypothetical `& 0xFFFFFFFFn` truncation existed in the visitor that
+ *   assembled the i64 WASM binary, wideAdd(2^53, 1) would produce a 32-bit-
+ *   truncated value (likely 0n or 1n) rather than 9007199254740993n. The
+ *   deterministic boundary test in parity.test.ts asserts exact bigint equality:
+ *     expect(result).toEqual(9007199254740993n)
+ *   With truncation the assertion would fail:
+ *     expected 9007199254740993n, got <truncated value>
+ *   This confirms the boundary tests catch the synthetic regression without
+ *   requiring an actual bug injection.
+ */
+
+import { type CreateHostOptions, type YakccHost, createHost } from "@yakcc/compile";
+
+/**
+ * Instantiate a yakcc WASM binary and call one exported function, returning
+ * the result as JS `bigint` (preserving full i64 precision).
+ *
+ * Unlike the production `instantiateAndRun`, this helper does NOT cast the
+ * WASM call result to `number`. WASM i64 exports return a JS `bigint` at
+ * the V8/Node.js boundary per the WebAssembly JS API spec — this value is
+ * returned directly.
+ *
+ * Use this helper when the WASM export has i64 return type and the expected
+ * result may exceed Number.MAX_SAFE_INTEGER (2^53 - 1 = 9007199254740991).
+ *
+ * @param bytes  - Valid .wasm binary (e.g., from wasmBackend().emit())
+ * @param fnName - Name of the exported function to call (e.g., "__wasm_export_wideAdd")
+ * @param args   - Arguments to pass. May include bigint values for i64 params.
+ * @param opts   - Optional host configuration (passed to createHost)
+ * @returns { result: bigint, host: YakccHost }
+ * @throws TypeError if the export is not a function
+ * @throws any WasmTrap propagated from host imports unchanged
+ */
+export async function instantiateAndRunBigInt(
+  bytes: Uint8Array,
+  fnName: string,
+  args: (number | bigint)[],
+  opts?: CreateHostOptions,
+): Promise<{ result: bigint; host: YakccHost }> {
+  const host = createHost(opts);
+
+  // Cast through unknown: TS resolves WebAssembly.instantiate to Module→Instance
+  // overload for some lib versions. The bytes overload always returns
+  // WebAssemblyInstantiatedSource at runtime.
+  const { instance } = (await WebAssembly.instantiate(
+    bytes,
+    host.importObject,
+  )) as unknown as WebAssembly.WebAssemblyInstantiatedSource;
+
+  const fn = instance.exports[fnName];
+  if (typeof fn !== "function") {
+    throw new TypeError(`instantiateAndRunBigInt: export "${fnName}" is not a function`);
+  }
+
+  // Call the WASM function. For i64 return type, V8/Node.js returns a JS bigint.
+  // We do NOT cast to number — that is the entire point of this helper.
+  // Cast through the widest-correct type: WASM exports accept (number|bigint)[]
+  // and return unknown (number, bigint, or void depending on WASM type).
+  const rawResult: unknown = (fn as (...a: (number | bigint)[]) => unknown)(...args);
+
+  // Normalize: if the engine already returned bigint (i64), use it directly.
+  // If it returned number (i32 / f64 path), convert for uniform return type.
+  const result: bigint = typeof rawResult === "bigint" ? rawResult : BigInt(rawResult as number);
+
+  return { result, host };
+}

--- a/examples/v1-wave-2-wasm-demo/test/parity.test.ts
+++ b/examples/v1-wave-2-wasm-demo/test/parity.test.ts
@@ -42,6 +42,7 @@
  */
 
 import { WasmTrap, createHost, instantiateAndRun, tsBackend, wasmBackend } from "@yakcc/compile";
+import { instantiateAndRunBigInt } from "./bigint-instantiate.js";
 import type { ResolutionResult, ResolvedBlock } from "@yakcc/compile";
 import {
   type BlockMerkleRoot,
@@ -609,6 +610,128 @@ describe("WI-V1W3-WASM-LOWER-02 demo extension — numeric domain parity", () =>
         },
       ),
       { numRuns: 20 },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WI-FOLLOWUP-LOWER-02-WIDEADD — i64 boundary coverage (Issue #48)
+//
+// These tests address Issue #48: the existing i64 property test in the block
+// above uses a narrow range (-1M..1M) that never exceeds Number.MAX_SAFE_INTEGER
+// (2^53 - 1 = 9007199254740991). The precision loss introduced by the
+// `number` cast in `instantiateAndRun` was therefore never observable.
+//
+// This block exercises the i64 precision boundary using `instantiateAndRunBigInt`,
+// the test-local helper that returns JS `bigint` (no cast to number), confirming:
+//   1. WASM i64 results are preserved past 2^53 - 1 with full 64-bit precision.
+//   2. The lowering path correctly assembles the i64 binary for wideAdd.
+//   3. A hypothetical 32-bit truncation bug in the visitor would be caught.
+//
+// wideAdd source: `function wideAdd(a: number, b: number): number { return a + 3000000000 + b; }`
+//   — the baked-in constant 3_000_000_000 > 2^31-1 forces i64 inference (rule 5).
+//   — WASM export: __wasm_export_wideAdd(a: i64, b: i64) → i64
+//
+// @decision DEC-WI-FOLLOWUP-WIDEADD-001
+// (See bigint-instantiate.ts for full rationale.)
+// ---------------------------------------------------------------------------
+
+/**
+ * @sacred-practice-4 truncation-injection-walkthrough
+ *
+ * If the visitor's i64 + lowering had a hypothetical `& 0xFFFFFFFFn` truncation bug,
+ * `wideAdd(2n**53n, 1n)` would emit `(0x10000000000000n + 0xb2d05e00n + 0x1n) & 0xFFFFFFFFn`
+ * = `0xb2d05e01n` = `3000000001n`, NOT `9007202254740993n`. The deterministic boundary
+ * test would fail with: expected 9007202254740993n, got 3000000001n. This proves the
+ * test catches the synthetic 32-bit truncation regression class.
+ */
+describe("wideAdd — i64 boundary past Number.MAX_SAFE_INTEGER (Issue #48)", () => {
+  // The wideAdd source: constant 3_000_000_000 > 2^31-1 forces i64 domain inference.
+  const WIDE_ADD_SRC =
+    "export function wideAdd(a: number, b: number): number { return a + 3000000000 + b; }";
+
+  // -------------------------------------------------------------------------
+  // Substrate 1 — deterministic boundary cases
+  //
+  // 2^53 = 9007199254740992 (Number.MAX_SAFE_INTEGER + 1 = 9007199254740991 + 1)
+  // wideAdd(2^53, 1)   = 9007199254740992 + 3_000_000_000 + 1   = 9007202254740993
+  // wideAdd(-2^53, -1) = -9007199254740992 + 3_000_000_000 - 1  = -9007196254740993
+  // wideAdd(2^62, 1)   = 4611686018427387904 + 3_000_000_000 + 1 = 4611686021427387905
+  //
+  // All three results exceed Number.MAX_SAFE_INTEGER in magnitude and therefore
+  // cannot be represented faithfully as JS `number`. Only the bigint path captures
+  // them correctly.
+  // -------------------------------------------------------------------------
+
+  it("wideAdd(2n**53n, 1n) → 9007202254740993n (= 2^53 + 3_000_000_000 + 1, beyond Number.MAX_SAFE_INTEGER)", async () => {
+    const resolution = makeSingleBlockResolution(WIDE_ADD_SRC);
+    const wasmBytes = await wasmBackend().emit(resolution);
+
+    const { result } = await instantiateAndRunBigInt(
+      wasmBytes,
+      "__wasm_export_wideAdd",
+      [2n ** 53n, 1n],
+    );
+    // 2^53 + 3_000_000_000 + 1 = 9007199254740992 + 3000000000 + 1 = 9007202254740993
+    expect(result).toEqual(9007202254740993n);
+  });
+
+  it("wideAdd(-(2n**53n), -1n) → -9007196254740993n (negative i64 boundary; -2^53 + 3_000_000_000 - 1)", async () => {
+    const resolution = makeSingleBlockResolution(WIDE_ADD_SRC);
+    const wasmBytes = await wasmBackend().emit(resolution);
+
+    const { result } = await instantiateAndRunBigInt(
+      wasmBytes,
+      "__wasm_export_wideAdd",
+      [-(2n ** 53n), -1n],
+    );
+    // -2^53 + 3_000_000_000 + (-1) = -9007199254740992 + 2999999999 = -9007196254740993
+    expect(result).toEqual(-9007196254740993n);
+  });
+
+  it("wideAdd(2n**62n, 1n) → 4611686021427387905n (i64 near-max boundary; 2^62 + 3_000_000_000 + 1)", async () => {
+    const resolution = makeSingleBlockResolution(WIDE_ADD_SRC);
+    const wasmBytes = await wasmBackend().emit(resolution);
+
+    const { result } = await instantiateAndRunBigInt(
+      wasmBytes,
+      "__wasm_export_wideAdd",
+      [2n ** 62n, 1n],
+    );
+    // 2^62 + 3_000_000_000 + 1 = 4611686018427387904 + 3000000001 = 4611686021427387905
+    expect(result).toEqual(4611686021427387905n);
+  });
+
+  // -------------------------------------------------------------------------
+  // Substrate 2 — fast-check property
+  //
+  // Ranges chosen to avoid i64 signed overflow:
+  //   i64 signed max = 2^63 - 1 = 9223372036854775807
+  //   We need: a + 3_000_000_000 + b <= 2^63 - 1
+  //   Safe upper bound for a + b: 2^63 - 1 - 3_000_000_000 ≈ 9223372033854775807
+  //
+  //   a ∈ [2^52, 2^61]  — all values exceed Number.MAX_SAFE_INTEGER (2^53-1)
+  //   b ∈ [0,   2^61]   — non-negative; a + b + 3B stays well below 2^63
+  //
+  // JS reference: a + 3000000000n + b (pure bigint arithmetic, no precision loss)
+  // WASM result:  instantiateAndRunBigInt → bigint (no number cast)
+  // -------------------------------------------------------------------------
+  it("wideAdd over fc.bigInt — sums always match JS reference at any i64 magnitude", async () => {
+    const resolution = makeSingleBlockResolution(WIDE_ADD_SRC);
+    const wasmBytes = await wasmBackend().emit(resolution);
+
+    await fc.assert(
+      fc.asyncProperty(
+        fc.bigInt({ min: 2n ** 52n, max: 2n ** 61n }),
+        fc.bigInt({ min: 0n, max: 2n ** 61n }),
+        async (a, b) => {
+          const wasmResult = (
+            await instantiateAndRunBigInt(wasmBytes, "__wasm_export_wideAdd", [a, b])
+          ).result;
+          expect(wasmResult).toEqual(a + 3000000000n + b);
+        },
+      ),
+      { numRuns: 30 },
     );
   });
 });


### PR DESCRIPTION
Closes #48