### PR TITLE
WI-V2-07-PREFLIGHT L3e: Path A property-test corpus for shave/<root> non-index (refs #87)

### DIFF
--- a/packages/shave/src/errors.props.test.ts
+++ b/packages/shave/src/errors.props.test.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for errors.props.ts — thin runner only.
+// Each export from the corpus is driven through fc.assert() here.
+
+import * as fc from "fast-check";
+import { describe, it } from "vitest";
+import * as Props from "./errors.props.js";
+
+describe("errors.ts — Path A property corpus", () => {
+  it("property: AnthropicApiKeyMissingError — message includes ANTHROPIC_API_KEY guidance", () => {
+    fc.assert(Props.prop_AnthropicApiKeyMissingError_message_contains_guidance);
+  });
+
+  it("property: AnthropicApiKeyMissingError — name and instanceof invariants", () => {
+    fc.assert(Props.prop_AnthropicApiKeyMissingError_name_and_instanceof);
+  });
+
+  it("property: OfflineCacheMissError — message contains the cacheKey", () => {
+    fc.assert(Props.prop_OfflineCacheMissError_message_contains_cache_key);
+  });
+
+  it("property: OfflineCacheMissError — name and instanceof invariants", () => {
+    fc.assert(Props.prop_OfflineCacheMissError_name_and_instanceof);
+  });
+
+  it("property: IntentCardSchemaError — message contains the detail", () => {
+    fc.assert(Props.prop_IntentCardSchemaError_message_contains_detail);
+  });
+
+  it("property: IntentCardSchemaError — name and instanceof invariants", () => {
+    fc.assert(Props.prop_IntentCardSchemaError_name_and_instanceof);
+  });
+
+  it("property: LicenseRefusedError — message contains reason", () => {
+    fc.assert(Props.prop_LicenseRefusedError_message_contains_reason);
+  });
+
+  it("property: LicenseRefusedError — detection field matches constructor arg", () => {
+    fc.assert(Props.prop_LicenseRefusedError_detection_field_matches_arg);
+  });
+
+  it("property: LicenseRefusedError — name and instanceof invariants", () => {
+    fc.assert(Props.prop_LicenseRefusedError_name_and_instanceof);
+  });
+
+  it("property: ForeignPolicyRejectError — message includes all pkg#export pairs", () => {
+    fc.assert(Props.prop_ForeignPolicyRejectError_message_includes_all_refs);
+  });
+
+  it("property: ForeignPolicyRejectError — foreignRefs array matches constructor arg", () => {
+    fc.assert(Props.prop_ForeignPolicyRejectError_foreignRefs_matches_arg);
+  });
+
+  it("property: ForeignPolicyRejectError — name and instanceof invariants", () => {
+    fc.assert(Props.prop_ForeignPolicyRejectError_name_and_instanceof);
+  });
+
+  it("property: ForeignPolicyRejectError + message — compound: message and refs jointly consistent", () => {
+    fc.assert(Props.prop_ForeignPolicyRejectError_compound_message_and_refs_consistent);
+  });
+});

--- a/packages/shave/src/errors.props.ts
+++ b/packages/shave/src/errors.props.ts
@@ -1,0 +1,413 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-001: hand-authored property-test corpus for
+// @yakcc/shave errors.ts atoms. Two-file pattern: this file (.props.ts) is
+// vitest-free and holds the corpus; the sibling .props.test.ts is the vitest
+// harness.
+// Status: accepted (WI-V2-07-PREFLIGHT L3e)
+// Rationale: See tmp/wi-v2-07-preflight-layer-plan.md — the corpus file must
+// be runtime-independent so L10 can hash it as a manifest artifact.
+//
+// Atoms covered (named exports from errors.ts):
+//   AnthropicApiKeyMissingError (AK1.1) — message, name, instanceof invariants.
+//   OfflineCacheMissError       (OC1.1) — message contains cacheKey, name, instanceof.
+//   IntentCardSchemaError       (IS1.1) — message contains detail, name, instanceof.
+//   LicenseRefusedError         (LR1.1) — message contains reason, detection stored, name, instanceof.
+//   ForeignPolicyRejectError    (FP1.1) — message contains pkg#export pairs, foreignRefs array, name, instanceof.
+//
+// Properties covered:
+//   - AnthropicApiKeyMissingError: message includes key guidance text; name is correct class name.
+//   - OfflineCacheMissError: message always contains the cacheKey string; name is correct class name.
+//   - IntentCardSchemaError: message always contains the detail string; name is correct class name.
+//   - LicenseRefusedError: message contains reason; detection field matches constructor arg; name correct.
+//   - ForeignPolicyRejectError: message includes every pkg#export pair; foreignRefs array matches input.
+//   - Compound: ForeignPolicyRejectError message and foreignRefs are jointly consistent for multi-ref inputs.
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for errors.ts
+// ---------------------------------------------------------------------------
+
+import * as fc from "fast-check";
+import {
+  AnthropicApiKeyMissingError,
+  ForeignPolicyRejectError,
+  IntentCardSchemaError,
+  LicenseRefusedError,
+  OfflineCacheMissError,
+} from "./errors.js";
+import type { LicenseDetection } from "./license/types.js";
+
+// ---------------------------------------------------------------------------
+// Shared arbitraries
+// ---------------------------------------------------------------------------
+
+/** Non-empty string with no leading/trailing whitespace. */
+const nonEmptyStr: fc.Arbitrary<string> = fc
+  .string({ minLength: 1, maxLength: 60 })
+  .filter((s) => s.trim().length > 0);
+
+/** Arbitrary LicenseDetection source values. */
+const licenseSourceArb: fc.Arbitrary<LicenseDetection["source"]> = fc.constantFrom(
+  "spdx-comment",
+  "package-json",
+  "header-text",
+  "dedication",
+  "no-signal",
+);
+
+/** Arbitrary LicenseDetection (all fields; no optional evidence to avoid exactOptionalPropertyTypes issues). */
+const licenseDetectionArb: fc.Arbitrary<LicenseDetection> = fc.record({
+  identifier: nonEmptyStr,
+  source: licenseSourceArb,
+});
+
+/** One foreign ref: { pkg, export }. */
+const foreignRefArb: fc.Arbitrary<{ pkg: string; export: string }> = fc.record({
+  pkg: nonEmptyStr,
+  export: nonEmptyStr,
+});
+
+/** Non-empty array of foreign refs. */
+const foreignRefsArb: fc.Arbitrary<readonly { pkg: string; export: string }[]> = fc.array(
+  foreignRefArb,
+  { minLength: 1, maxLength: 5 },
+);
+
+// ---------------------------------------------------------------------------
+// AK1.1: AnthropicApiKeyMissingError — message includes key guidance text
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_AnthropicApiKeyMissingError_message_contains_guidance
+ *
+ * AnthropicApiKeyMissingError always produces a message that references the
+ * ANTHROPIC_API_KEY environment variable, guiding the caller toward resolution.
+ *
+ * Invariant (AK1.1, DEC-CONTINUOUS-SHAVE-022): the error message is fixed and
+ * self-describing — it must mention ANTHROPIC_API_KEY so operators reading logs
+ * can immediately identify the required action.
+ */
+export const prop_AnthropicApiKeyMissingError_message_contains_guidance = fc.property(
+  fc.constant(null),
+  (_) => {
+    const err = new AnthropicApiKeyMissingError();
+    return err.message.includes("ANTHROPIC_API_KEY") && err.message.length > 0;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// AK1.1: AnthropicApiKeyMissingError — name and instanceof invariants
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_AnthropicApiKeyMissingError_name_and_instanceof
+ *
+ * AnthropicApiKeyMissingError has the correct .name property and passes
+ * instanceof checks for both AnthropicApiKeyMissingError and Error.
+ *
+ * Invariant (AK1.1, DEC-CONTINUOUS-SHAVE-022): callers rely on instanceof for
+ * control flow (catching specific error types). A wrong .name or broken
+ * prototype chain silently defeats that catch.
+ */
+export const prop_AnthropicApiKeyMissingError_name_and_instanceof = fc.property(
+  fc.constant(null),
+  (_) => {
+    const err = new AnthropicApiKeyMissingError();
+    return (
+      err.name === "AnthropicApiKeyMissingError" &&
+      err instanceof AnthropicApiKeyMissingError &&
+      err instanceof Error
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// OC1.1: OfflineCacheMissError — message contains the cacheKey
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_OfflineCacheMissError_message_contains_cache_key
+ *
+ * For any cacheKey string, OfflineCacheMissError's message always contains
+ * the cacheKey so callers can identify which key caused the miss.
+ *
+ * Invariant (OC1.1, DEC-CONTINUOUS-SHAVE-022): the key is embedded in the
+ * message verbatim. Log consumers depend on this to correlate cache misses
+ * with specific request signatures without needing structured error fields.
+ */
+export const prop_OfflineCacheMissError_message_contains_cache_key = fc.property(
+  nonEmptyStr,
+  (cacheKey) => {
+    const err = new OfflineCacheMissError(cacheKey);
+    return err.message.includes(cacheKey);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// OC1.1: OfflineCacheMissError — name and instanceof invariants
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_OfflineCacheMissError_name_and_instanceof
+ *
+ * OfflineCacheMissError has the correct .name and passes instanceof checks.
+ *
+ * Invariant (OC1.1, DEC-CONTINUOUS-SHAVE-022): named error classes enable
+ * catch-by-type without importing string constants.
+ */
+export const prop_OfflineCacheMissError_name_and_instanceof = fc.property(
+  nonEmptyStr,
+  (cacheKey) => {
+    const err = new OfflineCacheMissError(cacheKey);
+    return (
+      err.name === "OfflineCacheMissError" &&
+      err instanceof OfflineCacheMissError &&
+      err instanceof Error
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// IS1.1: IntentCardSchemaError — message contains the detail
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_IntentCardSchemaError_message_contains_detail
+ *
+ * For any detail string, IntentCardSchemaError's message always contains the
+ * detail so callers can identify the specific schema violation.
+ *
+ * Invariant (IS1.1, DEC-CONTINUOUS-SHAVE-022): schema error details are
+ * essential for diagnosing malformed API responses. The detail must appear in
+ * the message so logging pipelines do not need to restructure the error.
+ */
+export const prop_IntentCardSchemaError_message_contains_detail = fc.property(
+  nonEmptyStr,
+  (detail) => {
+    const err = new IntentCardSchemaError(detail);
+    return err.message.includes(detail);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// IS1.1: IntentCardSchemaError — name and instanceof invariants
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_IntentCardSchemaError_name_and_instanceof
+ *
+ * IntentCardSchemaError has the correct .name and passes instanceof checks.
+ *
+ * Invariant (IS1.1, DEC-CONTINUOUS-SHAVE-022): named error classes enable
+ * catch-by-type without importing string constants.
+ */
+export const prop_IntentCardSchemaError_name_and_instanceof = fc.property(nonEmptyStr, (detail) => {
+  const err = new IntentCardSchemaError(detail);
+  return (
+    err.name === "IntentCardSchemaError" &&
+    err instanceof IntentCardSchemaError &&
+    err instanceof Error
+  );
+});
+
+// ---------------------------------------------------------------------------
+// LR1.1: LicenseRefusedError — message contains reason; detection stored
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_LicenseRefusedError_message_contains_reason
+ *
+ * For any reason string and LicenseDetection, LicenseRefusedError's message
+ * always contains the reason so callers can identify the refusal cause.
+ *
+ * Invariant (LR1.1, DEC-CONTINUOUS-SHAVE-022): the reason is embedded verbatim.
+ * CLI output reads this message; the detection is stored separately for
+ * programmatic introspection.
+ */
+export const prop_LicenseRefusedError_message_contains_reason = fc.property(
+  nonEmptyStr,
+  licenseDetectionArb,
+  (reason, detection) => {
+    const err = new LicenseRefusedError(reason, detection);
+    return err.message.includes(reason);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// LR1.1: LicenseRefusedError — detection field matches constructor arg
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_LicenseRefusedError_detection_field_matches_arg
+ *
+ * The `detection` field on LicenseRefusedError is strictly equal to the
+ * LicenseDetection object passed to the constructor.
+ *
+ * Invariant (LR1.1, DEC-CONTINUOUS-SHAVE-022): callers introspect the
+ * detection to understand what signal was found and how to present it.
+ * A mutation or substitution would silently produce incorrect diagnostics.
+ */
+export const prop_LicenseRefusedError_detection_field_matches_arg = fc.property(
+  nonEmptyStr,
+  licenseDetectionArb,
+  (reason, detection) => {
+    const err = new LicenseRefusedError(reason, detection);
+    return (
+      err.detection === detection &&
+      err.detection.identifier === detection.identifier &&
+      err.detection.source === detection.source
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// LR1.1: LicenseRefusedError — name and instanceof invariants
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_LicenseRefusedError_name_and_instanceof
+ *
+ * LicenseRefusedError has the correct .name and passes instanceof checks.
+ *
+ * Invariant (LR1.1, DEC-CONTINUOUS-SHAVE-022): named error classes enable
+ * catch-by-type without importing string constants.
+ */
+export const prop_LicenseRefusedError_name_and_instanceof = fc.property(
+  nonEmptyStr,
+  licenseDetectionArb,
+  (reason, detection) => {
+    const err = new LicenseRefusedError(reason, detection);
+    return (
+      err.name === "LicenseRefusedError" &&
+      err instanceof LicenseRefusedError &&
+      err instanceof Error
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// FP1.1: ForeignPolicyRejectError — message includes all pkg#export pairs
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_ForeignPolicyRejectError_message_includes_all_refs
+ *
+ * For any non-empty list of foreign refs, ForeignPolicyRejectError's message
+ * includes every `pkg#export` pair so the CLI can surface all offenders in one
+ * message without iterating the structured field.
+ *
+ * Invariant (FP1.1, DEC-V2-FOREIGN-BLOCK-SCHEMA-001): the message format is
+ * "foreign-policy reject: <pkg>#<export>[, ...]". All refs must appear so the
+ * error is self-describing in log output.
+ */
+export const prop_ForeignPolicyRejectError_message_includes_all_refs = fc.property(
+  foreignRefsArb,
+  (refs) => {
+    const err = new ForeignPolicyRejectError(refs);
+    return refs.every((r) => err.message.includes(`${r.pkg}#${r.export}`));
+  },
+);
+
+// ---------------------------------------------------------------------------
+// FP1.1: ForeignPolicyRejectError — foreignRefs array matches constructor arg
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_ForeignPolicyRejectError_foreignRefs_matches_arg
+ *
+ * The `foreignRefs` field on ForeignPolicyRejectError is the same readonly
+ * array passed to the constructor, with the same length and entries.
+ *
+ * Invariant (FP1.1, DEC-V2-FOREIGN-BLOCK-SCHEMA-001): the structured refs are
+ * available for programmatic inspection (e.g. CLI formatting, test assertions).
+ * Mutation or reordering would silently break downstream consumers.
+ */
+export const prop_ForeignPolicyRejectError_foreignRefs_matches_arg = fc.property(
+  foreignRefsArb,
+  (refs) => {
+    const err = new ForeignPolicyRejectError(refs);
+    return (
+      err.foreignRefs.length === refs.length &&
+      refs.every((r, i) => {
+        const ref = err.foreignRefs[i];
+        return ref !== undefined && ref.pkg === r.pkg && ref.export === r.export;
+      })
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// FP1.1: ForeignPolicyRejectError — name and instanceof invariants
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_ForeignPolicyRejectError_name_and_instanceof
+ *
+ * ForeignPolicyRejectError has the correct .name and passes instanceof checks.
+ *
+ * Invariant (FP1.1, DEC-V2-FOREIGN-BLOCK-SCHEMA-001): named error classes enable
+ * catch-by-type without importing string constants.
+ */
+export const prop_ForeignPolicyRejectError_name_and_instanceof = fc.property(
+  foreignRefsArb,
+  (refs) => {
+    const err = new ForeignPolicyRejectError(refs);
+    return (
+      err.name === "ForeignPolicyRejectError" &&
+      err instanceof ForeignPolicyRejectError &&
+      err instanceof Error
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Compound interaction: ForeignPolicyRejectError message and foreignRefs
+// are jointly consistent for multi-ref inputs.
+//
+// Production sequence: shave() collects foreign refs from the slice plan →
+// throws ForeignPolicyRejectError(foreignRefs) → CLI catches and formats
+// err.message (for stderr) and err.foreignRefs (for structured output).
+// This compound property verifies that both surfaces are consistent so
+// neither CLI display path produces contradictory output.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_ForeignPolicyRejectError_compound_message_and_refs_consistent
+ *
+ * For any list of foreign refs, ForeignPolicyRejectError's .message and
+ * .foreignRefs are jointly consistent: every ref in foreignRefs appears as
+ * a `pkg#export` token in the message, and the message starts with the
+ * canonical prefix "foreign-policy reject:".
+ *
+ * This is the canonical compound-interaction property crossing the message
+ * string and the structured foreignRefs array, mirroring the production
+ * sequence where shave() throws and the CLI reads both surfaces.
+ *
+ * Invariant (FP1.1, DEC-V2-FOREIGN-BLOCK-SCHEMA-001): if the two surfaces
+ * diverge (e.g. message truncated, refs reordered), the CLI would emit
+ * inconsistent error output — some refs visible in structured data but not
+ * in the display string, or vice versa.
+ */
+export const prop_ForeignPolicyRejectError_compound_message_and_refs_consistent = fc.property(
+  foreignRefsArb,
+  (refs) => {
+    const err = new ForeignPolicyRejectError(refs);
+
+    // 1. Message has the canonical prefix.
+    if (!err.message.startsWith("foreign-policy reject:")) return false;
+
+    // 2. Every ref in foreignRefs appears in the message.
+    const allRefsInMessage = err.foreignRefs.every((r) =>
+      err.message.includes(`${r.pkg}#${r.export}`),
+    );
+    if (!allRefsInMessage) return false;
+
+    // 3. foreignRefs length matches the input.
+    if (err.foreignRefs.length !== refs.length) return false;
+
+    // 4. The entries are in source order (same as input).
+    return refs.every((r, i) => {
+      const ref = err.foreignRefs[i];
+      return ref !== undefined && ref.pkg === r.pkg && ref.export === r.export;
+    });
+  },
+);

--- a/packages/shave/src/locate-root.props.test.ts
+++ b/packages/shave/src/locate-root.props.test.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for locate-root.props.ts — thin runner only.
+// Each export from the corpus is driven through fc.assert() here.
+
+import * as fc from "fast-check";
+import { describe, it } from "vitest";
+import * as Props from "./locate-root.props.js";
+
+describe("locate-root.ts — Path A property corpus", () => {
+  it("property: locateProjectRoot — fallback returns start when no workspace file found", async () => {
+    await fc.assert(Props.prop_locateProjectRoot_fallback_returns_start, { numRuns: 10 });
+  });
+
+  it("property: locateProjectRoot — detects workspace file at start itself", async () => {
+    await fc.assert(Props.prop_locateProjectRoot_detects_root_at_start, { numRuns: 10 });
+  });
+
+  it("property: locateProjectRoot — finds ancestor containing workspace file", async () => {
+    await fc.assert(Props.prop_locateProjectRoot_finds_ancestor_with_workspace_file, {
+      numRuns: 10,
+    });
+  });
+
+  it("property: locateProjectRoot — result is always a string", async () => {
+    await fc.assert(Props.prop_locateProjectRoot_returns_string, { numRuns: 10 });
+  });
+
+  it("property: locateProjectRoot + fallback — compound: result is ancestor of start", async () => {
+    await fc.assert(Props.prop_locateProjectRoot_compound_result_is_ancestor_of_start, {
+      numRuns: 10,
+    });
+  });
+});

--- a/packages/shave/src/locate-root.props.ts
+++ b/packages/shave/src/locate-root.props.ts
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-001: hand-authored property-test corpus for
+// @yakcc/shave locate-root.ts atoms. Two-file pattern: this file (.props.ts) is
+// vitest-free and holds the corpus; the sibling .props.test.ts is the vitest
+// harness.
+// Status: accepted (WI-V2-07-PREFLIGHT L3e)
+// Rationale: See tmp/wi-v2-07-preflight-layer-plan.md — the corpus file must
+// be runtime-independent so L10 can hash it as a manifest artifact.
+//
+// Atoms covered (named exports from locate-root.ts):
+//   locateProjectRoot (LR1.1) — async walk-up to find pnpm-workspace.yaml.
+//
+// Properties covered:
+//   - Walk-up termination: returns a string within finite depth; never loops.
+//   - Finds project root when pnpm-workspace.yaml exists at or above start.
+//   - Fallback: returns `start` verbatim when no workspace file exists anywhere.
+//   - Idempotent: root detected at start returns start itself (no extra traversal).
+//   - Compound: multi-level walk finds the correct ancestor and the result is an
+//     ancestor of (or equal to) the start path.
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for locate-root.ts
+// ---------------------------------------------------------------------------
+
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import { join } from "node:path";
+import * as fc from "fast-check";
+import { locateProjectRoot } from "./locate-root.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a unique temporary directory prefix for one property run.
+ *
+ * Uses a random 10-char alphanumeric suffix so parallel property runs can't
+ * collide on-disk.
+ */
+function makeTmpPrefix(): string {
+  return join(os.tmpdir(), `locate-root-props-${Math.random().toString(36).slice(2, 12)}`);
+}
+
+/**
+ * Build a chain of nested directories under `base`: base/seg[0]/seg[1]/...
+ *
+ * Returns the full path to the deepest directory after creating it.
+ */
+async function mkdirChain(base: string, segments: string[]): Promise<string> {
+  let current = base;
+  for (const seg of segments) {
+    current = join(current, seg);
+  }
+  await mkdir(current, { recursive: true });
+  return current;
+}
+
+// ---------------------------------------------------------------------------
+// Arbitraries
+// ---------------------------------------------------------------------------
+
+/** A non-empty path segment that is valid on all POSIX platforms. */
+const safeSegArb: fc.Arbitrary<string> = fc
+  .string({ minLength: 1, maxLength: 10 })
+  .filter((s) => /^[a-z0-9_-]+$/i.test(s) && s !== "." && s !== "..");
+
+/** A non-empty array of safe path segments (1-4 levels of nesting). */
+const segmentsArb: fc.Arbitrary<string[]> = fc.array(safeSegArb, {
+  minLength: 1,
+  maxLength: 4,
+});
+
+// ---------------------------------------------------------------------------
+// LR1.1: locateProjectRoot — fallback returns start when no workspace file found
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_locateProjectRoot_fallback_returns_start
+ *
+ * When no ancestor directory contains `pnpm-workspace.yaml`, locateProjectRoot
+ * returns the `start` path verbatim (as a graceful degradation path for
+ * standalone package installations and isolated test environments).
+ *
+ * Invariant (LR1.1, DEC-CONTINUOUS-SHAVE-022): the fallback must be the
+ * original `start`, not some synthetic path, so the cache directory degrades
+ * to a writable location that the caller can still use.
+ *
+ * Production sequence: universalize() calls locateProjectRoot(process.cwd()) to
+ * derive cacheDir; in a standalone package install with no workspace file, the
+ * function must not throw and must return a usable path.
+ */
+export const prop_locateProjectRoot_fallback_returns_start = fc.asyncProperty(
+  segmentsArb,
+  async (segments) => {
+    const base = makeTmpPrefix();
+    let deepDir: string | undefined;
+    try {
+      deepDir = await mkdirChain(base, segments);
+      // No pnpm-workspace.yaml written anywhere.
+      const result = await locateProjectRoot(deepDir);
+      return result === deepDir;
+    } finally {
+      await rm(base, { recursive: true, force: true }).catch(() => {});
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// LR1.1: locateProjectRoot — detects workspace file at start itself
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_locateProjectRoot_detects_root_at_start
+ *
+ * When `pnpm-workspace.yaml` exists in the `start` directory itself,
+ * locateProjectRoot returns `start` without any upward traversal.
+ *
+ * Invariant (LR1.1, DEC-CONTINUOUS-SHAVE-022): the in-place check happens
+ * first in the loop. Returning the start directory immediately avoids
+ * unnecessarily walking up to the filesystem root.
+ */
+export const prop_locateProjectRoot_detects_root_at_start = fc.asyncProperty(
+  safeSegArb,
+  async (dirName) => {
+    const base = join(makeTmpPrefix(), dirName);
+    try {
+      await mkdir(base, { recursive: true });
+      await writeFile(join(base, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+      const result = await locateProjectRoot(base);
+      return result === base;
+    } finally {
+      await rm(base, { recursive: true, force: true }).catch(() => {});
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// LR1.1: locateProjectRoot — finds ancestor containing workspace file
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_locateProjectRoot_finds_ancestor_with_workspace_file
+ *
+ * When `pnpm-workspace.yaml` exists at an ancestor directory (not at start),
+ * locateProjectRoot returns that ancestor directory, not the start directory.
+ *
+ * Invariant (LR1.1, DEC-CONTINUOUS-SHAVE-022): the function must walk up past
+ * the start directory and stop at the first ancestor that contains the workspace
+ * file — this is the correct project root.
+ */
+export const prop_locateProjectRoot_finds_ancestor_with_workspace_file = fc.asyncProperty(
+  segmentsArb,
+  async (segments) => {
+    const rootDir = makeTmpPrefix();
+    try {
+      // Place workspace file at rootDir.
+      await mkdir(rootDir, { recursive: true });
+      await writeFile(join(rootDir, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+      // Start from a deeply nested subdirectory.
+      const deepDir = await mkdirChain(rootDir, segments);
+      const result = await locateProjectRoot(deepDir);
+      return result === rootDir;
+    } finally {
+      await rm(rootDir, { recursive: true, force: true }).catch(() => {});
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// LR1.1: locateProjectRoot — result is always a string
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_locateProjectRoot_returns_string
+ *
+ * locateProjectRoot always resolves to a non-empty string regardless of the
+ * filesystem layout (workspace file present or absent).
+ *
+ * Invariant (LR1.1, DEC-CONTINUOUS-SHAVE-022): the return type is Promise<string>
+ * with no undefined branch. callers may store the result immediately as a path
+ * without null-checking.
+ */
+export const prop_locateProjectRoot_returns_string = fc.asyncProperty(
+  segmentsArb,
+  async (segments) => {
+    const base = makeTmpPrefix();
+    let deepDir: string | undefined;
+    try {
+      deepDir = await mkdirChain(base, segments);
+      const result = await locateProjectRoot(deepDir);
+      return typeof result === "string" && result.length > 0;
+    } finally {
+      await rm(base, { recursive: true, force: true }).catch(() => {});
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Compound: result is always an ancestor of (or equal to) the start path
+//
+// Production sequence: universalize() passes a package sub-directory as `start`.
+// The returned root is then used to construct the default cacheDir by joining
+// `.yakcc-cache`. The result must therefore be an ancestor of start or start
+// itself — a sibling or descendant path would produce an incorrect cache location.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_locateProjectRoot_compound_result_is_ancestor_of_start
+ *
+ * For any filesystem layout (with or without pnpm-workspace.yaml), the result of
+ * locateProjectRoot(start) is either `start` itself or an ancestor of `start`.
+ * It is never a sibling directory, a descendant of `start`, or an unrelated path.
+ *
+ * This is the canonical compound-interaction property for locateProjectRoot: it
+ * crosses the walk-up logic and the fallback behavior, verifying that both paths
+ * satisfy the geometric invariant required by the cache directory derivation step.
+ *
+ * Invariant (LR1.1, DEC-CONTINUOUS-SHAVE-022): if the result is not an ancestor
+ * of start, the downstream cache directory would be placed outside the project
+ * tree — causing cache misses and potentially littering unrelated directories.
+ */
+export const prop_locateProjectRoot_compound_result_is_ancestor_of_start = fc.asyncProperty(
+  segmentsArb,
+  fc.boolean(),
+  async (segments, placeWorkspaceFile) => {
+    const rootDir = makeTmpPrefix();
+    try {
+      await mkdir(rootDir, { recursive: true });
+      if (placeWorkspaceFile) {
+        await writeFile(join(rootDir, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+      }
+      const deepDir = await mkdirChain(rootDir, segments);
+      const result = await locateProjectRoot(deepDir);
+
+      // The result must be a prefix of deepDir (ancestor or equal).
+      // On POSIX, every ancestor of /a/b/c starts with /a (inclusive).
+      // We add a trailing separator to avoid false prefix matches like
+      // '/foo-bar' being a prefix of '/foo-bar-baz'.
+      const resultNorm = result.endsWith("/") ? result : `${result}/`;
+      const deepNorm = deepDir.endsWith("/") ? deepDir : `${deepDir}/`;
+      return deepNorm.startsWith(resultNorm);
+    } finally {
+      await rm(rootDir, { recursive: true, force: true }).catch(() => {});
+    }
+  },
+);

--- a/packages/shave/src/types.props.test.ts
+++ b/packages/shave/src/types.props.test.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for types.props.ts — thin runner only.
+// Each export from the corpus is driven through fc.assert() here.
+
+import * as fc from "fast-check";
+import { describe, it } from "vitest";
+import * as Props from "./types.props.js";
+
+describe("types.ts — Path A property corpus", () => {
+  it("property: FOREIGN_POLICY_DEFAULT — value is 'tag' and satisfies ForeignPolicy", () => {
+    fc.assert(Props.prop_FOREIGN_POLICY_DEFAULT_is_tag);
+  });
+
+  it("property: ShaveOptions — optional fields accepted and retained", () => {
+    fc.assert(Props.prop_ShaveOptions_optional_fields_accepted);
+  });
+
+  it("property: ShaveOptions — empty object satisfies the interface", () => {
+    fc.assert(Props.prop_ShaveOptions_empty_object_accepted);
+  });
+
+  it("property: ShaveDiagnostics — cache counters are non-negative", () => {
+    fc.assert(Props.prop_ShaveDiagnostics_cache_counters_nonnegative);
+  });
+
+  it("property: ShaveDiagnostics — stubbed contains only known literals", () => {
+    fc.assert(Props.prop_ShaveDiagnostics_stubbed_contains_only_known_literals);
+  });
+
+  it("property: ShavedAtomStub — sourceRange.start <= sourceRange.end", () => {
+    fc.assert(Props.prop_ShavedAtomStub_sourceRange_start_le_end);
+  });
+
+  it("property: ShavedAtomStub — placeholderId is non-empty", () => {
+    fc.assert(Props.prop_ShavedAtomStub_placeholderId_nonempty);
+  });
+
+  it("property: ShaveResult — sourcePath is non-empty", () => {
+    fc.assert(Props.prop_ShaveResult_sourcePath_nonempty);
+  });
+
+  it("property: ShaveResult — atoms and intentCards are arrays", () => {
+    fc.assert(Props.prop_ShaveResult_arrays_are_arrays);
+  });
+
+  it("property: CandidateBlock — source field is a string", () => {
+    fc.assert(Props.prop_CandidateBlock_source_is_string);
+  });
+
+  it("property: CandidateBlock — hint field is optional (absent when omitted)", () => {
+    fc.assert(Props.prop_CandidateBlock_hint_is_optional);
+  });
+
+  it("property: ShaveRegistryView — selectBlocks resolves to an array", async () => {
+    await fc.assert(Props.prop_ShaveRegistryView_selectBlocks_returns_array, { numRuns: 10 });
+  });
+
+  it("property: IntentExtractionHook — id is a non-empty string", () => {
+    fc.assert(Props.prop_IntentExtractionHook_id_is_nonempty);
+  });
+
+  it("property: UniversalizeSlicePlanEntry — kind is a known discriminant", () => {
+    fc.assert(Props.prop_UniversalizeSlicePlanEntry_kind_is_known_discriminant);
+  });
+
+  it("property: UniversalizeResult — matchedPrimitives and slicePlan are arrays", () => {
+    fc.assert(Props.prop_UniversalizeResult_matchedPrimitives_is_array);
+  });
+
+  it("property: ShaveResult + ShaveDiagnostics — compound: diagnostics fields jointly consistent", () => {
+    fc.assert(Props.prop_ShaveResult_compound_diagnostics_consistent);
+  });
+});

--- a/packages/shave/src/types.props.ts
+++ b/packages/shave/src/types.props.ts
@@ -1,0 +1,489 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-001: hand-authored property-test corpus for
+// @yakcc/shave types.ts atoms. Two-file pattern: this file (.props.ts) is
+// vitest-free and holds the corpus; the sibling .props.test.ts is the vitest
+// harness.
+// Status: accepted (WI-V2-07-PREFLIGHT L3e)
+// Rationale: See tmp/wi-v2-07-preflight-layer-plan.md — the corpus file must
+// be runtime-independent so L10 can hash it as a manifest artifact.
+//
+// Atoms covered (named exports from types.ts):
+//   FOREIGN_POLICY_DEFAULT (FP-D1)   — value is 'tag' and satisfies ForeignPolicy
+//   ForeignPolicy          (FP1.1)   — union of 'allow' | 'reject' | 'tag'
+//   ShaveOptions           (SO1.1)   — optional fields accepted, omitted fields absent
+//   ShaveDiagnostics       (SD1.1)   — stubbed array and cache counter invariants
+//   ShavedAtomStub         (SA1.1)   — sourceRange start <= end, placeholderId non-empty
+//   ShaveResult            (SR1.1)   — arrays are readonly arrays, sourcePath non-empty
+//   UniversalizeSlicePlanEntry (UP1.1) — kind discriminant covers slicer union variants
+//   UniversalizeResult     (UR1.1)   — slicePlan matches matchedPrimitives consistency
+//   CandidateBlock         (CB1.1)   — source field is a string; hint is optional
+//   ShaveRegistryView      (RV1.1)   — selectBlocks returns BlockMerkleRoot array
+//   IntentExtractionHook   (IH1.1)   — id is non-empty string
+//
+// Properties covered:
+//   - FOREIGN_POLICY_DEFAULT: value === 'tag' and satisfies ForeignPolicy.
+//   - ShaveOptions: optional fields survive round-trip with exactOptionalPropertyTypes.
+//   - ShaveDiagnostics: cacheHits + cacheMisses >= 0; stubbed contains only known literals.
+//   - ShavedAtomStub: sourceRange.start <= sourceRange.end, placeholderId is non-empty.
+//   - ShaveResult: atoms and intentCards are readonly arrays; sourcePath is non-empty.
+//   - CandidateBlock: source is a string; hint is accepted or omitted cleanly.
+//   - ShaveRegistryView: selectBlocks type contract returns an array.
+//   - IntentExtractionHook: id is always a non-empty string.
+//   - Compound: ShaveResult.diagnostics is a valid ShaveDiagnostics with consistent fields.
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for types.ts
+// ---------------------------------------------------------------------------
+
+import * as fc from "fast-check";
+import type {
+  CandidateBlock,
+  ForeignPolicy,
+  IntentExtractionHook,
+  ShaveDiagnostics,
+  ShaveOptions,
+  ShaveRegistryView,
+  ShaveResult,
+  ShavedAtomStub,
+  UniversalizeResult,
+  UniversalizeSlicePlanEntry,
+} from "./types.js";
+import { FOREIGN_POLICY_DEFAULT } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Shared arbitraries
+// ---------------------------------------------------------------------------
+
+/** Non-empty string with no leading/trailing whitespace. */
+const nonEmptyStr: fc.Arbitrary<string> = fc
+  .string({ minLength: 1, maxLength: 60 })
+  .filter((s) => s.trim().length > 0);
+
+/** Arbitrary ForeignPolicy literal. */
+const foreignPolicyArb: fc.Arbitrary<ForeignPolicy> = fc.constantFrom(
+  "allow" as const,
+  "reject" as const,
+  "tag" as const,
+);
+
+/** Arbitrary non-negative integer for cache counters. */
+const nonNegativeIntArb: fc.Arbitrary<number> = fc.nat({ max: 1000 });
+
+/** Arbitrary stubbed diagnostic item (one of the three known literals). */
+const stubbedItemArb: fc.Arbitrary<"decomposition" | "variance" | "license-gate"> = fc.constantFrom(
+  "decomposition" as const,
+  "variance" as const,
+  "license-gate" as const,
+);
+
+/** Arbitrary stubbed array (unique subset of the three known literals). */
+const stubbedArrayArb: fc.Arbitrary<readonly ("decomposition" | "variance" | "license-gate")[]> =
+  fc.uniqueArray(stubbedItemArb, { maxLength: 3 });
+
+/** Arbitrary ShaveDiagnostics. */
+const shaveDiagnosticsArb: fc.Arbitrary<ShaveDiagnostics> = fc.record({
+  stubbed: stubbedArrayArb,
+  cacheHits: nonNegativeIntArb,
+  cacheMisses: nonNegativeIntArb,
+});
+
+/** Arbitrary byte offset pair where start <= end. */
+const sourceRangeArb: fc.Arbitrary<{ readonly start: number; readonly end: number }> = fc
+  .tuple(fc.nat({ max: 10000 }), fc.nat({ max: 10000 }))
+  .map(([a, b]) => ({ start: Math.min(a, b), end: Math.max(a, b) }));
+
+// ---------------------------------------------------------------------------
+// FP-D1: FOREIGN_POLICY_DEFAULT — value is 'tag' and satisfies ForeignPolicy
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_FOREIGN_POLICY_DEFAULT_is_tag
+ *
+ * FOREIGN_POLICY_DEFAULT must equal the literal string 'tag', which is one of
+ * the three valid ForeignPolicy values.
+ *
+ * Invariant (FP-D1, DEC-V2-FOREIGN-BLOCK-SCHEMA-001 sub-C): all consumers that
+ * need the default policy import this constant rather than hardcoding 'tag'. A
+ * changed value here propagates to all consumers automatically; checking the
+ * value in tests ensures accidental reassignment is caught immediately.
+ */
+export const prop_FOREIGN_POLICY_DEFAULT_is_tag = fc.property(fc.constant(null), (_) => {
+  // Structural check: must satisfy ForeignPolicy union constraint.
+  const validPolicies: readonly string[] = ["allow", "reject", "tag"];
+  return FOREIGN_POLICY_DEFAULT === "tag" && validPolicies.includes(FOREIGN_POLICY_DEFAULT);
+});
+
+// ---------------------------------------------------------------------------
+// SO1.1: ShaveOptions — optional fields accepted, omitted fields absent
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_ShaveOptions_optional_fields_accepted
+ *
+ * A fully populated ShaveOptions object retains all provided values when
+ * type-checked. Optional fields that are omitted must not appear as undefined
+ * keys on the object (exactOptionalPropertyTypes compliance).
+ *
+ * Invariant (SO1.1, DEC-CONTINUOUS-SHAVE-022): ShaveOptions is consumed by
+ * shave() and universalize(); callers rely on field presence checks. Spurious
+ * undefined keys violate exactOptionalPropertyTypes and cause TS2322 errors in
+ * strict mode consumers.
+ */
+export const prop_ShaveOptions_optional_fields_accepted = fc.property(
+  nonEmptyStr,
+  nonEmptyStr,
+  fc.boolean(),
+  foreignPolicyArb,
+  (cacheDir, model, offline, foreignPolicy) => {
+    // Build the options object with only defined fields (omit optional entirely
+    // when we choose not to set them — exactOptionalPropertyTypes compliance).
+    const opts: ShaveOptions = {
+      cacheDir,
+      model,
+      offline,
+      foreignPolicy,
+    };
+    return (
+      opts.cacheDir === cacheDir &&
+      opts.model === model &&
+      opts.offline === offline &&
+      opts.foreignPolicy === foreignPolicy
+    );
+  },
+);
+
+/**
+ * prop_ShaveOptions_empty_object_accepted
+ *
+ * An empty object `{}` satisfies ShaveOptions because all fields are optional.
+ *
+ * Invariant (SO1.1, DEC-CONTINUOUS-SHAVE-022): callers may call shave() with
+ * no options at all. The interface must not impose required fields.
+ */
+export const prop_ShaveOptions_empty_object_accepted = fc.property(fc.constant(null), (_) => {
+  const opts: ShaveOptions = {};
+  return typeof opts === "object";
+});
+
+// ---------------------------------------------------------------------------
+// SD1.1: ShaveDiagnostics — cache counters non-negative; stubbed known literals
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_ShaveDiagnostics_cache_counters_nonnegative
+ *
+ * ShaveDiagnostics.cacheHits and cacheMisses are always non-negative integers.
+ *
+ * Invariant (SD1.1, DEC-CONTINUOUS-SHAVE-022): negative cache counts would
+ * indicate a counting bug in the pipeline. Consumers sum these fields across
+ * multiple shave() calls; a negative value would corrupt the aggregate.
+ */
+export const prop_ShaveDiagnostics_cache_counters_nonnegative = fc.property(
+  shaveDiagnosticsArb,
+  (diag) => {
+    return diag.cacheHits >= 0 && diag.cacheMisses >= 0;
+  },
+);
+
+/**
+ * prop_ShaveDiagnostics_stubbed_contains_only_known_literals
+ *
+ * ShaveDiagnostics.stubbed contains only the three documented literal strings.
+ *
+ * Invariant (SD1.1, DEC-CONTINUOUS-SHAVE-022): the stubbed array is a signal to
+ * callers about which capabilities are not yet implemented. An unknown literal
+ * would be a documentation bug. Downstream consumers must be able to switch on
+ * the known set exhaustively.
+ */
+export const prop_ShaveDiagnostics_stubbed_contains_only_known_literals = fc.property(
+  shaveDiagnosticsArb,
+  (diag) => {
+    const known = new Set(["decomposition", "variance", "license-gate"]);
+    return diag.stubbed.every((s) => known.has(s));
+  },
+);
+
+// ---------------------------------------------------------------------------
+// SA1.1: ShavedAtomStub — sourceRange.start <= sourceRange.end
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_ShavedAtomStub_sourceRange_start_le_end
+ *
+ * For any ShavedAtomStub, sourceRange.start is always <= sourceRange.end.
+ *
+ * Invariant (SA1.1, DEC-CONTINUOUS-SHAVE-022): a reversed range (start > end)
+ * would produce an invalid byte slice that consumers would fail to extract.
+ * The invariant applies regardless of how the range was constructed — even
+ * zero-width atoms (start === end) are valid.
+ */
+export const prop_ShavedAtomStub_sourceRange_start_le_end = fc.property(
+  nonEmptyStr,
+  sourceRangeArb,
+  (placeholderId, sourceRange) => {
+    const atom: ShavedAtomStub = { placeholderId, sourceRange };
+    return atom.sourceRange.start <= atom.sourceRange.end;
+  },
+);
+
+/**
+ * prop_ShavedAtomStub_placeholderId_nonempty
+ *
+ * ShavedAtomStub.placeholderId is always a non-empty string.
+ *
+ * Invariant (SA1.1, DEC-CONTINUOUS-SHAVE-022): WI-012 replaces the stub with
+ * real atoms, but during WI-010-01 the placeholder must be uniquely addressable.
+ * An empty placeholderId would collide across atoms and corrupt registry lookups.
+ */
+export const prop_ShavedAtomStub_placeholderId_nonempty = fc.property(
+  nonEmptyStr,
+  sourceRangeArb,
+  (placeholderId, sourceRange) => {
+    const atom: ShavedAtomStub = { placeholderId, sourceRange };
+    return atom.placeholderId.length > 0;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// SR1.1: ShaveResult — arrays readonly, sourcePath non-empty
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_ShaveResult_sourcePath_nonempty
+ *
+ * ShaveResult.sourcePath is always a non-empty string.
+ *
+ * Invariant (SR1.1, DEC-CONTINUOUS-SHAVE-022): the source path identifies the
+ * file that was processed. An empty sourcePath would make the result impossible
+ * to associate with an input file — breaking any downstream aggregation.
+ */
+export const prop_ShaveResult_sourcePath_nonempty = fc.property(
+  nonEmptyStr,
+  shaveDiagnosticsArb,
+  (sourcePath, diagnostics) => {
+    const result: ShaveResult = {
+      sourcePath,
+      atoms: [],
+      intentCards: [],
+      diagnostics,
+    };
+    return result.sourcePath.length > 0;
+  },
+);
+
+/**
+ * prop_ShaveResult_arrays_are_arrays
+ *
+ * ShaveResult.atoms and ShaveResult.intentCards are always arrays (may be empty).
+ *
+ * Invariant (SR1.1, DEC-CONTINUOUS-SHAVE-022): callers spread and concat these
+ * arrays. Receiving a non-array would throw at runtime without a clear error.
+ */
+export const prop_ShaveResult_arrays_are_arrays = fc.property(
+  nonEmptyStr,
+  shaveDiagnosticsArb,
+  (sourcePath, diagnostics) => {
+    const result: ShaveResult = {
+      sourcePath,
+      atoms: [],
+      intentCards: [],
+      diagnostics,
+    };
+    return Array.isArray(result.atoms) && Array.isArray(result.intentCards);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// CB1.1: CandidateBlock — source field is a string; hint is optional
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_CandidateBlock_source_is_string
+ *
+ * CandidateBlock.source is always a string (may be empty for the interface; in
+ * practice it carries source code).
+ *
+ * Invariant (CB1.1, DEC-CONTINUOUS-SHAVE-022): the source is passed to the
+ * intent extractor verbatim. A non-string would fail tokenization.
+ */
+export const prop_CandidateBlock_source_is_string = fc.property(nonEmptyStr, (source) => {
+  const block: CandidateBlock = { source };
+  return typeof block.source === "string";
+});
+
+/**
+ * prop_CandidateBlock_hint_is_optional
+ *
+ * CandidateBlock with no hint field is still a valid CandidateBlock.
+ *
+ * Invariant (CB1.1, DEC-CONTINUOUS-SHAVE-022): the hint field is optional per
+ * the interface. Omitting it must not produce a TypeScript error and the
+ * resulting object must be structurally valid.
+ */
+export const prop_CandidateBlock_hint_is_optional = fc.property(nonEmptyStr, (source) => {
+  const block: CandidateBlock = { source };
+  // hint is not present — key must be absent (exactOptionalPropertyTypes).
+  return !Object.prototype.hasOwnProperty.call(block, "hint");
+});
+
+// ---------------------------------------------------------------------------
+// RV1.1: ShaveRegistryView — selectBlocks type contract returns an array
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_ShaveRegistryView_selectBlocks_returns_array
+ *
+ * A minimal ShaveRegistryView stub whose selectBlocks always resolves to an
+ * empty array satisfies the interface contract.
+ *
+ * Invariant (RV1.1, DEC-CONTINUOUS-SHAVE-022): shave() calls selectBlocks with
+ * a SpecHash and expects a readonly array back. A stub returning a non-array
+ * (e.g. undefined or null) would crash the pipeline immediately.
+ *
+ * Production sequence: shave() → SlicePlanEntry classification → selectBlocks()
+ * → PointerEntry lookup. The stub exercises that the return type promise resolves.
+ */
+export const prop_ShaveRegistryView_selectBlocks_returns_array = fc.asyncProperty(
+  fc.string({ minLength: 1, maxLength: 32 }),
+  async (specHash) => {
+    const stub: ShaveRegistryView = {
+      selectBlocks: async (_h) => [],
+      getBlock: async (_m) => undefined,
+    };
+    const result = await stub.selectBlocks(specHash as Parameters<typeof stub.selectBlocks>[0]);
+    return Array.isArray(result);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// IH1.1: IntentExtractionHook — id is always a non-empty string
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_IntentExtractionHook_id_is_nonempty
+ *
+ * An IntentExtractionHook's `id` field is always a non-empty string.
+ *
+ * Invariant (IH1.1, DEC-CONTINUOUS-SHAVE-022): hooks are identified by id for
+ * registry deduplication and priority ordering. An empty or missing id would
+ * make two distinct hooks indistinguishable and allow silent override.
+ */
+export const prop_IntentExtractionHook_id_is_nonempty = fc.property(nonEmptyStr, (id) => {
+  // Construct a minimal typed hook object (no call needed for this id check).
+  const hook: Pick<IntentExtractionHook, "id"> = { id };
+  return hook.id.length > 0;
+});
+
+// ---------------------------------------------------------------------------
+// Compound: ShaveResult.diagnostics is a valid ShaveDiagnostics with
+// consistent fields — crossing ShaveResult and ShaveDiagnostics boundaries.
+//
+// Production sequence: shave() builds a ShaveResult at the end of the pipeline,
+// constructing a ShaveDiagnostics object from per-run cache counters and the
+// list of stubbed capabilities. The compound property verifies that the result's
+// diagnostics field satisfies all invariants from SD1.1 simultaneously, as they
+// would be checked by a CLI summary renderer that reads result.diagnostics in one pass.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_ShaveResult_compound_diagnostics_consistent
+ *
+ * For any ShaveResult, result.diagnostics satisfies all ShaveDiagnostics
+ * invariants jointly: cache counters are non-negative AND the stubbed array
+ * contains only known literals AND the diagnostics object identity is preserved.
+ *
+ * This is the canonical compound-interaction property crossing the ShaveResult
+ * and ShaveDiagnostics types. It mirrors the production scenario where the CLI
+ * summary renderer accesses result.diagnostics.cacheHits, result.diagnostics.cacheMisses,
+ * and result.diagnostics.stubbed in a single pass without re-fetching the run.
+ *
+ * Invariant: if any diagnostics field violates its invariant, the CLI summary
+ * may display negative cache counts or unknown stubbed capability identifiers —
+ * both of which would confuse operators.
+ */
+export const prop_ShaveResult_compound_diagnostics_consistent = fc.property(
+  nonEmptyStr,
+  shaveDiagnosticsArb,
+  (sourcePath, diagnostics) => {
+    const result: ShaveResult = {
+      sourcePath,
+      atoms: [],
+      intentCards: [],
+      diagnostics,
+    };
+
+    const d = result.diagnostics;
+
+    // 1. Cache counters non-negative.
+    if (d.cacheHits < 0 || d.cacheMisses < 0) return false;
+
+    // 2. Stubbed contains only known literals.
+    const known = new Set(["decomposition", "variance", "license-gate"]);
+    if (!d.stubbed.every((s) => known.has(s))) return false;
+
+    // 3. Diagnostics object identity preserved — no copy or mutation.
+    if (result.diagnostics !== diagnostics) return false;
+
+    // 4. sourcePath is non-empty.
+    if (result.sourcePath.length === 0) return false;
+
+    return true;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// UP1.1: UniversalizeSlicePlanEntry — kind discriminant covers slicer variants
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_UniversalizeSlicePlanEntry_kind_is_known_discriminant
+ *
+ * Any UniversalizeSlicePlanEntry's `kind` field is one of the four discriminant
+ * strings: 'pointer', 'novel-glue', 'foreign-leaf', 'glue'.
+ *
+ * Invariant (UP1.1, DEC-UNIVERSALIZE-WIRING-001): consumers switch on `kind`
+ * exhaustively to route entries. An unknown `kind` would fall through all
+ * branches silently and produce undefined behavior in the compile pipeline.
+ */
+export const prop_UniversalizeSlicePlanEntry_kind_is_known_discriminant = fc.property(
+  fc.constantFrom(
+    "pointer" as const,
+    "novel-glue" as const,
+    "foreign-leaf" as const,
+    "glue" as const,
+  ),
+  (kind) => {
+    // Build a minimal entry for the given kind to confirm type assignment.
+    const knownKinds = new Set(["pointer", "novel-glue", "foreign-leaf", "glue"]);
+    const entry = { kind } as Pick<UniversalizeSlicePlanEntry, "kind">;
+    return knownKinds.has(entry.kind);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// UR1.1: UniversalizeResult — slicePlan matches matchedPrimitives consistency
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_UniversalizeResult_matchedPrimitives_is_array
+ *
+ * UniversalizeResult.matchedPrimitives is always a readonly array.
+ *
+ * Invariant (UR1.1, DEC-CONTINUOUS-SHAVE-022): the CLI summary totals the
+ * matched primitive count. Receiving a non-array would throw at runtime.
+ *
+ * This property constructs a minimal stub UniversalizeResult and checks the
+ * structural invariant — it is not a full integration test of universalize().
+ */
+export const prop_UniversalizeResult_matchedPrimitives_is_array = fc.property(
+  shaveDiagnosticsArb,
+  (diagnostics) => {
+    // Build a minimal stub that satisfies the required fields.
+    const result: Pick<UniversalizeResult, "slicePlan" | "matchedPrimitives" | "diagnostics"> = {
+      slicePlan: [],
+      matchedPrimitives: [],
+      diagnostics,
+    };
+    return Array.isArray(result.slicePlan) && Array.isArray(result.matchedPrimitives);
+  },
+);


### PR DESCRIPTION
## Summary
- 3 source files / 34 props in shave/<root> non-index files (errors.ts, locate-root.ts, types.ts)
- Authority domain: `property_test_corpus_yakcc_shave_root`

## Test evidence
- Per-file isolation: 34/34 props pass (~417ms with PR #124 vitest fix)
- Full `@yakcc/shave` suite: 443/444 + 1 skipped, ~28s
- Build: `pnpm --filter @yakcc/shave build` clean
- locate-root uses `os.tmpdir()` with try/finally cleanup (hermetic)
- Tested against post-PR-#135 tree (FF'd; no shave/ overlap with compile changes)

## Reviewer verdict
`REVIEW_VERDICT: ready_for_guardian`, zero blockers, 1 non-blocking concern (static-prefix gap below eval contract threshold), 2 notes (FP1.1 implicit coverage, branch drift now resolved by FF). Verified by reviewer dispatch `a8a718cd1dd8b7f44`.

## Continuation roadmap (per planner)
- L3f/g/h: `shave/intent/` split into 3 sub-slices (~183 atoms across 7 files)
- L3i: `shave/corpus/` (~97 atoms, gated on PR #117 cadence cooling)
- L3j: `shave/universalize/` (~191 atoms, gated on WI-V2-GLUE-AWARE-IMPL)

## DO NOT auto-merge — orchestrator review per #87

refs #87