### PR TITLE
B-V2-05: Flatten hooks-base buildIntentCardQuery return type (closes #72)

### DIFF
--- a/packages/hooks-base/src/index.ts
+++ b/packages/hooks-base/src/index.ts
@@ -102,16 +102,21 @@ export interface HookOptions {
 // ---------------------------------------------------------------------------
 
 /**
+ * Shape returned by buildIntentCardQuery() — the IntentQuery card fields derived from an EmissionContext.
+ *
+ * Named to give the return type a single-token representation; the static intent extractor uses the
+ * function's return-type annotation as the behavior fallback when no JSDoc summary is present in the
+ * leaf source. A named type avoids a multi-line object literal in that fallback string.
+ */
+export type IntentCardQuery = { behavior: string; inputs: never[]; outputs: never[] };
+
+/**
  * Build the behavior string for the intent query passed to findCandidatesByIntent().
  *
  * Concatenates intent and sourceContext when the latter is present, matching
  * the query construction that was previously inlined in all three consumer hooks.
  */
-export function buildIntentCardQuery(ctx: EmissionContext): {
-  behavior: string;
-  inputs: never[];
-  outputs: never[];
-} {
+export function buildIntentCardQuery(ctx: EmissionContext): IntentCardQuery {
   const behavior = ctx.sourceContext ? `${ctx.intent} ${ctx.sourceContext}` : ctx.intent;
   return { behavior, inputs: [], outputs: [] };
 }


### PR DESCRIPTION
## Summary

Closes #72 (B-V2-05-HOOKS-BASE-INTENTCARD-001 — Flatten multi-line JSDoc behavior in hooks-base/src/index.ts).

## Root cause

Surfaced by WI-V2-05 (PR #71): adding the SPDX header advanced `yakcc bootstrap` past the `LicenseRefusedError` and unmasked a pre-existing `IntentCardSchemaError: field "behavior" must not contain newline characters` on `packages/hooks-base/src/index.ts`.

The actual mechanism (corrected from the issue body's "JSDoc paragraph" hypothesis): the shave slicer uses `node.getStart()` which **excludes leading JSDoc trivia**. So per-atom `staticExtract()` doesn't see the JSDoc; `behavior` falls back to `sig.signatureString` — the raw return-type text. `buildIntentCardQuery`'s function had a multi-line inline return type literal, so the signature string contained newlines and the schema check rejected it.

## Fix

Introduce named type alias `IntentCardQuery` (single-line) and use it as the function's return type. The signature string is now `function buildIntentCardQuery(ctx) -> IntentCardQuery` — a single line, passing the schema check.

Diff: 1 file, +10/-5. Refactor-only — function body byte-identical, runtime semantics unchanged.

## Test plan

- [x] `pnpm --filter @yakcc/hooks-base build` clean
- [x] `pnpm --filter @yakcc/hooks-base test` — 18/18 pass
- [x] `pnpm -r build` clean
- [x] `pnpm -r test` clean (no downstream regression)
- [x] IDE adapters (`hooks-claude-code`, `hooks-cursor`, `hooks-codex`) all pass
- [x] `yakcc bootstrap` post-fix: SUCCESS=138, FAIL=2 — `hooks-base/src/index.ts` SUCCESS, hooks-base IntentCardSchemaError gone
- [x] Reviewer signoff: `ready_for_guardian` with root cause independently reproduced via direct `staticExtract` on pre/post atom source

## Notes

Two failures remain in bootstrap, both unrelated to this WI:
1. `examples/v0.7-mri-demo/src/gpl-fixture.ts` — intentional GPL fixture (expected; never closes).
2. `packages/contracts/src/contract-id.props.ts` — pre-existing `DidNotReachAtomError` from merged PR #80 (WI-V2-06 L1). Will file as a separate backlog issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)