### PR TITLE
WI-V2-07-PREFLIGHT-L8: wire *.props.ts corpus into bootstrap property_tests extraction (closes #101)

### DIFF
--- a/packages/cli/src/commands/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap.ts
@@ -98,6 +98,7 @@ function shouldSkip(absPath: string): boolean {
 
   // Skip by filename
   if (basename.endsWith(".test.ts")) return true;
+  if (basename.endsWith(".props.ts")) return true;
   if (basename.endsWith(".d.ts")) return true;
   if (basename === "vitest.config.ts") return true;
 

--- a/packages/shave/src/corpus/index.test.ts
+++ b/packages/shave/src/corpus/index.test.ts
@@ -2,26 +2,29 @@
 // title: Corpus extraction unit tests: determinism, cache seeding, priority chain, cascade, and error path
 // status: decided (WI-016)
 // rationale:
-//   Six tests cover the full contract of the corpus extraction module:
+//   Eight tests cover the full contract of the corpus extraction module:
 //   (1) upstream-test determinism, (2) documented-usage determinism,
 //   (3) ai-derived cache cold/warm, (4) priority order a>b>c,
-//   (5) cascade variant (a+b disabled → c), (6) all-disabled error.
+//   (5) cascade variant (a+b disabled → c), (6) all-disabled error,
+//   (7) extractFromPropsFile (match/no-match/missing-file),
+//   (8) props-file priority over upstream-test in extractCorpus().
 //   DEC-SHAVE-002: no Anthropic SDK import; cache is seeded via public seedCorpusCache.
 //   DEC-SHAVE-003: seedCorpusCache is the only authority for priming the AI-derived cache.
 
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { extractFromAiDerivedCached } from "./ai-derived.js";
 import { extractFromDocumentedUsage } from "./documented-usage.js";
 import {
   extractCorpus,
   extractCorpusCascade,
+  extractFromPropsFile,
   seedCorpusCache,
 } from "./index.js";
 import type { CorpusAtomSpec, IntentCardInput } from "./types.js";
 import { extractFromUpstreamTest } from "./upstream-test.js";
-import { extractFromAiDerivedCached } from "./ai-derived.js";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -265,5 +268,115 @@ describe("extractCorpus() — all-sources-disabled error", () => {
         enableAiDerived: false,
       }),
     ).rejects.toThrow("all enabled sources failed or were disabled");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 7: extractFromPropsFile — match, no-match, missing-file
+// ---------------------------------------------------------------------------
+
+/** Props file content containing a prop_parseIntList_ export (matching PLAIN_SOURCE). */
+const PROPS_FILE_CONTENT = `// Hand-authored fast-check property tests
+import * as fc from "fast-check";
+
+export const prop_parseIntList_returns_array = fc.property(
+  fc.array(fc.integer()),
+  (nums) => {
+    const raw = nums.join(",");
+    const result = parseIntList(raw);
+    return Array.isArray(result);
+  },
+);
+`;
+
+describe("extractFromPropsFile()", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(os.tmpdir(), "yakcc-props-file-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns a CorpusResult with source='props-file' when the file has a matching prop_<atomName>_ export", async () => {
+    const propsPath = join(tmpDir, "parseIntList.props.ts");
+    writeFileSync(propsPath, PROPS_FILE_CONTENT, "utf-8");
+
+    const result = await extractFromPropsFile(propsPath, makeIntentCard(), PLAIN_SOURCE);
+
+    expect(result).not.toBeUndefined();
+    expect(result!.source).toBe("props-file");
+    expect(result!.bytes).toBeInstanceOf(Uint8Array);
+    expect(result!.bytes.length).toBeGreaterThan(0);
+    expect(result!.path).toBe("parseIntList.props.ts");
+    expect(result!.contentHash.length).toBeGreaterThan(0);
+  });
+
+  it("returns undefined when the props file has no matching prop_<atomName>_ export", async () => {
+    const propsPath = join(tmpDir, "other.props.ts");
+    writeFileSync(propsPath, "export const prop_unrelatedFunction_foo = true;\n", "utf-8");
+
+    const result = await extractFromPropsFile(propsPath, makeIntentCard(), PLAIN_SOURCE);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when the props file does not exist", async () => {
+    const result = await extractFromPropsFile(
+      join(tmpDir, "nonexistent.props.ts"),
+      makeIntentCard(),
+      PLAIN_SOURCE,
+    );
+
+    expect(result).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 8: props-file takes priority over upstream-test in extractCorpus()
+// ---------------------------------------------------------------------------
+
+describe("extractCorpus() — props-file priority over upstream-test", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(os.tmpdir(), "yakcc-props-priority-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns props-file result (source 0) when propsFilePath has a matching export, even with enableUpstreamTest=true", async () => {
+    const propsPath = join(tmpDir, "parseIntList.props.ts");
+    writeFileSync(propsPath, PROPS_FILE_CONTENT, "utf-8");
+
+    const atomSpec: CorpusAtomSpec = {
+      source: PLAIN_SOURCE,
+      intentCard: makeIntentCard(),
+      propsFilePath: propsPath,
+    };
+
+    const result = await extractCorpus(atomSpec);
+
+    expect(result.source).toBe("props-file");
+    expect(new TextDecoder().decode(result.bytes)).toBe(PROPS_FILE_CONTENT);
+  });
+
+  it("falls through to upstream-test when propsFilePath has no matching export", async () => {
+    const propsPath = join(tmpDir, "other.props.ts");
+    writeFileSync(propsPath, "export const prop_unrelatedFunction_foo = true;\n", "utf-8");
+
+    const atomSpec: CorpusAtomSpec = {
+      source: PLAIN_SOURCE,
+      intentCard: makeIntentCard(),
+      propsFilePath: propsPath,
+    };
+
+    const result = await extractCorpus(atomSpec);
+
+    expect(result.source).toBe("upstream-test");
   });
 });

--- a/packages/shave/src/corpus/index.ts
+++ b/packages/shave/src/corpus/index.ts
@@ -33,9 +33,11 @@ export {
   CORPUS_DEFAULT_MODEL,
   CORPUS_PROMPT_VERSION,
 } from "./ai-derived.js";
+export { extractFromPropsFile } from "./props-file.js";
 
 import { extractFromAiDerivedCached } from "./ai-derived.js";
 import { extractFromDocumentedUsage } from "./documented-usage.js";
+import { extractFromPropsFile } from "./props-file.js";
 import type { CorpusAtomSpec, CorpusExtractionOptions, CorpusResult } from "./types.js";
 import { extractFromUpstreamTest } from "./upstream-test.js";
 
@@ -66,9 +68,24 @@ export async function extractCorpus(
   atomSpec: CorpusAtomSpec,
   options?: CorpusExtractionOptions,
 ): Promise<CorpusResult> {
+  const enableP = options?.enablePropsFile ?? true;
   const enableA = options?.enableUpstreamTest ?? true;
   const enableB = options?.enableDocumentedUsage ?? true;
   const enableC = options?.enableAiDerived ?? true;
+
+  // Source (0): props-file — hand-authored *.props.ts sibling.
+  // Highest priority. Only attempted when propsFilePath is provided.
+  // Returns undefined if the file is absent or has no matching prop_<atomName>_ export.
+  if (enableP && atomSpec.propsFilePath !== undefined) {
+    const result = await extractFromPropsFile(
+      atomSpec.propsFilePath,
+      atomSpec.intentCard,
+      atomSpec.source,
+    );
+    if (result !== undefined) {
+      return result;
+    }
+  }
 
   // Source (a): upstream-test adaptation.
   // Always succeeds (pure, deterministic). Attempted first.
@@ -128,9 +145,22 @@ export async function extractCorpusCascade(
   atomSpec: CorpusAtomSpec,
   options?: CorpusExtractionOptions,
 ): Promise<CorpusResult> {
+  const enableP = options?.enablePropsFile ?? true;
   const enableA = options?.enableUpstreamTest ?? true;
   const enableB = options?.enableDocumentedUsage ?? true;
   const enableC = options?.enableAiDerived ?? true;
+
+  // Source (0): props-file — hand-authored *.props.ts sibling (highest priority).
+  if (enableP && atomSpec.propsFilePath !== undefined) {
+    const result = await extractFromPropsFile(
+      atomSpec.propsFilePath,
+      atomSpec.intentCard,
+      atomSpec.source,
+    );
+    if (result !== undefined) {
+      return result;
+    }
+  }
 
   // Source (a): upstream-test adaptation (always succeeds when enabled).
   if (enableA) {

--- a/packages/shave/src/corpus/props-file.ts
+++ b/packages/shave/src/corpus/props-file.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-07-PREFLIGHT-L8-001
+// title: props-file extraction uses name-based prop_<atom>_<property> mapping, whole-file corpus
+// status: accepted (WI-V2-07-PREFLIGHT L8)
+// rationale:
+//   When a sibling *.props.ts file exists alongside the source file being shaved,
+//   and it contains at least one `export const prop_<atomName>_` export matching the
+//   atom's function name, the entire .props.ts file is used as the corpus artifact.
+//   This is "source (0)" in the priority chain — it takes precedence over all
+//   auto-generated sources (upstream-test, documented-usage, ai-derived) because
+//   hand-authored fast-check properties are always higher quality than generated stubs.
+//
+//   Whole-file strategy: the entire .props.ts file is emitted as-is rather than
+//   filtering to only the matching prop_<atomName>_* exports. This preserves shared
+//   arbitraries, helper functions, and imports that multiple property exports depend on.
+//
+//   Name inference: the atom name is inferred from the source text by matching the
+//   first `function <name>` or `const <name> =` declaration. This mirrors the logic
+//   in upstream-test.ts (inferFunctionName). If no name can be inferred, the source
+//   returns undefined (no match).
+
+import { readFile } from "node:fs/promises";
+import { blake3 } from "@noble/hashes/blake3";
+import { bytesToHex } from "@noble/hashes/utils";
+import type { CorpusResult, IntentCardInput } from "./types.js";
+
+const encoder = new TextEncoder();
+
+/**
+ * Attempt to infer the primary function name from a source string.
+ *
+ * Mirrors inferFunctionName() in upstream-test.ts — looks for the first
+ * `function <name>` or `const/let/var <name> =` declaration.
+ */
+function inferFunctionName(source: string): string | undefined {
+  const fnMatch = source.match(/(?:^|\s)function\s+([a-zA-Z_$][a-zA-Z0-9_$]*)/);
+  if (fnMatch?.[1]) return fnMatch[1];
+
+  const constMatch = source.match(/(?:^|\s)(?:const|let|var)\s+([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+  if (constMatch?.[1]) return constMatch[1];
+
+  return undefined;
+}
+
+/**
+ * Extract a property-test corpus from a sibling *.props.ts file.
+ *
+ * This is corpus extraction source (0): props-file. It takes priority over all
+ * auto-generated sources (upstream-test, documented-usage, ai-derived).
+ *
+ * Returns undefined when:
+ *   - The props file does not exist (ENOENT or other read error).
+ *   - No function name can be inferred from the atom source.
+ *   - The props file contains no `export const prop_<atomName>_` exports.
+ *
+ * When successful, returns a CorpusResult whose bytes are the entire props file
+ * content (UTF-8 encoded) and whose path is `<atomName>.props.ts`.
+ *
+ * @param propsFilePath - Absolute path to the sibling *.props.ts file.
+ * @param _intentCard   - The intent card (unused; reserved for future filtering).
+ * @param source        - The raw source text of the atom (used for name inference).
+ * @returns A CorpusResult with source="props-file", or undefined on no match.
+ */
+export async function extractFromPropsFile(
+  propsFilePath: string,
+  _intentCard: IntentCardInput,
+  source: string,
+): Promise<CorpusResult | undefined> {
+  let fileContent: string;
+  try {
+    fileContent = await readFile(propsFilePath, "utf-8");
+  } catch {
+    return undefined;
+  }
+
+  const atomName = inferFunctionName(source);
+  if (atomName === undefined) return undefined;
+
+  // Check that the props file contains at least one prop_<atomName>_ export.
+  if (!new RegExp(`(?:^|[\\s;])export\\s+const\\s+prop_${atomName}_`).test(fileContent)) {
+    return undefined;
+  }
+
+  const bytes = encoder.encode(fileContent);
+  return {
+    source: "props-file",
+    bytes,
+    path: `${atomName}.props.ts`,
+    contentHash: bytesToHex(blake3(bytes)),
+  };
+}

--- a/packages/shave/src/corpus/types.ts
+++ b/packages/shave/src/corpus/types.ts
@@ -18,10 +18,14 @@
 /**
  * Which extraction source produced this corpus result.
  *
- * Priority order: upstream-test > documented-usage > ai-derived.
+ * Priority order: props-file > upstream-test > documented-usage > ai-derived.
  * The highest-priority available source wins; the rest are not consulted.
+ *
+ * "props-file": hand-authored *.props.ts sibling file (WI-V2-07-PREFLIGHT L8).
+ *   Takes priority over all auto-generated sources. Only available when a sibling
+ *   *.props.ts file exists and contains a matching prop_<atomName>_ export.
  */
-export type CorpusSource = "upstream-test" | "documented-usage" | "ai-derived";
+export type CorpusSource = "props-file" | "upstream-test" | "documented-usage" | "ai-derived";
 
 /**
  * The output of extractCorpus() for a single atom.
@@ -72,6 +76,14 @@ export interface CorpusAtomSpec {
    * Omitting this disables source (c).
    */
   readonly cacheDir?: string | undefined;
+
+  /**
+   * Absolute path to a sibling *.props.ts file for source (0) props-file extraction.
+   * When provided, extractCorpus() attempts to read this file and match prop_<atomName>_
+   * exports before trying any auto-generated source. Omitting this disables source (0).
+   * Set to `undefined` when no sibling .props.ts is available (WI-V2-07-PREFLIGHT L8).
+   */
+  readonly propsFilePath?: string | undefined;
 }
 
 /**
@@ -105,10 +117,15 @@ export interface IntentCardInput {
 /**
  * Options controlling which sources are attempted by extractCorpus().
  *
- * By default all three sources are enabled. Disable individual sources for
+ * By default all sources are enabled. Disable individual sources for
  * testing or to force a specific extraction path.
  */
 export interface CorpusExtractionOptions {
+  /**
+   * Whether to attempt props-file extraction (source 0).
+   * Default: true. Only takes effect when atomSpec.propsFilePath is provided.
+   */
+  readonly enablePropsFile?: boolean | undefined;
   /**
    * Whether to attempt upstream-test adaptation (source a).
    * Default: true.

--- a/packages/shave/src/index.ts
+++ b/packages/shave/src/index.ts
@@ -754,6 +754,7 @@ export async function shave(
       const merkleRoot = await maybePersistNovelGlueAtom(entry, registry, {
         ...options,
         parentBlockRoot,
+        sourceFilePath: sourcePath,
       });
       merkleRoots.push(merkleRoot);
       if (merkleRoot !== undefined) {

--- a/packages/shave/src/persist/atom-persist.ts
+++ b/packages/shave/src/persist/atom-persist.ts
@@ -76,6 +76,20 @@ export interface PersistOptions {
    * part of the block's content address — it is registry row metadata only.
    */
   readonly parentBlockRoot?: BlockMerkleRoot | null | undefined;
+
+  /**
+   * Absolute path of the source file being shaved (WI-V2-07-PREFLIGHT L8).
+   *
+   * When provided, persistNovelGlueAtom derives the sibling *.props.ts path by
+   * replacing the .ts extension with .props.ts and passes it to extractCorpus()
+   * as atomSpec.propsFilePath. This enables props-file corpus source (0) — the
+   * highest-priority source — when a sibling .props.ts exists and contains a
+   * matching prop_<atomName>_ export.
+   *
+   * When omitted, source (0) is silently skipped and extraction falls through to
+   * upstream-test (a), documented-usage (b), and ai-derived (c) in priority order.
+   */
+  readonly sourceFilePath?: string | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -113,10 +127,16 @@ export async function persistNovelGlueAtom(
   // The corpus result carries the artifact bytes that become the "property_tests"
   // entry in the ProofManifest, making the BlockMerkleRoot content-dependent on
   // the actual test corpus (not empty bytes).
+  //
+  // WI-V2-07-PREFLIGHT L8: derive sibling .props.ts path from sourceFilePath.
+  // When sourceFilePath is provided, replace the .ts extension with .props.ts
+  // so that extractCorpus() can attempt source (0) props-file extraction first.
+  const propsFilePath = options?.sourceFilePath?.replace(/\.ts$/, ".props.ts");
   const atomSpec: CorpusAtomSpec = {
     source: entry.source,
     intentCard,
     cacheDir: options?.cacheDir,
+    propsFilePath,
   };
   const corpusResult = await extractCorpus(atomSpec, options?.corpusOptions);
 


### PR DESCRIPTION
## Summary

- **New corpus source (0) `props-file`** — highest-priority in `extractCorpus()` / `extractCorpusCascade()` chain. `extractFromPropsFile(propsFilePath, intentCard, atomSource)` reads the sibling `*.props.ts`, finds `prop_<atomName>_*` exports via name-based convention, returns the full file as corpus bytes when ≥1 match exists. Falls through to upstream-test (source a) when no match.
- **Type surface additions**: `CorpusSource` gains `"props-file"` variant; `CorpusAtomSpec.propsFilePath` and `CorpusExtractionOptions.enablePropsFile` added; `PersistOptions.sourceFilePath` added.
- **`shave()` wiring**: passes `sourceFilePath: sourcePath` into `maybePersistNovelGlueAtom` options; `atom-persist.ts` derives the sibling `.props.ts` path via `sourceFilePath.replace(/\.ts$/, ".props.ts")` and threads it into `CorpusAtomSpec.propsFilePath` before calling `extractCorpus()`.
- **Bootstrap walker fix**: `shouldSkip()` now excludes `*.props.ts` files — corpus files are not shaved as source atoms.

## Test evidence

```
 Test Files  24 passed | 1 skipped (25)
      Tests  337 passed | 1 skipped (338)   ← +5 new props-file tests
   Duration  ~59s

 Test Files  4 passed (4)
      Tests  79 passed (79)
```

New tests cover: `extractFromPropsFile` (match, no-match, missing-file) and priority chain in `extractCorpus()` (source 0 wins over source a; falls through when no matching export).

Closes #101

🤖 FuckGoblin

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkdBnYQPo4o5XZcj7PPhJh)_