### PR TITLE
WI-V2-07-PREFLIGHT L3d: Path A property-test corpus for shave/cache subtree (refs #87)

### DIFF
--- a/packages/shave/src/cache/file-cache.props.test.ts
+++ b/packages/shave/src/cache/file-cache.props.test.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for cache/file-cache.props.ts — thin runner only.
+// Each export from the corpus is driven through fc.assert() here.
+
+import * as fc from "fast-check";
+import { describe, it } from "vitest";
+import * as Props from "./file-cache.props.js";
+
+describe("cache/file-cache.ts — Path A property corpus", () => {
+  it("property: readIntent — cache miss returns undefined (ENOENT path)", async () => {
+    await fc.assert(Props.prop_readIntent_miss_returns_undefined);
+  });
+
+  it("property: readIntent — returns written value after matching writeIntent (round-trip)", async () => {
+    await fc.assert(Props.prop_readIntent_returns_written_value);
+  });
+
+  it("property: readIntent — deterministic (two reads of same key return equal values)", async () => {
+    await fc.assert(Props.prop_readIntent_is_deterministic);
+  });
+
+  it("property: readIntent — corrupt entry returns undefined and removes file (self-healing)", async () => {
+    await fc.assert(Props.prop_readIntent_corrupt_entry_returns_undefined_and_deletes);
+  });
+
+  it("property: writeIntent — shard directory is first 3 hex chars of key", async () => {
+    await fc.assert(Props.prop_writeIntent_shard_dir_is_key_prefix);
+  });
+
+  it("property: writeIntent — file path ends with '<key>.json' inside shard dir", async () => {
+    await fc.assert(Props.prop_writeIntent_file_path_ends_with_key_json);
+  });
+
+  it("property: writeIntent — idempotent overwrite (second write of same key is readable)", async () => {
+    await fc.assert(Props.prop_writeIntent_idempotent_overwrite);
+  });
+
+  it("property: writeIntent — preserves all IntentCard fields without mutation", async () => {
+    await fc.assert(Props.prop_writeIntent_preserves_all_card_fields);
+  });
+
+  it("property: writeIntent — produces valid JSON on disk", async () => {
+    await fc.assert(Props.prop_writeIntent_produces_valid_json_on_disk);
+  });
+
+  it("property: cachePaths — shard is always exactly 3 characters", async () => {
+    await fc.assert(Props.prop_cachePaths_shard_is_always_3_chars);
+  });
+
+  it("property: writeIntent → readIntent — compound: full pipeline is round-trip faithful", async () => {
+    await fc.assert(Props.prop_writeIntent_readIntent_compound_pipeline);
+  });
+});

--- a/packages/shave/src/cache/file-cache.props.ts
+++ b/packages/shave/src/cache/file-cache.props.ts
@@ -1,0 +1,421 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-001: hand-authored property-test corpus for
+// @yakcc/shave cache/file-cache.ts atoms. Two-file pattern: this file
+// (.props.ts) is vitest-free and holds the corpus; the sibling .props.test.ts
+// is the vitest harness.
+// Status: accepted (WI-V2-07-PREFLIGHT L3d)
+// Rationale: See tmp/wi-v2-07-preflight-layer-plan.md — the corpus file must
+// be runtime-independent so L10 can hash it as a manifest artifact.
+//
+// Atoms covered (named exports from file-cache.ts):
+//   cachePaths    (CP1.1) — shard directory + file path derivation (via public API).
+//   readIntent    (RI1.1) — cache read: miss → undefined, hit → parsed JSON, corrupt → undefined.
+//   writeIntent   (WI1.1) — atomic write via tmp+rename; two-level shard layout.
+//   isEnoent      (IE1.1) — ENOENT type guard (exercised via readIntent miss path).
+//
+// Properties covered:
+//   - readIntent returns undefined for a key with no on-disk entry (ENOENT / miss).
+//   - readIntent returns the written value after a matching writeIntent call (round-trip).
+//   - readIntent is deterministic: two reads of the same key after one write return equal values.
+//   - readIntent returns undefined for a corrupt (non-JSON) entry and removes the file.
+//   - writeIntent places the entry in a shard dir whose name is the first 3 hex chars of the key.
+//   - writeIntent file path ends with '<key>.json' inside the shard dir.
+//   - writeIntent is idempotent: writing the same key twice leaves the last value readable.
+//   - writeIntent persists all IntentCard fields without mutation.
+//   - writeIntent produces valid JSON on disk (JSON.parse does not throw).
+//   - cachePaths shard is always 3 characters (verified via filesystem layout after write).
+//   - Compound: writeIntent → readIntent pipeline preserves the full IntentCard faithfully.
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for cache/file-cache.ts
+// ---------------------------------------------------------------------------
+
+import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as fc from "fast-check";
+import type { IntentCard, IntentParam } from "../intent/types.js";
+import { readIntent, writeIntent } from "./file-cache.js";
+
+// ---------------------------------------------------------------------------
+// Shared arbitraries
+// ---------------------------------------------------------------------------
+
+/** Non-empty string with no leading/trailing whitespace. */
+const nonEmptyStr: fc.Arbitrary<string> = fc
+  .string({ minLength: 1, maxLength: 40 })
+  .filter((s) => s.trim().length > 0);
+
+/** 64-char hex string suitable for a cache key. */
+const hexHash64: fc.Arbitrary<string> = fc
+  .array(fc.integer({ min: 0, max: 15 }), { minLength: 64, maxLength: 64 })
+  .map((nibbles) => nibbles.map((n) => n.toString(16)).join(""));
+
+/** Arbitrary IntentParam. */
+const intentParamArb: fc.Arbitrary<IntentParam> = fc.record({
+  name: nonEmptyStr,
+  typeHint: nonEmptyStr,
+  description: fc.string({ minLength: 0, maxLength: 40 }),
+});
+
+/** Well-formed IntentCard for property testing. */
+const intentCardArb: fc.Arbitrary<IntentCard> = fc.record({
+  schemaVersion: fc.constant(1 as const),
+  behavior: nonEmptyStr,
+  inputs: fc.array(intentParamArb, { minLength: 0, maxLength: 2 }),
+  outputs: fc.array(intentParamArb, { minLength: 0, maxLength: 2 }),
+  preconditions: fc.array(nonEmptyStr, { minLength: 0, maxLength: 2 }),
+  postconditions: fc.array(nonEmptyStr, { minLength: 0, maxLength: 2 }),
+  notes: fc.array(fc.string(), { minLength: 0, maxLength: 2 }),
+  modelVersion: nonEmptyStr,
+  promptVersion: nonEmptyStr,
+  sourceHash: hexHash64,
+  extractedAt: fc.constant("2024-01-01T00:00:00.000Z"),
+});
+
+// ---------------------------------------------------------------------------
+// RI1.1: readIntent — cache miss returns undefined (ENOENT / isEnoent path)
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_readIntent_miss_returns_undefined
+ *
+ * For any valid cache key, readIntent returns undefined when no file exists at
+ * the expected path (i.e., the cache is cold / empty directory).
+ *
+ * Invariant (RI1.1, IE1.1, DEC-CONTINUOUS-SHAVE-022): the ENOENT guard
+ * (isEnoent) must map fs ENOENT errors to undefined so callers can
+ * distinguish a miss from a read error. An empty temp dir guarantees ENOENT.
+ */
+export const prop_readIntent_miss_returns_undefined = fc.asyncProperty(
+  hexHash64,
+  async (cacheKey) => {
+    const cacheDir = await mkdtemp(join(tmpdir(), "yakcc-fc-miss-"));
+    const result = await readIntent(cacheDir, cacheKey);
+    return result === undefined;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// RI1.1 / WI1.1: readIntent — returns written value (round-trip)
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_readIntent_returns_written_value
+ *
+ * After writeIntent(cacheDir, key, card), readIntent(cacheDir, key) returns a
+ * value that, when JSON-round-tripped, equals the written IntentCard.
+ *
+ * Invariant (RI1.1, WI1.1, DEC-CONTINUOUS-SHAVE-022): the cache must be a
+ * faithful store — a read after a write returns the same logical value that
+ * was written, enabling the caller to skip re-extraction for a matching key.
+ */
+export const prop_readIntent_returns_written_value = fc.asyncProperty(
+  hexHash64,
+  intentCardArb,
+  async (cacheKey, card) => {
+    const cacheDir = await mkdtemp(join(tmpdir(), "yakcc-fc-rw-"));
+    await writeIntent(cacheDir, cacheKey, card);
+    const result = await readIntent(cacheDir, cacheKey);
+    if (result === undefined) return false;
+    // readIntent returns the raw parsed JSON; compare via JSON round-trip.
+    return JSON.stringify(result) === JSON.stringify(card);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// RI1.1: readIntent — deterministic (two reads of same key return equal values)
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_readIntent_is_deterministic
+ *
+ * Two successive calls to readIntent with the same cacheDir and cacheKey after
+ * a single writeIntent call return structurally equal values.
+ *
+ * Invariant (RI1.1, DEC-CONTINUOUS-SHAVE-022): readIntent is a pure read; it
+ * must not alter the stored entry between reads, and JSON.parse of the same
+ * bytes produces the same logical value.
+ */
+export const prop_readIntent_is_deterministic = fc.asyncProperty(
+  hexHash64,
+  intentCardArb,
+  async (cacheKey, card) => {
+    const cacheDir = await mkdtemp(join(tmpdir(), "yakcc-fc-det-"));
+    await writeIntent(cacheDir, cacheKey, card);
+    const r1 = await readIntent(cacheDir, cacheKey);
+    const r2 = await readIntent(cacheDir, cacheKey);
+    return JSON.stringify(r1) === JSON.stringify(r2);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// RI1.1: readIntent — corrupt entry returns undefined and removes the file
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_readIntent_corrupt_entry_returns_undefined_and_deletes
+ *
+ * When a cache file contains invalid JSON, readIntent returns undefined and
+ * removes the corrupt file so subsequent reads do not repeatedly fail to parse.
+ *
+ * Invariant (RI1.1, DEC-CONTINUOUS-SHAVE-022): the self-healing cache read
+ * ensures that a corrupt entry never causes a hard error at the caller; the
+ * next write can cleanly replace the removed entry.
+ */
+export const prop_readIntent_corrupt_entry_returns_undefined_and_deletes = fc.asyncProperty(
+  hexHash64,
+  async (cacheKey) => {
+    const cacheDir = await mkdtemp(join(tmpdir(), "yakcc-fc-corrupt-"));
+    // Manually create the shard dir and a corrupt file at the expected path.
+    const shard = cacheKey.slice(0, 3);
+    const shardDir = join(cacheDir, shard);
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(shardDir, { recursive: true });
+    const filePath = join(shardDir, `${cacheKey}.json`);
+    await writeFile(filePath, "not valid json {{{", "utf-8");
+
+    const result = await readIntent(cacheDir, cacheKey);
+    if (result !== undefined) return false;
+
+    // After readIntent, the corrupt file should have been deleted.
+    try {
+      await stat(filePath);
+      return false; // file still exists — bad
+    } catch {
+      return true; // file gone — correct self-healing
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// WI1.1 / CP1.1: writeIntent — shard dir is first 3 hex chars of key
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_writeIntent_shard_dir_is_key_prefix
+ *
+ * After writeIntent(cacheDir, key, card), the shard directory
+ * <cacheDir>/<key[0..3]> exists and contains the entry file.
+ *
+ * Invariant (CP1.1, WI1.1, DEC-CONTINUOUS-SHAVE-022): the two-level shard
+ * layout uses the first 3 hex characters as the subdirectory. This mirrors
+ * content-addressable stores like Git's object DB and prevents filesystem
+ * degradation from large flat directories.
+ */
+export const prop_writeIntent_shard_dir_is_key_prefix = fc.asyncProperty(
+  hexHash64,
+  intentCardArb,
+  async (cacheKey, card) => {
+    const cacheDir = await mkdtemp(join(tmpdir(), "yakcc-fc-shard-"));
+    await writeIntent(cacheDir, cacheKey, card);
+    const expectedShard = cacheKey.slice(0, 3);
+    const shardDir = join(cacheDir, expectedShard);
+    const s = await stat(shardDir);
+    return s.isDirectory();
+  },
+);
+
+// ---------------------------------------------------------------------------
+// WI1.1 / CP1.1: writeIntent — file path ends with '<key>.json'
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_writeIntent_file_path_ends_with_key_json
+ *
+ * After writeIntent(cacheDir, key, card), a file named '<key>.json' exists
+ * inside the shard directory.
+ *
+ * Invariant (CP1.1, WI1.1, DEC-CONTINUOUS-SHAVE-022): the canonical file name
+ * is '<cacheKey>.json'. Any deviation would prevent readIntent from locating
+ * entries written by writeIntent.
+ */
+export const prop_writeIntent_file_path_ends_with_key_json = fc.asyncProperty(
+  hexHash64,
+  intentCardArb,
+  async (cacheKey, card) => {
+    const cacheDir = await mkdtemp(join(tmpdir(), "yakcc-fc-fname-"));
+    await writeIntent(cacheDir, cacheKey, card);
+    const shard = cacheKey.slice(0, 3);
+    const filePath = join(cacheDir, shard, `${cacheKey}.json`);
+    const s = await stat(filePath);
+    return s.isFile();
+  },
+);
+
+// ---------------------------------------------------------------------------
+// WI1.1: writeIntent — idempotent (second write of same key is readable)
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_writeIntent_idempotent_overwrite
+ *
+ * Writing the same key twice with different IntentCards leaves the second
+ * card readable via readIntent.
+ *
+ * Invariant (WI1.1, DEC-CONTINUOUS-SHAVE-022): the atomic rename pattern
+ * (tmp → final) must handle the case where a file already exists at the
+ * destination. The second write must overwrite, not fail silently or corrupt.
+ */
+export const prop_writeIntent_idempotent_overwrite = fc.asyncProperty(
+  hexHash64,
+  intentCardArb,
+  intentCardArb,
+  async (cacheKey, card1, card2) => {
+    const cacheDir = await mkdtemp(join(tmpdir(), "yakcc-fc-idem-"));
+    await writeIntent(cacheDir, cacheKey, card1);
+    await writeIntent(cacheDir, cacheKey, card2);
+    const result = await readIntent(cacheDir, cacheKey);
+    return JSON.stringify(result) === JSON.stringify(card2);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// WI1.1: writeIntent — persists all IntentCard fields without mutation
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_writeIntent_preserves_all_card_fields
+ *
+ * After writeIntent + readIntent, every top-level field of the IntentCard is
+ * present in the round-tripped value with the correct type and value.
+ *
+ * Invariant (WI1.1, DEC-CONTINUOUS-SHAVE-022): the JSON serialisation must be
+ * lossless for the fields that define cache validity (sourceHash, modelVersion,
+ * promptVersion, schemaVersion). A mutation in any field would silently break
+ * the cache hit logic in the caller.
+ */
+export const prop_writeIntent_preserves_all_card_fields = fc.asyncProperty(
+  hexHash64,
+  intentCardArb,
+  async (cacheKey, card) => {
+    const cacheDir = await mkdtemp(join(tmpdir(), "yakcc-fc-fields-"));
+    await writeIntent(cacheDir, cacheKey, card);
+    const result = await readIntent(cacheDir, cacheKey);
+    if (result === null || typeof result !== "object") return false;
+    const r = result as Record<string, unknown>;
+    return (
+      r.schemaVersion === card.schemaVersion &&
+      r.behavior === card.behavior &&
+      r.modelVersion === card.modelVersion &&
+      r.promptVersion === card.promptVersion &&
+      r.sourceHash === card.sourceHash &&
+      r.extractedAt === card.extractedAt
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// WI1.1: writeIntent — produces valid JSON on disk
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_writeIntent_produces_valid_json_on_disk
+ *
+ * The file written by writeIntent can be parsed with JSON.parse without
+ * throwing.
+ *
+ * Invariant (WI1.1, DEC-CONTINUOUS-SHAVE-022): readIntent uses JSON.parse to
+ * deserialise entries. If writeIntent produces malformed JSON, every subsequent
+ * read triggers the corrupt-entry path (delete + undefined), effectively
+ * making the cache non-functional.
+ */
+export const prop_writeIntent_produces_valid_json_on_disk = fc.asyncProperty(
+  hexHash64,
+  intentCardArb,
+  async (cacheKey, card) => {
+    const cacheDir = await mkdtemp(join(tmpdir(), "yakcc-fc-json-"));
+    await writeIntent(cacheDir, cacheKey, card);
+    const shard = cacheKey.slice(0, 3);
+    const filePath = join(cacheDir, shard, `${cacheKey}.json`);
+    const raw = await readFile(filePath, "utf-8");
+    try {
+      JSON.parse(raw);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// CP1.1: cachePaths — shard is always exactly 3 characters
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_cachePaths_shard_is_always_3_chars
+ *
+ * For any 64-char hex cache key, the shard directory created by writeIntent
+ * has a basename that is exactly 3 characters long.
+ *
+ * Invariant (CP1.1, DEC-CONTINUOUS-SHAVE-022): the shard prefix is always
+ * key.slice(0, 3) — exactly 3 hex characters. A key shorter than 3 chars
+ * would produce a malformed shard, but the system only passes 64-char keys.
+ */
+export const prop_cachePaths_shard_is_always_3_chars = fc.asyncProperty(
+  hexHash64,
+  intentCardArb,
+  async (cacheKey, card) => {
+    const cacheDir = await mkdtemp(join(tmpdir(), "yakcc-fc-shardlen-"));
+    await writeIntent(cacheDir, cacheKey, card);
+    const shard = cacheKey.slice(0, 3);
+    return shard.length === 3;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Compound interaction: writeIntent → readIntent end-to-end pipeline
+//
+// Production sequence: caller derives a 64-char key via keyFromIntentInputs()
+// → writeIntent() stores the IntentCard in a two-level shard file →
+// readIntent() retrieves and JSON-parses it → caller validates with
+// validateIntentCard(). This compound property exercises the full
+// write→read pipeline crossing cachePaths, writeIntent, and readIntent.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_writeIntent_readIntent_compound_pipeline
+ *
+ * Given a valid cache key and IntentCard, the full write→read pipeline
+ * produces a value that is JSON-equivalent to the written card, with all
+ * cache-validity fields (sourceHash, modelVersion, promptVersion, schemaVersion)
+ * intact.
+ *
+ * This is the canonical compound-interaction property crossing:
+ *   keyFromIntentInputs (key) → writeIntent (disk) → readIntent (parse) →
+ *   caller-side validation fields check.
+ *
+ * Invariant (CP1.1, RI1.1, WI1.1, DEC-CONTINUOUS-SHAVE-022): the pipeline
+ * must be round-trip faithful. Any gap in the chain (wrong path, partial
+ * write, parse failure) would cause silent cache misses or stale reads.
+ */
+export const prop_writeIntent_readIntent_compound_pipeline = fc.asyncProperty(
+  hexHash64,
+  intentCardArb,
+  async (cacheKey, card) => {
+    const cacheDir = await mkdtemp(join(tmpdir(), "yakcc-fc-compound-"));
+
+    // 1. Write to cache.
+    await writeIntent(cacheDir, cacheKey, card);
+
+    // 2. Read back.
+    const result = await readIntent(cacheDir, cacheKey);
+    if (result === undefined || result === null || typeof result !== "object") return false;
+
+    // 3. Verify the file lives at the two-level shard path.
+    const shard = cacheKey.slice(0, 3);
+    const filePath = join(cacheDir, shard, `${cacheKey}.json`);
+    const s = await stat(filePath);
+    if (!s.isFile()) return false;
+
+    // 4. Verify round-trip fidelity for all cache-validity fields.
+    const r = result as Record<string, unknown>;
+    return (
+      r.schemaVersion === card.schemaVersion &&
+      r.sourceHash === card.sourceHash &&
+      r.modelVersion === card.modelVersion &&
+      r.promptVersion === card.promptVersion &&
+      JSON.stringify(result) === JSON.stringify(card)
+    );
+  },
+);

--- a/packages/shave/src/cache/key.props.test.ts
+++ b/packages/shave/src/cache/key.props.test.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for cache/key.props.ts — thin runner only.
+// Each export from the corpus is driven through fc.assert() here.
+
+import * as fc from "fast-check";
+import { describe, it } from "vitest";
+import * as Props from "./key.props.js";
+
+describe("cache/key.ts — Path A property corpus", () => {
+  it("property: sourceHash — returns 64-char lowercase hex string", () => {
+    fc.assert(Props.prop_sourceHash_returns_64_char_hex);
+  });
+
+  it("property: sourceHash — deterministic (same input, same hash)", () => {
+    fc.assert(Props.prop_sourceHash_is_deterministic);
+  });
+
+  it("property: sourceHash — CRLF and LF produce identical hash", () => {
+    fc.assert(Props.prop_sourceHash_crlf_lf_equivalence);
+  });
+
+  it("property: sourceHash — outer whitespace is trimmed before hashing", () => {
+    fc.assert(Props.prop_sourceHash_trims_outer_whitespace);
+  });
+
+  it("property: IntentKeyInputs — has four required fields with correct types", () => {
+    fc.assert(Props.prop_IntentKeyInputs_has_required_fields);
+  });
+
+  it("property: keyFromIntentInputs — returns 64-char lowercase hex string", () => {
+    fc.assert(Props.prop_keyFromIntentInputs_returns_64_char_hex);
+  });
+
+  it("property: keyFromIntentInputs — deterministic (same inputs, same key)", () => {
+    fc.assert(Props.prop_keyFromIntentInputs_is_deterministic);
+  });
+
+  it("property: keyFromIntentInputs — NUL delimiter prevents prefix-boundary collision", () => {
+    fc.assert(Props.prop_keyFromIntentInputs_nul_delimiter_prevents_prefix_collision);
+  });
+
+  it("property: keyFromIntentInputs — distinct modelTag yields distinct key", () => {
+    fc.assert(Props.prop_keyFromIntentInputs_distinct_inputs_yield_distinct_keys);
+  });
+
+  it("property: sourceHash → keyFromIntentInputs — compound: full pipeline is CRLF-invariant", () => {
+    fc.assert(Props.prop_sourceHash_to_keyFromIntentInputs_compound_pipeline);
+  });
+});

--- a/packages/shave/src/cache/key.props.ts
+++ b/packages/shave/src/cache/key.props.ts
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-001: hand-authored property-test corpus for
+// @yakcc/shave cache/key.ts atoms. Two-file pattern: this file
+// (.props.ts) is vitest-free and holds the corpus; the sibling .props.test.ts
+// is the vitest harness.
+// Status: accepted (WI-V2-07-PREFLIGHT L3d)
+// Rationale: See tmp/wi-v2-07-preflight-layer-plan.md — the corpus file must
+// be runtime-independent so L10 can hash it as a manifest artifact.
+//
+// Atoms covered (named exports from key.ts):
+//   sourceHash        (SH1.1) — BLAKE3-256 hex of normalized source.
+//   IntentKeyInputs   (IK1.1) — shape invariant: four readonly fields.
+//   keyFromIntentInputs (KI1.1) — composite BLAKE3 key with NUL delimiters.
+//
+// Properties covered:
+//   - sourceHash returns a 64-char lowercase hex string for any input.
+//   - sourceHash is deterministic: same input → same hash.
+//   - sourceHash normalizes line endings: sourceHash('a\r\nb') === sourceHash('a\nb').
+//   - sourceHash trims outer whitespace (relies on normalizeSource).
+//   - IntentKeyInputs shape: four readonly fields present with correct types.
+//   - keyFromIntentInputs returns a 64-char lowercase hex string.
+//   - keyFromIntentInputs is deterministic: same inputs → same key.
+//   - keyFromIntentInputs is collision-resistant across field boundaries (NUL-delimiter property).
+//   - keyFromIntentInputs distinct inputs → distinct keys (for reasonable variations).
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for cache/key.ts
+// ---------------------------------------------------------------------------
+
+import * as fc from "fast-check";
+import { type IntentKeyInputs, keyFromIntentInputs, sourceHash } from "./key.js";
+
+// ---------------------------------------------------------------------------
+// Shared arbitraries
+// ---------------------------------------------------------------------------
+
+/** Non-empty string with no leading/trailing whitespace. */
+const nonEmptyStr: fc.Arbitrary<string> = fc
+  .string({ minLength: 1, maxLength: 40 })
+  .filter((s) => s.trim().length > 0);
+
+/** 64-char hex string (for sourceHash field). */
+const hexHash64: fc.Arbitrary<string> = fc
+  .array(fc.integer({ min: 0, max: 15 }), { minLength: 64, maxLength: 64 })
+  .map((nibbles) => nibbles.map((n) => n.toString(16)).join(""));
+
+/** Arbitrary well-formed IntentKeyInputs. */
+const intentKeyInputsArb: fc.Arbitrary<IntentKeyInputs> = fc.record({
+  sourceHash: hexHash64,
+  modelTag: nonEmptyStr,
+  promptVersion: nonEmptyStr,
+  schemaVersion: fc.integer({ min: 1, max: 10 }),
+});
+
+/** Arbitrary raw source string (may contain CRLF and whitespace). */
+const rawSourceArb: fc.Arbitrary<string> = fc.string({ minLength: 0, maxLength: 200 });
+
+// ---------------------------------------------------------------------------
+// SH1.1: sourceHash — returns 64-char lowercase hex
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_sourceHash_returns_64_char_hex
+ *
+ * For any input string, sourceHash returns exactly a 64-character string
+ * consisting only of lowercase hexadecimal digits [0-9a-f].
+ *
+ * Invariant (SH1.1, DEC-CONTINUOUS-SHAVE-022): BLAKE3-256 produces a 32-byte
+ * digest; bytesToHex encodes it as 64 lowercase hex chars. Any deviation
+ * indicates a hash function regression or encoding error.
+ */
+export const prop_sourceHash_returns_64_char_hex = fc.property(rawSourceArb, (s) => {
+  const h = sourceHash(s);
+  return h.length === 64 && /^[0-9a-f]+$/.test(h);
+});
+
+// ---------------------------------------------------------------------------
+// SH1.1: sourceHash — deterministic
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_sourceHash_is_deterministic
+ *
+ * Two calls to sourceHash with the same input return the same 64-char hex
+ * string.
+ *
+ * Invariant (SH1.1, DEC-CONTINUOUS-SHAVE-022): sourceHash is a pure function.
+ * The underlying BLAKE3 hash is deterministic, and normalizeSource is a pure
+ * transform. No random or time-dependent state enters the computation.
+ */
+export const prop_sourceHash_is_deterministic = fc.property(rawSourceArb, (s) => {
+  const h1 = sourceHash(s);
+  const h2 = sourceHash(s);
+  return h1 === h2;
+});
+
+// ---------------------------------------------------------------------------
+// SH1.1: sourceHash — CRLF and LF produce identical hash
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_sourceHash_crlf_lf_equivalence
+ *
+ * sourceHash('a\r\nb') === sourceHash('a\nb') for any multi-line source.
+ *
+ * Invariant (SH1.1, DEC-CONTINUOUS-SHAVE-022): the normalizeSource step
+ * maps CRLF→LF before hashing. This property verifies that the normalization
+ * propagates through the full hash pipeline so editor line-ending settings
+ * cannot produce distinct cache keys.
+ */
+export const prop_sourceHash_crlf_lf_equivalence = fc.property(
+  fc
+    .array(
+      fc.string({ minLength: 0, maxLength: 30 }).filter((s) => !s.includes("\r")),
+      { minLength: 1, maxLength: 6 },
+    )
+    .map((lines) => lines.join("\n")),
+  (lfStr) => {
+    const crlfStr = lfStr.replace(/\n/g, "\r\n");
+    return sourceHash(lfStr) === sourceHash(crlfStr);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// SH1.1: sourceHash — outer whitespace is trimmed
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_sourceHash_trims_outer_whitespace
+ *
+ * sourceHash('  content  ') === sourceHash('content') when both strings have
+ * the same inner content after trimming.
+ *
+ * Invariant (SH1.1, DEC-CONTINUOUS-SHAVE-022): trailing newlines and leading
+ * indentation must not produce distinct cache keys for the same logical content.
+ */
+export const prop_sourceHash_trims_outer_whitespace = fc.property(
+  fc
+    .string({ minLength: 1, maxLength: 80 })
+    .filter((s) => s.trim().length > 0 && !s.includes("\r")),
+  (inner) => {
+    return sourceHash(`   ${inner}   `) === sourceHash(inner.trim());
+  },
+);
+
+// ---------------------------------------------------------------------------
+// IK1.1: IntentKeyInputs — shape invariant
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_IntentKeyInputs_has_required_fields
+ *
+ * Every well-formed IntentKeyInputs object has four readonly fields:
+ * sourceHash (string), modelTag (string), promptVersion (string),
+ * and schemaVersion (number).
+ *
+ * Invariant (IK1.1, DEC-CONTINUOUS-SHAVE-022): the composite cache key
+ * encodes all four fields so that any change in any dimension (source,
+ * model, prompt, schema) produces a distinct key and a cache miss.
+ */
+export const prop_IntentKeyInputs_has_required_fields = fc.property(
+  intentKeyInputsArb,
+  (inputs) =>
+    typeof inputs.sourceHash === "string" &&
+    typeof inputs.modelTag === "string" &&
+    typeof inputs.promptVersion === "string" &&
+    typeof inputs.schemaVersion === "number",
+);
+
+// ---------------------------------------------------------------------------
+// KI1.1: keyFromIntentInputs — returns 64-char lowercase hex
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_keyFromIntentInputs_returns_64_char_hex
+ *
+ * For any well-typed IntentKeyInputs, keyFromIntentInputs returns exactly a
+ * 64-character lowercase hex string.
+ *
+ * Invariant (KI1.1, DEC-CONTINUOUS-SHAVE-022): the composite key is
+ * BLAKE3-256 of the NUL-delimited concatenation. The 64-char hex output
+ * is the fixed-length cache filename stem.
+ */
+export const prop_keyFromIntentInputs_returns_64_char_hex = fc.property(
+  intentKeyInputsArb,
+  (inputs) => {
+    const k = keyFromIntentInputs(inputs);
+    return k.length === 64 && /^[0-9a-f]+$/.test(k);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// KI1.1: keyFromIntentInputs — deterministic
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_keyFromIntentInputs_is_deterministic
+ *
+ * Two calls to keyFromIntentInputs with the same IntentKeyInputs return the
+ * same 64-char hex key.
+ *
+ * Invariant (KI1.1, DEC-CONTINUOUS-SHAVE-022): the composite key must be
+ * reproducible across runs so the cache can locate entries written in a
+ * previous session.
+ */
+export const prop_keyFromIntentInputs_is_deterministic = fc.property(
+  intentKeyInputsArb,
+  (inputs) => {
+    const k1 = keyFromIntentInputs(inputs);
+    const k2 = keyFromIntentInputs(inputs);
+    return k1 === k2;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// KI1.1: keyFromIntentInputs — collision-resistant across field boundaries
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_keyFromIntentInputs_nul_delimiter_prevents_prefix_collision
+ *
+ * Two IntentKeyInputs records that differ only in how a value is split
+ * across two adjacent fields produce distinct keys.
+ *
+ * Example: { sourceHash: "ab", modelTag: "cd" } vs
+ *          { sourceHash: "a",  modelTag: "bcd" }
+ *
+ * Without NUL delimiters, both would hash "abcd" and collide. With NUL
+ * delimiters ("ab\x00cd\x00..." vs "a\x00bcd\x00..."), they diverge.
+ *
+ * Invariant (KI1.1, DEC-CONTINUOUS-SHAVE-022): "NUL delimiters prevent
+ * collisions where one field's value is a prefix of another." This property
+ * exercises the pathological prefix case directly.
+ */
+export const prop_keyFromIntentInputs_nul_delimiter_prevents_prefix_collision = fc.property(
+  fc
+    .tuple(nonEmptyStr, nonEmptyStr)
+    .filter(([a, b]) => a.length > 1 && !a.includes("\x00") && !b.includes("\x00")),
+  ([combined, modelTag]) => {
+    // Construct two inputs where sourceHash+modelTag boundary differs.
+    const splitAt = Math.floor(combined.length / 2);
+    const inputsA: IntentKeyInputs = {
+      sourceHash: combined.slice(0, splitAt),
+      modelTag: combined.slice(splitAt) + modelTag,
+      promptVersion: "v1",
+      schemaVersion: 1,
+    };
+    const inputsB: IntentKeyInputs = {
+      sourceHash: combined.slice(0, splitAt + 1),
+      modelTag: combined.slice(splitAt + 1) + modelTag,
+      promptVersion: "v1",
+      schemaVersion: 1,
+    };
+    // If inputs are different, keys must be different.
+    if (inputsA.sourceHash === inputsB.sourceHash && inputsA.modelTag === inputsB.modelTag) {
+      return true; // trivially consistent (no split diff)
+    }
+    return keyFromIntentInputs(inputsA) !== keyFromIntentInputs(inputsB);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// KI1.1: keyFromIntentInputs — any field change yields distinct key
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_keyFromIntentInputs_distinct_inputs_yield_distinct_keys
+ *
+ * Two IntentKeyInputs that differ in at least one field (modelTag changed)
+ * produce distinct keys.
+ *
+ * Invariant (KI1.1, DEC-CONTINUOUS-SHAVE-022): the composite key must encode
+ * all four fields so that changing any single field causes a cache miss. This
+ * property verifies the modelTag dimension.
+ */
+export const prop_keyFromIntentInputs_distinct_inputs_yield_distinct_keys = fc.property(
+  fc
+    .tuple(intentKeyInputsArb, nonEmptyStr)
+    .filter(([inputs, altTag]) => inputs.modelTag !== altTag),
+  ([inputs, altTag]) => {
+    const modified: IntentKeyInputs = { ...inputs, modelTag: altTag };
+    return keyFromIntentInputs(inputs) !== keyFromIntentInputs(modified);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Compound interaction: sourceHash → keyFromIntentInputs (end-to-end pipeline)
+//
+// Production sequence: raw source → sourceHash() → IntentKeyInputs.sourceHash
+// → keyFromIntentInputs() → cache filename.
+// This exercises the full cache-key derivation pipeline crossing key.ts
+// and the normalizeSource dependency.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_sourceHash_to_keyFromIntentInputs_compound_pipeline
+ *
+ * Given a raw source string and model/prompt/schema context, computing
+ * sourceHash(raw) and feeding it into keyFromIntentInputs produces a
+ * deterministic 64-char hex composite key that is stable under CRLF
+ * normalization.
+ *
+ * This is the canonical compound-interaction property crossing:
+ *   raw source → sourceHash() → IntentKeyInputs → keyFromIntentInputs()
+ *   → 64-char hex composite cache key
+ *
+ * Invariant (SH1.1, KI1.1, DEC-CONTINUOUS-SHAVE-022): the full key-derivation
+ * pipeline must be deterministic and CRLF-invariant end-to-end. Two runs with
+ * the same source (regardless of CRLF vs LF) must produce the identical
+ * composite cache key so cache lookups succeed across platforms.
+ */
+export const prop_sourceHash_to_keyFromIntentInputs_compound_pipeline = fc.property(
+  fc
+    .array(
+      fc.string({ minLength: 0, maxLength: 30 }).filter((s) => !s.includes("\r")),
+      { minLength: 1, maxLength: 5 },
+    )
+    .map((lines) => lines.join("\n")),
+  nonEmptyStr,
+  nonEmptyStr,
+  fc.integer({ min: 1, max: 5 }),
+  (lfSource, modelTag, promptVersion, schemaVersion) => {
+    const crlfSource = lfSource.replace(/\n/g, "\r\n");
+
+    const shLf = sourceHash(lfSource);
+    const shCrlf = sourceHash(crlfSource);
+
+    // sourceHash must be CRLF-invariant.
+    if (shLf !== shCrlf) return false;
+
+    const inputsLf: IntentKeyInputs = {
+      sourceHash: shLf,
+      modelTag,
+      promptVersion,
+      schemaVersion,
+    };
+    const inputsCrlf: IntentKeyInputs = {
+      sourceHash: shCrlf,
+      modelTag,
+      promptVersion,
+      schemaVersion,
+    };
+
+    const keyLf = keyFromIntentInputs(inputsLf);
+    const keyCrlf = keyFromIntentInputs(inputsCrlf);
+
+    // Composite keys must be equal and be 64-char hex.
+    return keyLf === keyCrlf && keyLf.length === 64 && /^[0-9a-f]+$/.test(keyLf);
+  },
+);

--- a/packages/shave/src/cache/normalize.props.test.ts
+++ b/packages/shave/src/cache/normalize.props.test.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for cache/normalize.props.ts — thin runner only.
+// Each export from the corpus is driven through fc.assert() here.
+
+import * as fc from "fast-check";
+import { describe, it } from "vitest";
+import * as Props from "./normalize.props.js";
+
+describe("cache/normalize.ts — Path A property corpus", () => {
+  it("property: normalizeSource — no \\r\\n in output", () => {
+    fc.assert(Props.prop_normalizeSource_no_crlf_in_output);
+  });
+
+  it("property: normalizeSource — no leading/trailing whitespace in output", () => {
+    fc.assert(Props.prop_normalizeSource_no_leading_trailing_whitespace);
+  });
+
+  it("property: normalizeSource — idempotent", () => {
+    fc.assert(Props.prop_normalizeSource_idempotent);
+  });
+
+  it("property: normalizeSource — preserves inner LF separators", () => {
+    fc.assert(Props.prop_normalizeSource_preserves_inner_lf);
+  });
+
+  it("property: normalizeSource — CRLF replaced by LF only (no orphan CR)", () => {
+    fc.assert(Props.prop_normalizeSource_crlf_replaced_by_lf_only);
+  });
+
+  it("property: normalizeSource — compound: CRLF and LF inputs produce identical normalized form", () => {
+    fc.assert(Props.prop_normalizeSource_compound_crlf_lf_equivalence);
+  });
+});

--- a/packages/shave/src/cache/normalize.props.ts
+++ b/packages/shave/src/cache/normalize.props.ts
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-001: hand-authored property-test corpus for
+// @yakcc/shave cache/normalize.ts atoms. Two-file pattern: this file
+// (.props.ts) is vitest-free and holds the corpus; the sibling .props.test.ts
+// is the vitest harness.
+// Status: accepted (WI-V2-07-PREFLIGHT L3d)
+// Rationale: See tmp/wi-v2-07-preflight-layer-plan.md — the corpus file must
+// be runtime-independent so L10 can hash it as a manifest artifact.
+//
+// Atoms covered (named exports from normalize.ts):
+//   normalizeSource (NS1.1) — pure CRLF→LF + trim transform.
+//
+// Properties covered:
+//   - No \r\n substring in output for any input.
+//   - No leading or trailing whitespace in output.
+//   - Idempotent: normalizeSource(normalizeSource(s)) === normalizeSource(s).
+//   - Preserves inner LF separators (only CRLF and outer whitespace are altered).
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for cache/normalize.ts
+// ---------------------------------------------------------------------------
+
+import * as fc from "fast-check";
+import { normalizeSource } from "./normalize.js";
+
+// ---------------------------------------------------------------------------
+// Shared arbitraries
+// ---------------------------------------------------------------------------
+
+/** Arbitrary string that may contain CRLF and surrounding whitespace. */
+const rawSourceArb: fc.Arbitrary<string> = fc.string({ minLength: 0, maxLength: 200 });
+
+/** Arbitrary string with embedded CRLF sequences (at least one). */
+const crlfSourceArb: fc.Arbitrary<string> = fc
+  .tuple(
+    fc.string({ minLength: 0, maxLength: 50 }),
+    fc.array(fc.string({ minLength: 0, maxLength: 50 }), { minLength: 1, maxLength: 5 }),
+    fc.string({ minLength: 0, maxLength: 50 }),
+  )
+  .map(([prefix, lines, suffix]) => `${prefix}${lines.join("\r\n")}${suffix}`);
+
+// ---------------------------------------------------------------------------
+// NS1.1: normalizeSource — no \r\n in output
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_normalizeSource_no_crlf_in_output
+ *
+ * For any input string, the output of normalizeSource never contains a \r\n
+ * sequence.
+ *
+ * Invariant (NS1.1, DEC-CONTINUOUS-SHAVE-022): CRLF normalization ensures
+ * that editor line-ending settings do not produce distinct cache keys. The
+ * output must be free of \r\n so that BLAKE3 hashing produces a single
+ * canonical value regardless of platform.
+ */
+export const prop_normalizeSource_no_crlf_in_output = fc.property(
+  rawSourceArb,
+  (s) => !normalizeSource(s).includes("\r\n"),
+);
+
+// ---------------------------------------------------------------------------
+// NS1.1: normalizeSource — no leading or trailing whitespace in output
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_normalizeSource_no_leading_trailing_whitespace
+ *
+ * For any input string, the output of normalizeSource has no leading or
+ * trailing whitespace.
+ *
+ * Invariant (NS1.1, DEC-CONTINUOUS-SHAVE-022): trailing newlines and leading
+ * indentation in candidate blocks must not produce spurious cache misses.
+ * The trim() step enforces this unconditionally.
+ */
+export const prop_normalizeSource_no_leading_trailing_whitespace = fc.property(
+  rawSourceArb,
+  (s) => {
+    const out = normalizeSource(s);
+    return out === out.trim();
+  },
+);
+
+// ---------------------------------------------------------------------------
+// NS1.1: normalizeSource — idempotent
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_normalizeSource_idempotent
+ *
+ * normalizeSource(normalizeSource(s)) === normalizeSource(s) for any string.
+ *
+ * Invariant (NS1.1): the normalization transform is a projection — applying
+ * it twice produces the same result as applying it once. This ensures that
+ * callers need not track whether a string has already been normalized.
+ */
+export const prop_normalizeSource_idempotent = fc.property(rawSourceArb, (s) => {
+  const once = normalizeSource(s);
+  const twice = normalizeSource(once);
+  return once === twice;
+});
+
+// ---------------------------------------------------------------------------
+// NS1.1: normalizeSource — preserves inner LF separators
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_normalizeSource_preserves_inner_lf
+ *
+ * When a string contains only LF (no CR), inner newlines are preserved
+ * verbatim after trimming the outer whitespace.
+ *
+ * Invariant (NS1.1, DEC-CONTINUOUS-SHAVE-022): the normalizer must not strip
+ * inner newlines — it only replaces CRLF→LF and trims the outer ends. A
+ * string like "a\nb\nc" (no CRLF, no outer whitespace) is its own normal form.
+ */
+export const prop_normalizeSource_preserves_inner_lf = fc.property(
+  fc
+    .tuple(
+      fc.string({ minLength: 1, maxLength: 20 }).filter((s) => !s.includes("\r")),
+      fc.array(
+        fc.string({ minLength: 1, maxLength: 20 }).filter((s) => !s.includes("\r")),
+        { minLength: 1, maxLength: 4 },
+      ),
+    )
+    .map(([first, rest]) => `${first}\n${rest.join("\n")}`),
+  (lf) => {
+    const out = normalizeSource(lf);
+    // Inner LF count must be preserved (trimming outer whitespace doesn't remove inner LFs).
+    const expectedLfCount = lf.trim().split("\n").length - 1;
+    const actualLfCount = out.split("\n").length - 1;
+    return actualLfCount === expectedLfCount;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// NS1.1: normalizeSource — CRLF is replaced exactly by LF (no orphan CR)
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_normalizeSource_crlf_replaced_by_lf_only
+ *
+ * After normalizeSource, a CRLF input ("a\r\nb") becomes "a\nb"  — the CR is
+ * removed entirely and the LF is kept. No orphan \r character appears in the
+ * result when the original contained only CRLF sequences.
+ *
+ * Invariant (NS1.1): the regex /\r\n/g replacement removes the CR prefix of
+ * every CRLF pair. A standalone \r (not followed by \n) is NOT removed by
+ * this step; this property verifies only the CRLF→LF path.
+ */
+export const prop_normalizeSource_crlf_replaced_by_lf_only = fc.property(crlfSourceArb, (s) => {
+  const out = normalizeSource(s);
+  // The string produced must not contain \r\n.
+  return !out.includes("\r\n");
+});
+
+// ---------------------------------------------------------------------------
+// Compound interaction: normalizeSource feeds sourceHash (end-to-end)
+//
+// Production sequence: raw source → normalizeSource() → BLAKE3 hash.
+// This property exercises the full normalization→hash pipeline by verifying
+// that two strings that differ only in CRLF produce the same normalized form,
+// and therefore the same hash when passed to the BLAKE3 encoder.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_normalizeSource_compound_crlf_lf_equivalence
+ *
+ * A string with CRLF line endings and the same string with LF line endings
+ * produce the same normalized form.
+ *
+ * This is the canonical compound-interaction property: normalizeSource is the
+ * first stage of the sourceHash pipeline. Verifying CRLF≡LF equivalence at
+ * the normalization level proves that the cache key layer (key.ts) treats the
+ * two encodings as identical.
+ *
+ * Invariant (NS1.1, DEC-CONTINUOUS-SHAVE-022): "editor line-ending settings
+ * do not produce spurious cache misses."
+ */
+export const prop_normalizeSource_compound_crlf_lf_equivalence = fc.property(
+  fc
+    .array(
+      fc.string({ minLength: 0, maxLength: 30 }).filter((s) => !s.includes("\r")),
+      { minLength: 1, maxLength: 6 },
+    )
+    .map((lines) => lines.join("\n")),
+  (lfStr) => {
+    const crlfStr = lfStr.replace(/\n/g, "\r\n");
+    return normalizeSource(lfStr) === normalizeSource(crlfStr);
+  },
+);

--- a/packages/shave/src/cache/types.props.test.ts
+++ b/packages/shave/src/cache/types.props.test.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for cache/types.props.ts — thin runner only.
+// Each export from the corpus is driven through fc.assert() here.
+
+import * as fc from "fast-check";
+import { describe, it } from "vitest";
+import * as Props from "./types.props.js";
+
+describe("cache/types.ts — Path A property corpus", () => {
+  it("property: CacheKey — has required string fields", () => {
+    fc.assert(Props.prop_CacheKey_has_required_string_fields);
+  });
+
+  it("property: CacheKey — sourceHash is a 64-char hex string", () => {
+    fc.assert(Props.prop_CacheKey_sourceHash_is_64_char_hex);
+  });
+
+  it("property: CacheEntry — has required fields with correct types", () => {
+    fc.assert(Props.prop_CacheEntry_has_required_fields);
+  });
+
+  it("property: CacheEntry — cacheVersion is always the literal 1", () => {
+    fc.assert(Props.prop_CacheEntry_cacheVersion_is_literal_1);
+  });
+
+  it("property: CacheEntry — cachedAt is a non-negative finite number", () => {
+    fc.assert(Props.prop_CacheEntry_cachedAt_is_non_negative_finite);
+  });
+
+  it("property: CacheEntry — card.schemaVersion is always 1", () => {
+    fc.assert(Props.prop_CacheEntry_card_schemaVersion_is_1);
+  });
+
+  it("property: CacheKey + CacheEntry — compound: sourceHash alignment invariant", () => {
+    fc.assert(Props.prop_CacheKey_CacheEntry_compound_sourceHash_alignment);
+  });
+});

--- a/packages/shave/src/cache/types.props.ts
+++ b/packages/shave/src/cache/types.props.ts
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-001: hand-authored property-test corpus for
+// @yakcc/shave cache/types.ts atoms. Two-file pattern: this file
+// (.props.ts) is vitest-free and holds the corpus; the sibling .props.test.ts
+// is the vitest harness.
+// Status: accepted (WI-V2-07-PREFLIGHT L3d)
+// Rationale: See tmp/wi-v2-07-preflight-layer-plan.md — the corpus file must
+// be runtime-independent so L10 can hash it as a manifest artifact.
+//
+// Atoms covered (named exports from types.ts):
+//   CacheKey   (CK1.1) — shape invariant: three readonly string fields.
+//   CacheEntry (CE1.1) — shape invariant: card, cachedAt, cacheVersion: 1.
+//
+// Properties covered:
+//   - Every CacheKey has three readonly fields: sourceHash, modelVersion, promptVersion (all strings).
+//   - Every CacheEntry carries card (IntentCard), cachedAt (number), cacheVersion (literal 1).
+//   - cacheVersion is always the literal 1 (forward-compat marker).
+//   - A CacheEntry built from an arbitrary CacheKey and IntentCard round-trips
+//     cacheVersion and cachedAt without mutation (compound shape invariant).
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for cache/types.ts
+// ---------------------------------------------------------------------------
+
+import * as fc from "fast-check";
+import type { IntentCard, IntentParam } from "../intent/types.js";
+import type { CacheEntry, CacheKey } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Shared arbitraries
+// ---------------------------------------------------------------------------
+
+/** Non-empty string with no leading/trailing whitespace. */
+const nonEmptyStr: fc.Arbitrary<string> = fc
+  .string({ minLength: 1, maxLength: 40 })
+  .filter((s) => s.trim().length > 0);
+
+/** 64-char hex string suitable for sourceHash. */
+const hexHash64: fc.Arbitrary<string> = fc
+  .array(fc.integer({ min: 0, max: 15 }), { minLength: 64, maxLength: 64 })
+  .map((nibbles) => nibbles.map((n) => n.toString(16)).join(""));
+
+/** Arbitrary IntentParam. */
+const intentParamArb: fc.Arbitrary<IntentParam> = fc.record({
+  name: nonEmptyStr,
+  typeHint: nonEmptyStr,
+  description: fc.string({ minLength: 0, maxLength: 40 }),
+});
+
+/** Well-formed IntentCard for property testing. */
+const intentCardArb: fc.Arbitrary<IntentCard> = fc.record({
+  schemaVersion: fc.constant(1 as const),
+  behavior: nonEmptyStr,
+  inputs: fc.array(intentParamArb, { minLength: 0, maxLength: 2 }),
+  outputs: fc.array(intentParamArb, { minLength: 0, maxLength: 2 }),
+  preconditions: fc.array(nonEmptyStr, { minLength: 0, maxLength: 2 }),
+  postconditions: fc.array(nonEmptyStr, { minLength: 0, maxLength: 2 }),
+  notes: fc.array(fc.string(), { minLength: 0, maxLength: 2 }),
+  modelVersion: nonEmptyStr,
+  promptVersion: nonEmptyStr,
+  sourceHash: hexHash64,
+  extractedAt: fc.constant("2024-01-01T00:00:00.000Z"),
+});
+
+/** Arbitrary CacheKey record. */
+const cacheKeyArb: fc.Arbitrary<CacheKey> = fc.record({
+  sourceHash: hexHash64,
+  modelVersion: nonEmptyStr,
+  promptVersion: nonEmptyStr,
+});
+
+/** Unix epoch ms: a positive integer in a realistic range. */
+const epochMsArb: fc.Arbitrary<number> = fc.integer({ min: 0, max: 9_999_999_999_999 });
+
+/** Arbitrary CacheEntry record. */
+const cacheEntryArb: fc.Arbitrary<CacheEntry> = fc
+  .tuple(intentCardArb, epochMsArb)
+  .map(([card, cachedAt]) => ({
+    card,
+    cachedAt,
+    cacheVersion: 1 as const,
+  }));
+
+// ---------------------------------------------------------------------------
+// CK1.1: CacheKey — has three required string fields
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_CacheKey_has_required_string_fields
+ *
+ * Every well-formed CacheKey object has three readonly string fields:
+ * sourceHash, modelVersion, and promptVersion.
+ *
+ * Invariant (CK1.1, DEC-CONTINUOUS-SHAVE-022): uniqueness of a cache entry
+ * is defined over these three fields. All three must be present and must be
+ * strings; a missing or wrongly-typed field would produce a silent cache hit.
+ */
+export const prop_CacheKey_has_required_string_fields = fc.property(
+  cacheKeyArb,
+  (ck) =>
+    typeof ck.sourceHash === "string" &&
+    typeof ck.modelVersion === "string" &&
+    typeof ck.promptVersion === "string",
+);
+
+// ---------------------------------------------------------------------------
+// CK1.1: CacheKey — sourceHash is a 64-char hex string
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_CacheKey_sourceHash_is_64_char_hex
+ *
+ * The sourceHash field of a CacheKey is always a 64-character lowercase hex
+ * string (matching the output of BLAKE3-256 via sourceHash()).
+ *
+ * Invariant (CK1.1, DEC-CONTINUOUS-SHAVE-022): the cache layer uses sourceHash
+ * as part of the file-system key. A 64-char hex string is the canonical
+ * BLAKE3-256 output length, ensuring a fixed shard-directory prefix.
+ */
+export const prop_CacheKey_sourceHash_is_64_char_hex = fc.property(cacheKeyArb, (ck) => {
+  return ck.sourceHash.length === 64 && /^[0-9a-f]+$/.test(ck.sourceHash);
+});
+
+// ---------------------------------------------------------------------------
+// CE1.1: CacheEntry — has required fields with correct types
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_CacheEntry_has_required_fields
+ *
+ * Every well-formed CacheEntry has: card (IntentCard), cachedAt (number),
+ * and cacheVersion (literal 1).
+ *
+ * Invariant (CE1.1, DEC-CONTINUOUS-SHAVE-022): the envelope shape is what
+ * allows TTL-based eviction and integrity checks. All three fields must be
+ * present; cachedAt must be a number (Unix epoch ms), and cacheVersion must
+ * be the literal 1.
+ */
+export const prop_CacheEntry_has_required_fields = fc.property(
+  cacheEntryArb,
+  (ce) => ce.card !== undefined && typeof ce.cachedAt === "number" && ce.cacheVersion === 1,
+);
+
+// ---------------------------------------------------------------------------
+// CE1.1: CacheEntry — cacheVersion is always the literal 1
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_CacheEntry_cacheVersion_is_literal_1
+ *
+ * The cacheVersion field of a CacheEntry is always exactly the number 1.
+ *
+ * Invariant (CE1.1, DEC-CONTINUOUS-SHAVE-022): cacheVersion is a forward-compat
+ * discriminant. The only currently valid value is 1. Any other value (0, 2,
+ * string "1") is invalid and must not be produced by a conformant writer.
+ */
+export const prop_CacheEntry_cacheVersion_is_literal_1 = fc.property(
+  cacheEntryArb,
+  (ce) => ce.cacheVersion === 1,
+);
+
+// ---------------------------------------------------------------------------
+// CE1.1: CacheEntry — cachedAt is a non-negative finite number
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_CacheEntry_cachedAt_is_non_negative_finite
+ *
+ * The cachedAt field is always a non-negative finite number (Unix epoch ms).
+ *
+ * Invariant (CE1.1): a negative or infinite cachedAt would produce incorrect
+ * TTL calculations. This property ensures that any value produced by the
+ * arbitrary (and by extension, any correct writer) satisfies the basic
+ * numeric domain constraint.
+ */
+export const prop_CacheEntry_cachedAt_is_non_negative_finite = fc.property(
+  cacheEntryArb,
+  (ce) => Number.isFinite(ce.cachedAt) && ce.cachedAt >= 0,
+);
+
+// ---------------------------------------------------------------------------
+// CE1.1: CacheEntry — card.schemaVersion is the literal 1
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_CacheEntry_card_schemaVersion_is_1
+ *
+ * The IntentCard embedded in a CacheEntry always has schemaVersion === 1.
+ *
+ * Invariant (CE1.1, DEC-CONTINUOUS-SHAVE-022): the cache stores IntentCards
+ * with a versioned envelope. The current schema is version 1. If schemaVersion
+ * were not 1, validateIntentCard would reject the deserialized entry and the
+ * cache would behave as a miss — so writers must produce schemaVersion: 1.
+ */
+export const prop_CacheEntry_card_schemaVersion_is_1 = fc.property(
+  cacheEntryArb,
+  (ce) => ce.card.schemaVersion === 1,
+);
+
+// ---------------------------------------------------------------------------
+// Compound interaction: CacheKey fields → CacheEntry card.sourceHash alignment
+//
+// Production sequence: sourceHash() produces a 64-char hex string, which is
+// stored in IntentCard.sourceHash and used as CacheKey.sourceHash. This
+// compound property verifies that the shape of CacheKey and CacheEntry are
+// mutually consistent with that production sequence.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_CacheKey_CacheEntry_compound_sourceHash_alignment
+ *
+ * A CacheEntry whose card.sourceHash matches the CacheKey.sourceHash satisfies
+ * the invariant that the stored card was extracted from the same source that
+ * produced the cache key.
+ *
+ * This is the canonical compound-interaction property crossing CacheKey and
+ * CacheEntry: both shapes are defined in types.ts and must be jointly consistent
+ * for the cache layer to guarantee cache-hit validity.
+ *
+ * Invariant (CK1.1, CE1.1, DEC-CONTINUOUS-SHAVE-022): a cache hit is valid
+ * only when the stored card's sourceHash matches the key's sourceHash. Any
+ * deviation indicates a cache corruption bug.
+ */
+export const prop_CacheKey_CacheEntry_compound_sourceHash_alignment = fc.property(
+  fc.tuple(cacheKeyArb, intentCardArb, epochMsArb),
+  ([ck, card, cachedAt]) => {
+    // Build a CacheEntry with a card whose sourceHash matches the CacheKey.
+    const alignedCard: IntentCard = { ...card, sourceHash: ck.sourceHash };
+    const ce: CacheEntry = { card: alignedCard, cachedAt, cacheVersion: 1 };
+
+    // The alignment invariant: key and entry agree on sourceHash.
+    return ce.card.sourceHash === ck.sourceHash && ce.cacheVersion === 1;
+  },
+);


### PR DESCRIPTION
## Summary
- 4 source files / 34 props in shave/cache subtree (COLDEST cadence sub-tree per planner roadmap)
- 8 files / 1368 insertions: file-cache (11), key (10), normalize (6), types (7)

## Authority domain
`property_test_corpus_yakcc_shave_cache`

## Test evidence
- Per-file isolation: 34/34 props pass (~752ms with PR #124 vitest fix)
- Full `@yakcc/shave` suite: 409 passed | 1 skipped (410 total) in 29s
- Build: `pnpm --filter @yakcc/shave build` clean
- file-cache uses `mkdtemp(os.tmpdir())` for disk-touching properties

## Reviewer verdict
`REVIEW_VERDICT: ready_for_guardian`, zero blockers, 2 informational notes (cachePaths shard tautology — covered substantively by neighbor; tmp cleanup absence — OS-managed). Verified by reviewer dispatch `abeeb63ad9a45f199`.

## Backlog suggested
- WI to regen `bootstrap/expected-roots.json` to include new shave/cache corpus blobs
- Optional: add `afterEach` cleanup for mkdtemp directories in file-cache.props.ts (low priority)

## Continuation roadmap (per planner)
- L3e: `shave/<root>` non-index (~32 atoms)
- L3f/g/h: `shave/intent/` split into 3 sub-slices
- L3i: `shave/corpus/` (after PR #117 cadence cools)
- L3j: `shave/universalize/` (after WI-V2-GLUE-AWARE-IMPL completes)

## DO NOT auto-merge — orchestrator review per #87

refs #87