### PR TITLE
WI-L3i-FIX-5: props-file.ts regex-escape fix (closes #165)

### DIFF
--- a/packages/shave/src/corpus/props-file.props.ts
+++ b/packages/shave/src/corpus/props-file.props.ts
@@ -75,17 +75,10 @@ const intentCardInputArb: fc.Arbitrary<IntentCardInput> = fc.record({
   promptVersion: nonEmptyStr,
 });
 
-/**
- * Valid identifier string for use as an atom/function name.
- *
- * Note: regex excludes `$` even though TypeScript identifier syntax allows
- * it. The `$` exclusion dodges #165 (props-file.ts:79 builds a regex from
- * atomName without escaping, breaking on `$`-containing names). When #165
- * lands, this filter can be widened back to `/^[a-zA-Z_$][a-zA-Z0-9_$]*$/`.
- */
+/** Valid identifier string for use as an atom/function name. */
 const identifierArb: fc.Arbitrary<string> = fc
   .string({ minLength: 1, maxLength: 20 })
-  .filter((s) => /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(s));
+  .filter((s) => /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(s));
 
 /** Source string with a valid function declaration (inferFunctionName → function-decl path). */
 const sourceFnDeclArb: fc.Arbitrary<[string, string]> = identifierArb.map((name) => [

--- a/packages/shave/src/corpus/props-file.ts
+++ b/packages/shave/src/corpus/props-file.ts
@@ -76,7 +76,11 @@ export async function extractFromPropsFile(
   // Check whether any prop_<atomName>_* export exists (name-based mapping).
   // The regex uses a word boundary before `prop_` to avoid false matches on
   // names like `my_prop_foo_bar` (which would not be a valid prop export).
-  if (!new RegExp(`(?:^|\\s|;)export\\s+const\\s+prop_${atomName}_`).test(fileContent)) {
+  // Escape regex meta chars in atomName before substitution. Fixes #165: identifiers
+  // like `$` or `$0` contain regex metacharacters (notably `$` as end-of-input anchor)
+  // that would silently break the match when interpolated unescaped.
+  const escapedAtomName = atomName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  if (!new RegExp(`(?:^|\\s|;)export\\s+const\\s+prop_${escapedAtomName}_`).test(fileContent)) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary
- Fixes #165: `props-file.ts:79` constructed regex `prop_${atomName}_` without escaping regex meta chars in `atomName`. Identifiers like `$` or `$0` (valid per JS/TS spec, accepted by `inferFunctionName`) silently broke the match.
- Applies standard JS regex-escape via `atomName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")` before substitution.
- Widens `identifierArb` in `props-file.props.ts` back to `/^[a-zA-Z_$][a-zA-Z0-9_$]*$/` (the L3i workaround narrowing is no longer needed). The 3 previously-failing properties now pass.

## Test plan
- [x] pnpm -F @yakcc/shave test props-file.props.test (12/12, deterministic across 2 runs)
- [x] Reviewer ready_for_guardian on HEAD 507d5df (zero findings)
- [x] Pre-existing baseline failures (`@yakcc/contracts`/`@yakcc/registry`/`@yakcc/ir` import errors on origin/main) unchanged

Closes #165. Refs #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)