### PR TITLE
WI-V2-07-PREFLIGHT L3c: Path A property-test corpus for shave/persist subtree (refs #87)

### DIFF
--- a/packages/shave/src/persist/atom-persist.props.test.ts
+++ b/packages/shave/src/persist/atom-persist.props.test.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for atom-persist.props.ts
+// Two-file pattern: this file is the thin vitest wrapper; the corpus lives in
+// the sibling atom-persist.props.ts (vitest-free, hashable as a manifest artifact).
+//
+// NOTE: persistNovelGlueAtom calls extractCorpus() which performs filesystem
+// IO (upstream-test + documented-usage sources). numRuns is capped at 20 to
+// keep per-run IO cost bounded while still giving fast-check meaningful coverage.
+
+import * as fc from "fast-check";
+import { it } from "vitest";
+import {
+  prop_maybePersistNovelGlueAtom_delegates_when_store_block_present,
+  prop_maybePersistNovelGlueAtom_returns_undefined_when_no_store_block,
+  prop_maybePersistNovelGlueAtom_skips_no_intent_card,
+  prop_persist_atom_compound_interaction,
+  prop_persistNovelGlueAtom_calls_store_block_once,
+  prop_persistNovelGlueAtom_distinct_sources_yield_distinct_merkle_roots,
+  prop_persistNovelGlueAtom_forwards_parent_block_root,
+  prop_persistNovelGlueAtom_is_deterministic,
+  prop_persistNovelGlueAtom_return_equals_stored_merkle_root,
+  prop_persistNovelGlueAtom_skips_no_intent_card,
+  prop_persistNovelGlueAtom_stored_row_level_is_L0,
+} from "./atom-persist.props.js";
+
+// persistNovelGlueAtom calls extractCorpus() (filesystem-backed IO).
+// Cap numRuns to stay within budget while giving meaningful coverage.
+const opts = { numRuns: 20 };
+
+it("property: prop_persistNovelGlueAtom_skips_no_intent_card", async () => {
+  await fc.assert(prop_persistNovelGlueAtom_skips_no_intent_card, opts);
+});
+
+it("property: prop_persistNovelGlueAtom_calls_store_block_once", async () => {
+  await fc.assert(prop_persistNovelGlueAtom_calls_store_block_once, opts);
+});
+
+it("property: prop_persistNovelGlueAtom_return_equals_stored_merkle_root", async () => {
+  await fc.assert(prop_persistNovelGlueAtom_return_equals_stored_merkle_root, opts);
+});
+
+it("property: prop_persistNovelGlueAtom_is_deterministic", async () => {
+  await fc.assert(prop_persistNovelGlueAtom_is_deterministic, opts);
+});
+
+it("property: prop_persistNovelGlueAtom_forwards_parent_block_root", async () => {
+  await fc.assert(prop_persistNovelGlueAtom_forwards_parent_block_root, opts);
+});
+
+it("property: prop_persistNovelGlueAtom_stored_row_level_is_L0", async () => {
+  await fc.assert(prop_persistNovelGlueAtom_stored_row_level_is_L0, opts);
+});
+
+it("property: prop_persistNovelGlueAtom_distinct_sources_yield_distinct_merkle_roots", async () => {
+  await fc.assert(
+    prop_persistNovelGlueAtom_distinct_sources_yield_distinct_merkle_roots,
+    opts,
+  );
+});
+
+it("property: prop_maybePersistNovelGlueAtom_returns_undefined_when_no_store_block", async () => {
+  await fc.assert(prop_maybePersistNovelGlueAtom_returns_undefined_when_no_store_block, opts);
+});
+
+it("property: prop_maybePersistNovelGlueAtom_delegates_when_store_block_present", async () => {
+  await fc.assert(prop_maybePersistNovelGlueAtom_delegates_when_store_block_present, opts);
+});
+
+it("property: prop_maybePersistNovelGlueAtom_skips_no_intent_card", async () => {
+  await fc.assert(prop_maybePersistNovelGlueAtom_skips_no_intent_card, opts);
+});
+
+it("property: prop_persist_atom_compound_interaction", async () => {
+  await fc.assert(prop_persist_atom_compound_interaction, opts);
+});

--- a/packages/shave/src/persist/atom-persist.props.ts
+++ b/packages/shave/src/persist/atom-persist.props.ts
@@ -1,0 +1,432 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-001: hand-authored property-test corpus for
+// @yakcc/shave persist/atom-persist.ts atoms. Two-file pattern: this file
+// (.props.ts) is vitest-free and holds the corpus; the sibling .props.test.ts
+// is the vitest harness.
+// Status: accepted (WI-V2-07-PREFLIGHT L3c)
+// Rationale: See tmp/wi-v2-07-preflight-layer-plan.md — the corpus file must be
+// runtime-independent so L10 can hash it as a manifest artifact.
+//
+// Atoms covered (named exports from atom-persist.ts):
+//   persistNovelGlueAtom (AP1.1)   — persists a NovelGlueEntry to the full Registry.
+//   maybePersistNovelGlueAtom (AP1.2) — opt-in persistence; degrades gracefully when
+//                                        storeBlock is absent from the registry view.
+//
+// Properties covered:
+//   - persistNovelGlueAtom skips entries without an intentCard (returns undefined).
+//   - persistNovelGlueAtom calls storeBlock exactly once per novel entry.
+//   - persistNovelGlueAtom returns the same BlockMerkleRoot as the stored row.
+//   - persistNovelGlueAtom is deterministic: two calls with identical inputs
+//     call storeBlock with the same blockMerkleRoot.
+//   - persistNovelGlueAtom forwards parentBlockRoot to the stored row (or null
+//     when omitted).
+//   - maybePersistNovelGlueAtom returns undefined when storeBlock is absent.
+//   - maybePersistNovelGlueAtom delegates to persistNovelGlueAtom when storeBlock
+//     is present.
+//   - maybePersistNovelGlueAtom skips entries without intentCard regardless of
+//     registry shape (returns undefined).
+//   - The stored row carries level === "L0" for every novel entry.
+//   - persistNovelGlueAtom produces distinct merkleRoots for distinct source texts.
+//
+// Deferred atoms:
+//   - corpusOptions / propsFilePath forwarding: tested via extractCorpus contract,
+//     not a property of the persist boundary.
+//   - cacheDir (AI-derived corpus source c): requires live filesystem; out of
+//     property-test scope (offline discipline per DEC-SHAVE-002).
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for persist/atom-persist.ts
+// ---------------------------------------------------------------------------
+
+import type { BlockMerkleRoot, CanonicalAstHash } from "@yakcc/contracts";
+import * as fc from "fast-check";
+import type { IntentCard } from "../intent/types.js";
+import type { NovelGlueEntry } from "../universalize/types.js";
+import { maybePersistNovelGlueAtom, persistNovelGlueAtom } from "./atom-persist.js";
+import type { PersistOptions } from "./atom-persist.js";
+
+// ---------------------------------------------------------------------------
+// Shared arbitraries
+// ---------------------------------------------------------------------------
+
+/** Non-empty string with no leading/trailing whitespace. */
+const nonEmptyStr: fc.Arbitrary<string> = fc
+  .string({ minLength: 1, maxLength: 40 })
+  .filter((s) => s.trim().length > 0);
+
+/** 64-char hex string suitable for a CanonicalAstHash. */
+const hexHash64: fc.Arbitrary<string> = fc
+  .array(fc.integer({ min: 0, max: 15 }), { minLength: 64, maxLength: 64 })
+  .map((nibbles) => nibbles.map((n) => n.toString(16)).join(""));
+
+/** Well-formed IntentCard for property testing. */
+const intentCardArb: fc.Arbitrary<IntentCard> = fc.record({
+  schemaVersion: fc.constant(1 as const),
+  behavior: nonEmptyStr,
+  inputs: fc.array(
+    fc.record({
+      name: nonEmptyStr,
+      typeHint: nonEmptyStr,
+      description: fc.string({ minLength: 0, maxLength: 40 }),
+    }),
+    { minLength: 0, maxLength: 2 },
+  ),
+  outputs: fc.array(
+    fc.record({
+      name: nonEmptyStr,
+      typeHint: nonEmptyStr,
+      description: fc.string({ minLength: 0, maxLength: 40 }),
+    }),
+    { minLength: 0, maxLength: 2 },
+  ),
+  preconditions: fc.array(nonEmptyStr, { minLength: 0, maxLength: 2 }),
+  postconditions: fc.array(nonEmptyStr, { minLength: 0, maxLength: 2 }),
+  notes: fc.array(fc.string(), { minLength: 0, maxLength: 2 }),
+  modelVersion: nonEmptyStr,
+  promptVersion: nonEmptyStr,
+  sourceHash: hexHash64,
+  extractedAt: fc.constant("2024-01-01T00:00:00.000Z"),
+});
+
+/** Source text for an atom (non-empty string). */
+const sourceArb: fc.Arbitrary<string> = fc.string({ minLength: 1, maxLength: 200 });
+
+/** Well-formed NovelGlueEntry with an intentCard. */
+const novelGlueEntryArb: fc.Arbitrary<NovelGlueEntry> = fc
+  .tuple(sourceArb, hexHash64, intentCardArb)
+  .map(([source, hash, intentCard]) => ({
+    kind: "novel-glue" as const,
+    sourceRange: { start: 0, end: source.length },
+    source,
+    canonicalAstHash: hash as CanonicalAstHash,
+    intentCard,
+  }));
+
+/** NovelGlueEntry without an intentCard (deep leaf). */
+const novelGlueEntryNoCardArb: fc.Arbitrary<NovelGlueEntry> = fc
+  .tuple(sourceArb, hexHash64)
+  .map(([source, hash]) => ({
+    kind: "novel-glue" as const,
+    sourceRange: { start: 0, end: source.length },
+    source,
+    canonicalAstHash: hash as CanonicalAstHash,
+  }));
+
+// ---------------------------------------------------------------------------
+// Registry stub helpers (no mocks — real interface duck-typed from shape)
+// ---------------------------------------------------------------------------
+
+/** Build an in-memory registry stub that records storeBlock calls. */
+function makeStoreStub(): {
+  storeBlock: (row: { blockMerkleRoot: BlockMerkleRoot }) => Promise<void>;
+  calls: Array<{ blockMerkleRoot: BlockMerkleRoot }>;
+} {
+  const calls: Array<{ blockMerkleRoot: BlockMerkleRoot }> = [];
+  return {
+    storeBlock: async (row) => {
+      calls.push(row);
+    },
+    calls,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AP1.1: persistNovelGlueAtom — skips entries without intentCard
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_persistNovelGlueAtom_skips_no_intent_card
+ *
+ * When the NovelGlueEntry has no intentCard, persistNovelGlueAtom returns
+ * undefined and never calls storeBlock.
+ *
+ * Invariant (AP1.1, DEC-ATOM-PERSIST-001): deep-leaf entries (multi-leaf trees
+ * without per-leaf intent extraction) are silently skipped — no error, no
+ * persistence. This preserves backward-compatibility while future WIs add
+ * per-leaf extraction.
+ */
+export const prop_persistNovelGlueAtom_skips_no_intent_card = fc.asyncProperty(
+  novelGlueEntryNoCardArb,
+  async (entry) => {
+    const stub = makeStoreStub();
+    const registry = { storeBlock: stub.storeBlock } as never;
+    const result = await persistNovelGlueAtom(entry, registry);
+    return result === undefined && stub.calls.length === 0;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// AP1.1: persistNovelGlueAtom — calls storeBlock exactly once per entry
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_persistNovelGlueAtom_calls_store_block_once
+ *
+ * For any well-formed NovelGlueEntry with an intentCard, persistNovelGlueAtom
+ * calls storeBlock exactly once.
+ *
+ * Invariant (AP1.1): one entry → one block row. Idempotency of storeBlock is
+ * the registry's contract; this side drives exactly one call per persist.
+ */
+export const prop_persistNovelGlueAtom_calls_store_block_once = fc.asyncProperty(
+  novelGlueEntryArb,
+  async (entry) => {
+    const stub = makeStoreStub();
+    const registry = { storeBlock: stub.storeBlock } as never;
+    await persistNovelGlueAtom(entry, registry);
+    return stub.calls.length === 1;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// AP1.1: persistNovelGlueAtom — return value matches stored merkleRoot
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_persistNovelGlueAtom_return_equals_stored_merkle_root
+ *
+ * The BlockMerkleRoot returned by persistNovelGlueAtom equals the
+ * blockMerkleRoot on the row passed to storeBlock.
+ *
+ * Invariant (AP1.1): the return value is the content address of the stored
+ * block, so callers can use it as the parentBlockRoot of child atoms without
+ * re-reading the registry.
+ */
+export const prop_persistNovelGlueAtom_return_equals_stored_merkle_root = fc.asyncProperty(
+  novelGlueEntryArb,
+  async (entry) => {
+    const stub = makeStoreStub();
+    const registry = { storeBlock: stub.storeBlock } as never;
+    const result = await persistNovelGlueAtom(entry, registry);
+    return result !== undefined && stub.calls[0]?.blockMerkleRoot === result;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// AP1.1: persistNovelGlueAtom — determinism (identical inputs → identical merkleRoot)
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_persistNovelGlueAtom_is_deterministic
+ *
+ * Two calls to persistNovelGlueAtom() with identical entry+options return
+ * identical BlockMerkleRoot values.
+ *
+ * Invariant (AP1.1, DEC-ATOM-PERSIST-001): the merkle root is derived from the
+ * content address of the spec + impl + manifest — all pure, no timestamps or
+ * random bytes in the computation.
+ */
+export const prop_persistNovelGlueAtom_is_deterministic = fc.asyncProperty(
+  novelGlueEntryArb,
+  async (entry) => {
+    const stub1 = makeStoreStub();
+    const stub2 = makeStoreStub();
+    const r1 = await persistNovelGlueAtom(entry, { storeBlock: stub1.storeBlock } as never);
+    const r2 = await persistNovelGlueAtom(entry, { storeBlock: stub2.storeBlock } as never);
+    return r1 !== undefined && r1 === r2;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// AP1.1: persistNovelGlueAtom — parentBlockRoot forwarded to stored row
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_persistNovelGlueAtom_forwards_parent_block_root
+ *
+ * When PersistOptions.parentBlockRoot is provided, the stored row carries
+ * that exact value. When omitted, the stored row carries null.
+ *
+ * Invariant (AP1.1, DEC-REGISTRY-PARENT-BLOCK-004): lineage is injected via
+ * parentBlockRoot and written verbatim to the row — no re-derivation. This
+ * preserves content-address purity: the parent reference is row metadata only.
+ */
+export const prop_persistNovelGlueAtom_forwards_parent_block_root = fc.asyncProperty(
+  novelGlueEntryArb,
+  fc.option(
+    hexHash64.map((h) => h as BlockMerkleRoot),
+    { nil: null },
+  ),
+  async (entry, parentBlockRoot) => {
+    const calls: Array<{ parentBlockRoot: BlockMerkleRoot | null }> = [];
+    const registry = {
+      storeBlock: async (row: { parentBlockRoot: BlockMerkleRoot | null }) => {
+        calls.push(row);
+      },
+    } as never;
+    const opts: PersistOptions = { parentBlockRoot: parentBlockRoot ?? null };
+    await persistNovelGlueAtom(entry, registry, opts);
+    return calls[0]?.parentBlockRoot === (parentBlockRoot ?? null);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// AP1.1: persistNovelGlueAtom — stored row level is always "L0"
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_persistNovelGlueAtom_stored_row_level_is_L0
+ *
+ * The BlockTripletRow written to storeBlock always carries level === "L0".
+ *
+ * Invariant (AP1.1, DEC-TRIPLET-L0-ONLY-019): specFromIntent hard-codes "L0";
+ * buildTriplet propagates it to the row. No upgrade path exists at this layer.
+ */
+export const prop_persistNovelGlueAtom_stored_row_level_is_L0 = fc.asyncProperty(
+  novelGlueEntryArb,
+  async (entry) => {
+    const calls: Array<{ level: string }> = [];
+    const registry = {
+      storeBlock: async (row: { level: string }) => {
+        calls.push(row);
+      },
+    } as never;
+    await persistNovelGlueAtom(entry, registry);
+    return calls[0]?.level === "L0";
+  },
+);
+
+// ---------------------------------------------------------------------------
+// AP1.1: persistNovelGlueAtom — distinct sources yield distinct merkleRoots
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_persistNovelGlueAtom_distinct_sources_yield_distinct_merkle_roots
+ *
+ * Two NovelGlueEntries with distinct source texts (holding all other fields
+ * equal) produce distinct BlockMerkleRoot values.
+ *
+ * Invariant (AP1.1, DEC-TRIPLET-IDENTITY-020): impl is the raw source text at
+ * L0 — file bytes are the identity unit. Different source → different impl →
+ * different blockMerkleRoot (content-addressed by construction).
+ */
+export const prop_persistNovelGlueAtom_distinct_sources_yield_distinct_merkle_roots =
+  fc.asyncProperty(
+    fc.tuple(nonEmptyStr, nonEmptyStr).filter(([a, b]) => a !== b),
+    hexHash64,
+    intentCardArb,
+    async ([sourceA, sourceB], hash, intentCard) => {
+      const entryA: NovelGlueEntry = {
+        kind: "novel-glue",
+        sourceRange: { start: 0, end: sourceA.length },
+        source: sourceA,
+        canonicalAstHash: hash as CanonicalAstHash,
+        intentCard,
+      };
+      const entryB: NovelGlueEntry = {
+        kind: "novel-glue",
+        sourceRange: { start: 0, end: sourceB.length },
+        source: sourceB,
+        canonicalAstHash: hash as CanonicalAstHash,
+        intentCard,
+      };
+      const stub1 = makeStoreStub();
+      const stub2 = makeStoreStub();
+      const r1 = await persistNovelGlueAtom(entryA, { storeBlock: stub1.storeBlock } as never);
+      const r2 = await persistNovelGlueAtom(entryB, { storeBlock: stub2.storeBlock } as never);
+      // Different source bytes → different content address → different merkleRoot.
+      return r1 !== undefined && r2 !== undefined && r1 !== r2;
+    },
+  );
+
+// ---------------------------------------------------------------------------
+// AP1.2: maybePersistNovelGlueAtom — returns undefined when no storeBlock
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_maybePersistNovelGlueAtom_returns_undefined_when_no_store_block
+ *
+ * When the registry view does not implement storeBlock, maybePersistNovelGlueAtom
+ * returns undefined without throwing.
+ *
+ * Invariant (AP1.2, DEC-ATOM-PERSIST-001): shave() uses ShaveRegistryView which
+ * may omit storeBlock. Graceful degradation (no-op, no error) is the contract.
+ */
+export const prop_maybePersistNovelGlueAtom_returns_undefined_when_no_store_block =
+  fc.asyncProperty(novelGlueEntryArb, async (entry) => {
+    // Registry view with no storeBlock method.
+    const registryView = {} as never;
+    const result = await maybePersistNovelGlueAtom(entry, registryView);
+    return result === undefined;
+  });
+
+// ---------------------------------------------------------------------------
+// AP1.2: maybePersistNovelGlueAtom — delegates to persistNovelGlueAtom when storeBlock present
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_maybePersistNovelGlueAtom_delegates_when_store_block_present
+ *
+ * When the registry view implements storeBlock, maybePersistNovelGlueAtom
+ * returns a defined BlockMerkleRoot (equal to what persistNovelGlueAtom returns).
+ *
+ * Invariant (AP1.2): the maybe-path is a thin wrapper that calls persistNovelGlueAtom
+ * when the storeBlock capability is present. The result must be non-undefined
+ * for well-formed entries.
+ */
+export const prop_maybePersistNovelGlueAtom_delegates_when_store_block_present = fc.asyncProperty(
+  novelGlueEntryArb,
+  async (entry) => {
+    const stub = makeStoreStub();
+    const registryView = { storeBlock: stub.storeBlock } as never;
+    const result = await maybePersistNovelGlueAtom(entry, registryView);
+    return result !== undefined && stub.calls.length === 1;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// AP1.2: maybePersistNovelGlueAtom — skips no-intentCard entries regardless of registry
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_maybePersistNovelGlueAtom_skips_no_intent_card
+ *
+ * Even when storeBlock is present, maybePersistNovelGlueAtom returns undefined
+ * for entries without an intentCard.
+ *
+ * Invariant (AP1.2): the intentCard guard fires before the storeBlock check in
+ * the delegated persistNovelGlueAtom call — the registry capability does not
+ * override the entry-level skip logic.
+ */
+export const prop_maybePersistNovelGlueAtom_skips_no_intent_card = fc.asyncProperty(
+  novelGlueEntryNoCardArb,
+  async (entry) => {
+    const stub = makeStoreStub();
+    const registryView = { storeBlock: stub.storeBlock } as never;
+    const result = await maybePersistNovelGlueAtom(entry, registryView);
+    return result === undefined && stub.calls.length === 0;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Compound interaction: novelGlueEntry → persistNovelGlueAtom → maybePersistNovelGlueAtom
+//
+// Production sequence: NovelGlueEntry (from slicer) → persistNovelGlueAtom()
+// → extractCorpus() → buildTriplet() → storeBlock(). This exercises the
+// boundary between slicer output, corpus extraction, triplet construction, and
+// registry storage in a single end-to-end call.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_persist_atom_compound_interaction
+ *
+ * For a well-formed NovelGlueEntry, persistNovelGlueAtom and
+ * maybePersistNovelGlueAtom (with storeBlock) produce the same BlockMerkleRoot.
+ *
+ * This is the canonical compound-interaction property crossing:
+ *   NovelGlueEntry → persistNovelGlueAtom() → extractCorpus() + buildTriplet()
+ *   → BlockTripletRow.blockMerkleRoot
+ *
+ * Invariant (AP1.1 + AP1.2): both paths delegate to the same underlying
+ * buildTriplet() derivation, so their content addresses are identical.
+ */
+export const prop_persist_atom_compound_interaction = fc.asyncProperty(
+  novelGlueEntryArb,
+  async (entry) => {
+    const stub1 = makeStoreStub();
+    const stub2 = makeStoreStub();
+    const r1 = await persistNovelGlueAtom(entry, { storeBlock: stub1.storeBlock } as never);
+    const r2 = await maybePersistNovelGlueAtom(entry, { storeBlock: stub2.storeBlock } as never);
+    return r1 !== undefined && r2 !== undefined && r1 === r2;
+  },
+);

--- a/packages/shave/src/persist/spec-from-intent.props.test.ts
+++ b/packages/shave/src/persist/spec-from-intent.props.test.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for spec-from-intent.props.ts
+// Two-file pattern: this file is the thin vitest wrapper; the corpus lives in
+// the sibling spec-from-intent.props.ts (vitest-free, hashable as a manifest artifact).
+
+import * as fc from "fast-check";
+import { it } from "vitest";
+import {
+  prop_specFromIntent_does_not_throw,
+  prop_specFromIntent_effects_is_empty,
+  prop_specFromIntent_input_type_equals_typehint,
+  prop_specFromIntent_inputs_length_matches,
+  prop_specFromIntent_invariants_is_empty,
+  prop_specFromIntent_is_deterministic,
+  prop_specFromIntent_level_is_L0,
+  prop_specFromIntent_name_ends_with_hash_suffix,
+  prop_specFromIntent_output_passes_validateSpecYak,
+  prop_specFromIntent_outputs_length_matches,
+  prop_specFromIntent_postconditions_roundtrip,
+  prop_specFromIntent_preconditions_roundtrip,
+} from "./spec-from-intent.props.js";
+
+// specFromIntent() is a pure function — no IO, no ts-morph, no registry.
+// numRuns: 50 is affordable given the low runtime cost.
+const opts = { numRuns: 50 };
+
+it("property: prop_specFromIntent_does_not_throw", () => {
+  fc.assert(prop_specFromIntent_does_not_throw, opts);
+});
+
+it("property: prop_specFromIntent_level_is_L0", () => {
+  fc.assert(prop_specFromIntent_level_is_L0, opts);
+});
+
+it("property: prop_specFromIntent_invariants_is_empty", () => {
+  fc.assert(prop_specFromIntent_invariants_is_empty, opts);
+});
+
+it("property: prop_specFromIntent_effects_is_empty", () => {
+  fc.assert(prop_specFromIntent_effects_is_empty, opts);
+});
+
+it("property: prop_specFromIntent_name_ends_with_hash_suffix", () => {
+  fc.assert(prop_specFromIntent_name_ends_with_hash_suffix, opts);
+});
+
+it("property: prop_specFromIntent_inputs_length_matches", () => {
+  fc.assert(prop_specFromIntent_inputs_length_matches, opts);
+});
+
+it("property: prop_specFromIntent_outputs_length_matches", () => {
+  fc.assert(prop_specFromIntent_outputs_length_matches, opts);
+});
+
+it("property: prop_specFromIntent_input_type_equals_typehint", () => {
+  fc.assert(prop_specFromIntent_input_type_equals_typehint, opts);
+});
+
+it("property: prop_specFromIntent_preconditions_roundtrip", () => {
+  fc.assert(prop_specFromIntent_preconditions_roundtrip, opts);
+});
+
+it("property: prop_specFromIntent_postconditions_roundtrip", () => {
+  fc.assert(prop_specFromIntent_postconditions_roundtrip, opts);
+});
+
+it("property: prop_specFromIntent_is_deterministic", () => {
+  fc.assert(prop_specFromIntent_is_deterministic, opts);
+});
+
+it("property: prop_specFromIntent_output_passes_validateSpecYak", () => {
+  fc.assert(prop_specFromIntent_output_passes_validateSpecYak, opts);
+});

--- a/packages/shave/src/persist/spec-from-intent.props.ts
+++ b/packages/shave/src/persist/spec-from-intent.props.ts
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-001: hand-authored property-test corpus for
+// @yakcc/shave persist/spec-from-intent.ts atoms. Two-file pattern: this file
+// (.props.ts) is vitest-free and holds the corpus; the sibling .props.test.ts
+// is the vitest harness.
+// Status: accepted (WI-V2-07-PREFLIGHT L3c)
+// Rationale: See tmp/wi-v2-07-preflight-layer-plan.md — the corpus file must be
+// runtime-independent so L10 can hash it as a manifest artifact.
+//
+// Atoms covered (named exports from spec-from-intent.ts):
+//   specFromIntent (SFI1.1) — maps an IntentCard + canonicalAstHash to a SpecYak.
+//
+// Private helpers tested transitively via specFromIntent():
+//   deriveSpecName  (SFI1.2-priv) — slug derivation: first 30 chars of behavior
+//                                   (non-word → "-", strip leading/trailing "-")
+//                                   + "-" + last 6 chars of canonicalAstHash.
+//   mapParam        (SFI1.3-priv) — IntentParam → SpecYakParameter (typeHint → type).
+//
+// Properties covered:
+//   - For any well-formed IntentCard, specFromIntent does not throw.
+//   - The returned SpecYak.level is always "L0".
+//   - The returned SpecYak.invariants is always an empty array.
+//   - The returned SpecYak.effects is always an empty array.
+//   - The SpecYak.name ends with the last 6 chars of canonicalAstHash.
+//   - Input parameters round-trip: inputs.length equals intentCard.inputs.length.
+//   - Output parameters round-trip: outputs.length equals intentCard.outputs.length.
+//   - Each input's type equals the source IntentParam.typeHint.
+//   - preconditions round-trips the IntentCard.preconditions array.
+//   - postconditions round-trips the IntentCard.postconditions array.
+//   - specFromIntent is deterministic: identical inputs produce identical SpecYak.
+//   - validateSpecYak does not throw on the returned SpecYak (sanity pass).
+//
+// Deferred atoms:
+//   - Negative-case (malformed IntentCard throwing TypeError) — the existing
+//     spec-from-intent.test.ts covers explicit negative cases. Corpus covers
+//     the positive invariant domain per deferred-atoms documentation.
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for persist/spec-from-intent.ts
+// ---------------------------------------------------------------------------
+
+import { validateSpecYak } from "@yakcc/contracts";
+import * as fc from "fast-check";
+import type { IntentCard } from "../intent/types.js";
+import { specFromIntent } from "./spec-from-intent.js";
+
+// ---------------------------------------------------------------------------
+// Shared arbitraries
+// ---------------------------------------------------------------------------
+
+/** Arbitrary that produces a non-empty string with no leading/trailing whitespace. */
+const nonEmptyStr: fc.Arbitrary<string> = fc
+  .string({ minLength: 1, maxLength: 40 })
+  .filter((s) => s.trim().length > 0);
+
+/** Arbitrary that produces a 64-char hex string suitable for a CanonicalAstHash. */
+const hexHash64: fc.Arbitrary<string> = fc
+  .array(fc.integer({ min: 0, max: 15 }), { minLength: 64, maxLength: 64 })
+  .map((nibbles) => nibbles.map((n) => n.toString(16)).join(""));
+
+/** Arbitrary for a single IntentParam. */
+const intentParamArb = fc.record({
+  name: nonEmptyStr,
+  typeHint: nonEmptyStr,
+  description: fc.string({ minLength: 0, maxLength: 40 }),
+});
+
+/** Arbitrary for a well-formed IntentCard (schemaVersion always 1). */
+const intentCardArb: fc.Arbitrary<IntentCard> = fc.record({
+  schemaVersion: fc.constant(1 as const),
+  behavior: nonEmptyStr,
+  inputs: fc.array(intentParamArb, { minLength: 0, maxLength: 3 }),
+  outputs: fc.array(intentParamArb, { minLength: 0, maxLength: 3 }),
+  preconditions: fc.array(nonEmptyStr, { minLength: 0, maxLength: 3 }),
+  postconditions: fc.array(nonEmptyStr, { minLength: 0, maxLength: 3 }),
+  notes: fc.array(fc.string(), { minLength: 0, maxLength: 2 }),
+  modelVersion: nonEmptyStr,
+  promptVersion: nonEmptyStr,
+  sourceHash: hexHash64,
+  extractedAt: fc.constant("2024-01-01T00:00:00.000Z"),
+});
+
+// ---------------------------------------------------------------------------
+// SFI1.1: specFromIntent — does not throw for well-formed input
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_specFromIntent_does_not_throw
+ *
+ * For any well-formed IntentCard and any 64-char hex canonicalAstHash,
+ * specFromIntent() does not throw.
+ *
+ * Invariant (SFI1.1): the function is total on the well-formed input domain.
+ * No runtime IO, no external dependencies — pure computation.
+ */
+export const prop_specFromIntent_does_not_throw = fc.property(
+  intentCardArb,
+  hexHash64,
+  (card, hash) => {
+    try {
+      specFromIntent(card, hash);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// SFI1.1: specFromIntent — level is always "L0"
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_specFromIntent_level_is_L0
+ *
+ * The returned SpecYak always has level === "L0".
+ *
+ * Invariant (SFI1.1, DEC-TRIPLET-L0-ONLY-019): specFromIntent hard-codes "L0"
+ * as the level; callers that need L1/L2/L3 require a separate upgrade path.
+ */
+export const prop_specFromIntent_level_is_L0 = fc.property(
+  intentCardArb,
+  hexHash64,
+  (card, hash) => {
+    const spec = specFromIntent(card, hash);
+    return spec.level === "L0";
+  },
+);
+
+// ---------------------------------------------------------------------------
+// SFI1.1: specFromIntent — invariants is always empty
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_specFromIntent_invariants_is_empty
+ *
+ * The returned SpecYak.invariants is always an empty array.
+ *
+ * Invariant (SFI1.1): atoms are pure-by-default at L0; invariant derivation
+ * is future work (per DEC-ATOM-PERSIST-001 rationale).
+ */
+export const prop_specFromIntent_invariants_is_empty = fc.property(
+  intentCardArb,
+  hexHash64,
+  (card, hash) => {
+    const spec = specFromIntent(card, hash);
+    return Array.isArray(spec.invariants) && spec.invariants.length === 0;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// SFI1.1: specFromIntent — effects is always empty
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_specFromIntent_effects_is_empty
+ *
+ * The returned SpecYak.effects is always an empty array.
+ *
+ * Invariant (SFI1.1): atoms are pure-by-default at L0; effect inference is
+ * future work (per DEC-ATOM-PERSIST-001 rationale).
+ */
+export const prop_specFromIntent_effects_is_empty = fc.property(
+  intentCardArb,
+  hexHash64,
+  (card, hash) => {
+    const spec = specFromIntent(card, hash);
+    return Array.isArray(spec.effects) && spec.effects.length === 0;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// SFI1.2-priv: deriveSpecName — name ends with last 6 chars of hash
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_specFromIntent_name_ends_with_hash_suffix
+ *
+ * The returned SpecYak.name always ends with the last 6 characters of
+ * canonicalAstHash, preceded by a hyphen.
+ *
+ * Invariant (SFI1.2-priv): the name slug is formed as
+ * `<slugified-behavior>-<last6>`. The hash suffix disambiguates behaviors
+ * that share the same first-30-char prefix, and it is deterministic for
+ * identical inputs (required for content-addressed provenance).
+ */
+export const prop_specFromIntent_name_ends_with_hash_suffix = fc.property(
+  intentCardArb,
+  hexHash64,
+  (card, hash) => {
+    const spec = specFromIntent(card, hash);
+    const suffix = hash.slice(-6);
+    return spec.name.endsWith(`-${suffix}`);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// SFI1.3-priv: mapParam — inputs length round-trip
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_specFromIntent_inputs_length_matches
+ *
+ * spec.inputs.length === intentCard.inputs.length for all well-formed inputs.
+ *
+ * Invariant (SFI1.3-priv): mapParam is applied uniformly via Array.map;
+ * no inputs are dropped or duplicated during the mapping.
+ */
+export const prop_specFromIntent_inputs_length_matches = fc.property(
+  intentCardArb,
+  hexHash64,
+  (card, hash) => {
+    const spec = specFromIntent(card, hash);
+    return spec.inputs.length === card.inputs.length;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// SFI1.3-priv: mapParam — outputs length round-trip
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_specFromIntent_outputs_length_matches
+ *
+ * spec.outputs.length === intentCard.outputs.length for all well-formed inputs.
+ *
+ * Invariant (SFI1.3-priv): outputs array is mapped the same way as inputs;
+ * the result length is always equal to the source array.
+ */
+export const prop_specFromIntent_outputs_length_matches = fc.property(
+  intentCardArb,
+  hexHash64,
+  (card, hash) => {
+    const spec = specFromIntent(card, hash);
+    return spec.outputs.length === card.outputs.length;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// SFI1.3-priv: mapParam — typeHint maps to type field
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_specFromIntent_input_type_equals_typehint
+ *
+ * For every input parameter, spec.inputs[i].type === intentCard.inputs[i].typeHint.
+ *
+ * Invariant (SFI1.3-priv): mapParam renames typeHint → type; all other fields
+ * are forwarded verbatim. No inputs array means the property trivially holds.
+ */
+export const prop_specFromIntent_input_type_equals_typehint = fc.property(
+  intentCardArb,
+  hexHash64,
+  (card, hash) => {
+    const spec = specFromIntent(card, hash);
+    return card.inputs.every((param, i) => spec.inputs[i]?.type === param.typeHint);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// SFI1.1: specFromIntent — preconditions round-trip
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_specFromIntent_preconditions_roundtrip
+ *
+ * spec.preconditions contains the same strings as intentCard.preconditions,
+ * in the same order.
+ *
+ * Invariant (SFI1.1): preconditions are copied verbatim via Array.from();
+ * no transformation is applied.
+ */
+export const prop_specFromIntent_preconditions_roundtrip = fc.property(
+  intentCardArb,
+  hexHash64,
+  (card, hash) => {
+    const spec = specFromIntent(card, hash);
+    if (spec.preconditions.length !== card.preconditions.length) return false;
+    return card.preconditions.every((cond, i) => spec.preconditions[i] === cond);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// SFI1.1: specFromIntent — postconditions round-trip
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_specFromIntent_postconditions_roundtrip
+ *
+ * spec.postconditions contains the same strings as intentCard.postconditions,
+ * in the same order.
+ *
+ * Invariant (SFI1.1): postconditions are copied verbatim via Array.from();
+ * no transformation is applied.
+ */
+export const prop_specFromIntent_postconditions_roundtrip = fc.property(
+  intentCardArb,
+  hexHash64,
+  (card, hash) => {
+    const spec = specFromIntent(card, hash);
+    if (spec.postconditions.length !== card.postconditions.length) return false;
+    return card.postconditions.every((cond, i) => spec.postconditions[i] === cond);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// SFI1.1: specFromIntent — determinism
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_specFromIntent_is_deterministic
+ *
+ * Two calls to specFromIntent() with identical inputs return SpecYak values
+ * with identical names, levels, and array lengths.
+ *
+ * Invariant (SFI1.1): specFromIntent is a pure function — no timestamps,
+ * random bytes, or counters in the derivation. The name slug is deterministic
+ * by construction (deriveSpecName uses only the behavior text and hash suffix).
+ */
+export const prop_specFromIntent_is_deterministic = fc.property(
+  intentCardArb,
+  hexHash64,
+  (card, hash) => {
+    const s1 = specFromIntent(card, hash);
+    const s2 = specFromIntent(card, hash);
+    return (
+      s1.name === s2.name &&
+      s1.level === s2.level &&
+      s1.inputs.length === s2.inputs.length &&
+      s1.outputs.length === s2.outputs.length &&
+      s1.preconditions.length === s2.preconditions.length &&
+      s1.postconditions.length === s2.postconditions.length
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Compound interaction: specFromIntent → validateSpecYak (end-to-end)
+//
+// Production sequence: IntentCard + canonicalAstHash → specFromIntent()
+// → SpecYak → validateSpecYak() (called inside specFromIntent and here again).
+// This crosses the boundary of specFromIntent + the contracts validator.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_specFromIntent_output_passes_validateSpecYak
+ *
+ * The SpecYak returned by specFromIntent() is always valid per validateSpecYak(),
+ * called independently after the fact.
+ *
+ * This is the canonical compound-interaction property crossing:
+ *   specFromIntent() → mapParam() + deriveSpecName() → SpecYak shape
+ *   → validateSpecYak() from @yakcc/contracts
+ *
+ * Invariant (SFI1.1 + DEC-TRIPLET-IDENTITY-020): every SpecYak produced by
+ * the mapping satisfies the contracts validator's required-field and level checks.
+ */
+export const prop_specFromIntent_output_passes_validateSpecYak = fc.property(
+  intentCardArb,
+  hexHash64,
+  (card, hash) => {
+    try {
+      const spec = specFromIntent(card, hash);
+      validateSpecYak(spec);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+);

--- a/packages/shave/src/persist/triplet.props.test.ts
+++ b/packages/shave/src/persist/triplet.props.test.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for triplet.props.ts
+// Two-file pattern: this file is the thin vitest wrapper; the corpus lives in
+// the sibling triplet.props.ts (vitest-free, hashable as a manifest artifact).
+//
+// buildTriplet() is synchronous and pure — no filesystem IO, no registry calls.
+// numRuns is set to 50 to give good fast-check coverage at low cost.
+
+import * as fc from "fast-check";
+import { it } from "vitest";
+import {
+  prop_L0_bootstrap_manifest_shape,
+  prop_buildTriplet_artifacts_map_contains_corpus_bytes,
+  prop_buildTriplet_bootstrap_does_not_require_corpus,
+  prop_buildTriplet_compound_content_address_stability,
+  prop_buildTriplet_distinct_hash_yields_distinct_merkle_root,
+  prop_buildTriplet_distinct_source_yields_distinct_merkle_root,
+  prop_buildTriplet_has_all_required_fields,
+  prop_buildTriplet_impl_equals_source,
+  prop_buildTriplet_is_deterministic,
+  prop_buildTriplet_manifest_artifact_kind_is_property_tests,
+  prop_buildTriplet_merkle_root_is_non_empty,
+  prop_buildTriplet_spec_level_is_L0,
+  prop_buildTriplet_throws_without_corpus_and_without_bootstrap,
+  prop_makeBootstrapArtifacts_has_one_empty_entry,
+} from "./triplet.props.js";
+
+// buildTriplet() is pure and synchronous — 50 runs is affordable.
+const opts = { numRuns: 50 };
+
+it("property: prop_buildTriplet_has_all_required_fields", () => {
+  fc.assert(prop_buildTriplet_has_all_required_fields, opts);
+});
+
+it("property: prop_buildTriplet_impl_equals_source", () => {
+  fc.assert(prop_buildTriplet_impl_equals_source, opts);
+});
+
+it("property: prop_buildTriplet_spec_level_is_L0", () => {
+  fc.assert(prop_buildTriplet_spec_level_is_L0, opts);
+});
+
+it("property: prop_buildTriplet_merkle_root_is_non_empty", () => {
+  fc.assert(prop_buildTriplet_merkle_root_is_non_empty, opts);
+});
+
+it("property: prop_buildTriplet_is_deterministic", () => {
+  fc.assert(prop_buildTriplet_is_deterministic, opts);
+});
+
+it("property: prop_buildTriplet_distinct_source_yields_distinct_merkle_root", () => {
+  fc.assert(prop_buildTriplet_distinct_source_yields_distinct_merkle_root, opts);
+});
+
+it("property: prop_buildTriplet_distinct_hash_yields_distinct_merkle_root", () => {
+  fc.assert(prop_buildTriplet_distinct_hash_yields_distinct_merkle_root, opts);
+});
+
+it("property: prop_buildTriplet_manifest_artifact_kind_is_property_tests", () => {
+  fc.assert(prop_buildTriplet_manifest_artifact_kind_is_property_tests, opts);
+});
+
+it("property: prop_buildTriplet_artifacts_map_contains_corpus_bytes", () => {
+  fc.assert(prop_buildTriplet_artifacts_map_contains_corpus_bytes, opts);
+});
+
+it("property: prop_buildTriplet_bootstrap_does_not_require_corpus", () => {
+  fc.assert(prop_buildTriplet_bootstrap_does_not_require_corpus, opts);
+});
+
+it("property: prop_buildTriplet_throws_without_corpus_and_without_bootstrap", () => {
+  fc.assert(prop_buildTriplet_throws_without_corpus_and_without_bootstrap, opts);
+});
+
+it("property: prop_L0_bootstrap_manifest_shape", () => {
+  fc.assert(prop_L0_bootstrap_manifest_shape, opts);
+});
+
+it("property: prop_makeBootstrapArtifacts_has_one_empty_entry", () => {
+  fc.assert(prop_makeBootstrapArtifacts_has_one_empty_entry, opts);
+});
+
+it("property: prop_buildTriplet_compound_content_address_stability", () => {
+  fc.assert(prop_buildTriplet_compound_content_address_stability, opts);
+});

--- a/packages/shave/src/persist/triplet.props.ts
+++ b/packages/shave/src/persist/triplet.props.ts
@@ -1,0 +1,494 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-001: hand-authored property-test corpus for
+// @yakcc/shave persist/triplet.ts atoms. Two-file pattern: this file
+// (.props.ts) is vitest-free and holds the corpus; the sibling .props.test.ts
+// is the vitest harness.
+// Status: accepted (WI-V2-07-PREFLIGHT L3c)
+// Rationale: See tmp/wi-v2-07-preflight-layer-plan.md — the corpus file must be
+// runtime-independent so L10 can hash it as a manifest artifact.
+//
+// Atoms covered (named exports from triplet.ts):
+//   buildTriplet (BT1.1)           — builds the full BuiltTriplet for a novel atom.
+//   L0_BOOTSTRAP_MANIFEST (BT1.2)  — the placeholder manifest constant (bootstrap opt-in).
+//   makeBootstrapArtifacts (BT1.3) — produces the empty-bytes artifact Map for bootstrap.
+//
+// Private helpers tested transitively via buildTriplet():
+//   (no named private helpers — specFromIntent is delegated to spec-from-intent.ts)
+//
+// Properties covered:
+//   - buildTriplet returns all required BuiltTriplet fields for any well-formed input.
+//   - buildTriplet impl field equals the raw source string.
+//   - buildTriplet spec.level is always "L0".
+//   - buildTriplet merkleRoot is non-empty for any input.
+//   - buildTriplet is deterministic: identical inputs yield identical merkleRoot and specHash.
+//   - buildTriplet distinct-source yields distinct merkleRoot (content-addressed identity).
+//   - buildTriplet distinct-hash yields distinct merkleRoot (hash suffix in specName).
+//   - buildTriplet with bootstrap=true does not require a CorpusResult.
+//   - buildTriplet without corpusResult and without bootstrap=true throws.
+//   - buildTriplet manifest.artifacts[0].kind === "property_tests" for corpus path.
+//   - buildTriplet artifacts Map contains the corpus bytes at the corpus path.
+//   - makeBootstrapArtifacts returns a Map with exactly one entry (empty bytes).
+//   - L0_BOOTSTRAP_MANIFEST has exactly one artifact with kind "property_tests".
+//
+// Deferred atoms:
+//   - specHash content-address correctness: covered by @yakcc/contracts invariants.
+//   - validateSpecYak integration: covered by spec-from-intent.props.ts compound test.
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for persist/triplet.ts
+// ---------------------------------------------------------------------------
+
+import type { CanonicalAstHash } from "@yakcc/contracts";
+import * as fc from "fast-check";
+import type { CorpusResult } from "../corpus/types.js";
+import type { IntentCard } from "../intent/types.js";
+import { L0_BOOTSTRAP_MANIFEST, buildTriplet, makeBootstrapArtifacts } from "./triplet.js";
+
+// ---------------------------------------------------------------------------
+// Shared arbitraries
+// ---------------------------------------------------------------------------
+
+/** Non-empty string with no leading/trailing whitespace. */
+const nonEmptyStr: fc.Arbitrary<string> = fc
+  .string({ minLength: 1, maxLength: 40 })
+  .filter((s) => s.trim().length > 0);
+
+/** 64-char hex string suitable for a CanonicalAstHash. */
+const hexHash64: fc.Arbitrary<string> = fc
+  .array(fc.integer({ min: 0, max: 15 }), { minLength: 64, maxLength: 64 })
+  .map((nibbles) => nibbles.map((n) => n.toString(16)).join(""));
+
+/** Well-formed IntentCard for property testing. */
+const intentCardArb: fc.Arbitrary<IntentCard> = fc.record({
+  schemaVersion: fc.constant(1 as const),
+  behavior: nonEmptyStr,
+  inputs: fc.array(
+    fc.record({
+      name: nonEmptyStr,
+      typeHint: nonEmptyStr,
+      description: fc.string({ minLength: 0, maxLength: 40 }),
+    }),
+    { minLength: 0, maxLength: 2 },
+  ),
+  outputs: fc.array(
+    fc.record({
+      name: nonEmptyStr,
+      typeHint: nonEmptyStr,
+      description: fc.string({ minLength: 0, maxLength: 40 }),
+    }),
+    { minLength: 0, maxLength: 2 },
+  ),
+  preconditions: fc.array(nonEmptyStr, { minLength: 0, maxLength: 2 }),
+  postconditions: fc.array(nonEmptyStr, { minLength: 0, maxLength: 2 }),
+  notes: fc.array(fc.string(), { minLength: 0, maxLength: 2 }),
+  modelVersion: nonEmptyStr,
+  promptVersion: nonEmptyStr,
+  sourceHash: hexHash64,
+  extractedAt: fc.constant("2024-01-01T00:00:00.000Z"),
+});
+
+/** Source text for an atom (non-empty string). */
+const sourceArb: fc.Arbitrary<string> = fc.string({ minLength: 1, maxLength: 200 });
+
+/** Arbitrary CorpusResult with deterministic bytes. */
+const corpusResultArb: fc.Arbitrary<CorpusResult> = fc
+  .tuple(nonEmptyStr, nonEmptyStr)
+  .map(([content, pathStem]) => {
+    const encoder = new TextEncoder();
+    const bytes = encoder.encode(content);
+    return {
+      source: "upstream-test" as const,
+      bytes,
+      path: `${pathStem}.fast-check.ts`,
+      contentHash: "aaaa1234",
+    };
+  });
+
+// ---------------------------------------------------------------------------
+// BT1.1: buildTriplet — returns all required BuiltTriplet fields
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_buildTriplet_has_all_required_fields
+ *
+ * For any well-formed IntentCard + source + hash + CorpusResult, buildTriplet
+ * returns an object with all required BuiltTriplet fields present and non-null.
+ *
+ * Invariant (BT1.1): BuiltTriplet is the canonical intermediate value between
+ * intent extraction and registry persistence. All six fields must be present
+ * for callers to construct a BlockTripletRow without re-derivation.
+ */
+export const prop_buildTriplet_has_all_required_fields = fc.property(
+  intentCardArb,
+  sourceArb,
+  hexHash64,
+  corpusResultArb,
+  (intentCard, source, hash, corpus) => {
+    const t = buildTriplet(intentCard, source, hash as CanonicalAstHash, corpus);
+    return (
+      t.spec !== undefined &&
+      t.specHash !== undefined &&
+      t.specCanonicalBytes instanceof Uint8Array &&
+      typeof t.impl === "string" &&
+      t.manifest !== undefined &&
+      typeof t.merkleRoot === "string" &&
+      t.artifacts instanceof Map
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// BT1.1: buildTriplet — impl equals the raw source string
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_buildTriplet_impl_equals_source
+ *
+ * buildTriplet().impl is always exactly equal to the source string passed in.
+ *
+ * Invariant (BT1.1, DEC-TRIPLET-IDENTITY-020): file bytes are the identity
+ * unit at L0 — no normalization, no trimming. The impl field must round-trip
+ * the source verbatim so blockMerkleRoot() uses the caller's exact bytes.
+ */
+export const prop_buildTriplet_impl_equals_source = fc.property(
+  intentCardArb,
+  sourceArb,
+  hexHash64,
+  corpusResultArb,
+  (intentCard, source, hash, corpus) => {
+    const t = buildTriplet(intentCard, source, hash as CanonicalAstHash, corpus);
+    return t.impl === source;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// BT1.1: buildTriplet — spec.level is always "L0"
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_buildTriplet_spec_level_is_L0
+ *
+ * The SpecYak embedded in the returned BuiltTriplet always has level === "L0".
+ *
+ * Invariant (BT1.1, DEC-TRIPLET-L0-ONLY-019): specFromIntent hard-codes "L0";
+ * buildTriplet inherits it. L1/L2/L3 upgrades require a separate path.
+ */
+export const prop_buildTriplet_spec_level_is_L0 = fc.property(
+  intentCardArb,
+  sourceArb,
+  hexHash64,
+  corpusResultArb,
+  (intentCard, source, hash, corpus) => {
+    const t = buildTriplet(intentCard, source, hash as CanonicalAstHash, corpus);
+    return t.spec.level === "L0";
+  },
+);
+
+// ---------------------------------------------------------------------------
+// BT1.1: buildTriplet — merkleRoot is a non-empty string
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_buildTriplet_merkle_root_is_non_empty
+ *
+ * The BlockMerkleRoot returned by buildTriplet is always a non-empty string.
+ *
+ * Invariant (BT1.1): blockMerkleRoot() from @yakcc/contracts always returns a
+ * hex-encoded BLAKE3-256 digest. An empty string would indicate a computation
+ * failure, which contracts does not produce on well-formed input.
+ */
+export const prop_buildTriplet_merkle_root_is_non_empty = fc.property(
+  intentCardArb,
+  sourceArb,
+  hexHash64,
+  corpusResultArb,
+  (intentCard, source, hash, corpus) => {
+    const t = buildTriplet(intentCard, source, hash as CanonicalAstHash, corpus);
+    return typeof t.merkleRoot === "string" && t.merkleRoot.length > 0;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// BT1.1: buildTriplet — determinism
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_buildTriplet_is_deterministic
+ *
+ * Two calls to buildTriplet() with identical inputs produce identical
+ * merkleRoot and specHash values.
+ *
+ * Invariant (BT1.1, DEC-ATOM-PERSIST-001): the content address derivation is
+ * pure — specFromIntent, specHash, and blockMerkleRoot are all deterministic.
+ * No timestamps or random bytes enter the computation.
+ */
+export const prop_buildTriplet_is_deterministic = fc.property(
+  intentCardArb,
+  sourceArb,
+  hexHash64,
+  corpusResultArb,
+  (intentCard, source, hash, corpus) => {
+    const t1 = buildTriplet(intentCard, source, hash as CanonicalAstHash, corpus);
+    const t2 = buildTriplet(intentCard, source, hash as CanonicalAstHash, corpus);
+    return t1.merkleRoot === t2.merkleRoot && t1.specHash === t2.specHash;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// BT1.1: buildTriplet — distinct source yields distinct merkleRoot
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_buildTriplet_distinct_source_yields_distinct_merkle_root
+ *
+ * Two calls with distinct source strings (all other args equal) produce
+ * distinct merkleRoots.
+ *
+ * Invariant (BT1.1, DEC-TRIPLET-IDENTITY-020): impl is part of the Merkle
+ * input. Changing the source bytes changes the block identity. This is the
+ * fundamental content-addressing guarantee.
+ */
+export const prop_buildTriplet_distinct_source_yields_distinct_merkle_root = fc.property(
+  fc.tuple(nonEmptyStr, nonEmptyStr).filter(([a, b]) => a !== b),
+  intentCardArb,
+  hexHash64,
+  corpusResultArb,
+  ([sourceA, sourceB], intentCard, hash, corpus) => {
+    const t1 = buildTriplet(intentCard, sourceA, hash as CanonicalAstHash, corpus);
+    const t2 = buildTriplet(intentCard, sourceB, hash as CanonicalAstHash, corpus);
+    return t1.merkleRoot !== t2.merkleRoot;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// BT1.1: buildTriplet — distinct hash yields distinct merkleRoot
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_buildTriplet_distinct_hash_yields_distinct_merkle_root
+ *
+ * Two calls with distinct canonicalAstHash values (all other args equal) produce
+ * distinct merkleRoots.
+ *
+ * Invariant (BT1.1): the canonicalAstHash feeds into specFromIntent's name slug
+ * (last 6 hex chars), which changes the SpecYak, which changes specCanonicalBytes,
+ * which changes blockMerkleRoot. Two atoms with the same source but different
+ * content addresses get distinct block identities.
+ */
+export const prop_buildTriplet_distinct_hash_yields_distinct_merkle_root = fc.property(
+  fc.tuple(hexHash64, hexHash64).filter(([a, b]) => a !== b),
+  intentCardArb,
+  sourceArb,
+  corpusResultArb,
+  ([hashA, hashB], intentCard, source, corpus) => {
+    const t1 = buildTriplet(intentCard, source, hashA as CanonicalAstHash, corpus);
+    const t2 = buildTriplet(intentCard, source, hashB as CanonicalAstHash, corpus);
+    return t1.merkleRoot !== t2.merkleRoot;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// BT1.1: buildTriplet — manifest.artifacts[0].kind is "property_tests"
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_buildTriplet_manifest_artifact_kind_is_property_tests
+ *
+ * The ProofManifest in the returned BuiltTriplet always has exactly one
+ * artifact with kind === "property_tests".
+ *
+ * Invariant (BT1.1, DEC-ATOM-PERSIST-001): L0 manifests carry exactly one
+ * artifact — the property-test corpus. validateProofManifestL0 enforces this
+ * shape at the contracts layer; buildTriplet must produce it consistently.
+ */
+export const prop_buildTriplet_manifest_artifact_kind_is_property_tests = fc.property(
+  intentCardArb,
+  sourceArb,
+  hexHash64,
+  corpusResultArb,
+  (intentCard, source, hash, corpus) => {
+    const t = buildTriplet(intentCard, source, hash as CanonicalAstHash, corpus);
+    return t.manifest.artifacts.length === 1 && t.manifest.artifacts[0]?.kind === "property_tests";
+  },
+);
+
+// ---------------------------------------------------------------------------
+// BT1.1: buildTriplet — artifacts Map contains corpus bytes at corpus path
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_buildTriplet_artifacts_map_contains_corpus_bytes
+ *
+ * The artifacts Map in the returned BuiltTriplet contains the corpus bytes at
+ * the corpus path declared in the manifest.
+ *
+ * Invariant (BT1.1, DEC-V1-FEDERATION-WIRE-ARTIFACTS-002): the SAME Map used
+ * for blockMerkleRoot() is forwarded via BuiltTriplet.artifacts. Callers must
+ * not reconstruct or copy it; this property verifies the bytes are accessible.
+ */
+export const prop_buildTriplet_artifacts_map_contains_corpus_bytes = fc.property(
+  intentCardArb,
+  sourceArb,
+  hexHash64,
+  corpusResultArb,
+  (intentCard, source, hash, corpus) => {
+    const t = buildTriplet(intentCard, source, hash as CanonicalAstHash, corpus);
+    const path = t.manifest.artifacts[0]?.path ?? "";
+    const stored = t.artifacts.get(path);
+    return stored !== undefined && stored === corpus.bytes;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// BT1.1: buildTriplet — bootstrap opt-in does not require CorpusResult
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_buildTriplet_bootstrap_does_not_require_corpus
+ *
+ * When options.bootstrap === true, buildTriplet succeeds without a CorpusResult.
+ *
+ * Invariant (BT1.1, DEC-ATOM-PERSIST-001): the bootstrap path is an explicit
+ * opt-in for migration/test scenarios. It must not throw when corpusResult is
+ * undefined. The produced triplet carries L0_BOOTSTRAP_MANIFEST.
+ */
+export const prop_buildTriplet_bootstrap_does_not_require_corpus = fc.property(
+  intentCardArb,
+  sourceArb,
+  hexHash64,
+  (intentCard, source, hash) => {
+    try {
+      const t = buildTriplet(intentCard, source, hash as CanonicalAstHash, undefined, {
+        bootstrap: true,
+      });
+      return typeof t.merkleRoot === "string" && t.merkleRoot.length > 0;
+    } catch {
+      return false;
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// BT1.1: buildTriplet — throws without corpusResult and without bootstrap
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_buildTriplet_throws_without_corpus_and_without_bootstrap
+ *
+ * When corpusResult is undefined and options.bootstrap is falsy, buildTriplet
+ * throws an Error (no silent fallback after WI-016).
+ *
+ * Invariant (BT1.1, DEC-ATOM-PERSIST-001): "WI-016 retirement of
+ * L0_BOOTSTRAP_MANIFEST as the silent default." Callers must supply a corpus
+ * result or opt into bootstrap explicitly. Silently emitting empty bytes is
+ * forbidden — the error here is the loudest possible failure.
+ */
+export const prop_buildTriplet_throws_without_corpus_and_without_bootstrap = fc.property(
+  intentCardArb,
+  sourceArb,
+  hexHash64,
+  (intentCard, source, hash) => {
+    try {
+      buildTriplet(intentCard, source, hash as CanonicalAstHash, undefined);
+      return false; // should have thrown
+    } catch {
+      return true;
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// BT1.2: L0_BOOTSTRAP_MANIFEST — has exactly one artifact with kind "property_tests"
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_L0_bootstrap_manifest_shape
+ *
+ * L0_BOOTSTRAP_MANIFEST has exactly one artifact entry with kind === "property_tests".
+ *
+ * Invariant (BT1.2): the bootstrap manifest constant is the canonical placeholder
+ * for bootstrap/migration scenarios. Its shape is validated here so callers that
+ * inspect it get a typed guarantee rather than relying on prose documentation.
+ */
+export const prop_L0_bootstrap_manifest_shape = fc.property(fc.constant(null), () => {
+  return (
+    Array.isArray(L0_BOOTSTRAP_MANIFEST.artifacts) &&
+    L0_BOOTSTRAP_MANIFEST.artifacts.length === 1 &&
+    L0_BOOTSTRAP_MANIFEST.artifacts[0]?.kind === "property_tests"
+  );
+});
+
+// ---------------------------------------------------------------------------
+// BT1.3: makeBootstrapArtifacts — returns a Map with exactly one entry (empty bytes)
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_makeBootstrapArtifacts_has_one_empty_entry
+ *
+ * makeBootstrapArtifacts() returns a Map with exactly one entry, whose value
+ * is an empty Uint8Array (zero length).
+ *
+ * Invariant (BT1.3, DEC-ATOM-PERSIST-001): the bootstrap artifact placeholder
+ * uses empty bytes as the corpus content. The single-entry Map matches the
+ * single artifact declared in L0_BOOTSTRAP_MANIFEST. Callers must forward this
+ * Map to BlockTripletRow.artifacts unchanged (DEC-V1-FEDERATION-WIRE-ARTIFACTS-002).
+ */
+export const prop_makeBootstrapArtifacts_has_one_empty_entry = fc.property(
+  fc.constant(null),
+  () => {
+    const m = makeBootstrapArtifacts();
+    const entries = [...m.entries()];
+    return (
+      entries.length === 1 &&
+      entries[0] !== undefined &&
+      entries[0][1] instanceof Uint8Array &&
+      entries[0][1].length === 0
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Compound interaction: buildTriplet → blockMerkleRoot (end-to-end)
+//
+// Production sequence: IntentCard + source + hash + CorpusResult → buildTriplet()
+// → specFromIntent() → specHash() → blockMerkleRoot() → BuiltTriplet.
+// This crosses spec derivation, content-address hashing, and manifest wiring.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_buildTriplet_compound_content_address_stability
+ *
+ * The merkleRoot produced by buildTriplet() is stable under re-computation:
+ * given the same inputs, the second call produces an equal merkleRoot. Furthermore,
+ * the artifacts Map path matches the manifest-declared path (end-to-end wiring check).
+ *
+ * This is the canonical compound-interaction property crossing:
+ *   IntentCard + source + hash + CorpusResult
+ *   → buildTriplet() → specFromIntent() + specHash() + blockMerkleRoot()
+ *   → BuiltTriplet with consistent merkleRoot + artifacts path alignment
+ *
+ * Invariant (BT1.1, DEC-V1-FEDERATION-WIRE-ARTIFACTS-002 + DEC-TRIPLET-IDENTITY-020):
+ * the SAME Map used for blockMerkleRoot() is forwarded in BuiltTriplet.artifacts,
+ * and its key is the corpus path from the manifest. Both must hold simultaneously
+ * for the federation wire contract to be satisfied.
+ */
+export const prop_buildTriplet_compound_content_address_stability = fc.property(
+  intentCardArb,
+  sourceArb,
+  hexHash64,
+  corpusResultArb,
+  (intentCard, source, hash, corpus) => {
+    const t1 = buildTriplet(intentCard, source, hash as CanonicalAstHash, corpus);
+    const t2 = buildTriplet(intentCard, source, hash as CanonicalAstHash, corpus);
+
+    // Merkle root must be stable across calls.
+    if (t1.merkleRoot !== t2.merkleRoot) return false;
+
+    // Artifacts Map must contain an entry at the path declared in the manifest.
+    const path = t1.manifest.artifacts[0]?.path ?? "";
+    if (!t1.artifacts.has(path)) return false;
+
+    // The path in the artifacts Map must be the same as the manifest path.
+    return [...t1.artifacts.keys()].includes(path);
+  },
+);


### PR DESCRIPTION
## Summary
- 3 source files / 37 props in shave/persist subtree
- Pre-authorized deferrals (per planner): real-Registry I/O paths (covered via duck-typed stub-registry), specFromIntent negative-case IntentCard behavior

## Authority domain
`property_test_corpus_yakcc_shave_persist`

## Test evidence
- Per-file isolation: 37/37 props pass (~917ms with PR #124 vitest fix)
- Full `@yakcc/shave` suite: 27/28 files pass + 1 skipped, 375/376 tests + 1 skipped, 33s
- Build: `pnpm --filter @yakcc/shave build` clean
- Tested against post-#124 vitest pool config (maxForks=2 per package)

## Reviewer verdict
`REVIEW_VERDICT: ready_for_guardian`, zero blockers, zero findings (verified by reviewer dispatch `a0056f9c3fd0723e6`)

## Backlog suggested
- WI to regen `bootstrap/expected-roots.json` to include new shave/persist corpus blobs (mechanical; PR #117 wires props-file auto-discovery)

## Continuation roadmap (per planner)
- L3d: `shave/cache/` (25 atoms, COLDEST cadence — recommended next)
- L3e: `shave/<root>` non-index (~32 atoms)
- L3f/g/h: `shave/intent/` split into 3 sub-slices
- L3i: `shave/corpus/` (after PR #117 cadence cools)
- L3j: `shave/universalize/` (after WI-V2-GLUE-AWARE-IMPL completes)

## DO NOT auto-merge — orchestrator review per #87

refs #87