### PR TITLE
fix(visitor): align lowerModule LoweringContext with post-PR-#88 field set (hot-fix for PR #89 build break)

### DIFF
--- a/packages/compile/src/wasm-lowering/visitor.ts
+++ b/packages/compile/src/wasm-lowering/visitor.ts
@@ -4309,8 +4309,13 @@ export class LoweringVisitor {
       locals: [],
       blockDepth: 0,
       loopNestDepth: 0,
-      stringIterImportIdx: 9,
+      // WI-08 followup (closes #82): codepoint import indices in the string import section.
+      // See buildStringImportSection() in wasm-backend.ts for the index layout.
+      codepointAtImportIdx: 9,
+      codepointNextOffsetImportIdx: 10,
       stringEqImportIdx: 8,
+      usesForOfString: false,
+      usesStringSwitch: false,
       funcIndexTable,
       importedFuncCount,
     };


### PR DESCRIPTION
## Hot-fix

PR #89 (WI-V1W3-WASM-LOWER-09 calls, merge `87fada3`) shipped to main with a build-breaking reference to the obsolete `LoweringContext.stringIterImportIdx` field, which PR #88 had previously renamed/split into `codepointAtImportIdx` + `codepointNextOffsetImportIdx` + `usesForOfString` + `usesStringSwitch`.

## Root cause

PR #89 was cherry-picked onto current main during conflict resolution (the branch was authored before PR #85 + PR #88 landed). The 3-way merge correctly resolved 2 of 3 `LoweringContext` constructions but missed the 3rd — Wrath's new `lowerModule()` context creation at `visitor.ts:4312` — because that line wasn't a textual conflict (it was a fresh field, not a rename of an existing one). Local verify caught the build break and the fix was applied to the working tree, but **the fix was never staged or committed before the force-push** to PR #89's branch. So `87fada3` shipped without it.

## What this commit does

Replaces line 4312's `stringIterImportIdx: 9,` with the post-#88 field set:
```diff
-      stringIterImportIdx: 9,
+      // WI-08 followup (closes #82): codepoint import indices in the string import section.
+      // See buildStringImportSection() in wasm-backend.ts for the index layout.
+      codepointAtImportIdx: 9,
+      codepointNextOffsetImportIdx: 10,
       stringEqImportIdx: 8,
+      usesForOfString: false,
+      usesStringSwitch: false,
```

Identical to the fix already applied to the other two `LoweringContext` constructions in PR #89's conflict resolution. No semantic change vs the intent of either PR #88 or PR #89.

## Test plan

- [x] `pnpm --filter @yakcc/compile build` — clean
- [ ] CI verifies the rest

## Process note

Bad orchestrator hygiene on my part — I edited the working tree, ran build + tests against the edited tree, and then pushed without staging the edit. The local verify lied about what was being shipped. Going forward: always `git status` between local verify and push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018RFmeHWE8TTDvzT8PeotLq)_