### PR TITLE
WI-V2-07-PREFLIGHT-L3g: shave/intent property-test corpus

### DIFF
--- a/packages/shave/src/intent/anthropic-client.props.test.ts
+++ b/packages/shave/src/intent/anthropic-client.props.test.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for anthropic-client.props.ts — thin runner only.
+// Each export from the corpus is driven through fc.assert() here.
+
+import * as fc from "fast-check";
+import { describe, it } from "vitest";
+import * as Props from "./anthropic-client.props.js";
+
+describe("anthropic-client.ts — Path A property corpus", () => {
+  it("property: AnthropicTextBlock shape conformance", () => {
+    fc.assert(Props.prop_anthropicClient_AnthropicTextBlock_shape_conformance);
+  });
+
+  it("property: AnthropicLikeClient mock satisfies interface", async () => {
+    await fc.assert(Props.prop_anthropicClient_mock_satisfies_interface);
+  });
+});

--- a/packages/shave/src/intent/anthropic-client.props.ts
+++ b/packages/shave/src/intent/anthropic-client.props.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-001: hand-authored property-test corpus for
+// @yakcc/shave intent/anthropic-client.ts atoms. Two-file pattern: this file
+// (.props.ts) is vitest-free and holds the corpus; the sibling
+// .props.test.ts is the vitest harness.
+// Status: accepted (WI-V2-07-PREFLIGHT L3g)
+// Rationale: See tmp/wi-v2-07-preflight-layer-plan.md — the corpus file must
+// be runtime-independent so L10 can hash it as a manifest artifact.
+//
+// Atoms covered (named exports from anthropic-client.ts):
+//   AnthropicTextBlock       (AC1.1) — interface shape: type "text", text string
+//   AnthropicMessageResponse (AC1.1) — interface shape: content array
+//   AnthropicCreateParams    (AC1.1) — interface shape: model/system/messages/max_tokens
+//   AnthropicLikeClient      (AC1.2) — interface shape: create method returns Promise
+//
+// Properties covered (2 atoms):
+//   (m1) Interface shape conformance — compile-time exact-shape via typed locals
+//   (m2) AnthropicLikeClient mock satisfies the interface at runtime
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for intent/anthropic-client.ts
+// ---------------------------------------------------------------------------
+
+import * as fc from "fast-check";
+import type {
+  AnthropicCreateParams,
+  AnthropicLikeClient,
+  AnthropicMessageResponse,
+  AnthropicTextBlock,
+} from "./anthropic-client.js";
+
+// ---------------------------------------------------------------------------
+// Shared arbitraries
+// ---------------------------------------------------------------------------
+
+/** Non-empty string up to 40 chars. */
+const nonEmptyStr: fc.Arbitrary<string> = fc
+  .string({ minLength: 1, maxLength: 40 })
+  .filter((s) => s.trim().length > 0);
+
+/** Arbitrary AnthropicTextBlock — type must be "text". */
+const anthropicTextBlockArb: fc.Arbitrary<AnthropicTextBlock> = fc.record({
+  type: fc.constant("text" as const),
+  text: fc.string({ minLength: 0, maxLength: 100 }),
+});
+
+/** Arbitrary AnthropicCreateParams — all fields required, readonly. */
+const anthropicCreateParamsArb: fc.Arbitrary<AnthropicCreateParams> = fc.record({
+  model: nonEmptyStr,
+  system: fc.string({ minLength: 0, maxLength: 200 }),
+  messages: fc.array(
+    fc.record({
+      role: fc.oneof(fc.constant("user" as const), fc.constant("assistant" as const)),
+      content: fc.string({ minLength: 0, maxLength: 100 }),
+    }),
+    { minLength: 1, maxLength: 3 },
+  ),
+  max_tokens: fc.integer({ min: 1, max: 4096 }),
+});
+
+// ---------------------------------------------------------------------------
+// AC1.1 / (m1): AnthropicTextBlock interface shape conformance
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_anthropicClient_AnthropicTextBlock_shape_conformance
+ *
+ * Any object produced by anthropicTextBlockArb satisfies the AnthropicTextBlock
+ * interface shape: type === "text" and text is a string.
+ *
+ * Invariant (AC1.1, DEC-CONTINUOUS-SHAVE-022): the AnthropicTextBlock interface
+ * is the extraction target from API responses. The type discriminant "text" must
+ * be a string literal, and text must be a string — both are required by the
+ * interface. Compile-time typed assignment here ensures that any future shape
+ * change in the interface causes a TypeScript error, not a silent runtime failure.
+ */
+export const prop_anthropicClient_AnthropicTextBlock_shape_conformance = fc.property(
+  anthropicTextBlockArb,
+  (block: AnthropicTextBlock) => block.type === "text" && typeof block.text === "string",
+);
+
+// ---------------------------------------------------------------------------
+// AC1.2 / (m2): AnthropicLikeClient mock satisfies interface at runtime
+//
+// Production sequence: extractIntent receives ctx.client (AnthropicLikeClient),
+// calls client.create(params) → awaits AnthropicMessageResponse. The mock must
+// satisfy the interface shape so the type system catches drift in the real SDK
+// adapter or in extract.ts. This compound property exercises the full mock
+// inject → create → response sequence crossing the AnthropicLikeClient interface.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_anthropicClient_mock_satisfies_interface
+ *
+ * An object that conforms to AnthropicLikeClient can be called via create() and
+ * returns an AnthropicMessageResponse with the expected shape.
+ *
+ * This is the compound-interaction property for anthropic-client.ts: it exercises
+ * the AnthropicLikeClient interface → create() call → AnthropicMessageResponse
+ * pipeline, mirroring the extract.ts LLM path where ctx.client is injected.
+ * Typed locals for params and response ensure compile-time shape enforcement.
+ *
+ * Invariant (AC1.2, DEC-CONTINUOUS-SHAVE-022): any object that satisfies
+ * AnthropicLikeClient (including test mocks) must produce an
+ * AnthropicMessageResponse with a content array containing AnthropicTextBlock
+ * entries. If the interface drifts from what extract.ts uses, this test will
+ * fail to compile or the runtime check will fail.
+ */
+export const prop_anthropicClient_mock_satisfies_interface = fc.asyncProperty(
+  anthropicCreateParamsArb,
+  fc.string({ minLength: 0, maxLength: 200 }),
+  async (params: AnthropicCreateParams, responseText: string) => {
+    // Build a minimal mock that satisfies AnthropicLikeClient.
+    const textBlock: AnthropicTextBlock = { type: "text", text: responseText };
+    const response: AnthropicMessageResponse = { content: [textBlock] };
+
+    const mockClient: AnthropicLikeClient = {
+      create(_p: AnthropicCreateParams): Promise<AnthropicMessageResponse> {
+        return Promise.resolve(response);
+      },
+    };
+
+    // Call create with typed params — TypeScript will flag any interface mismatch.
+    const result: AnthropicMessageResponse = await mockClient.create(params);
+
+    // Runtime shape verification.
+    if (!Array.isArray(result.content)) return false;
+    const first = result.content[0];
+    if (first === undefined) return false;
+    if (first.type !== "text") return false;
+    const textFirst = first as AnthropicTextBlock;
+    return typeof textFirst.text === "string" && textFirst.text === responseText;
+  },
+);

--- a/packages/shave/src/intent/constants.props.test.ts
+++ b/packages/shave/src/intent/constants.props.test.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for constants.props.ts — thin runner only.
+// Each export from the corpus is driven through fc.assert() here.
+
+import * as fc from "fast-check";
+import { describe, it } from "vitest";
+import * as Props from "./constants.props.js";
+
+describe("constants.ts — Path A property corpus", () => {
+  it("property: DEFAULT_MODEL is non-empty", () => {
+    fc.assert(Props.prop_constants_DEFAULT_MODEL_is_non_empty);
+  });
+
+  it("property: DEFAULT_MODEL matches haiku-4-5-YYYYMMDD format", () => {
+    fc.assert(Props.prop_constants_DEFAULT_MODEL_matches_haiku_format);
+  });
+
+  it("property: INTENT_PROMPT_VERSION is string '1'", () => {
+    fc.assert(Props.prop_constants_INTENT_PROMPT_VERSION_is_string_1);
+  });
+
+  it("property: INTENT_SCHEMA_VERSION is number 1", () => {
+    fc.assert(Props.prop_constants_INTENT_SCHEMA_VERSION_is_number_1);
+  });
+
+  it("property: STATIC_MODEL_TAG is literal 'static-ts@1'", () => {
+    fc.assert(Props.prop_constants_STATIC_MODEL_TAG_is_literal);
+  });
+
+  it("property: STATIC_PROMPT_VERSION is literal 'static-jsdoc@1'", () => {
+    fc.assert(Props.prop_constants_STATIC_PROMPT_VERSION_is_literal);
+  });
+
+  it("property: static and LLM cache keys are disjoint for same source", () => {
+    fc.assert(Props.prop_constants_static_and_llm_cache_keys_are_disjoint);
+  });
+
+  it("property: static cache key is deterministic", () => {
+    fc.assert(Props.prop_constants_static_key_is_deterministic);
+  });
+});

--- a/packages/shave/src/intent/constants.props.ts
+++ b/packages/shave/src/intent/constants.props.ts
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-001: hand-authored property-test corpus for
+// @yakcc/shave intent/constants.ts atoms. Two-file pattern: this file
+// (.props.ts) is vitest-free and holds the corpus; the sibling .props.test.ts
+// is the vitest harness.
+// Status: accepted (WI-V2-07-PREFLIGHT L3g)
+// Rationale: See tmp/wi-v2-07-preflight-layer-plan.md — the corpus file must
+// be runtime-independent so L10 can hash it as a manifest artifact.
+//
+// Atoms covered (named exports from constants.ts):
+//   DEFAULT_MODEL          (CON1.1) — non-empty, format haiku-4-5-YYYYMMDD
+//   INTENT_PROMPT_VERSION  (CON1.2) — literal '1'
+//   INTENT_SCHEMA_VERSION  (CON1.3) — const 1
+//   STATIC_MODEL_TAG       (CON1.4) — literal 'static-ts@1'
+//   STATIC_PROMPT_VERSION  (CON1.5) — literal 'static-jsdoc@1'
+//   keyFromIntentInputs    (CON1.6) — domain disjointness via cache key
+//
+// Properties covered (3 atoms, 6 props):
+//   (n) DEFAULT_MODEL non-empty, matches haiku-4-5-YYYYMMDD format
+//   (o) INTENT_PROMPT_VERSION === '1' literal
+//   (p) INTENT_SCHEMA_VERSION === 1 const number
+//   (q) STATIC_MODEL_TAG === 'static-ts@1' literal
+//   (r) STATIC_PROMPT_VERSION === 'static-jsdoc@1' literal
+//   (s) keyFromIntentInputs domain disjointness — STATIC_MODEL_TAG vs Anthropic model id
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for intent/constants.ts
+// ---------------------------------------------------------------------------
+
+import * as fc from "fast-check";
+import { keyFromIntentInputs, sourceHash } from "../cache/key.js";
+import {
+  DEFAULT_MODEL,
+  INTENT_PROMPT_VERSION,
+  INTENT_SCHEMA_VERSION,
+  STATIC_MODEL_TAG,
+  STATIC_PROMPT_VERSION,
+} from "./constants.js";
+
+// ---------------------------------------------------------------------------
+// Shared arbitraries
+// ---------------------------------------------------------------------------
+
+/** Non-empty string with no leading/trailing whitespace, max 40 chars. */
+const nonEmptyStr: fc.Arbitrary<string> = fc
+  .string({ minLength: 1, maxLength: 40 })
+  .filter((s) => s.trim().length > 0);
+
+/** 64-char lowercase hex string (BLAKE3-like, from nibble array). */
+const hexHash64: fc.Arbitrary<string> = fc
+  .array(fc.integer({ min: 0, max: 15 }), { minLength: 64, maxLength: 64 })
+  .map((nibbles) => nibbles.map((n) => n.toString(16)).join(""));
+
+// ---------------------------------------------------------------------------
+// CON1.1 / (n): DEFAULT_MODEL is non-empty and matches expected format
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_constants_DEFAULT_MODEL_is_non_empty
+ *
+ * DEFAULT_MODEL must be a non-empty string.
+ *
+ * Invariant (CON1.1, DEC-CONTINUOUS-SHAVE-022): an empty DEFAULT_MODEL would
+ * produce an invalid cache key component and potentially break LLM extraction.
+ */
+export const prop_constants_DEFAULT_MODEL_is_non_empty = fc.property(
+  fc.constant(DEFAULT_MODEL),
+  (model) => typeof model === "string" && model.length > 0,
+);
+
+/**
+ * prop_constants_DEFAULT_MODEL_matches_haiku_format
+ *
+ * DEFAULT_MODEL matches the expected Anthropic Haiku 4.5 model identifier
+ * format (claude-haiku-4-5-YYYYMMDD).
+ *
+ * Invariant (CON1.1, DEC-CONTINUOUS-SHAVE-022): the model identifier must be
+ * parseable as a dated Haiku 4.5 model tag. Changing the identifier without
+ * bumping the format sentinel invalidates all cached intent entries.
+ */
+export const prop_constants_DEFAULT_MODEL_matches_haiku_format = fc.property(
+  fc.constant(DEFAULT_MODEL),
+  (model) => /^claude-haiku-4-5-\d{8}$/.test(model),
+);
+
+// ---------------------------------------------------------------------------
+// CON1.2 / (o): INTENT_PROMPT_VERSION is the literal string '1'
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_constants_INTENT_PROMPT_VERSION_is_string_1
+ *
+ * INTENT_PROMPT_VERSION must be the string literal '1'.
+ *
+ * Invariant (CON1.2, DEC-CONTINUOUS-SHAVE-022): the prompt version tag is a
+ * string used in cache key derivation. Changing its value or type invalidates
+ * all existing LLM-path cache entries and must be a deliberate decision.
+ */
+export const prop_constants_INTENT_PROMPT_VERSION_is_string_1 = fc.property(
+  fc.constant(INTENT_PROMPT_VERSION),
+  (v) => v === "1",
+);
+
+// ---------------------------------------------------------------------------
+// CON1.3 / (p): INTENT_SCHEMA_VERSION is the const number 1
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_constants_INTENT_SCHEMA_VERSION_is_number_1
+ *
+ * INTENT_SCHEMA_VERSION must be the number 1 (not string "1", not 0, not 2).
+ *
+ * Invariant (CON1.3, DEC-CONTINUOUS-SHAVE-022): INTENT_SCHEMA_VERSION is used
+ * in both cache key derivation and as the schemaVersion discriminant inside
+ * IntentCard. It must be exactly the number 1 matching the schemaVersion field
+ * accepted by validateIntentCard.
+ */
+export const prop_constants_INTENT_SCHEMA_VERSION_is_number_1 = fc.property(
+  fc.constant(INTENT_SCHEMA_VERSION),
+  (v) => v === 1 && typeof v === "number",
+);
+
+// ---------------------------------------------------------------------------
+// CON1.4 / (q): STATIC_MODEL_TAG is the literal 'static-ts@1'
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_constants_STATIC_MODEL_TAG_is_literal
+ *
+ * STATIC_MODEL_TAG must be the exact string 'static-ts@1'.
+ *
+ * Invariant (CON1.4, DEC-INTENT-STATIC-CACHE-001): the '@'-separated versioned
+ * tag format ensures it cannot equal any Anthropic model identifier, which
+ * guarantees disjoint cache key namespaces by construction.
+ */
+export const prop_constants_STATIC_MODEL_TAG_is_literal = fc.property(
+  fc.constant(STATIC_MODEL_TAG),
+  (tag) => tag === "static-ts@1",
+);
+
+// ---------------------------------------------------------------------------
+// CON1.5 / (r): STATIC_PROMPT_VERSION is the literal 'static-jsdoc@1'
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_constants_STATIC_PROMPT_VERSION_is_literal
+ *
+ * STATIC_PROMPT_VERSION must be the exact string 'static-jsdoc@1'.
+ *
+ * Invariant (CON1.5, DEC-INTENT-STATIC-CACHE-001): same isolation guarantee
+ * as STATIC_MODEL_TAG — the '@'-versioned form cannot collide with numeric
+ * LLM prompt version strings like '1' or '2'.
+ */
+export const prop_constants_STATIC_PROMPT_VERSION_is_literal = fc.property(
+  fc.constant(STATIC_PROMPT_VERSION),
+  (v) => v === "static-jsdoc@1",
+);
+
+// ---------------------------------------------------------------------------
+// CON1.6 / (s): keyFromIntentInputs domain disjointness
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_constants_static_and_llm_cache_keys_are_disjoint
+ *
+ * For the same source text, keyFromIntentInputs with STATIC_MODEL_TAG /
+ * STATIC_PROMPT_VERSION always produces a different cache key than with
+ * any plausible Anthropic model identifier and numeric prompt version.
+ *
+ * Invariant (CON1.6, DEC-INTENT-STATIC-CACHE-001): static and LLM cards must
+ * land in permanently disjoint cache namespaces. This property verifies the
+ * disjointness guarantee for arbitrary source strings and a realistic set of
+ * Anthropic model identifiers.
+ */
+export const prop_constants_static_and_llm_cache_keys_are_disjoint = fc.property(
+  nonEmptyStr,
+  // Plausible Anthropic model ids (won't contain '@')
+  fc
+    .string({ minLength: 4, maxLength: 30 })
+    .filter((s) => !s.includes("@") && s.trim().length > 0),
+  // Numeric prompt version strings
+  fc
+    .integer({ min: 1, max: 9 })
+    .map((n) => String(n)),
+  (src, llmModel, llmPromptVersion) => {
+    const srcHashVal = sourceHash(src);
+
+    const staticKey = keyFromIntentInputs({
+      sourceHash: srcHashVal,
+      modelTag: STATIC_MODEL_TAG,
+      promptVersion: STATIC_PROMPT_VERSION,
+      schemaVersion: INTENT_SCHEMA_VERSION,
+    });
+
+    const llmKey = keyFromIntentInputs({
+      sourceHash: srcHashVal,
+      modelTag: llmModel,
+      promptVersion: llmPromptVersion,
+      schemaVersion: INTENT_SCHEMA_VERSION,
+    });
+
+    return staticKey !== llmKey;
+  },
+);
+
+/**
+ * prop_constants_static_key_is_deterministic
+ *
+ * keyFromIntentInputs with STATIC_MODEL_TAG / STATIC_PROMPT_VERSION produces
+ * the same cache key for the same source string on every invocation.
+ *
+ * Invariant (CON1.6, DEC-INTENT-STATIC-CACHE-001): the cache key derivation
+ * is a pure function of the inputs. Non-determinism would cause spurious cache
+ * misses on every call.
+ */
+export const prop_constants_static_key_is_deterministic = fc.property(hexHash64, (srcHashVal) => {
+  const k1 = keyFromIntentInputs({
+    sourceHash: srcHashVal,
+    modelTag: STATIC_MODEL_TAG,
+    promptVersion: STATIC_PROMPT_VERSION,
+    schemaVersion: INTENT_SCHEMA_VERSION,
+  });
+  const k2 = keyFromIntentInputs({
+    sourceHash: srcHashVal,
+    modelTag: STATIC_MODEL_TAG,
+    promptVersion: STATIC_PROMPT_VERSION,
+    schemaVersion: INTENT_SCHEMA_VERSION,
+  });
+  return k1 === k2;
+});

--- a/packages/shave/src/intent/extract.props.test.ts
+++ b/packages/shave/src/intent/extract.props.test.ts
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for extract.props.ts — thin runner only.
+// Each export from the corpus is driven through fc.assert() here.
+
+import * as fc from "fast-check";
+import { describe, it } from "vitest";
+import * as Props from "./extract.props.js";
+
+describe("extract.ts — Path A property corpus", () => {
+  // -------------------------------------------------------------------------
+  // (a) parseJsonFence happy path
+  // -------------------------------------------------------------------------
+  it("property: llm happy path returns validated IntentCard", async () => {
+    await fc.assert(Props.prop_extract_llm_happy_path_returns_validated_card, {
+      numRuns: 20,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // (b) parseJsonFence — fences absent
+  // -------------------------------------------------------------------------
+  it("property: llm no-fence response throws IntentCardSchemaError", async () => {
+    await fc.assert(Props.prop_extract_llm_no_fence_throws_schema_error, {
+      numRuns: 20,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // (c) parseJsonFence — end <= start (inverted fences)
+  // -------------------------------------------------------------------------
+  it("property: llm inverted fences throws IntentCardSchemaError", async () => {
+    await fc.assert(Props.prop_extract_llm_inverted_fences_throws_schema_error, {
+      numRuns: 20,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // (d) parseJsonFence — malformed JSON between fences
+  // -------------------------------------------------------------------------
+  it("property: llm malformed JSON in fence throws IntentCardSchemaError", async () => {
+    await fc.assert(Props.prop_extract_llm_malformed_json_in_fence_throws_schema_error, {
+      numRuns: 20,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // (e) strategy default resolves to 'static'
+  // -------------------------------------------------------------------------
+  it("property: omitting strategy defaults to static (no client needed)", async () => {
+    await fc.assert(Props.prop_extract_strategy_default_is_static, {
+      numRuns: 5,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // (f) strategy='static' uses STATIC_MODEL_TAG / STATIC_PROMPT_VERSION
+  // -------------------------------------------------------------------------
+  it("property: strategy='static' uses STATIC_MODEL_TAG and STATIC_PROMPT_VERSION", async () => {
+    await fc.assert(Props.prop_extract_static_strategy_uses_static_tags, {
+      numRuns: 5,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // (g) strategy='llm' uses ctx.model / ctx.promptVersion
+  // -------------------------------------------------------------------------
+  it("property: strategy='llm' card has modelVersion and promptVersion from ctx", async () => {
+    await fc.assert(Props.prop_extract_llm_strategy_uses_ctx_model_and_prompt_version, {
+      numRuns: 20,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // (h) srcHash determinism
+  // -------------------------------------------------------------------------
+  it("property: sourceHash is deterministic for same source", async () => {
+    await fc.assert(Props.prop_extract_srcHash_is_deterministic, {
+      numRuns: 20,
+    });
+  });
+
+  it("property: sourceHash differs for distinct sources", async () => {
+    await fc.assert(Props.prop_extract_srcHash_differs_for_different_sources, {
+      numRuns: 20,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // (i) extractedAt whole-second truncation
+  // -------------------------------------------------------------------------
+  it("property: extractedAt is truncated to whole second ISO-8601", async () => {
+    await fc.assert(Props.prop_extract_extractedAt_is_whole_second_iso8601, {
+      numRuns: 20,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // (j) offline + cache miss → OfflineCacheMissError
+  // -------------------------------------------------------------------------
+  it("property: offline + cold cache throws OfflineCacheMissError", async () => {
+    await fc.assert(
+      Props.prop_extract_llm_offline_cache_miss_throws_OfflineCacheMissError,
+      { numRuns: 20 },
+    );
+  });
+
+  it("property: offline + warm cache returns cached card", async () => {
+    await fc.assert(Props.prop_extract_llm_offline_cache_hit_returns_card, {
+      numRuns: 20,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // (k) no client + no API key → AnthropicApiKeyMissingError
+  // -------------------------------------------------------------------------
+  it("property: no client and no ANTHROPIC_API_KEY throws AnthropicApiKeyMissingError", async () => {
+    await fc.assert(
+      Props.prop_extract_llm_no_client_no_key_throws_AnthropicApiKeyMissingError,
+      { numRuns: 20 },
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // (l) IntentCard fields from ctx
+  // -------------------------------------------------------------------------
+  it("property: llm card fields come from ctx (model, promptVersion, srcHash, extractedAt)", async () => {
+    await fc.assert(Props.prop_extract_llm_card_fields_come_from_ctx, {
+      numRuns: 20,
+    });
+  });
+
+  it("property: llm result passes validateIntentCard (idempotent)", async () => {
+    await fc.assert(Props.prop_extract_llm_result_passes_validateIntentCard, {
+      numRuns: 20,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Compound interactions
+  // -------------------------------------------------------------------------
+  it("property: compound — static miss then hit returns same card from cache", async () => {
+    await fc.assert(Props.prop_extract_static_compound_miss_then_hit, {
+      numRuns: 5,
+    });
+  });
+
+  it("property: compound — llm miss then hit (offline on second call succeeds)", async () => {
+    await fc.assert(Props.prop_extract_llm_compound_miss_then_hit, {
+      numRuns: 20,
+    });
+  });
+});

--- a/packages/shave/src/intent/extract.props.ts
+++ b/packages/shave/src/intent/extract.props.ts
@@ -1,0 +1,861 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-001: hand-authored property-test corpus for
+// @yakcc/shave intent/extract.ts atoms. Two-file pattern: this file (.props.ts)
+// is vitest-free and holds the corpus; the sibling .props.test.ts is the
+// vitest harness.
+// Status: accepted (WI-V2-07-PREFLIGHT L3g)
+// Rationale: See tmp/wi-v2-07-preflight-layer-plan.md — the corpus file must
+// be runtime-independent so L10 can hash it as a manifest artifact.
+//
+// Atoms covered (named exports from extract.ts):
+//   parseJsonFence     — internal fence parser (exercised via extractIntent llm path)
+//   extractIntent      — main entry point (strategy dispatch, cache, validation)
+//   ExtractIntentContext — interface shape
+//
+// Properties covered (43 atoms across invariants a–l):
+//   (a) parseJsonFence happy-path round-trips well-formed <json>...</json> fences
+//   (b) parseJsonFence throws IntentCardSchemaError when fences absent
+//   (c) parseJsonFence throws IntentCardSchemaError when end <= start
+//   (d) parseJsonFence throws IntentCardSchemaError when JSON malformed
+//   (e) extractIntent strategy default resolves to 'static'
+//   (f) extractIntent strategy='static' uses STATIC_MODEL_TAG/STATIC_PROMPT_VERSION
+//   (g) extractIntent strategy='llm' uses ctx.model/ctx.promptVersion
+//   (h) extractIntent computes srcHash + cacheKey deterministically
+//   (i) extractedAt is truncated to whole-second ISO-8601 from ctx.now
+//   (j) strategy='llm' + ctx.offline===true + no cache hit → OfflineCacheMissError
+//   (k) strategy='llm' + no ctx.client + no ANTHROPIC_API_KEY → AnthropicApiKeyMissingError
+//   (l) strategy='llm' assembles IntentCard from ctx.model/promptVersion/srcHash/extractedAt
+//
+// Deferred (Path C — see tmp/wi-v2-07-preflight-L3g-deferred-atoms.md):
+//   - createDefaultAnthropicClient lazy SDK import path
+//   - process.env.ANTHROPIC_API_KEY live read (non-arrange-restorable in property context)
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for intent/extract.ts
+// ---------------------------------------------------------------------------
+
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as fc from "fast-check";
+import {
+  AnthropicApiKeyMissingError,
+  IntentCardSchemaError,
+  OfflineCacheMissError,
+} from "../errors.js";
+import type {
+  AnthropicCreateParams,
+  AnthropicLikeClient,
+  AnthropicMessageResponse,
+} from "./anthropic-client.js";
+import { INTENT_SCHEMA_VERSION, STATIC_MODEL_TAG, STATIC_PROMPT_VERSION } from "./constants.js";
+import { extractIntent } from "./extract.js";
+
+// ---------------------------------------------------------------------------
+// Shared arbitraries
+// ---------------------------------------------------------------------------
+
+/** Non-empty string with no leading/trailing whitespace. */
+const nonEmptyStr: fc.Arbitrary<string> = fc
+  .string({ minLength: 1, maxLength: 40 })
+  .filter((s) => s.trim().length > 0);
+
+/** 64-char lowercase hex string (nibble array). */
+const hexHash64: fc.Arbitrary<string> = fc
+  .array(fc.integer({ min: 0, max: 15 }), { minLength: 64, maxLength: 64 })
+  .map((nibbles) => nibbles.map((n) => n.toString(16)).join(""));
+
+/** Behavior string: non-empty, no newlines, ≤ 200 chars. */
+const behaviorArb: fc.Arbitrary<string> = fc
+  .string({ minLength: 1, maxLength: 150 })
+  .filter((s) => s.trim().length > 0 && !/[\n\r]/.test(s));
+
+/** Non-empty TypeScript source string — used as unitSource. */
+const unitSourceArb: fc.Arbitrary<string> = fc
+  .string({ minLength: 10, maxLength: 200 })
+  .filter((s) => s.trim().length > 0);
+
+/** Well-formed IntentCard raw object (unknown-typed, for JSON fence assembly). */
+const rawIntentCardArb = fc
+  .tuple(behaviorArb, hexHash64, nonEmptyStr, nonEmptyStr)
+  .map(([behavior, sourceHash, modelVersion, promptVersion]) => ({
+    schemaVersion: 1,
+    behavior,
+    inputs: [],
+    outputs: [],
+    preconditions: [],
+    postconditions: [],
+    notes: [],
+    modelVersion,
+    promptVersion,
+    sourceHash,
+    extractedAt: "2024-01-01T00:00:00.000Z",
+  }));
+
+/** Minimal well-formed JSON fence string wrapping a valid IntentCard. */
+const validFencedResponseArb: fc.Arbitrary<{ raw: Record<string, unknown>; fenced: string }> =
+  rawIntentCardArb.map((raw) => ({
+    raw,
+    fenced: `<json>${JSON.stringify(raw)}</json>`,
+  }));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Allocates an isolated cacheDir under os.tmpdir() for each property run. */
+async function isolatedCacheDir(prefix: string): Promise<string> {
+  return mkdtemp(join(tmpdir(), `yakcc-ep-${prefix}-`));
+}
+
+/** Builds a mock AnthropicLikeClient that returns a fenced IntentCard response. */
+function mockClient(responseText: string): AnthropicLikeClient {
+  return {
+    create(_params: AnthropicCreateParams): Promise<AnthropicMessageResponse> {
+      return Promise.resolve({
+        content: [{ type: "text", text: responseText }],
+      });
+    },
+  };
+}
+
+/** Throws IntentCardSchemaError if extractIntent does not throw it. */
+async function assertThrowsSchemaError(fn: () => Promise<unknown>): Promise<boolean> {
+  try {
+    await fn();
+    return false;
+  } catch (err) {
+    return err instanceof IntentCardSchemaError;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// (a): parseJsonFence happy-path round-trips well-formed <json>…</json> fences
+//
+// Exercised via extractIntent LLM path with a mock client returning a valid fence.
+// The fence parser is internal; we verify it via the public extractIntent API.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_extract_llm_happy_path_returns_validated_card
+ *
+ * When strategy='llm' and the mock client returns a valid <json>…</json> fence,
+ * extractIntent returns a validated IntentCard with the expected fields.
+ *
+ * Invariant (a, DEC-CONTINUOUS-SHAVE-022): parseJsonFence correctly extracts
+ * the JSON between well-formed fences and the result passes validateIntentCard.
+ */
+export const prop_extract_llm_happy_path_returns_validated_card = fc.asyncProperty(
+  unitSourceArb,
+  validFencedResponseArb,
+  nonEmptyStr,
+  nonEmptyStr,
+  async (unitSource, { fenced }, model, promptVersion) => {
+    const cacheDir = await isolatedCacheDir("llm-happy");
+    const card = await extractIntent(unitSource, {
+      strategy: "llm",
+      model,
+      promptVersion,
+      cacheDir,
+      client: mockClient(fenced),
+    });
+    return (
+      card.schemaVersion === 1 &&
+      typeof card.behavior === "string" &&
+      card.behavior.length > 0 &&
+      typeof card.sourceHash === "string" &&
+      card.sourceHash.length === 64
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// (b): parseJsonFence throws IntentCardSchemaError when fences absent
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_extract_llm_no_fence_throws_schema_error
+ *
+ * When strategy='llm' and the mock client returns a response without
+ * <json>…</json> fences, extractIntent throws IntentCardSchemaError.
+ *
+ * Invariant (b, DEC-CONTINUOUS-SHAVE-022): absence of fences means the model
+ * produced unexpected output; the caller must surface this immediately rather
+ * than silently storing a corrupt entry.
+ */
+export const prop_extract_llm_no_fence_throws_schema_error = fc.asyncProperty(
+  unitSourceArb,
+  // String that contains neither <json> nor </json>
+  fc
+    .string({ minLength: 1, maxLength: 100 })
+    .filter((s) => !s.includes("<json>")),
+  nonEmptyStr,
+  nonEmptyStr,
+  async (unitSource, noFenceText, model, promptVersion) => {
+    const cacheDir = await isolatedCacheDir("no-fence");
+    return assertThrowsSchemaError(() =>
+      extractIntent(unitSource, {
+        strategy: "llm",
+        model,
+        promptVersion,
+        cacheDir,
+        client: mockClient(noFenceText),
+      }),
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// (c): parseJsonFence throws IntentCardSchemaError when end <= start
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_extract_llm_inverted_fences_throws_schema_error
+ *
+ * When strategy='llm' and the response has </json> before <json>,
+ * extractIntent throws IntentCardSchemaError (end <= start).
+ *
+ * Invariant (c, DEC-CONTINUOUS-SHAVE-022): the fence parser checks
+ * end <= start and throws immediately rather than slicing a negative range.
+ */
+export const prop_extract_llm_inverted_fences_throws_schema_error = fc.asyncProperty(
+  unitSourceArb,
+  fc.string({ minLength: 0, maxLength: 40 }),
+  nonEmptyStr,
+  nonEmptyStr,
+  async (unitSource, middle, model, promptVersion) => {
+    // Put </json> before <json> so end <= start in the source.
+    const invertedFence = `</json>${middle}<json>`;
+    const cacheDir = await isolatedCacheDir("inverted");
+    return assertThrowsSchemaError(() =>
+      extractIntent(unitSource, {
+        strategy: "llm",
+        model,
+        promptVersion,
+        cacheDir,
+        client: mockClient(invertedFence),
+      }),
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// (d): parseJsonFence throws IntentCardSchemaError when JSON malformed
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_extract_llm_malformed_json_in_fence_throws_schema_error
+ *
+ * When strategy='llm' and the response wraps malformed JSON in <json>…</json>,
+ * extractIntent throws IntentCardSchemaError.
+ *
+ * Invariant (d, DEC-CONTINUOUS-SHAVE-022): the JSON.parse call inside
+ * parseJsonFence throws on malformed input; the catch block must re-throw
+ * as IntentCardSchemaError, not as a generic SyntaxError.
+ */
+export const prop_extract_llm_malformed_json_in_fence_throws_schema_error = fc.asyncProperty(
+  unitSourceArb,
+  // String that is not valid JSON when used as fence content
+  fc
+    .string({ minLength: 1, maxLength: 50 })
+    .filter((s) => {
+      try {
+        JSON.parse(s);
+        return false; // skip valid JSON
+      } catch {
+        return true;
+      }
+    }),
+  nonEmptyStr,
+  nonEmptyStr,
+  async (unitSource, malformedJson, model, promptVersion) => {
+    const fenced = `<json>${malformedJson}</json>`;
+    const cacheDir = await isolatedCacheDir("malformed-json");
+    return assertThrowsSchemaError(() =>
+      extractIntent(unitSource, {
+        strategy: "llm",
+        model,
+        promptVersion,
+        cacheDir,
+        client: mockClient(fenced),
+      }),
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// (e): extractIntent strategy default resolves to 'static'
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_extract_strategy_default_is_static
+ *
+ * When ctx.strategy is omitted, extractIntent behaves as strategy='static':
+ * it succeeds without a client and without ANTHROPIC_API_KEY, and does not
+ * throw AnthropicApiKeyMissingError.
+ *
+ * Invariant (e, DEC-INTENT-STRATEGY-001): default strategy is "static" per
+ * DEC-INTENT-STRATEGY-001. The common case must never require network access.
+ */
+export const prop_extract_strategy_default_is_static = fc.asyncProperty(
+  // Minimal TypeScript source with a JSDoc comment so staticExtract returns a card
+  fc.constant(
+    `/**
+ * Adds two numbers.
+ * @param a - First number
+ * @param b - Second number
+ * @returns Sum
+ */
+export function add(a: number, b: number): number { return a + b; }`,
+  ),
+  nonEmptyStr,
+  nonEmptyStr,
+  async (unitSource, model, promptVersion) => {
+    const cacheDir = await isolatedCacheDir("default-static");
+    try {
+      const card = await extractIntent(unitSource, {
+        // strategy omitted — must default to "static"
+        model,
+        promptVersion,
+        cacheDir,
+        // No client, no API key — static must not require either
+      });
+      return card.schemaVersion === 1 && typeof card.behavior === "string";
+    } catch {
+      // Static path must not throw for well-formed source
+      return false;
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// (f): strategy='static' uses STATIC_MODEL_TAG / STATIC_PROMPT_VERSION
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_extract_static_strategy_uses_static_tags
+ *
+ * When strategy='static', the returned IntentCard has modelVersion===STATIC_MODEL_TAG
+ * and promptVersion===STATIC_PROMPT_VERSION (the static cache namespace tags).
+ *
+ * Invariant (f, DEC-INTENT-STRATEGY-001, DEC-INTENT-STATIC-CACHE-001):
+ * static and LLM cards must occupy disjoint cache namespaces. The model/prompt
+ * version tags in the returned card are the authority for cache key derivation;
+ * they must be the static constants, not ctx.model / ctx.promptVersion.
+ */
+export const prop_extract_static_strategy_uses_static_tags = fc.asyncProperty(
+  fc.constant(
+    `/**
+ * Multiplies two numbers.
+ * @param x - First factor
+ * @param y - Second factor
+ * @returns Product
+ */
+export function multiply(x: number, y: number): number { return x * y; }`,
+  ),
+  nonEmptyStr,
+  nonEmptyStr,
+  async (unitSource, model, promptVersion) => {
+    const cacheDir = await isolatedCacheDir("static-tags");
+    const card = await extractIntent(unitSource, {
+      strategy: "static",
+      model,
+      promptVersion,
+      cacheDir,
+    });
+    return card.modelVersion === STATIC_MODEL_TAG && card.promptVersion === STATIC_PROMPT_VERSION;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// (g): strategy='llm' uses ctx.model / ctx.promptVersion as cache-key components
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_extract_llm_strategy_uses_ctx_model_and_prompt_version
+ *
+ * When strategy='llm', the returned IntentCard has modelVersion===ctx.model
+ * and promptVersion===ctx.promptVersion (from the assembled card in step 4e).
+ *
+ * Invariant (g, DEC-CONTINUOUS-SHAVE-022): the LLM path overwrites
+ * modelVersion and promptVersion on the assembled card so the cache key
+ * components are always the values from ctx, not whatever the model returned
+ * in the JSON fence. This prevents cache pollution from model-generated values.
+ */
+export const prop_extract_llm_strategy_uses_ctx_model_and_prompt_version = fc.asyncProperty(
+  unitSourceArb,
+  nonEmptyStr,
+  nonEmptyStr,
+  validFencedResponseArb,
+  async (unitSource, model, promptVersion, { fenced }) => {
+    const cacheDir = await isolatedCacheDir("llm-model-pv");
+    const card = await extractIntent(unitSource, {
+      strategy: "llm",
+      model,
+      promptVersion,
+      cacheDir,
+      client: mockClient(fenced),
+    });
+    return card.modelVersion === model && card.promptVersion === promptVersion;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// (h): extractIntent computes srcHash via computeSourceHash deterministically
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_extract_srcHash_is_deterministic
+ *
+ * Two calls to extractIntent with the same unitSource produce IntentCards
+ * with the same sourceHash.
+ *
+ * Invariant (h, DEC-CONTINUOUS-SHAVE-022): sourceHash is the BLAKE3 of
+ * the normalized source text. It must be deterministic so the cache key
+ * derivation produces the same key for the same source on every run.
+ */
+export const prop_extract_srcHash_is_deterministic = fc.asyncProperty(
+  unitSourceArb,
+  nonEmptyStr,
+  nonEmptyStr,
+  validFencedResponseArb,
+  async (unitSource, model, promptVersion, { fenced }) => {
+    const cacheDir = await isolatedCacheDir("srchash-det");
+    // First call — miss path.
+    const card1 = await extractIntent(unitSource, {
+      strategy: "llm",
+      model,
+      promptVersion,
+      cacheDir,
+      client: mockClient(fenced),
+    });
+    // Second call — cache hit path (same cacheDir, same source).
+    const card2 = await extractIntent(unitSource, {
+      strategy: "llm",
+      model,
+      promptVersion,
+      cacheDir,
+      client: mockClient(fenced),
+    });
+    return card1.sourceHash === card2.sourceHash && card1.sourceHash.length === 64;
+  },
+);
+
+/**
+ * prop_extract_srcHash_differs_for_different_sources
+ *
+ * Different unitSource strings (that differ after normalization) produce
+ * different sourceHash values in the returned IntentCard.
+ *
+ * Invariant (h, DEC-CONTINUOUS-SHAVE-022): the hash function is injective
+ * over the normalized source domain. Collisions would cause incorrect
+ * cache hits across different source units.
+ */
+export const prop_extract_srcHash_differs_for_different_sources = fc.asyncProperty(
+  // Two distinct source strings (not equal after trimming)
+  fc
+    .tuple(unitSourceArb, unitSourceArb)
+    .filter(([a, b]) => a.trim() !== b.trim()),
+  nonEmptyStr,
+  nonEmptyStr,
+  validFencedResponseArb,
+  async ([src1, src2], model, promptVersion, { fenced }) => {
+    const cacheDir1 = await isolatedCacheDir("srchash-diff1");
+    const cacheDir2 = await isolatedCacheDir("srchash-diff2");
+    const card1 = await extractIntent(src1, {
+      strategy: "llm",
+      model,
+      promptVersion,
+      cacheDir: cacheDir1,
+      client: mockClient(fenced),
+    });
+    const card2 = await extractIntent(src2, {
+      strategy: "llm",
+      model,
+      promptVersion,
+      cacheDir: cacheDir2,
+      client: mockClient(fenced),
+    });
+    return card1.sourceHash !== card2.sourceHash;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// (i): extractedAt is truncated to whole-second ISO-8601 from ctx.now
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_extract_extractedAt_is_whole_second_iso8601
+ *
+ * When ctx.now returns a Date with sub-second precision, the returned
+ * IntentCard.extractedAt is the same timestamp truncated to the whole second
+ * (milliseconds === 0) in ISO-8601 format.
+ *
+ * Invariant (i, DEC-CONTINUOUS-SHAVE-022): the truncation formula is
+ * new Date(Math.floor(now.getTime() / 1000) * 1000).toISOString(). This
+ * ensures extractedAt is always a clean second boundary, preventing millisecond
+ * drift from causing cache key mismatches in time-sensitive tests.
+ */
+export const prop_extract_extractedAt_is_whole_second_iso8601 = fc.asyncProperty(
+  unitSourceArb,
+  nonEmptyStr,
+  nonEmptyStr,
+  validFencedResponseArb,
+  // A timestamp with arbitrary sub-second component.
+  fc
+    .integer({ min: 0, max: 999 })
+    .map((ms) => {
+      const base = new Date("2024-06-15T12:34:56.000Z").getTime();
+      return new Date(base + ms);
+    }),
+  async (unitSource, model, promptVersion, { fenced }, nowDate) => {
+    const cacheDir = await isolatedCacheDir("extractedAt");
+    const card = await extractIntent(unitSource, {
+      strategy: "llm",
+      model,
+      promptVersion,
+      cacheDir,
+      client: mockClient(fenced),
+      now: () => nowDate,
+    });
+
+    // extractedAt must end with .000Z (milliseconds truncated).
+    if (!card.extractedAt.endsWith(".000Z")) return false;
+
+    // The whole-second timestamp must match the truncated now.
+    const expectedMs = Math.floor(nowDate.getTime() / 1000) * 1000;
+    const expected = new Date(expectedMs).toISOString();
+    return card.extractedAt === expected;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// (j): strategy='llm' + ctx.offline===true + no cache hit → OfflineCacheMissError
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_extract_llm_offline_cache_miss_throws_OfflineCacheMissError
+ *
+ * When strategy='llm', ctx.offline===true, and the cache is cold (empty dir),
+ * extractIntent throws OfflineCacheMissError.
+ *
+ * Invariant (j, DEC-CONTINUOUS-SHAVE-022): offline mode must never make API
+ * calls. On a cold cache it must throw OfflineCacheMissError rather than
+ * silently returning undefined or calling the client.
+ */
+export const prop_extract_llm_offline_cache_miss_throws_OfflineCacheMissError = fc.asyncProperty(
+  unitSourceArb,
+  nonEmptyStr,
+  nonEmptyStr,
+  async (unitSource, model, promptVersion) => {
+    const cacheDir = await isolatedCacheDir("offline-miss");
+    try {
+      await extractIntent(unitSource, {
+        strategy: "llm",
+        model,
+        promptVersion,
+        cacheDir,
+        offline: true,
+        // No client — must not reach the API check anyway.
+      });
+      return false;
+    } catch (err) {
+      return err instanceof OfflineCacheMissError;
+    }
+  },
+);
+
+/**
+ * prop_extract_llm_offline_cache_hit_returns_card
+ *
+ * When strategy='llm', ctx.offline===true, but the cache already has an entry
+ * for the given source+model+promptVersion, extractIntent returns the cached card.
+ *
+ * Invariant (j, DEC-CONTINUOUS-SHAVE-022): the offline guard only fires on
+ * cache misses. A pre-populated cache entry must be returned even in offline mode.
+ * This verifies the ordering: step 3 (cache lookup) runs before step 4a (offline check).
+ */
+export const prop_extract_llm_offline_cache_hit_returns_card = fc.asyncProperty(
+  unitSourceArb,
+  nonEmptyStr,
+  nonEmptyStr,
+  validFencedResponseArb,
+  async (unitSource, model, promptVersion, { fenced }) => {
+    const cacheDir = await isolatedCacheDir("offline-hit");
+    // Warm the cache with an online call first.
+    await extractIntent(unitSource, {
+      strategy: "llm",
+      model,
+      promptVersion,
+      cacheDir,
+      client: mockClient(fenced),
+    });
+    // Now call offline — must return the cached card, not throw.
+    try {
+      const card = await extractIntent(unitSource, {
+        strategy: "llm",
+        model,
+        promptVersion,
+        cacheDir,
+        offline: true,
+      });
+      return card.schemaVersion === 1;
+    } catch {
+      return false;
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// (k): strategy='llm' + no ctx.client + no ANTHROPIC_API_KEY →
+//      AnthropicApiKeyMissingError
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_extract_llm_no_client_no_key_throws_AnthropicApiKeyMissingError
+ *
+ * When strategy='llm', ctx.client is undefined, and ANTHROPIC_API_KEY is not
+ * set (or is empty), extractIntent throws AnthropicApiKeyMissingError.
+ *
+ * Invariant (k, DEC-CONTINUOUS-SHAVE-022): the API-key guard (step 4b) must
+ * fire before any SDK import or network call. The error class is
+ * AnthropicApiKeyMissingError, not a generic Error or a network error.
+ *
+ * @decision DEC-V2-PROPTEST-PATH-A-001: process.env.ANTHROPIC_API_KEY is
+ * temporarily cleared inside an arrange-act-restore bracket. This is the only
+ * Path A mechanism available without SDK mocking. The restore is synchronous
+ * (the await completes before the restore) — safe in single-threaded Node.
+ */
+export const prop_extract_llm_no_client_no_key_throws_AnthropicApiKeyMissingError =
+  fc.asyncProperty(
+    unitSourceArb,
+    nonEmptyStr,
+    nonEmptyStr,
+    async (unitSource, model, promptVersion) => {
+      const cacheDir = await isolatedCacheDir("no-key");
+      const saved = process.env.ANTHROPIC_API_KEY;
+      // biome-ignore lint/performance/noDelete: arrange-restore bracket — only safe way to unset env var
+      delete process.env.ANTHROPIC_API_KEY;
+      try {
+        await extractIntent(unitSource, {
+          strategy: "llm",
+          model,
+          promptVersion,
+          cacheDir,
+          // No client — must hit the API-key guard.
+        });
+        return false;
+      } catch (err) {
+        return err instanceof AnthropicApiKeyMissingError;
+      } finally {
+        if (saved !== undefined) {
+          process.env.ANTHROPIC_API_KEY = saved;
+        }
+      }
+    },
+  );
+
+// ---------------------------------------------------------------------------
+// (l): strategy='llm' assembles IntentCard from ctx.model / promptVersion /
+//      srcHash / extractedAt fields and validates via validateIntentCard
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_extract_llm_card_fields_come_from_ctx
+ *
+ * When strategy='llm' succeeds, the returned IntentCard has:
+ *   modelVersion  === ctx.model
+ *   promptVersion === ctx.promptVersion
+ *   sourceHash    is a 64-char lowercase hex (BLAKE3 of source)
+ *   extractedAt   is a non-empty ISO-8601 string truncated to the whole second
+ *   schemaVersion === INTENT_SCHEMA_VERSION (1)
+ *
+ * Invariant (l, DEC-CONTINUOUS-SHAVE-022): extractIntent assembles the card
+ * in step 4e by spreading the parsed JSON and then overwriting modelVersion,
+ * promptVersion, sourceHash, extractedAt. This property verifies each field
+ * comes from the correct authority: ctx for model/prompt, BLAKE3 for hash,
+ * ctx.now for timestamp.
+ */
+export const prop_extract_llm_card_fields_come_from_ctx = fc.asyncProperty(
+  unitSourceArb,
+  nonEmptyStr,
+  nonEmptyStr,
+  validFencedResponseArb,
+  fc.integer({ min: 0, max: 999 }).map((ms) => {
+    const base = new Date("2025-03-01T10:00:00.000Z").getTime();
+    return new Date(base + ms);
+  }),
+  async (unitSource, model, promptVersion, { fenced }, nowDate) => {
+    const cacheDir = await isolatedCacheDir("card-fields");
+    const card = await extractIntent(unitSource, {
+      strategy: "llm",
+      model,
+      promptVersion,
+      cacheDir,
+      client: mockClient(fenced),
+      now: () => nowDate,
+    });
+    const expectedExtractedAt = new Date(Math.floor(nowDate.getTime() / 1000) * 1000).toISOString();
+
+    return (
+      card.schemaVersion === INTENT_SCHEMA_VERSION &&
+      card.modelVersion === model &&
+      card.promptVersion === promptVersion &&
+      /^[0-9a-f]{64}$/.test(card.sourceHash) &&
+      card.extractedAt === expectedExtractedAt
+    );
+  },
+);
+
+/**
+ * prop_extract_llm_result_passes_validateIntentCard
+ *
+ * The value returned by extractIntent (strategy='llm') is a fully valid
+ * IntentCard that passes a second call to validateIntentCard.
+ *
+ * Invariant (l, DEC-CONTINUOUS-SHAVE-022): extractIntent calls
+ * validateIntentCard (step 4f) before writing to cache and returning.
+ * The returned value must be validate-idempotent — validateIntentCard on the
+ * result must not throw.
+ */
+export const prop_extract_llm_result_passes_validateIntentCard = fc.asyncProperty(
+  unitSourceArb,
+  nonEmptyStr,
+  nonEmptyStr,
+  validFencedResponseArb,
+  async (unitSource, model, promptVersion, { fenced }) => {
+    const cacheDir = await isolatedCacheDir("validate-idem");
+    const card = await extractIntent(unitSource, {
+      strategy: "llm",
+      model,
+      promptVersion,
+      cacheDir,
+      client: mockClient(fenced),
+    });
+    // Re-validate — must not throw.
+    try {
+      const { validateIntentCard } = await import("./validate-intent-card.js");
+      validateIntentCard(card);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Compound interaction: full extractIntent static pipeline (cache miss → write → hit)
+//
+// Production sequence:
+//   1. extractIntent(src, ctx) — cold cache: miss → staticExtract → validate → write
+//   2. extractIntent(src, ctx) — warm cache: hit → validate → return
+// This crosses the boundaries of extractIntent, file-cache (readIntent/writeIntent),
+// computeSourceHash, keyFromIntentInputs, staticExtract, and validateIntentCard.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_extract_static_compound_miss_then_hit
+ *
+ * The first call to extractIntent(strategy='static') on a cold cache succeeds
+ * (miss path: AST extract → validate → write). The second call returns the
+ * same card from cache (hit path: readIntent → validate → return).
+ *
+ * This is the canonical compound-interaction property for extract.ts: it
+ * exercises the real production sequence — miss → write → hit — crossing
+ * multiple internal component boundaries. Both calls must return cards with
+ * the same sourceHash, modelVersion, and behavior.
+ *
+ * Invariant (h, f, DEC-INTENT-STRATEGY-001, DEC-CONTINUOUS-SHAVE-022):
+ * the cache write/read cycle must be round-trip faithful and the second call
+ * must not re-run extraction (it reads from cache). The deterministic sourceHash
+ * and static tags guarantee cache key stability across calls.
+ */
+export const prop_extract_static_compound_miss_then_hit = fc.asyncProperty(
+  fc.constant(
+    `/**
+ * Returns the absolute value of a number.
+ * @param n - The input number
+ * @returns Absolute value
+ */
+export function abs(n: number): number { return n < 0 ? -n : n; }`,
+  ),
+  nonEmptyStr,
+  nonEmptyStr,
+  async (unitSource, model, promptVersion) => {
+    const cacheDir = await isolatedCacheDir("compound-miss-hit");
+
+    // First call: cold cache → static extraction path.
+    const card1 = await extractIntent(unitSource, {
+      strategy: "static",
+      model,
+      promptVersion,
+      cacheDir,
+    });
+
+    // Second call: warm cache → cache hit path (must not re-run staticExtract).
+    const card2 = await extractIntent(unitSource, {
+      strategy: "static",
+      model,
+      promptVersion,
+      cacheDir,
+    });
+
+    // Both must agree on all cache-validity fields.
+    return (
+      card1.sourceHash === card2.sourceHash &&
+      card1.modelVersion === card2.modelVersion &&
+      card1.promptVersion === card2.promptVersion &&
+      card1.schemaVersion === card2.schemaVersion &&
+      card1.behavior === card2.behavior &&
+      card1.modelVersion === STATIC_MODEL_TAG &&
+      card1.promptVersion === STATIC_PROMPT_VERSION
+    );
+  },
+);
+
+/**
+ * prop_extract_llm_compound_miss_then_hit
+ *
+ * The first call to extractIntent(strategy='llm') on a cold cache triggers
+ * the mock client and writes to cache. The second call returns the cached card
+ * without calling the client again.
+ *
+ * Invariant (h, g, DEC-CONTINUOUS-SHAVE-022): same round-trip guarantee as the
+ * static compound property but for the LLM path. The client call count is
+ * verified indirectly: a null client on the second call (offline=true) must
+ * succeed, proving the cache was written on the first call.
+ */
+export const prop_extract_llm_compound_miss_then_hit = fc.asyncProperty(
+  unitSourceArb,
+  nonEmptyStr,
+  nonEmptyStr,
+  validFencedResponseArb,
+  async (unitSource, model, promptVersion, { fenced }) => {
+    const cacheDir = await isolatedCacheDir("llm-compound");
+
+    // First call: miss → client → validate → write.
+    const card1 = await extractIntent(unitSource, {
+      strategy: "llm",
+      model,
+      promptVersion,
+      cacheDir,
+      client: mockClient(fenced),
+    });
+
+    // Second call: hit → validate → return (offline=true confirms no client needed).
+    const card2 = await extractIntent(unitSource, {
+      strategy: "llm",
+      model,
+      promptVersion,
+      cacheDir,
+      offline: true,
+    });
+
+    return (
+      card1.sourceHash === card2.sourceHash &&
+      card1.modelVersion === card2.modelVersion &&
+      card1.promptVersion === card2.promptVersion &&
+      card1.behavior === card2.behavior
+    );
+  },
+);

--- a/packages/shave/src/intent/types.props.test.ts
+++ b/packages/shave/src/intent/types.props.test.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for types.props.ts — thin runner only.
+// Each export from the corpus is driven through fc.assert() here.
+
+import * as fc from "fast-check";
+import { describe, it } from "vitest";
+import * as Props from "./types.props.js";
+
+describe("types.ts — Path A property corpus", () => {
+  it("property: IntentParam shape conformance", () => {
+    fc.assert(Props.prop_types_IntentParam_shape_conformance);
+  });
+
+  it("property: IntentParam all fields are strings", () => {
+    fc.assert(Props.prop_types_IntentParam_all_fields_are_strings);
+  });
+
+  it("property: IntentCard schemaVersion is literal 1", () => {
+    fc.assert(Props.prop_types_IntentCard_schemaVersion_is_literal_1);
+  });
+
+  it("property: IntentCard round-trip through validateIntentCard", () => {
+    fc.assert(Props.prop_types_IntentCard_round_trip_through_validator);
+  });
+});

--- a/packages/shave/src/intent/types.props.ts
+++ b/packages/shave/src/intent/types.props.ts
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-001: hand-authored property-test corpus for
+// @yakcc/shave intent/types.ts atoms. Two-file pattern: this file (.props.ts)
+// is vitest-free and holds the corpus; the sibling .props.test.ts is the
+// vitest harness.
+// Status: accepted (WI-V2-07-PREFLIGHT L3g)
+// Rationale: See tmp/wi-v2-07-preflight-layer-plan.md — the corpus file must
+// be runtime-independent so L10 can hash it as a manifest artifact.
+//
+// Atoms covered (named exports from types.ts):
+//   IntentParam  (TYP1.1) — shape conformance: name/typeHint/description required strings
+//   IntentCard   (TYP1.2) — shape conformance: schemaVersion===1 literal, all fields
+//
+// Properties covered (4 atoms):
+//   (t1) IntentParam shape conformance — well-formed objects satisfy the interface
+//   (t2) IntentParam shape conformance — name/typeHint/description all strings
+//   (u1) IntentCard shape conformance — schemaVersion literal === 1
+//   (u2) IntentCard round-trip through validateIntentCard
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for intent/types.ts
+// ---------------------------------------------------------------------------
+
+import * as fc from "fast-check";
+import type { IntentCard, IntentParam } from "./types.js";
+import { validateIntentCard } from "./validate-intent-card.js";
+
+// ---------------------------------------------------------------------------
+// Shared arbitraries
+// ---------------------------------------------------------------------------
+
+/** Non-empty string with no leading/trailing whitespace. */
+const nonEmptyStr: fc.Arbitrary<string> = fc
+  .string({ minLength: 1, maxLength: 40 })
+  .filter((s) => s.trim().length > 0);
+
+/** 64-char lowercase hex string. */
+const hexHash64: fc.Arbitrary<string> = fc
+  .array(fc.integer({ min: 0, max: 15 }), { minLength: 64, maxLength: 64 })
+  .map((nibbles) => nibbles.map((n) => n.toString(16)).join(""));
+
+/** Behavior string: non-empty, no newlines, ≤ 200 chars. */
+const behaviorArb: fc.Arbitrary<string> = fc
+  .string({ minLength: 1, maxLength: 200 })
+  .filter((s) => s.trim().length > 0 && !/[\n\r]/.test(s));
+
+/** Arbitrary IntentParam typed as the interface. */
+const intentParamArb: fc.Arbitrary<IntentParam> = fc.record({
+  name: nonEmptyStr,
+  typeHint: nonEmptyStr,
+  description: fc.string({ minLength: 0, maxLength: 40 }),
+});
+
+/** Well-formed IntentCard typed as the interface. */
+const intentCardArb: fc.Arbitrary<IntentCard> = fc.record({
+  schemaVersion: fc.constant(1 as const),
+  behavior: behaviorArb,
+  inputs: fc.array(intentParamArb, { minLength: 0, maxLength: 3 }),
+  outputs: fc.array(intentParamArb, { minLength: 0, maxLength: 3 }),
+  preconditions: fc.array(fc.string(), { minLength: 0, maxLength: 3 }),
+  postconditions: fc.array(fc.string(), { minLength: 0, maxLength: 3 }),
+  notes: fc.array(fc.string(), { minLength: 0, maxLength: 3 }),
+  modelVersion: nonEmptyStr,
+  promptVersion: nonEmptyStr,
+  sourceHash: hexHash64,
+  extractedAt: fc.constant("2024-01-01T00:00:00.000Z"),
+});
+
+// ---------------------------------------------------------------------------
+// TYP1.1 / (t1): IntentParam shape conformance — typed local assignment
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_types_IntentParam_shape_conformance
+ *
+ * Any object produced by intentParamArb can be assigned to an IntentParam
+ * typed local and its fields read back with correct types.
+ *
+ * Invariant (TYP1.1, DEC-CONTINUOUS-SHAVE-022): the TypeScript interface
+ * requires name, typeHint, and description to be strings. This property verifies
+ * the arbitrary produces objects that structurally satisfy the interface at
+ * runtime (type-checking catches compile-time drift; this catches build-time
+ * regressions where the type and runtime diverge).
+ */
+export const prop_types_IntentParam_shape_conformance = fc.property(
+  intentParamArb,
+  (param: IntentParam) =>
+    typeof param.name === "string" &&
+    typeof param.typeHint === "string" &&
+    typeof param.description === "string",
+);
+
+// ---------------------------------------------------------------------------
+// TYP1.1 / (t2): IntentParam all fields are strings (no optional / undefined)
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_types_IntentParam_all_fields_are_strings
+ *
+ * For any IntentParam produced by intentParamArb, name, typeHint, and
+ * description are all non-undefined string values.
+ *
+ * Invariant (TYP1.1, DEC-CONTINUOUS-SHAVE-022): all three IntentParam fields
+ * are required strings per the interface. Under exactOptionalPropertyTypes:true,
+ * they must never be undefined. This property verifies the runtime shape.
+ */
+export const prop_types_IntentParam_all_fields_are_strings = fc.property(
+  intentParamArb,
+  (param: IntentParam) =>
+    param.name !== undefined &&
+    param.typeHint !== undefined &&
+    param.description !== undefined &&
+    typeof param.name === "string" &&
+    typeof param.typeHint === "string" &&
+    typeof param.description === "string",
+);
+
+// ---------------------------------------------------------------------------
+// TYP1.2 / (u1): IntentCard shape conformance — schemaVersion === 1 literal
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_types_IntentCard_schemaVersion_is_literal_1
+ *
+ * For any IntentCard produced by intentCardArb, schemaVersion is exactly the
+ * number 1 (the literal type).
+ *
+ * Invariant (TYP1.2, DEC-CONTINUOUS-SHAVE-022): schemaVersion is typed as the
+ * literal 1, which is a discriminant for forward-compatible deserialization.
+ * This property verifies the const assertion is preserved at the value level.
+ */
+export const prop_types_IntentCard_schemaVersion_is_literal_1 = fc.property(
+  intentCardArb,
+  (card: IntentCard) => card.schemaVersion === 1 && typeof card.schemaVersion === "number",
+);
+
+// ---------------------------------------------------------------------------
+// TYP1.2 / (u2): IntentCard round-trip through validateIntentCard
+//
+// Production sequence: IntentCard value (typed) → JSON.parse(JSON.stringify())
+// → validateIntentCard() → IntentCard with same fields.
+// Crosses the IntentCard interface boundary and the validator, mirroring the
+// cache read path (readIntent returns unknown → validateIntentCard).
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_types_IntentCard_round_trip_through_validator
+ *
+ * A well-formed IntentCard value survives a JSON round-trip and validateIntentCard
+ * with all fields intact.
+ *
+ * This is the compound-interaction property for types.ts: it exercises the
+ * IntentCard interface shape → JSON serialization → deserialization → validation
+ * sequence, which is the exact path the cache module follows when reading a
+ * stored entry. Both the schema and the runtime shape must be consistent.
+ *
+ * Invariant (TYP1.2, DEC-CONTINUOUS-SHAVE-022): the IntentCard interface must
+ * be structurally complete enough that any conformant value can survive
+ * JSON round-trip and re-validation. If a field added to the interface is not
+ * accepted by validateIntentCard, the cache pipeline silently evicts valid entries.
+ */
+export const prop_types_IntentCard_round_trip_through_validator = fc.property(
+  intentCardArb,
+  (card: IntentCard) => {
+    // Simulate the cache read path: JSON serialize then deserialize.
+    const raw = JSON.parse(JSON.stringify(card)) as unknown;
+
+    try {
+      const validated = validateIntentCard(raw);
+      // All cache-validity fields must survive the round-trip.
+      return (
+        validated.schemaVersion === card.schemaVersion &&
+        validated.behavior === card.behavior &&
+        validated.modelVersion === card.modelVersion &&
+        validated.promptVersion === card.promptVersion &&
+        validated.sourceHash === card.sourceHash &&
+        validated.extractedAt === card.extractedAt &&
+        validated.inputs.length === card.inputs.length &&
+        validated.outputs.length === card.outputs.length
+      );
+    } catch {
+      return false;
+    }
+  },
+);


### PR DESCRIPTION
## Summary

Adds property-based test corpus for `packages/shave/src/intent/{extract, anthropic-client, constants, types}.ts` following the two-file pattern (`.props.ts` + `.props.test.ts`) established by L3a-L3f.

- **31 `prop_*` exports** across 4 source files
- **49 of 52 Path A atoms covered** (3 deferred to L4: live SDK / live env coupling)
- LLM-path properties inject `AnthropicLikeClient` mock via `ctx.client`
- Cache-hit/miss properties use isolated `mkdtemp` cacheDirs
- Rejection paths assert specific error classes (`IntentCardSchemaError`, `AnthropicApiKeyMissingError`, `OfflineCacheMissError`)
- `.props.ts` files are vitest-free (hashable as L7 conformance manifest)

## Atom coverage

| Source file | Atoms in Path A | Covered in L3g | Deferred |
|---|---|---|---|
| `extract.ts` | 39 | 39 | 0 |
| `anthropic-client.ts` | 4 | 2 | 2 (live SDK, live env) |
| `constants.ts` | 7 | 6 | 1 (live env) |
| `types.ts` | 2 | 2 | 0 |
| **Total** | **52** | **49** | **3** |

Deferred atom rationale documented in `tmp/wi-v2-07-preflight-L3g-deferred-atoms.md`.

## Conventions enforced

- Two-file split: `.props.ts` (vitest-free, hashable) + `.props.test.ts` (vitest harness only)
- `.js` extension on all relative imports (NodeNext resolution)
- Specific error class assertions (no generic `Error` matchers)
- No live SDK import in L3g properties (mocked via `ctx.client`)
- No `fc.hexaString` (use `fc.hexa()`/`fc.string` per L3d convention)
- `mkdtemp`-isolated cacheDirs for filesystem properties

## Testing

\`\`\`
pnpm --filter @yakcc/shave test
# 514 pass, 1 skip, 0 fail (~27s)
\`\`\`

The reviewer noted a pre-existing flake in `examples/v1-wave-3-wasm-lower-demo` (closer-parity test); this is **not a regression from L3g** - the L3g corpus is fully isolated to `packages/shave/src/intent/`.

## Out of scope

- `static-extract.ts` (73 atoms) and `static-pick.ts` (18 atoms) - deferred to L3h
- Live-SDK / live-env coupled atoms - deferred to L4
- Wave-3 demo flake - separate triage

## Continuation roadmap

- **L3h**: `intent-static-extract` (`static-extract.ts` 73 + `static-pick.ts` 18 = 91 Path A atoms across 2 files)
- **L3i / L3j**: remaining `packages/shave/src/intent/` modules per master plan
- **L4**: live SDK / live env atoms
- **L7**: conformance manifest hashing across full corpus

## Closure

Refs #87 - parent issue closes only after L7 conformance manifest lands.