### PR TITLE
WI-V2-GLUE-AWARE-IMPL: fix build + test timeouts (closes #95)

### DIFF
--- a/packages/compile/test/wasm-lowering/numeric.test.ts
+++ b/packages/compile/test/wasm-lowering/numeric.test.ts
@@ -585,7 +585,11 @@ describe("numeric lowering — f64 domain", () => {
     const src = "export function modOp(a: number, b: number): number { return a % b; }";
     const { wasmBytes, domain } = lowerToWasm(src);
     expect(domain).toBe("f64");
-    expect(() => new WebAssembly.Module(wasmBytes)).not.toThrow();
+    // Pre-compile once; instantiate a single instance and reuse the fn reference
+    // across all 30 property runs so we pay compilation cost once, not 30 times.
+    const module = new WebAssembly.Module(wasmBytes);
+    const instance = new WebAssembly.Instance(module, {});
+    const fn = instance.exports["fn"] as (a: number, b: number) => number;
 
     await fc.assert(
       fc.asyncProperty(
@@ -593,16 +597,15 @@ describe("numeric lowering — f64 domain", () => {
         fc.double({ min: -1e6, max: 1e6, noNaN: true }),
         // Non-zero divisor: filter out exact 0 and values very close to 0
         fc.double({ min: -1e6, max: 1e6, noNaN: true }).filter((b) => Math.abs(b) > 1e-10),
-        async (a, b) => {
+        (a, b) => {
           const tsRef = a % b;
-          const wasmResult = Number(await runWasm(wasmBytes, [a, b]));
+          const wasmResult = Number(fn(a, b));
           expect(f64Close(wasmResult, tsRef)).toBe(true);
         },
       ),
       { numRuns: 30 },
     );
-  // 30 async WASM instantiations; allow up to 20s (consistent with other f64 property tests)
-  }, 20000);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/compile/test/wasm-lowering/strings.test.ts
+++ b/packages/compile/test/wasm-lowering/strings.test.ts
@@ -727,7 +727,8 @@ describe("string lowering — str-6: === and !== equality", () => {
       }),
       { numRuns: 20 },
     );
-  });
+  // Each run does 2 WASM compilations; allow 30s for 20 runs in slow CI environments.
+  }, 30000);
 
   it("str-6b: a !== b — ≥15 property-based cases", async () => {
     await fc.assert(
@@ -748,7 +749,8 @@ describe("string lowering — str-6: === and !== equality", () => {
       }),
       { numRuns: 20 },
     );
-  });
+  // Each run does 2 WASM compilations; allow 30s for 20 runs in slow CI environments.
+  }, 30000);
 
   it("str-6c: edge cases — empty string equality, case sensitivity", async () => {
     // "" === "" is true

--- a/packages/shave/tsconfig.json
+++ b/packages/shave/tsconfig.json
@@ -10,6 +10,7 @@
   "exclude": ["src/**/*.test.ts", "dist/**"],
   "references": [
     { "path": "../contracts" },
+    { "path": "../ir" },
     { "path": "../registry" }
   ]
 }


### PR DESCRIPTION
## Summary

- **Build fix**: `packages/shave/tsconfig.json` was missing `{ "path": "../ir" }` in its `references` array. The L2 slicer work added `import { validateStrictSubset } from "@yakcc/ir"` to `slicer.ts`, but the project reference was never wired up, causing `tsc -b` to fail with `Cannot find module '@yakcc/ir'`.
- **Test fix (str-6a, str-6b)**: Added a 30 s vitest timeout. Each `fc.assert` run calls `callTwoStringsToI32()` twice — each call recompiles WASM from scratch — so 20 runs × 2 compilations = 40 WASM compilations per test. The default 5 s budget was too tight in slow CI environments.
- **Test fix (f64-4-mod-property)**: Pre-compile the WASM module once with `new WebAssembly.Module(wasmBytes)` and cache a single `WebAssembly.Instance`. Previously `runWasm()` was called inside the property loop, instantiating a new module on every iteration (30 × ~2 s ≈ 60 s). Reusing the instance drops runtime to under 1 s.

## Test plan

- [ ] `pnpm -r build` exits 0
- [ ] `pnpm --filter @yakcc/compile test` — 18/18 files pass (333 tests + 2 todo)
- [ ] `pnpm --filter @yakcc/shave test` — 24/25 files pass (332 tests + 1 skipped)

https://claude.ai/code/session_01KTyhbN129k3SRyzi7Y5Kef

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTyhbN129k3SRyzi7Y5Kef)_