### PR TITLE
Issue #116: flatten L3a + contract-id props.ts JSDoc summaries (closes #116)

### DIFF
--- a/packages/compile/src/assemble.props.ts
+++ b/packages/compile/src/assemble.props.ts
@@ -122,13 +122,11 @@ function makeAssembleStubRegistry(
 // ---------------------------------------------------------------------------
 
 /**
- * prop_assemble_artifact_shape
+ * assemble() returns a well-formed Artifact for a single-block registry.
  *
- * For a single-block registry with a simple export function impl, assemble()
- * returns an Artifact with:
- *   - source: a non-empty string
- *   - manifest.entry === the entry BlockMerkleRoot
- *   - manifest.entries.length === 1
+ * For a registry with one block and a simple export function impl, the
+ * returned Artifact has: source (non-empty string), manifest.entry ===
+ * entry BlockMerkleRoot, and manifest.entries.length === 1.
  *
  * Invariant (A2.6, A2.7): assemble() always returns a well-formed Artifact;
  * the manifest entry count matches the transitive block closure size.
@@ -151,9 +149,7 @@ export const prop_assemble_artifact_shape = fc.asyncProperty(
 );
 
 /**
- * prop_assemble_source_includes_header_comment
- *
- * The emitted source always starts with the "Assembled by @yakcc/compile" header.
+ * assemble() emitted source always starts with the yakcc/compile header comment.
  *
  * Invariant (A2.6, DEC-COMPILE-TS-BACKEND-001): tsBackend always prepends the
  * header comment; assemble() does not alter the backend's output.
@@ -175,10 +171,7 @@ export const prop_assemble_source_includes_header_comment = fc.asyncProperty(
 // ---------------------------------------------------------------------------
 
 /**
- * prop_assemble_throws_ResolutionError_for_missing_block
- *
- * When the entry BlockMerkleRoot is not in the registry, assemble() throws
- * a ResolutionError with kind="missing-block".
+ * assemble() throws ResolutionError with kind="missing-block" for absent entry root.
  *
  * Invariant (A2.6): assemble() propagates ResolutionError from resolveComposition()
  * unwrapped for the missing-block case.
@@ -202,10 +195,7 @@ export const prop_assemble_throws_ResolutionError_for_missing_block = fc.asyncPr
 // ---------------------------------------------------------------------------
 
 /**
- * prop_assemble_deterministic_byte_identical_reemit
- *
- * Two consecutive calls to assemble() with the same entry root and registry
- * produce byte-identical source strings.
+ * Two assemble() calls with the same registry and entry root are byte-identical.
  *
  * Invariant (A2.6, DEC-COMPILE-ASSEMBLE-003): given an unchanged registry,
  * selectBlocks returns the same ordered list, the same BlockMerkleRoot is chosen,
@@ -230,11 +220,11 @@ export const prop_assemble_deterministic_byte_identical_reemit = fc.asyncPropert
 // ---------------------------------------------------------------------------
 
 /**
- * prop_assemble_knownMerkleRoots_enables_sub_block_resolution
+ * knownMerkleRoots enables sub-block resolution via stem-to-SpecHash index.
  *
- * When knownMerkleRoots is supplied, assemble() pre-builds a stem → SpecHash index
- * and can resolve sub-block imports via selectBlocks. For a two-block graph where
- * the parent imports a child via "@yakcc/seeds/blocks/leaf", passing both roots as
+ * When knownMerkleRoots is supplied, assemble() pre-builds a stem → SpecHash
+ * index and resolves sub-block imports via selectBlocks. For a two-block graph
+ * where the parent imports a child via "@yakcc/seeds/blocks/leaf", both roots as
  * knownMerkleRoots enables the child to be found and included in the manifest.
  *
  * Invariant (A2.4, A2.5, A2.8): buildStemSpecHashIndex pre-fetches known roots;
@@ -274,18 +264,14 @@ export function entry(x: number): number { return x; }`;
 // ---------------------------------------------------------------------------
 
 /**
- * prop_importPathStem_seeds_prefix_extracts_stem
+ * importPathStem extracts the last segment from "@yakcc/seeds/blocks/<name>" paths.
  *
- * The private importPathStem function extracts the last path segment (without ".js")
- * from "@yakcc/seeds/blocks/<name>" import paths.
+ * Tested transitively via assemble(): when a block's implSource has an import
+ * from "@yakcc/seeds/blocks/<stem>" and knownMerkleRoots provides a block that
+ * exports a function named camelCase(stem), assemble() resolves the sub-block.
  *
- * Tested transitively: when a block's implSource has `import type { X } from
- * "@yakcc/seeds/blocks/<stem>"`, and knownMerkleRoots provides a block that exports
- * a function named `<camelCase(stem)>`, assemble() successfully builds the index and
- * resolves the sub-block reference.
- *
- * This property verifies the stem extraction is consistent with the camelCase
- * conversion by checking a simple case: stem "bracket" → fnName "bracket" (no hyphens).
+ * This property verifies stem extraction is consistent with the camelCase
+ * conversion: stem "bracket" → fnName "bracket" (no hyphens, trivial case).
  *
  * Invariant (A2.1, A2.2): importPathStem + stemToCamelCase must produce the same
  * identifier that extractFunctionName returns from the sub-block's implSource.

--- a/packages/compile/src/manifest.props.ts
+++ b/packages/compile/src/manifest.props.ts
@@ -136,17 +136,12 @@ function makeSingleBlockResolution(
 // ---------------------------------------------------------------------------
 
 /**
- * prop_buildManifest_single_block_shape
+ * buildManifest() returns a well-formed ProvenanceManifest for a single block.
  *
- * For a registry with exactly one block and no test history, buildManifest
- * returns a ProvenanceManifest where:
- *   - manifest.entry === resolution.entry
- *   - manifest.entries.length === 1
- *   - entries[0].blockMerkleRoot === entry root
- *   - entries[0].specHash === the block's specHash
- *   - entries[0].source === implSource
- *   - entries[0].subBlocks is an array (possibly empty)
- *   - entries[0].referencedForeign is an array
+ * For a registry with one block and no test history the manifest has:
+ * entry === resolution.entry, entries.length === 1, entries[0].blockMerkleRoot
+ * === root, entries[0].specHash, entries[0].source, and both subBlocks and
+ * referencedForeign are arrays.
  *
  * Invariant (A3.2, A3.3, A3.7): buildManifest populates all required
  * ProvenanceEntry fields for every block in the resolution.
@@ -180,10 +175,7 @@ export const prop_buildManifest_single_block_shape = fc.asyncProperty(
 // ---------------------------------------------------------------------------
 
 /**
- * prop_buildManifest_unverified_when_no_passing_history
- *
- * When the registry has no test history for a block (empty testHistory),
- * buildManifest sets verificationStatus to "unverified".
+ * buildManifest() sets verificationStatus to "unverified" when testHistory is empty.
  *
  * Invariant (A3.4): absence of a passing ProvenanceTestEntry → "unverified".
  * The sentinel empty provenance (testHistory: []) maps to "unverified".
@@ -203,9 +195,7 @@ export const prop_buildManifest_unverified_when_no_passing_history = fc.asyncPro
 );
 
 /**
- * prop_buildManifest_unverified_when_all_tests_failed
- *
- * When all test history entries have passed=false, verificationStatus is "unverified".
+ * buildManifest() is "unverified" when all test history entries have passed=false.
  *
  * Invariant (A3.4): "passing" requires at least one entry with passed===true;
  * all-false histories do not satisfy that condition.
@@ -230,10 +220,7 @@ export const prop_buildManifest_unverified_when_all_tests_failed = fc.asyncPrope
 // ---------------------------------------------------------------------------
 
 /**
- * prop_buildManifest_passing_when_at_least_one_passing_test
- *
- * When the registry has at least one ProvenanceTestEntry with passed=true,
- * buildManifest sets verificationStatus to "passing".
+ * buildManifest() sets verificationStatus to "passing" when any test entry passed.
  *
  * Invariant (A3.4): `some(entry => entry.passed)` → "passing".
  * The check is non-exclusive: one pass among many failures still yields "passing".
@@ -259,10 +246,7 @@ export const prop_buildManifest_passing_when_at_least_one_passing_test = fc.asyn
 // ---------------------------------------------------------------------------
 
 /**
- * prop_buildManifest_referencedForeign_is_always_array
- *
- * For every block, the referencedForeign field in the manifest entry is always
- * an array (never undefined, never null).
+ * buildManifest() referencedForeign is always an array, never undefined or null.
  *
  * Invariant (A3.5, DEC-COMPILE-MANIFEST-003, L4-I3): referencedForeign is a
  * required field. [] is the empty case for blocks with no foreign deps.
@@ -291,10 +275,7 @@ export const prop_buildManifest_referencedForeign_is_always_array = fc.asyncProp
 // ---------------------------------------------------------------------------
 
 /**
- * prop_buildManifest_entries_count_matches_order_length
- *
- * The number of entries in the manifest always equals the length of
- * ResolutionResult.order (one entry per resolved block, in order).
+ * buildManifest() entries count always equals ResolutionResult.order length.
  *
  * Invariant (A3.6): buildManifest iterates exactly over resolution.order;
  * no blocks are silently dropped or duplicated.
@@ -330,10 +311,7 @@ export const prop_buildManifest_entries_count_matches_order_length = fc.asyncPro
 );
 
 /**
- * prop_buildManifest_entry_field_matches_resolution_entry
- *
- * manifest.entry always equals resolution.entry, regardless of how many
- * blocks are in the resolution.
+ * buildManifest() manifest.entry always equals resolution.entry.
  *
  * Invariant (A3.7): manifest.entry is derived directly from resolution.entry —
  * it is not re-derived from order or blocks.

--- a/packages/compile/src/resolve.props.ts
+++ b/packages/compile/src/resolve.props.ts
@@ -111,13 +111,10 @@ async function nullResolver(_importedFrom: string): Promise<BlockMerkleRoot | nu
 // ---------------------------------------------------------------------------
 
 /**
- * prop_resolveComposition_single_block_result_shape
+ * resolveComposition() returns a well-formed single-block ResolutionResult.
  *
- * For a registry with exactly one block (no sub-block imports), resolveComposition
- * returns a ResolutionResult where:
- *   - entry === the supplied merkleRoot
- *   - blocks.size === 1 (only the entry)
- *   - order.length === 1 and order[0] === entry
+ * For a registry with one block (no sub-block imports): entry === merkleRoot,
+ * blocks.size === 1, order.length === 1 and order[0] === entry.
  *
  * Invariant: the trivial no-composition case always produces a well-formed
  * ResolutionResult with the entry as the sole block.
@@ -140,10 +137,7 @@ export const prop_resolveComposition_single_block_result_shape = fc.asyncPropert
 );
 
 /**
- * prop_resolveComposition_resolved_block_fields
- *
- * The ResolvedBlock stored in result.blocks for a single-block registry contains
- * the correct merkleRoot, specHash, source (= implSource), and empty subBlocks.
+ * resolveComposition() ResolvedBlock has correct merkleRoot, specHash, source, subBlocks.
  *
  * Invariant (A5.5): visitBlock populates all four ResolvedBlock fields from the
  * registry row; no field is left undefined or mismatched.
@@ -173,10 +167,7 @@ export const prop_resolveComposition_resolved_block_fields = fc.asyncProperty(
 // ---------------------------------------------------------------------------
 
 /**
- * prop_resolveComposition_deterministic
- *
- * Two consecutive calls to resolveComposition with the same registry and entry
- * produce results with the same order array and the same blocks map keys.
+ * resolveComposition() is deterministic: same registry + entry → same order and blocks.
  *
  * Invariant: resolveComposition is a pure function with no observable
  * side effects between calls on the same registry state.
@@ -203,11 +194,7 @@ export const prop_resolveComposition_deterministic = fc.asyncProperty(
 // ---------------------------------------------------------------------------
 
 /**
- * prop_ResolutionError_missing_block_kind_and_root
- *
- * When the registry does not contain the entry block, resolveComposition throws
- * a ResolutionError with kind="missing-block" and merkleRoot equal to the
- * requested entry.
+ * resolveComposition() throws ResolutionError kind="missing-block" for absent entry.
  *
  * Invariant (A5.4): ResolutionError always carries kind and merkleRoot; kind is
  * one of "missing-block" | "cycle" | "invalid-block".
@@ -227,10 +214,7 @@ export const prop_ResolutionError_missing_block_kind_and_root = fc.asyncProperty
 );
 
 /**
- * prop_ResolutionError_is_instanceof_Error
- *
- * ResolutionError is a subclass of Error; every instance passes instanceof Error
- * and instanceof ResolutionError. The message field is a non-empty string.
+ * ResolutionError is an instanceof Error with a non-empty message string.
  *
  * Invariant: ResolutionError extends Error correctly so callers can use both
  * catch clauses and explicit instanceof guards interchangeably.
@@ -258,10 +242,7 @@ export const prop_ResolutionError_is_instanceof_Error = fc.asyncProperty(
 // ---------------------------------------------------------------------------
 
 /**
- * prop_ResolutionError_cycle_detected
- *
- * When the composition graph contains a self-cycle (a block that imports itself),
- * resolveComposition throws a ResolutionError with kind="cycle".
+ * resolveComposition() throws ResolutionError kind="cycle" for a self-cyclic graph.
  *
  * Invariant: visitBlock's path Set detects the cycle before recursing infinitely;
  * the error is thrown with kind="cycle" and the offending merkleRoot.
@@ -293,10 +274,7 @@ export const prop_ResolutionError_cycle_detected = fc.asyncProperty(
 // ---------------------------------------------------------------------------
 
 /**
- * prop_SubBlockResolver_null_skips_sub_block
- *
- * When the SubBlockResolver returns null for a sub-block import, the ref is
- * silently skipped: the resolved block has zero sub-block deps recorded.
+ * SubBlockResolver returning null silently skips the sub-block import.
  *
  * Invariant: visitBlock treats null from the resolver as "skip this import" —
  * it neither errors nor adds the null to subBlocks.
@@ -326,11 +304,7 @@ export const prop_SubBlockResolver_null_skips_sub_block = fc.asyncProperty(
 // ---------------------------------------------------------------------------
 
 /**
- * prop_extractSubBlockImports_seeds_prefix_resolved
- *
- * A block with an `import type { X } from "@yakcc/seeds/blocks/x"` line will
- * have that import resolved by the SubBlockResolver. When the resolver returns
- * a concrete root for that specifier, the sub-block appears in subBlocks.
+ * extractSubBlockImports resolves "@yakcc/seeds/blocks/x" imports via the resolver.
  *
  * Invariant (A5.1): SUB_BLOCK_IMPORT_RE matches the @yakcc/seeds/ prefix;
  * extractSubBlockImports correctly extracts the full specifier.
@@ -366,10 +340,7 @@ export const prop_extractSubBlockImports_seeds_prefix_resolved = fc.asyncPropert
 );
 
 /**
- * prop_extractSubBlockImports_dot_slash_prefix_resolved
- *
- * A block with `import type { X } from "./x.js"` is also matched by the
- * sub-block import regex and passed to the resolver.
+ * extractSubBlockImports also resolves "./" relative imports via the resolver.
  *
  * Invariant (A5.1): SUB_BLOCK_IMPORT_RE covers the "./" prefix in addition
  * to "@yakcc/seeds/" and "@yakcc/blocks/".
@@ -402,10 +373,7 @@ export const prop_extractSubBlockImports_dot_slash_prefix_resolved = fc.asyncPro
 // ---------------------------------------------------------------------------
 
 /**
- * prop_resolveComposition_topological_order_two_depth
- *
- * For a two-level chain (grandchild → child → parent), the order array places
- * grandchild first, child second, parent last.
+ * resolveComposition() order is topological: grandchild first, child, parent last.
  *
  * Invariant: post-order DFS in visitBlock guarantees topological order —
  * every dependency appears before its dependent in result.order.

--- a/packages/contracts/src/contract-id.props.ts
+++ b/packages/contracts/src/contract-id.props.ts
@@ -44,10 +44,8 @@ const distinctPairArb: fc.Arbitrary<[Uint8Array, Uint8Array]> = fc
 // ---------------------------------------------------------------------------
 
 /**
- * prop_contractIdFromBytes_deterministic
+ * contractIdFromBytes() is deterministic: same Uint8Array → same ContractId string.
  *
- * For every Uint8Array, two consecutive calls to contractIdFromBytes with the
- * same input return the same ContractId string.
  * Invariant: the function is a pure, deterministic mapping.
  */
 export const prop_contractIdFromBytes_deterministic = fc.property(uint8ArrayArb, (bytes) => {
@@ -57,20 +55,19 @@ export const prop_contractIdFromBytes_deterministic = fc.property(uint8ArrayArb,
 });
 
 /**
- * prop_contractIdFromBytes_format_brand
+ * contractIdFromBytes() always produces a well-formed 64-char lowercase hex ContractId.
  *
- * For every Uint8Array, the returned ContractId passes isValidContractId.
- * Invariant: contractIdFromBytes always produces a well-formed 64-char lowercase hex id.
+ * Invariant: every output passes isValidContractId (64-char lowercase hex).
  */
 export const prop_contractIdFromBytes_format_brand = fc.property(uint8ArrayArb, (bytes) => {
   return isValidContractId(contractIdFromBytes(bytes));
 });
 
 /**
- * prop_contractIdFromBytes_collision_resistance
+ * contractIdFromBytes() maps distinct byte arrays to distinct ContractIds.
  *
- * For two distinct Uint8Arrays of the same length (≥32 bytes), the resulting
- * ContractIds are distinct. Uses numRuns=200 to exercise a wider input space.
+ * For two distinct Uint8Arrays of the same length (≥32 bytes) the resulting
+ * ContractIds are distinct (numRuns=200 to exercise a wider input space).
  * Invariant: BLAKE3-256 has sufficient collision resistance for any realistic input set.
  */
 export const prop_contractIdFromBytes_collision_resistance = fc.property(
@@ -81,10 +78,9 @@ export const prop_contractIdFromBytes_collision_resistance = fc.property(
 );
 
 /**
- * prop_contractIdFromBytes_pure
+ * contractIdFromBytes() does not mutate its input Uint8Array.
  *
- * The input Uint8Array is byte-equal before and after calling contractIdFromBytes.
- * Invariant: the function does not mutate its input in place.
+ * Invariant: the function is pure — the input bytes are unchanged after the call.
  */
 export const prop_contractIdFromBytes_pure = fc.property(uint8ArrayArb, (bytes) => {
   const snapshot = new Uint8Array(bytes);
@@ -101,9 +97,8 @@ export const prop_contractIdFromBytes_pure = fc.property(uint8ArrayArb, (bytes) 
 // ---------------------------------------------------------------------------
 
 /**
- * prop_contractId_equals_idFromBytesOfCanonicalize
+ * contractId(spec) equals contractIdFromBytes(canonicalize(spec)) for every ContractSpec.
  *
- * For every ContractSpec, contractId(spec) === contractIdFromBytes(canonicalize(spec)).
  * Invariant: contractId is a composition of canonicalize then contractIdFromBytes.
  */
 export const prop_contractId_equals_idFromBytesOfCanonicalize = fc.property(
@@ -114,9 +109,8 @@ export const prop_contractId_equals_idFromBytesOfCanonicalize = fc.property(
 );
 
 /**
- * prop_contractId_field_order_invariant
+ * contractId() is invariant to ContractSpec key insertion order.
  *
- * Permuting object key insertion order in the input spec produces the same ContractId.
  * Invariant: contractId delegates to canonicalize which sorts keys — order is irrelevant.
  */
 export const prop_contractId_field_order_invariant = fc.property(contractSpecArb, (spec) => {
@@ -163,9 +157,8 @@ const nonHexArb: fc.Arbitrary<string> = fc
   .map((s) => `${s.replace(/[0-9a-fA-F]/g, "x")}!`); // ensure at least one non-hex
 
 /**
- * prop_isValidContractId_accepts_valid
+ * isValidContractId() accepts every 64-character lowercase hex string.
  *
- * For every 64-character lowercase hex string, isValidContractId returns true.
  * Invariant: the function accepts all well-formed ContractId strings.
  */
 export const prop_isValidContractId_accepts_valid = fc.property(validContractIdArb, (id) => {
@@ -173,9 +166,8 @@ export const prop_isValidContractId_accepts_valid = fc.property(validContractIdA
 });
 
 /**
- * prop_isValidContractId_rejects_wrong_length
+ * isValidContractId() rejects any hex string whose length is not 64.
  *
- * For every hex string whose length ≠ 64, isValidContractId returns false.
  * Invariant: a ContractId must be exactly 64 characters.
  */
 export const prop_isValidContractId_rejects_wrong_length = fc.property(wrongLengthHexArb, (s) => {
@@ -183,19 +175,17 @@ export const prop_isValidContractId_rejects_wrong_length = fc.property(wrongLeng
 });
 
 /**
- * prop_isValidContractId_rejects_uppercase
+ * isValidContractId() rejects 64-char hex strings that contain uppercase letters.
  *
- * For 64-char hex strings containing an uppercase letter, isValidContractId returns false.
- * Invariant: a ContractId must be lowercase hex.
+ * Invariant: a ContractId must be lowercase hex only.
  */
 export const prop_isValidContractId_rejects_uppercase = fc.property(uppercaseHexArb, (s) => {
   return !isValidContractId(s);
 });
 
 /**
- * prop_isValidContractId_rejects_non_hex
+ * isValidContractId() rejects 64-char strings that contain non-hex characters.
  *
- * For 64-char strings containing a non-hex character, isValidContractId returns false.
  * Invariant: a ContractId may only contain [0-9a-f].
  */
 export const prop_isValidContractId_rejects_non_hex = fc.property(nonHexArb, (s) => {
@@ -206,10 +196,9 @@ export const prop_isValidContractId_rejects_non_hex = fc.property(nonHexArb, (s)
 });
 
 /**
- * prop_isValidContractId_total
+ * isValidContractId() is total: never throws for any string input, only returns boolean.
  *
- * For every string (including empty, long, Unicode), isValidContractId never throws.
- * Invariant: the function is total — it never throws, only returns boolean.
+ * Invariant: the function is total — it handles empty, long, and Unicode inputs.
  */
 export const prop_isValidContractId_total = fc.property(fc.string(), (s) => {
   try {


### PR DESCRIPTION
## Summary
Flatten multi-line JSDoc summaries in 4 props.ts files to single-line summaries to satisfy the IntentCard schema's no-newline constraint on `behavior`. Mechanical fix; no logic changes.

## Files
- `packages/compile/src/assemble.props.ts` — 6 props
- `packages/compile/src/manifest.props.ts` — 7 props
- `packages/compile/src/resolve.props.ts` — 10 props
- `packages/contracts/src/contract-id.props.ts` — 11 props

Total 34 `prop_*` exports preserved (verified by reviewer).

## Diff stat
`4 files changed, 57 insertions(+), 136 deletions(-)`

## Verification
- Per-file vitest: 23 (compile) + 11 (contracts) = **34/34 PASS**
- `pnpm --filter @yakcc/compile build`: clean
- `pnpm --filter @yakcc/contracts build`: clean
- `yakcc bootstrap`: 133/134 success (only `examples/v0.7-mri-demo/src/gpl-fixture.ts` remains, intentional GPL fixture)

## Same precedent as
PR #85 (hooks-base/src/index.ts JSDoc flatten, closed #72)

## Reviewer
`REVIEW_VERDICT: ready_for_guardian`, zero findings.

## DO NOT auto-merge — orchestrator review per #87

closes #116
refs #87 (L3a follow-up)