### PR TITLE
tighten arr-2 bounds-check trap assertions to WasmTrap + panic code (closes #76)

### DIFF
--- a/packages/compile/test/wasm-lowering/arrays.test.ts
+++ b/packages/compile/test/wasm-lowering/arrays.test.ts
@@ -90,7 +90,7 @@ import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import type { ResolutionResult, ResolvedBlock } from "../../src/resolve.js";
 import { compileToWasm } from "../../src/wasm-backend.js";
-import { createHost } from "../../src/wasm-host.js";
+import { WasmTrap, createHost } from "../../src/wasm-host.js";
 
 // ---------------------------------------------------------------------------
 // Fixture helpers (mirrors records.test.ts pattern)
@@ -364,10 +364,13 @@ describe("arr-2: index access arr[i] with bounds check", () => {
       cap: number,
       i: number,
     ) => number;
-    // Index 3 is length, which is >= length (0-indexed) — should trap
-    expect(() => fn(ptr, length, capacity, 3)).toThrow();
-    // Negative-cast large index also traps (i32.ge_u treats 0xFFFFFFFF >= any length)
-    expect(() => fn(ptr, length, capacity, -1)).toThrow();
+    // Index 3 is length, which is >= length (0-indexed) — should trap.
+    // Must be a WasmTrap (execute-time WASM trap), not a JS error or module-validation failure.
+    // A regression where the bounds check is removed and the module fails at instantiate-time
+    // would throw a generic Error, not a WasmTrap, so this assertion catches that class.
+    expect(() => fn(ptr, length, capacity, 3)).toThrow(WasmTrap);
+    // Negative-cast large index also traps (i32.ge_u treats 0xFFFFFFFF >= any length).
+    expect(() => fn(ptr, length, capacity, -1)).toThrow(WasmTrap);
   });
 });
 

--- a/packages/compile/test/wasm-lowering/arrays.test.ts
+++ b/packages/compile/test/wasm-lowering/arrays.test.ts
@@ -364,13 +364,21 @@ describe("arr-2: index access arr[i] with bounds check", () => {
       cap: number,
       i: number,
     ) => number;
-    // Index 3 is length, which is >= length (0-indexed) — should trap.
-    // Must be a WasmTrap (execute-time WASM trap), not a JS error or module-validation failure.
-    // A regression where the bounds check is removed and the module fails at instantiate-time
-    // would throw a generic Error, not a WasmTrap, so this assertion catches that class.
-    expect(() => fn(ptr, length, capacity, 3)).toThrow(WasmTrap);
-    // Negative-cast large index also traps (i32.ge_u treats 0xFFFFFFFF >= any length).
-    expect(() => fn(ptr, length, capacity, -1)).toThrow(WasmTrap);
+    // Index 3 is >= length (0-indexed) — must trap via host_panic(0x04) (oob_memory)
+    // @decision DEC-V1-WAVE-3-WASM-LOWER-ARRAY-BOUNDS-CHECK-001: OOB index → host_panic(0x04)
+    for (const oobIndex of [3, -1]) {
+      let caught: unknown;
+      try {
+        fn(ptr, length, capacity, oobIndex);
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(WasmTrap);
+      // Verify this is specifically the bounds-check panic (0x04), not OOM (0x01)
+      // or any other host_panic code — prevents silent regression if the bounds
+      // check is removed and the module fails to validate instead.
+      expect((caught as WasmTrap).hostPanicCode).toBe(0x04);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Replaced bare `.toThrow()` on both arr-2 out-of-bounds assertions with a try-catch pattern that checks both the error type and the specific panic code.
- Verifies the thrown error is a `WasmTrap` (execute-time WASM host trap), not a generic JS error or a module-validation failure — catches the silent-regression class where a removed bounds check causes instantiation to fail instead.
- Verifies `hostPanicCode === 0x04` (the OOB panic code per `DEC-V1-WAVE-3-WASM-LOWER-ARRAY-BOUNDS-CHECK-001`), distinguishing a bounds-check trap from an OOM trap (`0x01`) or any other panic source.
- Added `WasmTrap` to the import from `../../src/wasm-host.js` (native `WebAssembly.RuntimeError` is not used — the host wraps all traps as `WasmTrap`).

## Test evidence

```
 RUN  v4.1.5 /home/user/yakcc/packages/compile

 Test Files  1 passed (1)
      Tests  31 passed (31)
   Start at  09:14:40
   Duration  5.62s (transform 275ms, setup 0ms, import 874ms, tests 4.61s, environment 0ms)
```

Closes #76

🤖 Picked up by FuckGoblin