### PR TITLE
WI-V2-07-PREFLIGHT L3j: shave/universalize property-test corpus

### DIFF
--- a/packages/shave/src/universalize/atom-test.props.test.ts
+++ b/packages/shave/src/universalize/atom-test.props.test.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for universalize/atom-test.props.ts — thin runner only.
+// Each export from the corpus is driven through fc.assert() here.
+
+import * as fc from "fast-check";
+import { describe, it } from "vitest";
+import * as Props from "./atom-test.props.js";
+
+describe("universalize/atom-test.ts — property corpus", () => {
+  // AT-REASON-1: reason is one of the 5 canonical AtomTestReason literals
+  it("property: isAtom — reason is always a valid AtomTestReason", async () => {
+    await fc.assert(Props.prop_isAtom_reason_is_valid_AtomTestReason);
+  });
+
+  // AT-CF-3: controlFlowBoundaryCount is always a non-negative integer
+  it("property: isAtom — controlFlowBoundaryCount is non-negative", async () => {
+    await fc.assert(Props.prop_isAtom_controlFlowBoundaryCount_is_non_negative);
+  });
+
+  // AT-CF-1: 0 CF boundaries + empty registry → always atomic
+  it("property: isAtom — 0 CF boundaries with empty registry is always atomic", async () => {
+    await fc.assert(Props.prop_isAtom_zero_cf_empty_registry_is_always_atomic);
+  });
+
+  // AT-CF-2: CF count > maxCF → too-many-cf-boundaries
+  it("property: isAtom — excess CF count returns too-many-cf-boundaries", async () => {
+    await fc.assert(Props.prop_isAtom_excess_cf_returns_too_many_cf_boundaries);
+  });
+
+  // AT-CF-4: undefined options → default maxCF = 1
+  it("property: isAtom — undefined options uses default maxControlFlowBoundaries = 1", async () => {
+    await fc.assert(Props.prop_isAtom_undefined_options_uses_default_max_cf_1);
+  });
+
+  // AT-REG-1: empty registry + 0 CF options sweep → always atomic
+  it("property: isAtom — empty registry + 0-CF source is always atomic across options sweep", async () => {
+    await fc.assert(
+      Props.prop_isAtom_empty_registry_zero_cf_options_sweep_always_atomic,
+    );
+  });
+
+  // AT-MATCH-1: matchedPrimitive is absent for non-contains-known-primitive results
+  it("property: isAtom — matchedPrimitive is absent for non-contains-known-primitive reason", async () => {
+    await fc.assert(
+      Props.prop_isAtom_matchedPrimitive_absent_for_non_contains_reason,
+    );
+  });
+
+  // AT-REG-2: always-match registry triggers contains-known-primitive
+  it("property: isAtom — always-match registry triggers contains-known-primitive", async () => {
+    await fc.assert(
+      Props.prop_isAtom_always_match_registry_triggers_contains_known_primitive,
+    );
+  });
+
+  // Compound: real parse → isAtom → CF-varies-by-maxCF correctness
+  it("property: compound — real parse sequence: CF-varies-by-maxCF joint invariants", async () => {
+    await fc.assert(Props.prop_compound_isAtom_real_parse_cf_varies_by_maxcf);
+  });
+});

--- a/packages/shave/src/universalize/atom-test.props.ts
+++ b/packages/shave/src/universalize/atom-test.props.ts
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-001: hand-authored property-test corpus for
+// @yakcc/shave universalize/atom-test.ts. Two-file pattern: this file
+// (.props.ts) is vitest-free and holds the corpus; the sibling .props.test.ts
+// is the vitest harness.
+// Status: accepted (WI-V2-07-PREFLIGHT L3j)
+// Rationale: See tmp/wi-v2-07-preflight-layer-plan.md — the corpus file must
+// be runtime-independent so L10 can hash it as a manifest artifact.
+//
+// Surface covered: universalize/atom-test.ts
+//   isAtom(node, source, registry, options?) → Promise<AtomTestResult>
+//
+// Properties covered:
+//   AT-REASON-1: reason is always one of the 5 canonical AtomTestReason literals.
+//   AT-CF-3: controlFlowBoundaryCount in result is always a non-negative integer.
+//   AT-CF-1: isAtom with 0 CF boundaries (empty registry) always returns isAtom=true.
+//   AT-CF-2: isAtom with CF count > maxCF always returns reason="too-many-cf-boundaries".
+//   AT-CF-4: undefined maxControlFlowBoundaries uses default (1).
+//   AT-REG-1: empty registry + 0 CF options-sweep → always atomic.
+//   AT-MATCH-1: matchedPrimitive is undefined IFF reason != "contains-known-primitive".
+//   AT-REG-2: always-match registry triggers contains-known-primitive on fn with 2 stmts.
+//   Compound: real parse → isAtom → result — CF-varies-by-maxCF correctness.
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for universalize/atom-test.ts
+// ---------------------------------------------------------------------------
+
+import type { BlockMerkleRoot, CanonicalAstHash } from "@yakcc/contracts";
+import * as fc from "fast-check";
+import { Project, ScriptKind } from "ts-morph";
+import { isAtom } from "./atom-test.js";
+import type { AtomTestOptions, AtomTestResult } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Shared arbitraries and helpers
+// ---------------------------------------------------------------------------
+
+/** The 5 canonical AtomTestReason literal values. */
+const ATOM_TEST_REASONS: ReadonlySet<string> = new Set([
+  "atomic",
+  "too-many-cf-boundaries",
+  "contains-known-primitive",
+  "non-decomposable-non-atom",
+  "loop-with-escaping-cf",
+]);
+
+/** Arbitrary non-negative integer for maxControlFlowBoundaries (0–5). */
+const natCFArb: fc.Arbitrary<number> = fc.nat({ max: 5 });
+
+/**
+ * Build a ts-morph Project + SourceFile from the given source string.
+ * Returns the root SourceFile node and the source for passing to isAtom().
+ */
+function parseSource(source: string) {
+  const project = new Project({
+    useInMemoryFileSystem: true,
+    compilerOptions: { allowJs: false, noEmit: true, skipLibCheck: true },
+  });
+  const file = project.createSourceFile("test.ts", source, {
+    scriptKind: ScriptKind.TS,
+  });
+  return { file, source };
+}
+
+/** Registry that always returns no matches. */
+const emptyRegistry = {
+  async findByCanonicalAstHash(_hash: CanonicalAstHash): Promise<readonly BlockMerkleRoot[]> {
+    return [];
+  },
+};
+
+/** Registry that returns a fake match for every hash query. */
+const alwaysMatchRegistry = {
+  async findByCanonicalAstHash(_hash: CanonicalAstHash): Promise<readonly BlockMerkleRoot[]> {
+    return ["fake-merkle" as BlockMerkleRoot];
+  },
+};
+
+// ---------------------------------------------------------------------------
+// AT-REASON-1: reason is always one of the 5 canonical AtomTestReason literals
+//
+// Invariant: reason is a discriminant used by downstream consumers (CLI,
+// slicer, decompose). Any value outside the canonical set is unreachable in
+// exhaustive switch statements and causes silent misclassification.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_isAtom_reason_is_valid_AtomTestReason
+ *
+ * Every AtomTestResult produced by isAtom() has a reason that belongs to the
+ * 5-element canonical AtomTestReason union, for varying maxControlFlowBoundaries.
+ *
+ * Invariant (AT-REASON-1, DEC-ATOM-TEST-003): reason drives branching in the
+ * CLI diagnostic output and in decompose(). Any sixth or unknown value would
+ * be silently dropped in exhaustive switch statements.
+ */
+export const prop_isAtom_reason_is_valid_AtomTestReason: fc.IAsyncProperty<[number]> =
+  fc.asyncProperty(natCFArb, async (maxCF) => {
+    const source = "function f(x: number) { if (x > 0) return x; return 0; }";
+    const { file } = parseSource(source);
+    const result: AtomTestResult = await isAtom(file, source, emptyRegistry, {
+      maxControlFlowBoundaries: maxCF,
+    });
+    return ATOM_TEST_REASONS.has(result.reason);
+  });
+
+// ---------------------------------------------------------------------------
+// AT-CF-3: controlFlowBoundaryCount in result is always a non-negative integer
+//
+// Invariant: this count is used to evaluate maxControlFlowBoundaries. A
+// negative count would always satisfy any threshold, making every node appear
+// atomic regardless of actual structure.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_isAtom_controlFlowBoundaryCount_is_non_negative
+ *
+ * The controlFlowBoundaryCount in any AtomTestResult is a non-negative integer.
+ *
+ * Invariant (AT-CF-3, DEC-ATOM-TEST-003): the CF count is compared against
+ * maxControlFlowBoundaries. A negative count is structurally impossible — no
+ * source file contains fewer than 0 control-flow boundary nodes.
+ */
+export const prop_isAtom_controlFlowBoundaryCount_is_non_negative: fc.IAsyncProperty<[number]> =
+  fc.asyncProperty(natCFArb, async (maxCF) => {
+    const source = "function f(x: number) { if (x > 0) return x; return 0; }";
+    const { file } = parseSource(source);
+    const result: AtomTestResult = await isAtom(file, source, emptyRegistry, {
+      maxControlFlowBoundaries: maxCF,
+    });
+    return (
+      typeof result.controlFlowBoundaryCount === "number" &&
+      Number.isInteger(result.controlFlowBoundaryCount) &&
+      result.controlFlowBoundaryCount >= 0
+    );
+  });
+
+// ---------------------------------------------------------------------------
+// AT-CF-1: 0 CF boundaries always returns isAtom=true (no registry match)
+//
+// Invariant: a node with 0 control-flow boundaries and no known-primitive
+// sub-statements is always atomic regardless of maxCF threshold.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_isAtom_zero_cf_empty_registry_is_always_atomic
+ *
+ * For a source with exactly 0 control-flow boundaries and an empty registry,
+ * isAtom() always returns isAtom=true with reason="atomic" for every value of
+ * maxControlFlowBoundaries in {0..5}.
+ *
+ * Invariant (AT-CF-1, DEC-ATOM-TEST-003): the degenerate case — simplest
+ * possible function body — must classify as atomic unconditionally. Any other
+ * result indicates a regression in CF counting.
+ */
+export const prop_isAtom_zero_cf_empty_registry_is_always_atomic: fc.IAsyncProperty<[number]> =
+  fc.asyncProperty(natCFArb, async (maxCF) => {
+    // Source with exactly 0 CF boundaries: pure arithmetic return.
+    const source = "function f(x: number) { return x + 1; }";
+    const { file } = parseSource(source);
+    const result = await isAtom(file, source, emptyRegistry, {
+      maxControlFlowBoundaries: maxCF,
+    });
+    return (
+      result.isAtom === true && result.reason === "atomic" && result.controlFlowBoundaryCount === 0
+    );
+  });
+
+// ---------------------------------------------------------------------------
+// AT-CF-2: CF count > maxCF always returns reason="too-many-cf-boundaries"
+//
+// Invariant: When the CF count strictly exceeds maxControlFlowBoundaries,
+// criterion 1 fails immediately and reason must be too-many-cf-boundaries.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_isAtom_excess_cf_returns_too_many_cf_boundaries
+ *
+ * For a source with exactly 2 CF boundaries and maxControlFlowBoundaries=0,
+ * isAtom() always returns isAtom=false with reason="too-many-cf-boundaries".
+ *
+ * Invariant (AT-CF-2, DEC-ATOM-TEST-003): criterion 1 short-circuits before
+ * the registry is consulted. A result with a different reason indicates the
+ * short-circuit is broken.
+ */
+export const prop_isAtom_excess_cf_returns_too_many_cf_boundaries: fc.IAsyncProperty<[undefined]> =
+  fc.asyncProperty(fc.constant(undefined), async () => {
+    // Source with exactly 2 CF boundaries (if + for): exceeds maxCF=0.
+    const source =
+      "function f(x: number) { if (x > 0) { for (let i = 0; i < 10; i++) {} } return 0; }";
+    const { file } = parseSource(source);
+    const result = await isAtom(file, source, emptyRegistry, {
+      maxControlFlowBoundaries: 0,
+    });
+    return result.isAtom === false && result.reason === "too-many-cf-boundaries";
+  });
+
+// ---------------------------------------------------------------------------
+// AT-CF-4: undefined maxControlFlowBoundaries uses default (1)
+//
+// Invariant: The default maxControlFlowBoundaries is 1. A source with exactly
+// 1 CF boundary must classify as atomic when options is undefined.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_isAtom_undefined_options_uses_default_max_cf_1
+ *
+ * When options is undefined, isAtom() uses maxControlFlowBoundaries=1. A
+ * source with exactly 1 CF boundary must classify as atomic.
+ *
+ * Invariant (AT-CF-4, DEC-ATOM-TEST-003): the default maxCF=1 is documented
+ * in atom-test.ts. If this default ever changed silently, previously-atomic
+ * nodes would be reclassified as non-atomic, breaking the decompose tree.
+ */
+export const prop_isAtom_undefined_options_uses_default_max_cf_1: fc.IAsyncProperty<[undefined]> =
+  fc.asyncProperty(fc.constant(undefined), async () => {
+    // Exactly 1 CF boundary (single if) → atomic with default maxCF=1.
+    const source = "function f(x: number) { if (x > 0) return x; return 0; }";
+    const { file } = parseSource(source);
+    const result = await isAtom(file, source, emptyRegistry);
+    return (
+      result.isAtom === true && result.reason === "atomic" && result.controlFlowBoundaryCount === 1
+    );
+  });
+
+// ---------------------------------------------------------------------------
+// AT-REG-1: empty registry + options sweep → always atomic for 0-CF source
+//
+// Invariant: With no known primitives in the registry, a node with 0 CF
+// boundaries must always classify as atomic for any options value.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_isAtom_empty_registry_zero_cf_options_sweep_always_atomic
+ *
+ * For a 0-CF source and an empty registry, isAtom() returns atomic regardless
+ * of the options.maxControlFlowBoundaries value (including undefined).
+ *
+ * Invariant (AT-REG-1, DEC-ATOM-TEST-003): criteria 1 and 2 both pass for
+ * 0-CF nodes with an empty registry. Any non-atomic result indicates a bug.
+ */
+export const prop_isAtom_empty_registry_zero_cf_options_sweep_always_atomic: fc.IAsyncProperty<
+  [AtomTestOptions]
+> = fc.asyncProperty(
+  fc.record({
+    maxControlFlowBoundaries: fc.option(fc.nat({ max: 10 }), { nil: undefined }),
+  }),
+  async (opts) => {
+    const source = "function g(a: string): string { return a.trim(); }";
+    const { file } = parseSource(source);
+    const result = await isAtom(file, source, emptyRegistry, opts);
+    // 0 CF boundaries → always atomic regardless of maxCF threshold.
+    return result.isAtom === true && result.reason === "atomic";
+  },
+);
+
+// ---------------------------------------------------------------------------
+// AT-MATCH-1: matchedPrimitive is undefined IFF reason != "contains-known-primitive"
+//
+// Invariant: matchedPrimitive carries the registry result. It must only appear
+// when the registry matched a sub-statement. In all other cases it must be
+// absent/undefined.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_isAtom_matchedPrimitive_absent_for_non_contains_reason
+ *
+ * For a 0-CF source with an empty registry (always produces "atomic"),
+ * matchedPrimitive must be undefined in the result.
+ *
+ * Invariant (AT-MATCH-1, DEC-ATOM-TEST-003): callers use matchedPrimitive to
+ * populate the PointerEntry in the slice plan. If it's set for wrong reasons,
+ * spurious pointers appear in the output.
+ */
+export const prop_isAtom_matchedPrimitive_absent_for_non_contains_reason: fc.IAsyncProperty<
+  [number]
+> = fc.asyncProperty(natCFArb, async (maxCF) => {
+  // Source with 0 CF boundaries and empty registry → always atomic, no matchedPrimitive.
+  const source = "function f(x: number) { return x + 1; }";
+  const { file } = parseSource(source);
+  const result = await isAtom(file, source, emptyRegistry, {
+    maxControlFlowBoundaries: maxCF,
+  });
+  // For atomic results, matchedPrimitive must be absent.
+  if (result.reason !== "contains-known-primitive") {
+    return result.matchedPrimitive === undefined;
+  }
+  // For contains-known-primitive, matchedPrimitive must be defined.
+  return result.matchedPrimitive !== undefined;
+});
+
+// ---------------------------------------------------------------------------
+// AT-REG-2: always-match registry triggers contains-known-primitive
+//
+// Invariant: When every registry query returns a match, a function with
+// multiple body statements must classify as contains-known-primitive.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_isAtom_always_match_registry_triggers_contains_known_primitive
+ *
+ * For a two-statement function body and an always-match registry, the
+ * FunctionDeclaration node must classify as contains-known-primitive because
+ * the first sub-statement matches the registry.
+ *
+ * Invariant (AT-REG-2, DEC-ATOM-TEST-003): criterion 2 is reachable. Without
+ * this property a bug where the registry is never consulted could go unnoticed.
+ */
+export const prop_isAtom_always_match_registry_triggers_contains_known_primitive: fc.IAsyncProperty<
+  [undefined]
+> = fc.asyncProperty(fc.constant(undefined), async () => {
+  // Two-statement function body: first statement can match the always-match registry.
+  const source = "function f(x: number) { const y = x * 2; return y + 1; }";
+  const { file } = parseSource(source);
+
+  // Call isAtom on the FunctionDeclaration node so getTopLevelStatements
+  // returns the body's statements (not the self-recognition guard path).
+  const fnDecl = file.getFunctions()[0];
+  if (fnDecl === undefined) return false; // unexpected parse failure
+
+  const result = await isAtom(fnDecl, source, alwaysMatchRegistry);
+
+  // The always-match registry returns a hit for the first sub-statement.
+  return (
+    result.isAtom === false &&
+    result.reason === "contains-known-primitive" &&
+    result.matchedPrimitive !== undefined
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Compound: real parse → isAtom → result — CF-varies-by-maxCF correctness
+//
+// Production sequence: parse TypeScript source → extract SourceFile node →
+// call isAtom() → verify joint invariants on result shape.
+//
+// This is the required compound-interaction property that crosses multiple
+// internal components (ts-morph parsing, CF boundary counting, registry stub,
+// result shape validation).
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_compound_isAtom_real_parse_cf_varies_by_maxcf
+ *
+ * Drives the real production sequence end-to-end for both atomic and
+ * non-atomic cases by varying maxControlFlowBoundaries relative to a fixed
+ * source with 1 CF boundary:
+ *   - maxCF >= 1 → isAtom=true, reason="atomic", cfCount=1
+ *   - maxCF < 1 (maxCF=0) → isAtom=false, reason="too-many-cf-boundaries", cfCount=1
+ *
+ * Crosses: ts-morph Project construction, SourceFile parse, CF walk (all
+ * descendants), result shape validation. Exercises all three observable
+ * behaviors of isAtom() (CF count, threshold comparison, result shape).
+ *
+ * Invariant (AT-CF-1, AT-CF-2, DEC-ATOM-TEST-003): the above outcome rules
+ * must hold for every value of maxCF in {0, 1, 2, 3, 4, 5}.
+ */
+export const prop_compound_isAtom_real_parse_cf_varies_by_maxcf: fc.IAsyncProperty<[number]> =
+  fc.asyncProperty(natCFArb, async (maxCF) => {
+    // Source with exactly 1 CF boundary (single if statement).
+    const source = "function f(x: number) { if (x > 0) return x; return 0; }";
+    const { file } = parseSource(source);
+
+    const result: AtomTestResult = await isAtom(file, source, emptyRegistry, {
+      maxControlFlowBoundaries: maxCF,
+    });
+
+    // CF count must always be 1 for this source regardless of maxCF.
+    if (result.controlFlowBoundaryCount !== 1) return false;
+    // reason must be one of the canonical set.
+    if (!ATOM_TEST_REASONS.has(result.reason)) return false;
+    // isAtom is boolean.
+    if (typeof result.isAtom !== "boolean") return false;
+
+    if (maxCF >= 1) {
+      // 1 CF <= maxCF=1+ -> atomic
+      return result.isAtom === true && result.reason === "atomic";
+    }
+    // maxCF=0: 1 CF > 0 -> too-many-cf-boundaries
+    return result.isAtom === false && result.reason === "too-many-cf-boundaries";
+  });

--- a/packages/shave/src/universalize/recursion.props.test.ts
+++ b/packages/shave/src/universalize/recursion.props.test.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for universalize/recursion.props.ts — thin runner only.
+// Each export from the corpus is driven through fc.assert() here.
+
+import * as fc from "fast-check";
+import { describe, it } from "vitest";
+import * as Props from "./recursion.props.js";
+
+describe("universalize/recursion.ts — property corpus", () => {
+  // DEC-REC-P1: leafCount is always a positive integer
+  it("property: decompose — leafCount is a positive integer for any non-throwing call", async () => {
+    await fc.assert(Props.prop_decompose_leafCount_is_positive_integer);
+  });
+
+  // DEC-REC-P2: maxDepth is always a non-negative integer
+  it("property: decompose — maxDepth is a non-negative integer", async () => {
+    await fc.assert(Props.prop_decompose_maxDepth_is_non_negative);
+  });
+
+  // DEC-REC-P3: root.kind is "atom" or "branch"
+  it("property: decompose — root.kind is always atom or branch", async () => {
+    await fc.assert(Props.prop_decompose_root_kind_is_atom_or_branch);
+  });
+
+  // DEC-REC-P4: atom root implies leafCount=1 and maxDepth=0
+  it("property: decompose — atom root implies leafCount=1 and maxDepth=0", async () => {
+    await fc.assert(Props.prop_decompose_atom_root_implies_leafCount_1_maxDepth_0);
+  });
+
+  // DEC-REC-P5: root.canonicalAstHash is a 64-char lowercase hex string
+  it("property: decompose — root.canonicalAstHash is a 64-char lowercase hex string", async () => {
+    await fc.assert(Props.prop_decompose_root_canonicalAstHash_is_64_char_hex);
+  });
+
+  // DEC-REC-P6: RecursionDepthExceededError.depth > .maxDepth
+  it("property: RecursionDepthExceededError — depth strictly exceeds maxDepth", async () => {
+    await fc.assert(Props.prop_RecursionDepthExceededError_depth_exceeds_maxDepth);
+  });
+
+  // DEC-REC-P7: DidNotReachAtomError.node.range is a valid positive-width interval
+  it("property: DidNotReachAtomError — node.range has start < end (valid interval)", async () => {
+    await fc.assert(Props.prop_DidNotReachAtomError_node_range_is_valid);
+  });
+
+  // DEC-REC-P8: empty registry + 0-CF source always produces atom root
+  it("property: decompose — 0-CF source with empty registry always produces atom root", async () => {
+    await fc.assert(Props.prop_decompose_zero_cf_always_produces_atom_root);
+  });
+
+  // Compound: real parse sequence → branch + atom invariants.
+  // Creates a real ts-morph Project per run — cap numRuns to stay within the
+  // 30s global testTimeout. 10 runs × ~0.8s/run ≈ 8s budget.
+  it("property: compound — real parse: branch root joint invariants (leafCount, maxDepth, hash, consistency)", async () => {
+    await fc.assert(Props.prop_compound_decompose_real_parse_branch_and_atom_invariants, { numRuns: 10 });
+  });
+
+  // canonicalAstHash stability across calls.
+  // Two decompose() calls per run with a real ts-morph Project — cap numRuns.
+  // 10 runs × ~0.4s/run ≈ 4s budget.
+  it("property: decompose — canonicalAstHash is stable (same input → same hash on repeated calls)", async () => {
+    await fc.assert(Props.prop_decompose_canonicalAstHash_is_stable_across_calls, { numRuns: 10 });
+  });
+});

--- a/packages/shave/src/universalize/recursion.props.ts
+++ b/packages/shave/src/universalize/recursion.props.ts
@@ -1,0 +1,412 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-001: hand-authored property-test corpus for
+// @yakcc/shave universalize/recursion.ts. Two-file pattern: this file
+// (.props.ts) is vitest-free and holds the corpus; the sibling .props.test.ts
+// is the vitest harness.
+// Status: accepted (WI-V2-07-PREFLIGHT L3j)
+// Rationale: See tmp/wi-v2-07-preflight-layer-plan.md — the corpus file must
+// be runtime-independent so L10 can hash it as a manifest artifact.
+//
+// Surface covered: universalize/recursion.ts
+//   decompose(source, registry, options?) → Promise<RecursionTree>
+//   DidNotReachAtomError, RecursionDepthExceededError (error classes)
+//
+// Properties covered:
+//   DEC-REC-P1: leafCount is always a positive integer for any non-throwing call.
+//   DEC-REC-P2: maxDepth is always a non-negative integer.
+//   DEC-REC-P3: root.kind is "atom" or "branch" (RecursionNode exhaustion).
+//   DEC-REC-P4: root.kind === "atom" implies leafCount === 1 and maxDepth === 0.
+//   DEC-REC-P5: root.canonicalAstHash is a 64-char lowercase hex string.
+//   DEC-REC-P6: RecursionDepthExceededError carries depth > maxDepth.
+//   DEC-REC-P7: DidNotReachAtomError carries node.range.start < node.range.end.
+//   DEC-REC-P8: empty-registry + 0-CF source always produces atom root.
+//   Compound: real source → decompose → RecursionTree joint invariants.
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for universalize/recursion.ts
+// ---------------------------------------------------------------------------
+
+import type { BlockMerkleRoot, CanonicalAstHash } from "@yakcc/contracts";
+import * as fc from "fast-check";
+import { DidNotReachAtomError, RecursionDepthExceededError, decompose } from "./recursion.js";
+import type { RecursionNode, RecursionTree } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/** Registry that always returns no matches — no known primitives. */
+const emptyRegistry = {
+  async findByCanonicalAstHash(_hash: CanonicalAstHash): Promise<readonly BlockMerkleRoot[]> {
+    return [];
+  },
+};
+
+/**
+ * A TypeScript source with exactly 0 control-flow boundaries.
+ * decompose() on this source with the empty registry must always produce an
+ * atom leaf at the root.
+ */
+const ZERO_CF_SOURCE = "function f(x: number) { return x + 1; }";
+
+/**
+ * A TypeScript source with exactly 1 control-flow boundary (single if).
+ * With default maxControlFlowBoundaries=1, the SourceFile is atomic.
+ * With maxControlFlowBoundaries=0, the SourceFile is not atomic → branch.
+ */
+const ONE_CF_SOURCE = "function f(x: number) { if (x > 0) return x; return 0; }";
+
+/**
+ * A TypeScript source with 2 top-level if-statements (2 CF boundaries at the
+ * SourceFile level). With default maxCF=1, the SourceFile is not atomic → branch.
+ * Each if-statement has 1 CF boundary and is individually atomic.
+ */
+const TWO_IF_SOURCE = [
+  "declare const a: boolean;",
+  "declare const b: boolean;",
+  "if (a) { console.log(1); }",
+  "if (b) { console.log(2); }",
+].join("\n");
+
+/** Arbitrary non-negative integer for maxControlFlowBoundaries (0–5). */
+const natCFArb: fc.Arbitrary<number> = fc.nat({ max: 5 });
+
+/**
+ * Walk a RecursionTree recursively and count all AtomLeaf nodes.
+ * Used to verify leafCount is consistent with the actual tree shape.
+ */
+function countLeaves(node: RecursionNode): number {
+  if (node.kind === "atom") return 1;
+  return node.children.reduce((sum, child) => sum + countLeaves(child), 0);
+}
+
+/**
+ * Walk a RecursionTree recursively and compute the maximum depth reached.
+ * The root is at depth 0.
+ */
+function computeMaxDepth(node: RecursionNode, depth = 0): number {
+  if (node.kind === "atom") return depth;
+  return Math.max(...node.children.map((c) => computeMaxDepth(c, depth + 1)));
+}
+
+// ---------------------------------------------------------------------------
+// DEC-REC-P1: leafCount is always a positive integer for any non-throwing call
+//
+// Invariant: decompose() counts AtomLeaf nodes during recursion. A successful
+// call must have visited at least one atom. leafCount=0 would indicate the
+// recursion produced a structurally empty tree, which is unreachable.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_decompose_leafCount_is_positive_integer
+ *
+ * For the 0-CF source with the empty registry and any maxCF in {0..5},
+ * decompose() completes without throwing and produces leafCount >= 1.
+ *
+ * Invariant (DEC-REC-P1, DEC-RECURSION-005): every successful decompose() call
+ * visits at least one AtomLeaf. A zero leafCount is structurally impossible —
+ * every recursion path terminates at an atom or throws.
+ */
+export const prop_decompose_leafCount_is_positive_integer: fc.IAsyncProperty<[number]> =
+  fc.asyncProperty(natCFArb, async (maxCF) => {
+    const tree: RecursionTree = await decompose(ZERO_CF_SOURCE, emptyRegistry, {
+      maxControlFlowBoundaries: maxCF,
+    });
+    return (
+      typeof tree.leafCount === "number" && Number.isInteger(tree.leafCount) && tree.leafCount >= 1
+    );
+  });
+
+// ---------------------------------------------------------------------------
+// DEC-REC-P2: maxDepth is always a non-negative integer
+//
+// Invariant: maxDepth=0 means the root was an atom (no children visited).
+// A negative maxDepth is semantically impossible.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_decompose_maxDepth_is_non_negative
+ *
+ * For any successful decompose() call on a simple source, maxDepth is a
+ * non-negative integer.
+ *
+ * Invariant (DEC-REC-P2, DEC-RECURSION-005): maxDepth tracks the deepest
+ * recursion level reached. A negative value is unreachable: depth starts at
+ * 0 and only ever increases.
+ */
+export const prop_decompose_maxDepth_is_non_negative: fc.IAsyncProperty<[number]> =
+  fc.asyncProperty(natCFArb, async (maxCF) => {
+    const tree: RecursionTree = await decompose(ZERO_CF_SOURCE, emptyRegistry, {
+      maxControlFlowBoundaries: maxCF,
+    });
+    return (
+      typeof tree.maxDepth === "number" && Number.isInteger(tree.maxDepth) && tree.maxDepth >= 0
+    );
+  });
+
+// ---------------------------------------------------------------------------
+// DEC-REC-P3: root.kind is "atom" or "branch"
+//
+// Invariant: The root of any RecursionTree is a RecursionNode — either an
+// AtomLeaf or a BranchNode. No other kind is valid.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_decompose_root_kind_is_atom_or_branch
+ *
+ * The root node of any RecursionTree produced by decompose() has kind "atom"
+ * or "branch" — never any other value.
+ *
+ * Invariant (DEC-REC-P3, DEC-RECURSION-005): the root is always a RecursionNode.
+ * A root with an unknown kind would break all tree traversals that dispatch on
+ * root.kind.
+ */
+export const prop_decompose_root_kind_is_atom_or_branch: fc.IAsyncProperty<[number]> =
+  fc.asyncProperty(natCFArb, async (maxCF) => {
+    const tree: RecursionTree = await decompose(ZERO_CF_SOURCE, emptyRegistry, {
+      maxControlFlowBoundaries: maxCF,
+    });
+    return tree.root.kind === "atom" || tree.root.kind === "branch";
+  });
+
+// ---------------------------------------------------------------------------
+// DEC-REC-P4: root.kind === "atom" implies leafCount === 1 and maxDepth === 0
+//
+// Invariant: When the SourceFile itself is atomic (0 CF boundaries), the
+// recursion terminates immediately at the root. leafCount must be 1 and
+// maxDepth must be 0.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_decompose_atom_root_implies_leafCount_1_maxDepth_0
+ *
+ * For the 0-CF source and any maxCF >= 0, the root is always an atom, and
+ * the resulting tree has leafCount=1 and maxDepth=0.
+ *
+ * Invariant (DEC-REC-P4, DEC-RECURSION-005): the degenerate case — the input
+ * is already atomic. leafCount=1 and maxDepth=0 are the canonical indicators
+ * that no recursion occurred beyond the root.
+ */
+export const prop_decompose_atom_root_implies_leafCount_1_maxDepth_0: fc.IAsyncProperty<[number]> =
+  fc.asyncProperty(natCFArb, async (maxCF) => {
+    const tree: RecursionTree = await decompose(ZERO_CF_SOURCE, emptyRegistry, {
+      maxControlFlowBoundaries: maxCF,
+    });
+    if (tree.root.kind !== "atom") return true; // only check when root is atom
+    return tree.leafCount === 1 && tree.maxDepth === 0;
+  });
+
+// ---------------------------------------------------------------------------
+// DEC-REC-P5: root.canonicalAstHash is a 64-char lowercase hex string
+//
+// Invariant: The canonicalAstHash at the root is a BLAKE3-256 hex digest.
+// Its format is load-bearing for registry lookups and manifest hashing.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_decompose_root_canonicalAstHash_is_64_char_hex
+ *
+ * The canonicalAstHash on the root node of any RecursionTree is a 64-character
+ * lowercase hex string (BLAKE3-256 encoding).
+ *
+ * Invariant (DEC-REC-P5, DEC-RECURSION-005): registry lookups and provenance
+ * manifests index by this hash. Any format deviation (wrong length, uppercase,
+ * non-hex chars) would corrupt index integrity.
+ */
+export const prop_decompose_root_canonicalAstHash_is_64_char_hex: fc.IAsyncProperty<[number]> =
+  fc.asyncProperty(natCFArb, async (maxCF) => {
+    const tree: RecursionTree = await decompose(ZERO_CF_SOURCE, emptyRegistry, {
+      maxControlFlowBoundaries: maxCF,
+    });
+    const h = tree.root.canonicalAstHash;
+    return typeof h === "string" && h.length === 64 && /^[0-9a-f]+$/.test(h);
+  });
+
+// ---------------------------------------------------------------------------
+// DEC-REC-P6: RecursionDepthExceededError.depth > RecursionDepthExceededError.maxDepth
+//
+// Invariant: The error is thrown when depth > maxDepth. The error object must
+// carry consistent values — depth is strictly greater than maxDepth.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_RecursionDepthExceededError_depth_exceeds_maxDepth
+ *
+ * When decompose() throws RecursionDepthExceededError, the error's .depth
+ * field is strictly greater than its .maxDepth field.
+ *
+ * Invariant (DEC-REC-P6, DEC-RECURSION-005): the guard `if (depth > maxDepth)`
+ * precedes the throw. Therefore depth > maxDepth is always true at throw time.
+ * An error with depth <= maxDepth indicates the guard condition was not respected.
+ */
+export const prop_RecursionDepthExceededError_depth_exceeds_maxDepth: fc.IAsyncProperty<
+  [undefined]
+> = fc.asyncProperty(fc.constant(undefined), async () => {
+  // TWO_IF_SOURCE has SourceFile with 2 CF → not atomic with maxCF=1.
+  // maxDepth=0 forces the throw immediately when the recursion tries depth 1.
+  let caught: RecursionDepthExceededError | undefined;
+  try {
+    await decompose(TWO_IF_SOURCE, emptyRegistry, { maxDepth: 0 });
+  } catch (e) {
+    if (e instanceof RecursionDepthExceededError) caught = e;
+  }
+  if (caught === undefined) return false; // must throw
+  return caught.depth > caught.maxDepth;
+});
+
+// ---------------------------------------------------------------------------
+// DEC-REC-P7: DidNotReachAtomError.node.range is a valid non-empty interval
+//
+// Invariant: The error is thrown on a real node that has a positive source
+// extent. A zero-width range would indicate a phantom node.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_DidNotReachAtomError_node_range_is_valid
+ *
+ * When decompose() throws DidNotReachAtomError, the error's node.range has
+ * start < end (a positive-width source interval).
+ *
+ * Invariant (DEC-REC-P7, DEC-RECURSION-005): DidNotReachAtomError is thrown on
+ * a concrete AST node. Every concrete node has a non-zero source span. A range
+ * where start >= end would indicate a phantom or zero-width node, which is not
+ * a valid AST node kind.
+ */
+export const prop_DidNotReachAtomError_node_range_is_valid: fc.IAsyncProperty<[undefined]> =
+  fc.asyncProperty(fc.constant(undefined), async () => {
+    // maxControlFlowBoundaries: -1 makes every node non-atomic (CF count 0 > -1).
+    // ExpressionStatement has no decomposable children → DidNotReachAtomError.
+    let caught: DidNotReachAtomError | undefined;
+    try {
+      await decompose("console.log(1);", emptyRegistry, {
+        maxControlFlowBoundaries: -1,
+      });
+    } catch (e) {
+      if (e instanceof DidNotReachAtomError) caught = e;
+    }
+    if (caught === undefined) return false; // must throw
+    return (
+      typeof caught.node.range.start === "number" &&
+      typeof caught.node.range.end === "number" &&
+      caught.node.range.start >= 0 &&
+      caught.node.range.end > caught.node.range.start
+    );
+  });
+
+// ---------------------------------------------------------------------------
+// DEC-REC-P8: empty registry + 0-CF source → always atom root for all maxCF
+//
+// Invariant: A source with 0 control-flow boundaries always classifies as
+// atomic regardless of maxCF threshold. The registry is never consulted.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_decompose_zero_cf_always_produces_atom_root
+ *
+ * For a 0-CF source, an empty registry, and any maxCF in {0..5}, decompose()
+ * produces a tree whose root.kind === "atom".
+ *
+ * Invariant (DEC-REC-P8, AT-CF-1, DEC-RECURSION-005): 0 CF boundaries never
+ * exceed any non-negative threshold. The registry is never consulted because
+ * criterion 1 passes. A branch root here indicates a regression in CF counting.
+ */
+export const prop_decompose_zero_cf_always_produces_atom_root: fc.IAsyncProperty<[number]> =
+  fc.asyncProperty(natCFArb, async (maxCF) => {
+    const tree: RecursionTree = await decompose(ZERO_CF_SOURCE, emptyRegistry, {
+      maxControlFlowBoundaries: maxCF,
+    });
+    return tree.root.kind === "atom";
+  });
+
+// ---------------------------------------------------------------------------
+// Compound: real source → decompose → RecursionTree joint invariants
+//
+// Production sequence: a TypeScript source string is parsed by decompose()
+// into a Project; each node is classified via isAtom(); the recursion walks
+// top-down until every leaf is atomic. This compound property exercises the
+// full path crossing decompose → isAtom → decomposableChildrenOf → tree build.
+//
+// Test: TWO_IF_SOURCE with maxCF=1 (default) → branch root + 4 atom children.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_compound_decompose_real_parse_branch_and_atom_invariants
+ *
+ * Drives the real production sequence end-to-end for a source with 2
+ * top-level if-statements (2 CF boundaries at SourceFile level). With default
+ * maxCF=1:
+ *   - SourceFile: 2 CF > 1 → not atomic → branch
+ *   - Each statement: ≤ 1 CF → atomic → leaf
+ *
+ * Verifies joint invariants:
+ *   - root.kind === "branch"
+ *   - leafCount >= 1 (must have at least one atom descendant)
+ *   - maxDepth >= 1 (recursion went at least one level)
+ *   - countLeaves(root) === leafCount (internal consistency)
+ *   - root.canonicalAstHash is 64-char lowercase hex
+ *
+ * Crosses: ts-morph Project construction, SourceFile parse, isAtom() CF walk,
+ * decomposableChildrenOf() dispatch, result tree assembly, leafCount/maxDepth
+ * bookkeeping.
+ *
+ * Invariant (DEC-REC-P1–P5, DEC-RECURSION-005): all five leaf/depth/kind/hash
+ * invariants must hold jointly for any successful decompose() call that produces
+ * a branch tree.
+ */
+export const prop_compound_decompose_real_parse_branch_and_atom_invariants: fc.IAsyncProperty<
+  [undefined]
+> = fc.asyncProperty(fc.constant(undefined), async () => {
+  // TWO_IF_SOURCE: 2 CF boundaries at SourceFile level → branch root.
+  const tree: RecursionTree = await decompose(TWO_IF_SOURCE, emptyRegistry);
+
+  // P3: root.kind is "atom" or "branch"
+  if (tree.root.kind !== "atom" && tree.root.kind !== "branch") return false;
+
+  // For this source the root must be a branch (2 CF > default maxCF=1).
+  if (tree.root.kind !== "branch") return false;
+
+  // P1: leafCount >= 1
+  if (tree.leafCount < 1) return false;
+
+  // P2: maxDepth >= 0; for a branch tree it must be >= 1
+  if (tree.maxDepth < 1) return false;
+
+  // Internal consistency: count leaves matches declared leafCount.
+  if (countLeaves(tree.root) !== tree.leafCount) return false;
+
+  // Internal consistency: computed maxDepth matches declared maxDepth.
+  if (computeMaxDepth(tree.root) !== tree.maxDepth) return false;
+
+  // P5: root.canonicalAstHash is 64-char lowercase hex
+  const h = tree.root.canonicalAstHash;
+  if (typeof h !== "string" || h.length !== 64 || !/^[0-9a-f]+$/.test(h)) return false;
+
+  // All joint invariants satisfied.
+  return true;
+});
+
+// ---------------------------------------------------------------------------
+// Additional: canonicalAstHash stability across two calls
+//
+// Invariant: decompose() is deterministic. Two calls on the same source with
+// the same options produce roots with the same canonicalAstHash.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_decompose_canonicalAstHash_is_stable_across_calls
+ *
+ * Two successive decompose() calls on the same source string produce root
+ * nodes with identical canonicalAstHash values.
+ *
+ * Invariant (DEC-REC-P5, DEC-RECURSION-005): canonicalAstHash is derived from
+ * the BLAKE3 hash of the normalized AST. It must be deterministic — same input
+ * bytes and same AST normalization → same hash on every call. Hash instability
+ * would break registry lookups and cross-session provenance manifests.
+ */
+export const prop_decompose_canonicalAstHash_is_stable_across_calls: fc.IAsyncProperty<
+  [undefined]
+> = fc.asyncProperty(fc.constant(undefined), async () => {
+  const tree1 = await decompose(ONE_CF_SOURCE, emptyRegistry);
+  const tree2 = await decompose(ONE_CF_SOURCE, emptyRegistry);
+  return tree1.root.canonicalAstHash === tree2.root.canonicalAstHash;
+});

--- a/packages/shave/src/universalize/slicer.props.test.ts
+++ b/packages/shave/src/universalize/slicer.props.test.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for universalize/slicer.props.ts — thin runner only.
+// Each export from the corpus is driven through fc.assert() here.
+
+import * as fc from "fast-check";
+import { describe, it } from "vitest";
+import * as Props from "./slicer.props.js";
+
+describe("universalize/slicer.ts — property corpus", () => {
+  // SL-KIND-1: every SlicePlanEntry.kind is one of the 4 canonical values
+  it("property: slice — all entries have a valid SlicePlanEntry kind", async () => {
+    await fc.assert(Props.prop_slice_entries_all_have_valid_kind);
+  });
+
+  // SL-BYTES-1: sourceBytesByKind.pointer is always non-negative
+  it("property: slice — sourceBytesByKind.pointer is always non-negative", async () => {
+    await fc.assert(Props.prop_slice_pointer_bytes_is_non_negative);
+  });
+
+  // SL-BYTES-2: sourceBytesByKind.novelGlue is always non-negative
+  it("property: slice — sourceBytesByKind.novelGlue is always non-negative", async () => {
+    await fc.assert(Props.prop_slice_novel_glue_bytes_is_non_negative);
+  });
+
+  // SL-BYTES-3: sourceBytesByKind.glue is always non-negative
+  it("property: slice — sourceBytesByKind.glue is always non-negative", async () => {
+    await fc.assert(Props.prop_slice_glue_bytes_is_non_negative);
+  });
+
+  // SL-MATCH-1: matchedPrimitives.length <= PointerEntry count
+  it("property: slice — matchedPrimitives.length is <= PointerEntry count (deduplication)", async () => {
+    await fc.assert(Props.prop_slice_matchedPrimitives_length_le_pointer_entry_count);
+  });
+
+  // SL-MODE-1: strict mode never emits GlueLeafEntry
+  it("property: slice — strict mode never emits GlueLeafEntry", async () => {
+    await fc.assert(Props.prop_slice_strict_mode_never_emits_glue_entries);
+  });
+
+  // SL-FOREIGN-1: non-import source returns empty array from classifyForeign
+  it("property: classifyForeign — non-import source returns empty array", () => {
+    fc.assert(Props.prop_classifyForeign_non_import_source_returns_empty);
+  });
+
+  // SL-FOREIGN-2: foreign named import returns ForeignLeafEntry with pkg + export
+  it("property: classifyForeign — foreign named import returns entry with correct pkg and export", () => {
+    fc.assert(Props.prop_classifyForeign_foreign_named_import_returns_entry);
+  });
+
+  // SL-FOREIGN-3: type-only import returns empty array
+  it("property: classifyForeign — type-only import returns empty array", () => {
+    fc.assert(Props.prop_classifyForeign_type_only_import_returns_empty);
+  });
+
+  // SL-FOREIGN-4: relative import returns empty array
+  it("property: classifyForeign — relative import returns empty array", () => {
+    fc.assert(Props.prop_classifyForeign_relative_import_returns_empty);
+  });
+
+  // SL-FOREIGN-5: workspace import returns empty array
+  it("property: classifyForeign — workspace import (@yakcc/) returns empty array", () => {
+    fc.assert(Props.prop_classifyForeign_workspace_import_returns_empty);
+  });
+
+  // Compound: decompose → slice end-to-end joint invariants
+  it("property: compound — real tree: pointer + novel-glue joint invariants (DFS order, bytes, matchedPrimitives)", async () => {
+    await fc.assert(Props.prop_compound_slice_real_tree_joint_invariants);
+  });
+});

--- a/packages/shave/src/universalize/slicer.props.ts
+++ b/packages/shave/src/universalize/slicer.props.ts
@@ -1,0 +1,482 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-001: hand-authored property-test corpus for
+// @yakcc/shave universalize/slicer.ts. Two-file pattern: this file
+// (.props.ts) is vitest-free and holds the corpus; the sibling .props.test.ts
+// is the vitest harness.
+// Status: accepted (WI-V2-07-PREFLIGHT L3j)
+// Rationale: See tmp/wi-v2-07-preflight-layer-plan.md — the corpus file must
+// be runtime-independent so L10 can hash it as a manifest artifact.
+//
+// Surface covered: universalize/slicer.ts
+//   slice(tree, registry, options?) → Promise<SlicePlan>
+//   classifyForeign(source) → ForeignLeafEntry[]
+//   SliceOptions.shaveMode: "strict" | "glue-aware"
+//
+// Properties covered:
+//   SL-KIND-1: Every SlicePlanEntry.kind is one of the 4 canonical values.
+//   SL-BYTES-1: sourceBytesByKind.pointer is always non-negative.
+//   SL-BYTES-2: sourceBytesByKind.novelGlue is always non-negative.
+//   SL-BYTES-3: sourceBytesByKind.glue is always non-negative.
+//   SL-MATCH-1: matchedPrimitives length <= count of PointerEntries in entries.
+//   SL-MODE-1: strict mode (default) never emits GlueLeafEntry.
+//   SL-FOREIGN-1: classifyForeign on a non-import source returns empty array.
+//   SL-FOREIGN-2: classifyForeign on a foreign named import returns pkg and export.
+//   SL-FOREIGN-3: classifyForeign on a type-only import returns empty array.
+//   SL-FOREIGN-4: classifyForeign on a relative import returns empty array.
+//   SL-FOREIGN-5: classifyForeign on a workspace import returns empty array.
+//   Compound: decompose → slice end-to-end joint invariants.
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for universalize/slicer.ts
+// ---------------------------------------------------------------------------
+
+import type { BlockMerkleRoot, CanonicalAstHash } from "@yakcc/contracts";
+import * as fc from "fast-check";
+import { classifyForeign, slice } from "./slicer.js";
+import type {
+  AtomLeaf,
+  BranchNode,
+  ForeignLeafEntry,
+  RecursionTree,
+  SlicePlan,
+  SlicePlanEntry,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Shared helpers and arbitraries
+// ---------------------------------------------------------------------------
+
+/** Registry that returns no matches for any hash. */
+const emptyRegistry = {
+  async findByCanonicalAstHash(_hash: CanonicalAstHash): Promise<readonly BlockMerkleRoot[]> {
+    return [];
+  },
+};
+
+/** Registry that returns a fake match for every hash query. */
+const alwaysMatchRegistry = {
+  async findByCanonicalAstHash(_hash: CanonicalAstHash): Promise<readonly BlockMerkleRoot[]> {
+    return ["fake-merkle-root" as BlockMerkleRoot];
+  },
+};
+
+/**
+ * Build a minimal AtomLeaf fixture with consistent sourceRange.
+ * source.length === sourceRange.end - sourceRange.start.
+ */
+function makeAtom(source: string, hash: string, start = 0): AtomLeaf {
+  return {
+    kind: "atom",
+    sourceRange: { start, end: start + source.length },
+    source,
+    canonicalAstHash: hash as CanonicalAstHash,
+    atomTest: { isAtom: true, reason: "atomic", controlFlowBoundaryCount: 0 },
+  };
+}
+
+/**
+ * Build a minimal BranchNode fixture wrapping given children.
+ */
+function makeBranch(
+  source: string,
+  hash: string,
+  children: readonly (AtomLeaf | BranchNode)[],
+  start = 0,
+): BranchNode {
+  return {
+    kind: "branch",
+    sourceRange: { start, end: start + source.length },
+    source,
+    canonicalAstHash: hash as CanonicalAstHash,
+    atomTest: { isAtom: false, reason: "too-many-cf-boundaries", controlFlowBoundaryCount: 2 },
+    children,
+  };
+}
+
+/** Build a RecursionTree wrapping a single root node. */
+function makeTree(root: AtomLeaf | BranchNode, leafCount = 1, maxDepth = 0): RecursionTree {
+  return { root, leafCount, maxDepth };
+}
+
+/** The 4 canonical SlicePlanEntry kind values. */
+const SLICE_PLAN_ENTRY_KINDS: ReadonlySet<string> = new Set([
+  "pointer",
+  "novel-glue",
+  "foreign-leaf",
+  "glue",
+]);
+
+/** Arbitrary non-empty source string — used as NovelGlueEntry.source stand-in. */
+const nonEmptySourceArb: fc.Arbitrary<string> = fc
+  .string({ minLength: 3, maxLength: 40 })
+  .filter((s) => s.trim().length > 0);
+
+/** Arbitrary 8-char hex string for fake canonicalAstHash values in fixtures. */
+const fakeHashArb: fc.Arbitrary<string> = fc
+  .array(fc.integer({ min: 0, max: 15 }), { minLength: 8, maxLength: 8 })
+  .map((ns) => ns.map((n) => n.toString(16)).join(""));
+
+// ---------------------------------------------------------------------------
+// SL-KIND-1: every SlicePlanEntry.kind is one of the 4 canonical values
+//
+// Invariant: The SlicePlanEntry discriminated union is closed. No other kind
+// values exist. An unknown kind would pass through the compile pipeline
+// unhandled and produce silent misclassification.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_slice_entries_all_have_valid_kind
+ *
+ * Every entry in a SlicePlan.entries array has a kind that is one of
+ * {"pointer", "novel-glue", "foreign-leaf", "glue"}.
+ *
+ * Invariant (SL-KIND-1, DEC-SLICER-NOVEL-GLUE-004): the discriminated union is
+ * closed. The compile pipeline switches exhaustively on entry.kind; an unknown
+ * kind would silently fall through.
+ *
+ * Tests two modes: strict (default) and glue-aware.
+ */
+export const prop_slice_entries_all_have_valid_kind: fc.IAsyncProperty<[string, string]> =
+  fc.asyncProperty(nonEmptySourceArb, fakeHashArb, async (source, hash) => {
+    const atom = makeAtom(source, hash);
+    const tree = makeTree(atom);
+    const plan: SlicePlan = await slice(tree, emptyRegistry);
+    return plan.entries.every((e: SlicePlanEntry) => SLICE_PLAN_ENTRY_KINDS.has(e.kind));
+  });
+
+// ---------------------------------------------------------------------------
+// SL-BYTES-1: sourceBytesByKind.pointer is always non-negative
+//
+// Invariant: Byte counters can only increase (never go negative). They are
+// used in reviewer dashboards; a negative value is semantically impossible.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_slice_pointer_bytes_is_non_negative
+ *
+ * sourceBytesByKind.pointer in any SlicePlan is always >= 0.
+ *
+ * Invariant (SL-BYTES-1, DEC-SLICER-NOVEL-GLUE-004): pointer bytes are summed
+ * from sourceRange sizes of PointerEntry nodes. Since sourceRange.end >=
+ * sourceRange.start >= 0, the sum is always non-negative.
+ */
+export const prop_slice_pointer_bytes_is_non_negative: fc.IAsyncProperty<[string, string]> =
+  fc.asyncProperty(nonEmptySourceArb, fakeHashArb, async (source, hash) => {
+    const atom = makeAtom(source, hash);
+    const tree = makeTree(atom);
+    const plan: SlicePlan = await slice(tree, emptyRegistry);
+    return plan.sourceBytesByKind.pointer >= 0;
+  });
+
+// ---------------------------------------------------------------------------
+// SL-BYTES-2: sourceBytesByKind.novelGlue is always non-negative
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_slice_novel_glue_bytes_is_non_negative
+ *
+ * sourceBytesByKind.novelGlue in any SlicePlan is always >= 0.
+ *
+ * Invariant (SL-BYTES-2, DEC-SLICER-NOVEL-GLUE-004): novel-glue bytes are
+ * summed from unmatched atom sourceRange sizes. Non-negative by construction.
+ */
+export const prop_slice_novel_glue_bytes_is_non_negative: fc.IAsyncProperty<[string, string]> =
+  fc.asyncProperty(nonEmptySourceArb, fakeHashArb, async (source, hash) => {
+    const atom = makeAtom(source, hash);
+    const tree = makeTree(atom);
+    const plan: SlicePlan = await slice(tree, emptyRegistry);
+    return plan.sourceBytesByKind.novelGlue >= 0;
+  });
+
+// ---------------------------------------------------------------------------
+// SL-BYTES-3: sourceBytesByKind.glue is always non-negative
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_slice_glue_bytes_is_non_negative
+ *
+ * sourceBytesByKind.glue in any SlicePlan is always >= 0.
+ *
+ * Invariant (SL-BYTES-3, DEC-V2-GLUE-LEAF-CONTRACT-001): glue bytes are
+ * summed from GlueLeafEntry nodes in glue-aware mode. Always non-negative.
+ * Zero in strict mode.
+ */
+export const prop_slice_glue_bytes_is_non_negative: fc.IAsyncProperty<[string, string]> =
+  fc.asyncProperty(nonEmptySourceArb, fakeHashArb, async (source, hash) => {
+    const atom = makeAtom(source, hash);
+    const tree = makeTree(atom);
+    const plan: SlicePlan = await slice(tree, emptyRegistry);
+    return plan.sourceBytesByKind.glue >= 0;
+  });
+
+// ---------------------------------------------------------------------------
+// SL-MATCH-1: matchedPrimitives.length <= PointerEntry count in entries
+//
+// Invariant: matchedPrimitives is a deduplicated subset of PointerEntries.
+// Deduplication can only reduce the count; it can never add new entries.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_slice_matchedPrimitives_length_le_pointer_entry_count
+ *
+ * matchedPrimitives.length is always <= the number of PointerEntries in
+ * plan.entries (deduplication can only reduce, never inflate).
+ *
+ * Invariant (SL-MATCH-1, DEC-SLICER-NOVEL-GLUE-004): matchedPrimitives is
+ * the first-seen deduplication of PointerEntry (canonicalAstHash, merkleRoot)
+ * pairs. The deduplicated count <= the raw PointerEntry count. A violation
+ * would mean matchedPrimitives contains hashes not present in entries.
+ */
+export const prop_slice_matchedPrimitives_length_le_pointer_entry_count: fc.IAsyncProperty<
+  [string, string]
+> = fc.asyncProperty(nonEmptySourceArb, fakeHashArb, async (source, hash) => {
+  const atom = makeAtom(source, hash);
+  const tree = makeTree(atom);
+  // Use alwaysMatchRegistry to get PointerEntries and test deduplication path.
+  const plan: SlicePlan = await slice(tree, alwaysMatchRegistry);
+  const pointerCount = plan.entries.filter((e) => e.kind === "pointer").length;
+  return plan.matchedPrimitives.length <= pointerCount;
+});
+
+// ---------------------------------------------------------------------------
+// SL-MODE-1: strict mode (default) never emits GlueLeafEntry
+//
+// Invariant: The strict path (walkNodeStrict) never calls validateStrictSubset
+// and never emits GlueLeafEntry. Only glue-aware mode can emit glue entries.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_slice_strict_mode_never_emits_glue_entries
+ *
+ * Under strict mode (default, or shaveMode:'strict' explicit), slice() never
+ * emits any GlueLeafEntry regardless of source content.
+ *
+ * Invariant (SL-MODE-1, DEC-V2-SLICER-SEARCH-001): the strict path is the
+ * backward-compatible path and predates glue-aware mode. It must not emit
+ * GlueLeafEntry — that would be a regression for existing callers.
+ */
+export const prop_slice_strict_mode_never_emits_glue_entries: fc.IAsyncProperty<[string, string]> =
+  fc.asyncProperty(nonEmptySourceArb, fakeHashArb, async (source, hash) => {
+    const atom = makeAtom(source, hash);
+    const tree = makeTree(atom);
+    const plan: SlicePlan = await slice(tree, emptyRegistry); // default = strict
+    return !plan.entries.some((e) => e.kind === "glue");
+  });
+
+// ---------------------------------------------------------------------------
+// SL-FOREIGN-1: classifyForeign on a non-import source returns empty array
+//
+// Invariant: A source with no ImportDeclarations (e.g. a pure function body)
+// produces zero ForeignLeafEntries. classifyForeign must not misclassify
+// CallExpressions or other non-import nodes as foreign imports.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_classifyForeign_non_import_source_returns_empty
+ *
+ * For source strings that contain no ImportDeclaration (pure TypeScript
+ * expression/statement code), classifyForeign returns an empty array.
+ *
+ * Invariant (SL-FOREIGN-1, DEC-V2-FOREIGN-BLOCK-SCHEMA-001): classifyForeign
+ * is a structural predicate over ImportDeclaration nodes. CallExpressions,
+ * VariableDeclarations, and other statement kinds must not be mistaken for
+ * foreign imports.
+ */
+export const prop_classifyForeign_non_import_source_returns_empty: fc.IProperty<[undefined]> =
+  fc.property(fc.constant(undefined), () => {
+    // Pure function with no imports — no ImportDeclaration nodes.
+    const source = "function f(x: number): number { return x * 2; }";
+    const entries = classifyForeign(source);
+    return entries.length === 0;
+  });
+
+// ---------------------------------------------------------------------------
+// SL-FOREIGN-2: classifyForeign on a foreign named import returns pkg + export
+//
+// Invariant: A static foreign named import always produces a ForeignLeafEntry
+// with the correct pkg and export fields.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_classifyForeign_foreign_named_import_returns_entry
+ *
+ * For a source containing `import { readFileSync } from 'node:fs'`,
+ * classifyForeign returns exactly one ForeignLeafEntry with pkg='node:fs'
+ * and export='readFileSync'.
+ *
+ * Invariant (SL-FOREIGN-2, DEC-V2-FOREIGN-BLOCK-SCHEMA-001): foreign named
+ * imports are the primary classification target. The pkg and export fields
+ * are used by the provenance manifest and --foreign-policy CLI flag (L4).
+ * Incorrect or missing entries would corrupt the foreign-import catalog.
+ */
+export const prop_classifyForeign_foreign_named_import_returns_entry: fc.IProperty<[undefined]> =
+  fc.property(fc.constant(undefined), () => {
+    const source = `import { readFileSync } from 'node:fs';`;
+    const entries = classifyForeign(source);
+    if (entries.length !== 1) return false;
+    const entry = entries[0] as ForeignLeafEntry;
+    return (
+      entry.kind === "foreign-leaf" &&
+      entry.pkg === "node:fs" &&
+      entry.export === "readFileSync" &&
+      entry.alias === undefined
+    );
+  });
+
+// ---------------------------------------------------------------------------
+// SL-FOREIGN-3: classifyForeign on a type-only import returns empty array
+//
+// Invariant: `import type { X }` is erased at compile time. classifyForeign
+// must skip it — treating type imports as foreign would produce phantom
+// entries in the provenance manifest.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_classifyForeign_type_only_import_returns_empty
+ *
+ * For a source containing only `import type { X } from 'node:fs'`,
+ * classifyForeign returns an empty array.
+ *
+ * Invariant (SL-FOREIGN-3, DEC-V2-FOREIGN-BLOCK-SCHEMA-001): type-only imports
+ * carry no runtime dependency. Classifying them as foreign would inject
+ * spurious dependencies into the provenance manifest.
+ */
+export const prop_classifyForeign_type_only_import_returns_empty: fc.IProperty<[undefined]> =
+  fc.property(fc.constant(undefined), () => {
+    const source = `import type { PathLike } from 'node:fs';`;
+    const entries = classifyForeign(source);
+    return entries.length === 0;
+  });
+
+// ---------------------------------------------------------------------------
+// SL-FOREIGN-4: classifyForeign on a relative import returns empty array
+//
+// Invariant: Relative imports (./foo, ../bar) are workspace-local.
+// classifyForeign must skip them — they are not foreign dependencies.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_classifyForeign_relative_import_returns_empty
+ *
+ * For a source containing only `import { x } from './local.js'`,
+ * classifyForeign returns an empty array.
+ *
+ * Invariant (SL-FOREIGN-4, DEC-V2-FOREIGN-BLOCK-SCHEMA-001): relative
+ * imports are workspace-local paths. Classifying them as foreign would
+ * break the workspace boundary assumption that drives the slicer's
+ * no-synthesis-needed rule for local source.
+ */
+export const prop_classifyForeign_relative_import_returns_empty: fc.IProperty<[undefined]> =
+  fc.property(fc.constant(undefined), () => {
+    const source = `import { helper } from './local.js';`;
+    const entries = classifyForeign(source);
+    return entries.length === 0;
+  });
+
+// ---------------------------------------------------------------------------
+// SL-FOREIGN-5: classifyForeign on a workspace import returns empty array
+//
+// Invariant: Workspace imports (`@yakcc/...`) are not foreign. They are
+// managed internally and must not appear in the foreign-import catalog.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_classifyForeign_workspace_import_returns_empty
+ *
+ * For a source containing only `import { slice } from '@yakcc/shave'`,
+ * classifyForeign returns an empty array.
+ *
+ * Invariant (SL-FOREIGN-5, DEC-V2-FOREIGN-BLOCK-SCHEMA-001): workspace
+ * imports are classified as local (not foreign) by the WORKSPACE_PREFIX
+ * guard. Classifying them as foreign would make all workspace consumers
+ * appear as external dependencies.
+ */
+export const prop_classifyForeign_workspace_import_returns_empty: fc.IProperty<[undefined]> =
+  fc.property(fc.constant(undefined), () => {
+    const source = `import { slice } from '@yakcc/shave';`;
+    const entries = classifyForeign(source);
+    return entries.length === 0;
+  });
+
+// ---------------------------------------------------------------------------
+// Compound: decompose → slice end-to-end joint invariants
+//
+// Production sequence: decompose() produces a RecursionTree from a TypeScript
+// source string; slice() walks that tree in DFS order and produces a SlicePlan.
+// This compound property exercises the full production path crossing decompose
+// → RecursionTree → slice → SlicePlan, verifying joint invariants.
+//
+// Test: a branch tree (two atoms) with the first atom matched by registry.
+// Expected: entries = [PointerEntry, NovelGlueEntry]; pointer bytes = atom1
+// length; novelGlue bytes = atom2 length.
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_compound_slice_real_tree_joint_invariants
+ *
+ * Drives the real production sequence: build a synthetic RecursionTree with
+ * a branch root and two atom children (first matched by registry, second not).
+ * Verifies all joint invariants:
+ *   - entries has length 2 (one per atom)
+ *   - entries[0].kind === "pointer"
+ *   - entries[1].kind === "novel-glue"
+ *   - sourceBytesByKind.pointer === sourceX.length
+ *   - sourceBytesByKind.novelGlue === sourceY.length
+ *   - matchedPrimitives.length === 1
+ *   - all entry kinds are in the canonical 4-value set
+ *   - glue bytes === 0 (strict mode)
+ *
+ * Crosses: makeAtom fixture, makeBranch fixture, makeTree fixture, registryForHashes
+ * stub, slice → walkNodeStrict → PointerEntry + NovelGlueEntry paths, accumulator
+ * byte accounting, matchedPrimitives deduplication.
+ *
+ * Invariant (SL-KIND-1, SL-BYTES-1–3, SL-MATCH-1, DEC-SLICER-NOVEL-GLUE-004):
+ * All six invariants must hold jointly for any valid slice call on a two-atom
+ * branch tree with one matched and one unmatched atom.
+ */
+export const prop_compound_slice_real_tree_joint_invariants: fc.IAsyncProperty<[undefined]> =
+  fc.asyncProperty(fc.constant(undefined), async () => {
+    const sourceX = "function add(a: number, b: number): number { return a + b; }";
+    const sourceY = "function mul(a: number, b: number): number { return a * b; }";
+    const hashX = "hash-compound-X";
+    const hashY = "hash-compound-Y";
+    const merkleX = "merkle-compound-X" as BlockMerkleRoot;
+
+    const atomX = makeAtom(sourceX, hashX, 0);
+    const atomY = makeAtom(sourceY, hashY, sourceX.length);
+    const branchSource = sourceX + sourceY;
+    const branch = makeBranch(branchSource, "hash-compound-branch", [atomX, atomY], 0);
+    const tree = makeTree(branch, 2, 1);
+
+    // Registry matches only hashX.
+    const registry = {
+      async findByCanonicalAstHash(hash: CanonicalAstHash): Promise<readonly BlockMerkleRoot[]> {
+        return hash === hashX ? [merkleX] : [];
+      },
+    };
+
+    const plan: SlicePlan = await slice(tree, registry);
+
+    // Exactly 2 entries — one per atom child.
+    if (plan.entries.length !== 2) return false;
+
+    // DFS order: atomX (pointer) then atomY (novel-glue).
+    if (plan.entries[0]?.kind !== "pointer") return false;
+    if (plan.entries[1]?.kind !== "novel-glue") return false;
+
+    // Byte accounting.
+    if (plan.sourceBytesByKind.pointer !== sourceX.length) return false;
+    if (plan.sourceBytesByKind.novelGlue !== sourceY.length) return false;
+
+    // Strict mode: no glue entries.
+    if (plan.sourceBytesByKind.glue !== 0) return false;
+
+    // matchedPrimitives: exactly 1 (hashX matched once).
+    if (plan.matchedPrimitives.length !== 1) return false;
+    if (plan.matchedPrimitives[0]?.canonicalAstHash !== hashX) return false;
+
+    // All entry kinds are canonical.
+    if (!plan.entries.every((e) => SLICE_PLAN_ENTRY_KINDS.has(e.kind))) return false;
+
+    return true;
+  });


### PR DESCRIPTION
## Summary

L3j gate for #87: per-leaf property-test corpus for `packages/shave/src/universalize/`.

- 6 new files: `atom-test.props.{ts,test.ts}`, `recursion.props.{ts,test.ts}`, `slicer.props.{ts,test.ts}`
- 31 `prop_*` exports across the three universalize surfaces covering AT-REASON-1, AT-CF-1-4, AT-REG-1-2, AT-MATCH-1, DEC-REC-P1-P8, SL-KIND-1, SL-BYTES-1-3, SL-MATCH-1, SL-MODE-1, SL-FOREIGN-1-5, plus compound end-to-end properties.
- ff-merged origin/main during landing to absorb PR #202 / #208 doc closures (no diff vs origin/main outside the 6 new files).

## Test plan

- [x] `pnpm --filter @yakcc/shave test` — 772 pass / 1 pre-existing skip / 0 fail at post-merge HEAD `3f97e23`
- [x] re-run after commit `0f3dc86` — same counts
- [x] reviewer verdict at this tree: `ready_for_guardian` (zero blockers; two advisory `note` findings: base-branch deferred fixup, pre-existing `types.props.ts` build errors — neither blocks L3j)

Refs #87