### PR TITLE
WI-V2-07-PREFLIGHT-L3-license: shave/license property-test corpus (refs #87)

### DIFF
--- a/packages/shave/src/license/detector.props.test.ts
+++ b/packages/shave/src/license/detector.props.test.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for license/detector.props.ts — thin runner only.
+// Each export from the corpus is driven through fc.assert() here.
+
+import * as fc from "fast-check";
+import { it } from "vitest";
+import {
+  prop_detector_0bsd_preferredOverIsc,
+  prop_detector_apacheHeader_yieldsCorrectDetection,
+  prop_detector_bsd2_whenNoThirdClause,
+  prop_detector_bsd3_distinguishedFromBsd2,
+  prop_detector_detectLicense_alwaysReturnsDetectionShape,
+  prop_detector_detectLicense_isTotalFunction,
+  prop_detector_iscHeader_yieldsCorrectDetection,
+  prop_detector_licenseTag_yieldsSpdxCommentSource,
+  prop_detector_mitHeader_yieldsCorrectDetection,
+  prop_detector_noSignal_yieldsUnknownDetection,
+  prop_detector_publicDomainPhrase_yieldsCorrectDetection,
+  prop_detector_spdxComment_takesPrecedence,
+  prop_detector_spdxEvidence_matchesMatchedSubstring,
+  prop_detector_unlicenseDedication_yieldsCorrectDetection,
+} from "./detector.props.js";
+
+const opts = { numRuns: 100 };
+
+it("property: detectLicense — always returns a LicenseDetection-shaped object", () => {
+  fc.assert(prop_detector_detectLicense_alwaysReturnsDetectionShape, opts);
+});
+
+it("property: detectLicense — SPDX comment takes precedence over all other signals", () => {
+  fc.assert(prop_detector_spdxComment_takesPrecedence, opts);
+});
+
+it("property: detectLicense — @license tag yields spdx-comment source", () => {
+  fc.assert(prop_detector_licenseTag_yieldsSpdxCommentSource, opts);
+});
+
+it("property: detectLicense — Unlicense dedication phrase yields correct detection", () => {
+  fc.assert(prop_detector_unlicenseDedication_yieldsCorrectDetection, opts);
+});
+
+it("property: detectLicense — public-domain phrase yields correct detection", () => {
+  fc.assert(prop_detector_publicDomainPhrase_yieldsCorrectDetection, opts);
+});
+
+it("property: detectLicense — MIT header text yields correct detection", () => {
+  fc.assert(prop_detector_mitHeader_yieldsCorrectDetection, opts);
+});
+
+it("property: detectLicense — Apache-2.0 header text yields correct detection", () => {
+  fc.assert(prop_detector_apacheHeader_yieldsCorrectDetection, opts);
+});
+
+it("property: detectLicense — ISC header text yields correct detection", () => {
+  fc.assert(prop_detector_iscHeader_yieldsCorrectDetection, opts);
+});
+
+it("property: detectLicense — no-signal input yields unknown/no-signal detection", () => {
+  fc.assert(prop_detector_noSignal_yieldsUnknownDetection, opts);
+});
+
+it("property: detectLicense — SPDX evidence field matches matched substring", () => {
+  fc.assert(prop_detector_spdxEvidence_matchesMatchedSubstring, opts);
+});
+
+it("property: detectLicense — 0BSD header preferred over ISC (precedence ordering)", () => {
+  fc.assert(prop_detector_0bsd_preferredOverIsc, opts);
+});
+
+it("property: detectLicense — BSD-3 distinguished from BSD-2 by neither-the-name-of clause", () => {
+  fc.assert(prop_detector_bsd3_distinguishedFromBsd2, opts);
+});
+
+it("property: detectLicense — BSD-2 detected when third-clause is absent", () => {
+  fc.assert(prop_detector_bsd2_whenNoThirdClause, opts);
+});
+
+it("property: detectLicense — total function: arbitrary strings never throw (compound)", () => {
+  fc.assert(prop_detector_detectLicense_isTotalFunction, opts);
+});

--- a/packages/shave/src/license/detector.props.ts
+++ b/packages/shave/src/license/detector.props.ts
@@ -1,0 +1,396 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-001: hand-authored property-test corpus for
+// @yakcc/shave license/detector.ts atoms. Two-file pattern: this file
+// (.props.ts) is vitest-free and holds the corpus; the sibling .props.test.ts
+// is the vitest harness.
+// Status: accepted (WI-V2-07-PREFLIGHT L3-license)
+// Rationale: See tmp/wi-v2-07-preflight-layer-plan.md — the corpus file must
+// be runtime-independent so L10 can hash it as a manifest artifact.
+//
+// Atoms covered (from detector.ts):
+//   detectLicense          (D1.1) — pure function: string → LicenseDetection.
+//
+// Properties covered:
+//   D1.1  detectLicense always returns a LicenseDetection-shaped object.
+//   D1.2  SPDX comment takes precedence over all other signals.
+//   D1.3  Unlicense dedication phrase yields identifier="Unlicense", source="dedication".
+//   D1.4  Public-domain phrase yields identifier="public-domain", source="dedication".
+//   D1.5  Header-text patterns yield the correct identifier and source="header-text".
+//   D1.6  No-signal input yields identifier="unknown", source="no-signal".
+//   D1.7  SPDX evidence matches the matched substring (non-empty string).
+//   D1.8  0BSD header is preferred over ISC header (precedence ordering).
+//   D1.9  BSD-3 is distinguished from BSD-2 by "neither the name of" clause.
+//   D1.10 detectLicense is total: arbitrary strings never throw.
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for license/detector.ts
+// ---------------------------------------------------------------------------
+
+import * as fc from "fast-check";
+import { detectLicense } from "./detector.js";
+import type { LicenseDetection } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Shared arbitraries
+// ---------------------------------------------------------------------------
+
+/** Non-empty string with no leading/trailing whitespace. */
+const nonEmptyStr: fc.Arbitrary<string> = fc
+  .string({ minLength: 1, maxLength: 60 })
+  .filter((s) => s.trim().length > 0);
+
+/** Arbitrary SPDX identifier (realistic but broad). */
+const spdxIdArb: fc.Arbitrary<string> = fc.constantFrom(
+  "MIT",
+  "Apache-2.0",
+  "ISC",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "0BSD",
+  "Unlicense",
+  "GPL-3.0-only",
+  "AGPL-3.0-or-later",
+  "LGPL-2.1-or-later",
+  "BUSL-1.1",
+  "PROPRIETARY",
+);
+
+/** Source text containing an SPDX-License-Identifier comment. */
+const spdxCommentSourceArb: fc.Arbitrary<string> = spdxIdArb.map(
+  (id) => `// SPDX-License-Identifier: ${id}\n// some source code`,
+);
+
+/** Source text containing a @license tag. */
+const licenseTagSourceArb: fc.Arbitrary<string> = spdxIdArb.map(
+  (id) => `/* @license ${id} */\nsome code`,
+);
+
+/** Source text with no recognizable license signal. */
+const noSignalSourceArb: fc.Arbitrary<string> = fc
+  .string({ minLength: 1, maxLength: 80 })
+  .filter(
+    (s) =>
+      !/(SPDX-License-Identifier|@license)/i.test(s) &&
+      !s.toLowerCase().includes("public domain") &&
+      !s.toLowerCase().includes("permission is hereby granted") &&
+      !s.toLowerCase().includes("apache license") &&
+      !s.toLowerCase().includes("redistribution and use in source") &&
+      !s.toLowerCase().includes("permission to use, copy, modify"),
+  );
+
+// ---------------------------------------------------------------------------
+// Helper type guard
+// ---------------------------------------------------------------------------
+
+function isLicenseDetectionShaped(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.identifier === "string" && typeof v.source === "string";
+}
+
+// ---------------------------------------------------------------------------
+// D1.1: detectLicense always returns a LicenseDetection-shaped object
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_detector_detectLicense_alwaysReturnsDetectionShape
+ *
+ * detectLicense(s) always returns an object with identifier: string and
+ * source: string for any input string. The evidence field may be absent.
+ *
+ * Invariant (D1.1): detectLicense is a total function — it must never throw
+ * or return a malformed shape. The gate (licenseGate) reads identifier and
+ * source unconditionally; a missing field would be a silent contract break.
+ */
+export const prop_detector_detectLicense_alwaysReturnsDetectionShape: fc.IPropertyWithHooks<
+  [string]
+> = fc.property(fc.string(), (source) => {
+  const result = detectLicense(source);
+  return isLicenseDetectionShaped(result);
+});
+
+// ---------------------------------------------------------------------------
+// D1.2: SPDX comment takes precedence over all other signals
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_detector_spdxComment_takesPrecedence
+ *
+ * A string containing an SPDX-License-Identifier comment is always detected
+ * with source="spdx-comment", regardless of any other text present.
+ *
+ * Invariant (D1.2): detection precedence: SPDX comment > public-domain >
+ * header text > no-signal. First match wins. This property ensures an SPDX
+ * comment at the top of a file is not overridden by body text.
+ */
+export const prop_detector_spdxComment_takesPrecedence: fc.IPropertyWithHooks<[string, string]> =
+  fc.property(spdxIdArb, nonEmptyStr, (id, suffix) => {
+    const source = `// SPDX-License-Identifier: ${id}\n${suffix}`;
+    const result = detectLicense(source);
+    return result.source === "spdx-comment" && result.identifier === id.trim();
+  });
+
+// ---------------------------------------------------------------------------
+// D1.3: @license tag also yields spdx-comment source
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_detector_licenseTag_yieldsSpdxCommentSource
+ *
+ * A string beginning with a @license tag is detected with source="spdx-comment".
+ *
+ * Invariant (D1.2): the SPDX_RE pattern matches both SPDX-License-Identifier
+ * and @license tags. This property ensures the tag variant is not missed.
+ */
+export const prop_detector_licenseTag_yieldsSpdxCommentSource: fc.IPropertyWithHooks<[string]> =
+  fc.property(spdxIdArb, (id) => {
+    const source = `/* @license ${id} */\n// code`;
+    const result = detectLicense(source);
+    return result.source === "spdx-comment";
+  });
+
+// ---------------------------------------------------------------------------
+// D1.4: Unlicense dedication phrase → identifier="Unlicense", source="dedication"
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_detector_unlicenseDedication_yieldsCorrectDetection
+ *
+ * A string containing the canonical Unlicense dedication phrase is detected as
+ * identifier="Unlicense" with source="dedication".
+ *
+ * Invariant (D1.3): the Unlicense phrase is checked before the generic
+ * public-domain phrase. This property verifies the specific Unlicense path.
+ */
+export const prop_detector_unlicenseDedication_yieldsCorrectDetection: fc.IPropertyWithHooks<
+  [string]
+> = fc.property(nonEmptyStr, (suffix) => {
+  const phrase = "This is free and unencumbered software released into the public domain";
+  const source = `${phrase}\n${suffix}`;
+  const result = detectLicense(source);
+  return result.identifier === "Unlicense" && result.source === "dedication";
+});
+
+// ---------------------------------------------------------------------------
+// D1.5: Public-domain phrase → identifier="public-domain", source="dedication"
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_detector_publicDomainPhrase_yieldsCorrectDetection
+ *
+ * A string containing "public domain" (but not the full Unlicense phrase) is
+ * detected as identifier="public-domain" with source="dedication".
+ *
+ * Invariant (D1.4): the generic public-domain phrase is the fallback after the
+ * Unlicense-specific phrase. This property covers the generic path.
+ */
+export const prop_detector_publicDomainPhrase_yieldsCorrectDetection: fc.IPropertyWithHooks<
+  [string]
+> = fc.property(nonEmptyStr, (suffix) => {
+  // Use a public-domain phrase that is NOT the full Unlicense dedication.
+  const source = `Released into the public domain. ${suffix}`;
+  const result = detectLicense(source);
+  return result.identifier === "public-domain" && result.source === "dedication";
+});
+
+// ---------------------------------------------------------------------------
+// D1.6: MIT header text → identifier="MIT", source="header-text"
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_detector_mitHeader_yieldsCorrectDetection
+ *
+ * A string containing the MIT permission preamble is detected as identifier="MIT"
+ * with source="header-text".
+ *
+ * Invariant (D1.5): header-text patterns are checked in order after SPDX and
+ * dedication signals. The MIT preamble is the first entry in HEADER_PATTERNS.
+ */
+export const prop_detector_mitHeader_yieldsCorrectDetection: fc.IPropertyWithHooks<[string]> =
+  fc.property(nonEmptyStr, (suffix) => {
+    const source = `Permission is hereby granted, free of charge, to any person obtaining a copy. ${suffix}`;
+    const result = detectLicense(source);
+    return result.identifier === "MIT" && result.source === "header-text";
+  });
+
+// ---------------------------------------------------------------------------
+// D1.7: Apache-2.0 header text → identifier="Apache-2.0", source="header-text"
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_detector_apacheHeader_yieldsCorrectDetection
+ *
+ * A string containing "Apache License, Version 2.0" is detected as
+ * identifier="Apache-2.0" with source="header-text".
+ *
+ * Invariant (D1.5): the Apache-2.0 entry in HEADER_PATTERNS must match the
+ * canonical header text. This property exercises that specific pattern.
+ */
+export const prop_detector_apacheHeader_yieldsCorrectDetection: fc.IPropertyWithHooks<[string]> =
+  fc.property(nonEmptyStr, (suffix) => {
+    const source = `Apache License, Version 2.0. ${suffix}`;
+    const result = detectLicense(source);
+    return result.identifier === "Apache-2.0" && result.source === "header-text";
+  });
+
+// ---------------------------------------------------------------------------
+// D1.8: ISC header text → identifier="ISC", source="header-text"
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_detector_iscHeader_yieldsCorrectDetection
+ *
+ * A string containing the ISC permission phrase (without the 0BSD-specific
+ * "or without fee" prefix) is detected as identifier="ISC" with source="header-text".
+ *
+ * Invariant (D1.5): 0BSD must be checked before ISC because 0BSD's phrase is a
+ * superset. A plain ISC preamble (without "or without fee") hits the ISC entry.
+ */
+export const prop_detector_iscHeader_yieldsCorrectDetection: fc.IPropertyWithHooks<[string]> =
+  fc.property(nonEmptyStr, (suffix) => {
+    // ISC phrase WITHOUT the "or without fee" prefix that distinguishes 0BSD.
+    const source = `Permission to use, copy, modify, and/or distribute this software for any purpose is granted. ${suffix}`;
+    const result = detectLicense(source);
+    return result.identifier === "ISC" && result.source === "header-text";
+  });
+
+// ---------------------------------------------------------------------------
+// D1.9: No-signal input → identifier="unknown", source="no-signal"
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_detector_noSignal_yieldsUnknownDetection
+ *
+ * A string with no recognizable license signal is detected as
+ * identifier="unknown" with source="no-signal" and no evidence field.
+ *
+ * Invariant (D1.6): the no-signal fallback is the last step in the precedence
+ * chain. Any input that reaches it must produce exactly this shape, with no
+ * evidence field set. Downstream consumers use identifier==="unknown" to
+ * short-circuit the gate.
+ */
+export const prop_detector_noSignal_yieldsUnknownDetection: fc.IPropertyWithHooks<[string]> =
+  fc.property(noSignalSourceArb, (source) => {
+    const result = detectLicense(source);
+    return (
+      result.identifier === "unknown" && result.source === "no-signal" && !("evidence" in result)
+    );
+  });
+
+// ---------------------------------------------------------------------------
+// D1.10: SPDX evidence field matches the matched SPDX substring
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_detector_spdxEvidence_matchesMatchedSubstring
+ *
+ * When detectLicense returns source="spdx-comment", the evidence field is
+ * present and is a non-empty string (it is the matched SPDX comment text).
+ *
+ * Invariant (D1.7): the evidence field is for diagnostics — it must be the
+ * actual matched text, not a synthetic string. This property verifies it is
+ * always non-empty when set for the SPDX path.
+ */
+export const prop_detector_spdxEvidence_matchesMatchedSubstring: fc.IPropertyWithHooks<[string]> =
+  fc.property(spdxCommentSourceArb, (source) => {
+    const result = detectLicense(source);
+    if (result.source !== "spdx-comment") return false;
+    return typeof result.evidence === "string" && result.evidence.length > 0;
+  });
+
+// ---------------------------------------------------------------------------
+// D1.11: 0BSD header is preferred over ISC header (precedence)
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_detector_0bsd_preferredOverIsc
+ *
+ * A string containing the 0BSD preamble (which includes "or without fee") is
+ * detected as identifier="0BSD", not "ISC".
+ *
+ * Invariant (D1.8): HEADER_PATTERNS places 0BSD before ISC because the 0BSD
+ * preamble is a superset of ISC's distinct phrase. A regression in ordering
+ * would mislabel 0BSD as ISC.
+ */
+export const prop_detector_0bsd_preferredOverIsc: fc.IPropertyWithHooks<[string]> = fc.property(
+  nonEmptyStr,
+  (suffix) => {
+    const source = `Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted. ${suffix}`;
+    const result = detectLicense(source);
+    return result.identifier === "0BSD" && result.source === "header-text";
+  },
+);
+
+// ---------------------------------------------------------------------------
+// D1.12: BSD-3 is distinguished from BSD-2 by "neither the name of" clause
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_detector_bsd3_distinguishedFromBsd2
+ *
+ * A string containing the BSD redistribution preamble AND the "neither the
+ * name of" clause is detected as BSD-3-Clause, not BSD-2-Clause.
+ *
+ * Invariant (D1.9): the BSD family is detected by a shared sentinel phrase,
+ * then refined by checking for the BSD-3 "Neither the name of" clause. This
+ * property verifies the refinement works correctly.
+ */
+export const prop_detector_bsd3_distinguishedFromBsd2: fc.IPropertyWithHooks<[string]> =
+  fc.property(nonEmptyStr, (suffix) => {
+    const source = `Redistribution and use in source and binary forms, with or without modification, are permitted. Neither the name of the author nor the names of contributors may be used. ${suffix}`;
+    const result = detectLicense(source);
+    return result.identifier === "BSD-3-Clause" && result.source === "header-text";
+  });
+
+// ---------------------------------------------------------------------------
+// D1.13: BSD-2 detected when "neither the name of" clause is absent
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_detector_bsd2_whenNoThirdClause
+ *
+ * A string containing the BSD redistribution preamble but WITHOUT the
+ * "neither the name of" clause is detected as BSD-2-Clause.
+ *
+ * Invariant (D1.9): complement of D1.12 — absence of the third clause
+ * selects BSD-2-Clause.
+ */
+export const prop_detector_bsd2_whenNoThirdClause: fc.IPropertyWithHooks<[string]> = fc.property(
+  noSignalSourceArb,
+  (suffix) => {
+    // Construct a clean BSD preamble with no "neither" clause.
+    // Use suffix that also won't contain "neither the name of".
+    const cleanSuffix = suffix.toLowerCase().includes("neither the name of")
+      ? "some other text"
+      : suffix;
+    const source = `Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: ${cleanSuffix}`;
+    const result = detectLicense(source);
+    return result.identifier === "BSD-2-Clause" && result.source === "header-text";
+  },
+);
+
+// ---------------------------------------------------------------------------
+// D1.14: detectLicense is total — arbitrary strings never throw (compound)
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_detector_detectLicense_isTotalFunction
+ *
+ * detectLicense(s) never throws for any string input. This is the compound
+ * end-to-end property: it exercises the full detection pipeline (SPDX →
+ * dedication → header-text → no-signal) across arbitrary strings and asserts
+ * both non-throwing and correct return shape.
+ *
+ * Invariant (D1.10): detectLicense must be unconditionally safe to call from
+ * the pipeline. A throw on any input would halt corpus scanning.
+ */
+export const prop_detector_detectLicense_isTotalFunction: fc.IPropertyWithHooks<[string]> =
+  fc.property(fc.string(), (source) => {
+    let result: LicenseDetection | undefined;
+    try {
+      result = detectLicense(source);
+    } catch {
+      return false;
+    }
+    return isLicenseDetectionShaped(result);
+  });

--- a/packages/shave/src/license/gate.props.test.ts
+++ b/packages/shave/src/license/gate.props.test.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Thin vitest harness for gate.props.ts.
+ *
+ * Each it() callback is async and awaits fc.assert() so that
+ * IAsyncPropertyWithHooks properties run correctly and do not produce
+ * vacuous 0ms passes.
+ *
+ * All properties are IPropertyWithHooks (sync) — we still use async/await
+ * uniformly to ensure correct fc.assert() behaviour and to future-proof
+ * against async property upgrades.
+ */
+
+import { describe, it } from "vitest";
+import * as fc from "fast-check";
+
+import {
+  prop_gate_licenseGate_alwaysReturnsGateResultShape,
+  prop_gate_unknown_alwaysRejected,
+  prop_gate_copyleftPrefix_alwaysRejected,
+  prop_gate_exactRejected_alwaysRejected,
+  prop_gate_canonicalAccepted_yieldsTrueWithCanonicalLicense,
+  prop_gate_normalization_whitespaceSeparatedVariants_accepted,
+  prop_gate_normalization_parenthesisWrappedVariants_accepted,
+  prop_gate_unrecognized_alwaysRejected,
+  prop_gate_rejected_alwaysCarriesOriginalDetection,
+  prop_gate_licenseGate_isTotalFunction,
+} from "./gate.props.js";
+
+const opts: fc.Parameters<unknown> = { numRuns: 200, verbose: false };
+
+describe("license/gate.props", () => {
+  it("G1.1 licenseGate always returns a LicenseGateResult-shaped object", async () => {
+    await fc.assert(prop_gate_licenseGate_alwaysReturnsGateResultShape, opts);
+  });
+
+  it("G1.2 identifier='unknown' always yields accepted=false with reason", async () => {
+    await fc.assert(prop_gate_unknown_alwaysRejected, opts);
+  });
+
+  it("G1.3 copyleft/proprietary prefix identifiers always yield accepted=false", async () => {
+    await fc.assert(prop_gate_copyleftPrefix_alwaysRejected, opts);
+  });
+
+  it("G1.4 exact rejected identifiers (PROPRIETARY, COMMERCIAL) yield accepted=false", async () => {
+    await fc.assert(prop_gate_exactRejected_alwaysRejected, opts);
+  });
+
+  it("G1.5 canonical accepted identifiers yield accepted=true with correct canonical form", async () => {
+    await fc.assert(prop_gate_canonicalAccepted_yieldsTrueWithCanonicalLicense, opts);
+  });
+
+  it("G1.6 normalization: whitespace-separated variants of accepted IDs are accepted", async () => {
+    await fc.assert(prop_gate_normalization_whitespaceSeparatedVariants_accepted, opts);
+  });
+
+  it("G1.7 normalization: parenthesis-wrapped variants of accepted IDs are accepted", async () => {
+    await fc.assert(prop_gate_normalization_parenthesisWrappedVariants_accepted, opts);
+  });
+
+  it("G1.8 unrecognized identifiers yield accepted=false with 'unrecognized' reason", async () => {
+    await fc.assert(prop_gate_unrecognized_alwaysRejected, opts);
+  });
+
+  it("G1.9 rejected result always carries the original detection reference", async () => {
+    await fc.assert(prop_gate_rejected_alwaysCarriesOriginalDetection, opts);
+  });
+
+  it("G1.10 licenseGate is total — arbitrary inputs never throw (compound)", async () => {
+    await fc.assert(prop_gate_licenseGate_isTotalFunction, opts);
+  });
+});

--- a/packages/shave/src/license/gate.props.ts
+++ b/packages/shave/src/license/gate.props.ts
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-001: hand-authored property-test corpus for
+// @yakcc/shave license/gate.ts atoms. Two-file pattern: this file
+// (.props.ts) is vitest-free and holds the corpus; the sibling .props.test.ts
+// is the vitest harness.
+// Status: accepted (WI-V2-07-PREFLIGHT L3-license)
+// Rationale: See tmp/wi-v2-07-preflight-layer-plan.md — the corpus file must
+// be runtime-independent so L10 can hash it as a manifest artifact.
+//
+// Atoms covered (from gate.ts):
+//   licenseGate                (G1.1) — pure function: LicenseDetection → LicenseGateResult.
+//   normalize (internal)       (G1.2) — exercised indirectly through licenseGate.
+//
+// Properties covered:
+//   G1.1  licenseGate always returns a LicenseGateResult-shaped object.
+//   G1.2  identifier="unknown" always yields accepted=false with a reason string.
+//   G1.3  Copyleft/proprietary prefix identifiers always yield accepted=false.
+//   G1.4  Exact rejected identifiers (PROPRIETARY, COMMERCIAL) yield accepted=false.
+//   G1.5  Canonical accepted identifiers yield accepted=true with the correct canonical form.
+//   G1.6  Normalization: whitespace-separated variants of accepted IDs are accepted.
+//   G1.7  Normalization: parenthesis-wrapped variants of accepted IDs are accepted.
+//   G1.8  Unrecognized (non-copyleft, non-canonical) identifiers yield accepted=false.
+//   G1.9  Rejected result always carries the original detection reference.
+//   G1.10 licenseGate is total: LicenseDetection inputs with arbitrary identifiers never throw.
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for license/gate.ts
+// ---------------------------------------------------------------------------
+
+import * as fc from "fast-check";
+import { licenseGate } from "./gate.js";
+import type { LicenseDetection, LicenseGateResult } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Shared arbitraries
+// ---------------------------------------------------------------------------
+
+/** Arbitrary LicenseDetection with a controlled identifier. */
+function makeDetection(identifier: string, source = "spdx-comment"): LicenseDetection {
+  return { identifier, source } as LicenseDetection;
+}
+
+/** Arbitrary LicenseDetection with an arbitrary identifier. */
+const arbitraryDetectionArb: fc.Arbitrary<LicenseDetection> = fc
+  .tuple(
+    fc.string({ minLength: 0, maxLength: 40 }),
+    fc.constantFrom("spdx-comment", "header-text", "dedication", "no-signal"),
+  )
+  .map(([id, src]) => ({ identifier: id, source: src }) as LicenseDetection);
+
+/** Copyleft/proprietary prefix identifiers as per gate.ts REJECTED_PREFIXES. */
+const copyleftPrefixArb: fc.Arbitrary<string> = fc
+  .tuple(
+    fc.constantFrom("GPL-", "AGPL-", "LGPL-", "BUSL-"),
+    fc.string({ minLength: 1, maxLength: 20 }),
+  )
+  .map(([prefix, suffix]) => `${prefix}${suffix}`);
+
+/** Exact rejected identifiers (case-insensitive via normalize). */
+const exactRejectedArb: fc.Arbitrary<string> = fc.constantFrom(
+  "PROPRIETARY",
+  "COMMERCIAL",
+  "proprietary",
+  "commercial",
+  "Proprietary",
+  "Commercial",
+);
+
+/** Canonical accepted identifiers (raw input forms recognized by gate.ts). */
+const canonicalAcceptedRawArb: fc.Arbitrary<string> = fc.constantFrom(
+  "Unlicense",
+  "MIT",
+  "BSD-2-Clause",
+  "BSD-2",
+  "BSD-3-Clause",
+  "BSD-3",
+  "Apache-2.0",
+  "Apache-2",
+  "ISC",
+  "0BSD",
+  "public-domain",
+);
+
+/** Canonical accepted identifiers with known expected output from gate.ts CANONICAL_MAP. */
+const canonicalAcceptedPairsArb: fc.Arbitrary<[string, string]> = fc.constantFrom(
+  ["Unlicense", "Unlicense"] as [string, string],
+  ["MIT", "MIT"] as [string, string],
+  ["BSD-2-Clause", "BSD-2-Clause"] as [string, string],
+  ["BSD-2", "BSD-2-Clause"] as [string, string],
+  ["BSD-3-Clause", "BSD-3-Clause"] as [string, string],
+  ["BSD-3", "BSD-3-Clause"] as [string, string],
+  ["Apache-2.0", "Apache-2.0"] as [string, string],
+  ["Apache-2", "Apache-2.0"] as [string, string],
+  ["ISC", "ISC"] as [string, string],
+  ["0BSD", "0BSD"] as [string, string],
+  ["public-domain", "public-domain"] as [string, string],
+);
+
+// ---------------------------------------------------------------------------
+// Helper type guard
+// ---------------------------------------------------------------------------
+
+function isLicenseGateResultShaped(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.accepted !== "boolean") return false;
+  if (typeof v.detection !== "object" || v.detection === null) return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// G1.1: licenseGate always returns a LicenseGateResult-shaped object
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_gate_licenseGate_alwaysReturnsGateResultShape
+ *
+ * licenseGate(d) always returns an object with accepted: boolean and
+ * detection: LicenseDetection for any LicenseDetection input.
+ *
+ * Invariant (G1.1): licenseGate is a total function — it must never throw
+ * or return a malformed shape. The pipeline reads accepted unconditionally.
+ */
+export const prop_gate_licenseGate_alwaysReturnsGateResultShape: fc.IPropertyWithHooks<
+  [LicenseDetection]
+> = fc.property(arbitraryDetectionArb, (detection) => {
+  const result = licenseGate(detection);
+  return isLicenseGateResultShaped(result);
+});
+
+// ---------------------------------------------------------------------------
+// G1.2: identifier="unknown" always yields accepted=false
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_gate_unknown_alwaysRejected
+ *
+ * A detection with identifier="unknown" always yields accepted=false and a
+ * non-empty reason string, regardless of source.
+ *
+ * Invariant (G1.2): the gate's first branch short-circuits on unknown. The
+ * pipeline uses identifier==="unknown" as the no-signal sentinel; a false
+ * accept here would let unlicensed files through.
+ */
+export const prop_gate_unknown_alwaysRejected: fc.IPropertyWithHooks<[string]> = fc.property(
+  fc.constantFrom("spdx-comment", "header-text", "dedication", "no-signal"),
+  (source) => {
+    const detection = makeDetection("unknown", source);
+    const result = licenseGate(detection);
+    return (
+      result.accepted === false &&
+      "reason" in result &&
+      typeof (result as { reason: unknown }).reason === "string" &&
+      (result as { reason: string }).reason.length > 0
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// G1.3: Copyleft/proprietary prefix identifiers always yield accepted=false
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_gate_copyleftPrefix_alwaysRejected
+ *
+ * Any identifier starting with GPL-, AGPL-, LGPL-, or BUSL- yields
+ * accepted=false with a reason mentioning "copyleft/proprietary".
+ *
+ * Invariant (G1.3): the rejected-prefix check runs before canonical matching.
+ * Any regression that lets a copyleft identifier through is a policy failure.
+ */
+export const prop_gate_copyleftPrefix_alwaysRejected: fc.IPropertyWithHooks<[string]> = fc.property(
+  copyleftPrefixArb,
+  (identifier) => {
+    const detection = makeDetection(identifier);
+    const result = licenseGate(detection);
+    return (
+      result.accepted === false &&
+      "reason" in result &&
+      (result as { reason: string }).reason.includes("copyleft/proprietary")
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// G1.4: Exact rejected identifiers yield accepted=false
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_gate_exactRejected_alwaysRejected
+ *
+ * PROPRIETARY and COMMERCIAL (in any case) yield accepted=false.
+ *
+ * Invariant (G1.4): REJECTED_EXACT handles proprietary/commercial identifiers
+ * that don't share a copyleft prefix. Case normalization must apply so
+ * "proprietary" and "Proprietary" are caught.
+ */
+export const prop_gate_exactRejected_alwaysRejected: fc.IPropertyWithHooks<[string]> = fc.property(
+  exactRejectedArb,
+  (identifier) => {
+    const detection = makeDetection(identifier);
+    const result = licenseGate(detection);
+    return result.accepted === false;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// G1.5: Canonical accepted identifiers yield accepted=true with correct form
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_gate_canonicalAccepted_yieldsTrueWithCanonicalLicense
+ *
+ * Each entry in the CANONICAL_MAP yields accepted=true with the correct
+ * canonical license string.
+ *
+ * Invariant (G1.5): canonical accepted identifiers must round-trip to the
+ * exact AcceptedLicense string expected by downstream consumers. A mismatch
+ * here would produce a wrong license label in the registry.
+ */
+export const prop_gate_canonicalAccepted_yieldsTrueWithCanonicalLicense: fc.IPropertyWithHooks<
+  [[string, string]]
+> = fc.property(canonicalAcceptedPairsArb, ([rawId, expectedCanonical]) => {
+  const detection = makeDetection(rawId);
+  const result = licenseGate(detection);
+  return (
+    result.accepted === true &&
+    "license" in result &&
+    (result as { license: unknown }).license === expectedCanonical
+  );
+});
+
+// ---------------------------------------------------------------------------
+// G1.6: Normalization — whitespace-separated variants are accepted
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_gate_normalization_whitespaceSeparatedVariants_accepted
+ *
+ * Whitespace-separated forms like "Apache 2.0" and "BSD 3 Clause" are
+ * normalized to hyphens and accepted when they map to a canonical form.
+ *
+ * Invariant (G1.6): normalize() replaces internal spaces with hyphens before
+ * CANONICAL_MAP lookup. This ensures common variant spellings are accepted
+ * without a full SPDX expression parser.
+ */
+export const prop_gate_normalization_whitespaceSeparatedVariants_accepted: fc.IPropertyWithHooks<
+  [string]
+> = fc.property(
+  fc.constantFrom(
+    "Apache 2.0", // → APACHE-2.0 → "Apache-2.0"
+    "Apache 2", // → APACHE-2   → "Apache-2.0"
+    "BSD 2 Clause", // → BSD-2-CLAUSE → "BSD-2-Clause"
+    "BSD 3 Clause", // → BSD-3-CLAUSE → "BSD-3-Clause"
+  ),
+  (rawId) => {
+    const detection = makeDetection(rawId);
+    const result = licenseGate(detection);
+    return result.accepted === true;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// G1.7: Normalization — parenthesis-wrapped variants are accepted
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_gate_normalization_parenthesisWrappedVariants_accepted
+ *
+ * A single pair of enclosing parentheses is stripped before normalization,
+ * so "(MIT)" and "(ISC)" yield accepted=true.
+ *
+ * Invariant (G1.7): normalize() strips one enclosing paren pair as step 2.
+ * This handles SPDX expressions like "(MIT OR Apache-2.0)" reduced to a
+ * single identifier after upstream processing.
+ */
+export const prop_gate_normalization_parenthesisWrappedVariants_accepted: fc.IPropertyWithHooks<
+  [string]
+> = fc.property(fc.constantFrom("(MIT)", "(ISC)", "(Unlicense)", "(0BSD)"), (rawId) => {
+  const detection = makeDetection(rawId);
+  const result = licenseGate(detection);
+  return result.accepted === true;
+});
+
+// ---------------------------------------------------------------------------
+// G1.8: Unrecognized identifiers yield accepted=false
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_gate_unrecognized_alwaysRejected
+ *
+ * An identifier that is not "unknown", not a copyleft/proprietary prefix,
+ * not an exact rejection, and not in CANONICAL_MAP yields accepted=false with
+ * a reason mentioning "unrecognized".
+ *
+ * Invariant (G1.8): the gate's final branch is the unrecognized fallback.
+ * Anything that falls through all prior checks must be rejected — the gate
+ * must be closed-world by default.
+ */
+export const prop_gate_unrecognized_alwaysRejected: fc.IPropertyWithHooks<[string]> = fc.property(
+  fc.constantFrom(
+    "EUPL-1.2",
+    "MPL-2.0",
+    "CDDL-1.0",
+    "EPL-2.0",
+    "CC-BY-4.0",
+    "WTFPL",
+    "Artistic-2.0",
+    "ZPL-2.1",
+  ),
+  (identifier) => {
+    const detection = makeDetection(identifier);
+    const result = licenseGate(detection);
+    return (
+      result.accepted === false &&
+      "reason" in result &&
+      (result as { reason: string }).reason.includes("unrecognized")
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// G1.9: Rejected result always carries the original detection reference
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_gate_rejected_alwaysCarriesOriginalDetection
+ *
+ * When licenseGate returns accepted=false, the detection field in the result
+ * is reference-equal to the input LicenseDetection (or structurally equal,
+ * as gate.ts spreads it directly).
+ *
+ * Invariant (G1.9): downstream error reporting reads result.detection to
+ * surface context. A missing or mutated detection field breaks diagnostics.
+ */
+export const prop_gate_rejected_alwaysCarriesOriginalDetection: fc.IPropertyWithHooks<
+  [LicenseDetection]
+> = fc.property(arbitraryDetectionArb, (detection) => {
+  const result = licenseGate(detection);
+  if (result.accepted === true) return true; // accepted path — not under test here
+  return (
+    result.detection === detection &&
+    result.detection.identifier === detection.identifier &&
+    result.detection.source === detection.source
+  );
+});
+
+// ---------------------------------------------------------------------------
+// G1.10: licenseGate is total — arbitrary inputs never throw (compound)
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_gate_licenseGate_isTotalFunction
+ *
+ * licenseGate(d) never throws for any LicenseDetection-shaped input. This
+ * is the compound end-to-end property: it exercises the full gate pipeline
+ * (unknown → copyleft prefix → exact rejected → canonical → unrecognized)
+ * across arbitrary identifiers and asserts non-throwing + correct shape.
+ *
+ * Invariant (G1.10): licenseGate must be unconditionally safe to call from
+ * the pipeline. A throw on any input would halt corpus scanning.
+ */
+export const prop_gate_licenseGate_isTotalFunction: fc.IPropertyWithHooks<[LicenseDetection]> =
+  fc.property(arbitraryDetectionArb, (detection) => {
+    let result: LicenseGateResult | undefined;
+    try {
+      result = licenseGate(detection);
+    } catch {
+      return false;
+    }
+    return isLicenseGateResultShaped(result);
+  });

--- a/packages/shave/src/license/types.props.test.ts
+++ b/packages/shave/src/license/types.props.test.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for license/types.props.ts — thin runner only.
+// Each export from the corpus is driven through fc.assert() here.
+
+import * as fc from "fast-check";
+import { it } from "vitest";
+import {
+  prop_types_acceptedLicense_literalUnionShape,
+  prop_types_licenseDetection_evidenceFieldOmittable,
+  prop_types_licenseDetection_requiredFieldsPresent,
+  prop_types_licenseDetection_sourceIsAllowedLiteral,
+  prop_types_licenseGateResult_acceptedFalseBranchShape,
+  prop_types_licenseGateResult_acceptedTrueBranchShape,
+  prop_types_licenseGateResult_discriminantDrivesBranch,
+} from "./types.props.js";
+
+const opts = { numRuns: 100 };
+
+it("property: AcceptedLicense — literal union accepts exactly the 8 allowed strings", () => {
+  fc.assert(prop_types_acceptedLicense_literalUnionShape, opts);
+});
+
+it("property: LicenseDetection — required fields identifier and source are present", () => {
+  fc.assert(prop_types_licenseDetection_requiredFieldsPresent, opts);
+});
+
+it("property: LicenseDetection — evidence field is omittable (exactOptionalPropertyTypes)", () => {
+  fc.assert(prop_types_licenseDetection_evidenceFieldOmittable, opts);
+});
+
+it("property: LicenseDetection — source is one of the 5 allowed literals", () => {
+  fc.assert(prop_types_licenseDetection_sourceIsAllowedLiteral, opts);
+});
+
+it("property: LicenseGateResult — accepted:true branch has license and detection fields", () => {
+  fc.assert(prop_types_licenseGateResult_acceptedTrueBranchShape, opts);
+});
+
+it("property: LicenseGateResult — accepted:false branch has reason and detection fields", () => {
+  fc.assert(prop_types_licenseGateResult_acceptedFalseBranchShape, opts);
+});
+
+it("property: LicenseGateResult — discriminant drives branch (compound)", () => {
+  fc.assert(prop_types_licenseGateResult_discriminantDrivesBranch, opts);
+});

--- a/packages/shave/src/license/types.props.ts
+++ b/packages/shave/src/license/types.props.ts
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-001: hand-authored property-test corpus for
+// @yakcc/shave license/types.ts atoms. Two-file pattern: this file
+// (.props.ts) is vitest-free and holds the corpus; the sibling .props.test.ts
+// is the vitest harness.
+// Status: accepted (WI-V2-07-PREFLIGHT L3-license)
+// Rationale: See tmp/wi-v2-07-preflight-layer-plan.md — the corpus file must
+// be runtime-independent so L10 can hash it as a manifest artifact.
+//
+// Atoms covered (type-level declarations from types.ts):
+//   AcceptedLicense      (T1.1) — literal union of 8 permissive license strings.
+//   LicenseDetection     (T1.2) — readonly interface with identifier/source/evidence.
+//   LicenseGateResult    (T1.3) — discriminated union on accepted: true|false.
+//
+// Properties covered:
+//   - AcceptedLicense accepts exactly the 8 allowed literal strings.
+//   - LicenseDetection has required fields identifier and source with correct types.
+//   - LicenseDetection optional evidence field is omittable (exactOptionalPropertyTypes).
+//   - LicenseDetection source is one of the 5 allowed literal strings.
+//   - LicenseGateResult accepted:true branch has license and detection fields.
+//   - LicenseGateResult accepted:false branch has reason and detection fields.
+//   - LicenseGateResult discriminated union: accepted field drives branch shape.
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for license/types.ts
+// ---------------------------------------------------------------------------
+
+import * as fc from "fast-check";
+import type { AcceptedLicense, LicenseDetection, LicenseGateResult } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Shared arbitraries
+// ---------------------------------------------------------------------------
+
+/** Non-empty string with no leading/trailing whitespace. */
+const nonEmptyStr: fc.Arbitrary<string> = fc
+  .string({ minLength: 1, maxLength: 40 })
+  .filter((s) => s.trim().length > 0);
+
+/** Arbitrary AcceptedLicense — the 8 allowed literals. */
+const acceptedLicenseArb: fc.Arbitrary<AcceptedLicense> = fc.constantFrom(
+  "Unlicense" as const,
+  "MIT" as const,
+  "BSD-2-Clause" as const,
+  "BSD-3-Clause" as const,
+  "Apache-2.0" as const,
+  "ISC" as const,
+  "0BSD" as const,
+  "public-domain" as const,
+);
+
+/** Arbitrary LicenseDetection source literal. */
+const detectionSourceArb: fc.Arbitrary<LicenseDetection["source"]> = fc.constantFrom(
+  "spdx-comment" as const,
+  "package-json" as const,
+  "header-text" as const,
+  "dedication" as const,
+  "no-signal" as const,
+);
+
+/** Arbitrary LicenseDetection without optional evidence. */
+const licenseDetectionNoEvidenceArb: fc.Arbitrary<LicenseDetection> = fc.record({
+  identifier: nonEmptyStr,
+  source: detectionSourceArb,
+});
+
+/** Arbitrary LicenseDetection with optional evidence present. */
+const licenseDetectionWithEvidenceArb: fc.Arbitrary<LicenseDetection> = fc.record({
+  identifier: nonEmptyStr,
+  source: detectionSourceArb,
+  evidence: nonEmptyStr,
+});
+
+/** Arbitrary LicenseDetection (either with or without evidence). */
+const licenseDetectionArb: fc.Arbitrary<LicenseDetection> = fc.oneof(
+  licenseDetectionNoEvidenceArb,
+  licenseDetectionWithEvidenceArb,
+);
+
+// ---------------------------------------------------------------------------
+// T1.1: AcceptedLicense — literal union shape (8 members)
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_types_acceptedLicense_literalUnionShape
+ *
+ * AcceptedLicense accepts exactly the 8 allowed permissive license strings.
+ * Any value sampled from acceptedLicenseArb is structurally one of the union
+ * members, verified at runtime by exhaustive enumeration.
+ *
+ * Invariant (T1.1): the accepted-license set is locked to MASTER_PLAN.md v0.7
+ * stage spec. A change to the union type must be reflected here.
+ */
+export const prop_types_acceptedLicense_literalUnionShape: fc.IPropertyWithHooks<
+  [AcceptedLicense]
+> = fc.property(acceptedLicenseArb, (license) => {
+  const allowed: ReadonlyArray<string> = [
+    "Unlicense",
+    "MIT",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "Apache-2.0",
+    "ISC",
+    "0BSD",
+    "public-domain",
+  ];
+  return allowed.includes(license);
+});
+
+// ---------------------------------------------------------------------------
+// T1.2: LicenseDetection — required fields with correct types
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_types_licenseDetection_requiredFieldsPresent
+ *
+ * Every LicenseDetection has identifier (string) and source (string) fields.
+ * The evidence field is optional and may be absent entirely.
+ *
+ * Invariant (T1.2): LicenseDetection is the output of detectLicense(); all
+ * downstream consumers (licenseGate) read identifier and source. A regression
+ * where either field is absent or wrong-typed would break the gate.
+ */
+export const prop_types_licenseDetection_requiredFieldsPresent: fc.IPropertyWithHooks<
+  [LicenseDetection]
+> = fc.property(licenseDetectionArb, (det) => {
+  return typeof det.identifier === "string" && typeof det.source === "string";
+});
+
+// ---------------------------------------------------------------------------
+// T1.2: LicenseDetection — evidence field is omittable (exactOptionalPropertyTypes)
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_types_licenseDetection_evidenceFieldOmittable
+ *
+ * A LicenseDetection without the evidence field is structurally valid.
+ * Under exactOptionalPropertyTypes, the field must be absent (not undefined)
+ * when the detection produced no evidence substring.
+ *
+ * Invariant (T1.2): the no-signal path in detectLicense omits evidence
+ * entirely. This property asserts the omission compiles and executes correctly.
+ */
+export const prop_types_licenseDetection_evidenceFieldOmittable: fc.IPropertyWithHooks<
+  [string, LicenseDetection["source"]]
+> = fc.property(nonEmptyStr, detectionSourceArb, (identifier, source) => {
+  // Omit evidence — do not assign undefined
+  const det: LicenseDetection = { identifier, source };
+  return !("evidence" in det) && det.identifier === identifier && det.source === source;
+});
+
+// ---------------------------------------------------------------------------
+// T1.2: LicenseDetection — source is one of the 5 allowed literals
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_types_licenseDetection_sourceIsAllowedLiteral
+ *
+ * The source field of any LicenseDetection is one of the 5 allowed literal
+ * strings: spdx-comment, package-json, header-text, dedication, no-signal.
+ *
+ * Invariant (T1.2): the source field documents provenance for diagnostics.
+ * Consumers may switch on it; unrecognized values would be a silent bug.
+ */
+export const prop_types_licenseDetection_sourceIsAllowedLiteral: fc.IPropertyWithHooks<
+  [LicenseDetection]
+> = fc.property(licenseDetectionArb, (det) => {
+  const allowed: ReadonlyArray<string> = [
+    "spdx-comment",
+    "package-json",
+    "header-text",
+    "dedication",
+    "no-signal",
+  ];
+  return allowed.includes(det.source);
+});
+
+// ---------------------------------------------------------------------------
+// T1.3: LicenseGateResult — accepted:true branch shape
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_types_licenseGateResult_acceptedTrueBranchShape
+ *
+ * When accepted is true, the LicenseGateResult has license (AcceptedLicense)
+ * and detection (LicenseDetection) fields, and no reason field.
+ *
+ * Invariant (T1.3): the discriminated union is the gate's public output shape.
+ * Downstream consumers check accepted first, then access license or reason.
+ * A regression where license is absent on the true branch would break callers.
+ */
+export const prop_types_licenseGateResult_acceptedTrueBranchShape: fc.IPropertyWithHooks<
+  [AcceptedLicense, LicenseDetection]
+> = fc.property(acceptedLicenseArb, licenseDetectionArb, (license, detection) => {
+  const result: LicenseGateResult = { accepted: true, license, detection };
+  return (
+    result.accepted === true &&
+    result.license === license &&
+    result.detection === detection &&
+    !("reason" in result)
+  );
+});
+
+// ---------------------------------------------------------------------------
+// T1.3: LicenseGateResult — accepted:false branch shape
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_types_licenseGateResult_acceptedFalseBranchShape
+ *
+ * When accepted is false, the LicenseGateResult has reason (string) and
+ * detection (LicenseDetection) fields, and no license field.
+ *
+ * Invariant (T1.3): the rejected branch must carry a human-readable reason.
+ * A regression where reason is absent on the false branch would silence errors.
+ */
+export const prop_types_licenseGateResult_acceptedFalseBranchShape: fc.IPropertyWithHooks<
+  [string, LicenseDetection]
+> = fc.property(nonEmptyStr, licenseDetectionArb, (reason, detection) => {
+  const result: LicenseGateResult = { accepted: false, reason, detection };
+  return (
+    result.accepted === false &&
+    result.reason === reason &&
+    result.detection === detection &&
+    !("license" in result)
+  );
+});
+
+// ---------------------------------------------------------------------------
+// T1.3: LicenseGateResult — discriminant drives branch (compound type invariant)
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_types_licenseGateResult_discriminantDrivesBranch
+ *
+ * A LicenseGateResult with accepted:true never has a reason field, and one
+ * with accepted:false never has a license field. This compound property
+ * exercises both branches and their mutual exclusion from one arbitrary.
+ *
+ * Invariant (T1.3): the discriminated union must be exhaustive and exclusive.
+ * This is the cross-branch compound-interaction property.
+ */
+export const prop_types_licenseGateResult_discriminantDrivesBranch: fc.IPropertyWithHooks<
+  [boolean, AcceptedLicense, string, LicenseDetection]
+> = fc.property(
+  fc.boolean(),
+  acceptedLicenseArb,
+  nonEmptyStr,
+  licenseDetectionArb,
+  (accepted, license, reason, detection) => {
+    if (accepted) {
+      const result: LicenseGateResult = { accepted: true, license, detection };
+      return result.accepted && !("reason" in result);
+    }
+    const result: LicenseGateResult = { accepted: false, reason, detection };
+    return !result.accepted && !("license" in result);
+  },
+);


### PR DESCRIPTION
## Summary
- Path-A property-test corpus for `shave/license` sub-tree (3 surfaces, 31 prop_* exports across 6 files)
- Two-file pattern: `<source>.props.ts` (vitest-free) + `<source>.props.test.ts` (thin harness)
- Zero deferrals to L4 — all atoms covered

## Layer
L3 sub-tree, continuing the WI-V2-07-PREFLIGHT layer plan after L3a/b/c/d/e/f/g/i. Only L3-universalize (4 files) + 2 compile gaps (slice-plan, wasm-lowering/symbol-table) remain in L3 after this lands.

## Test plan
- [x] pnpm -F @yakcc/shave test --run packages/shave/src/license/ (31/31, deterministic across 2 runs)
- [x] Full suite no new regressions vs origin/main baseline (pre-existing wire.test / @yakcc/contracts issue unchanged, out of scope)
- [x] Reviewer ready_for_guardian on HEAD 9c73308 (zero findings)

Refs #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)