### PR TITLE
WI-LINT-DRIFT-FIX: biome --fix on variance + seeds (closes #235)

### DIFF
--- a/packages/seeds/src/seed.test.ts
+++ b/packages/seeds/src/seed.test.ts
@@ -83,7 +83,9 @@ const BLOCK_DIRS = [
 
 describe("seedRegistry", () => {
   it("stores all 20 blocks and returns their merkleRoots", async () => {
-    const registry = await openRegistry(":memory:", { embeddings: createOfflineEmbeddingProvider() });
+    const registry = await openRegistry(":memory:", {
+      embeddings: createOfflineEmbeddingProvider(),
+    });
     let result: SeedResult;
     try {
       result = await seedRegistry(registry);
@@ -95,7 +97,9 @@ describe("seedRegistry", () => {
   });
 
   it("is idempotent — calling seedRegistry twice does not throw or double-count", async () => {
-    const registry = await openRegistry(":memory:", { embeddings: createOfflineEmbeddingProvider() });
+    const registry = await openRegistry(":memory:", {
+      embeddings: createOfflineEmbeddingProvider(),
+    });
     try {
       const r1 = await seedRegistry(registry);
       const r2 = await seedRegistry(registry);
@@ -109,8 +113,12 @@ describe("seedRegistry", () => {
 
   it("seedRegistry() re-runs deterministically — same BlockMerkleRoot for every block", async () => {
     // Run seedRegistry twice on separate in-memory DBs; merkleRoots must match.
-    const registry1 = await openRegistry(":memory:", { embeddings: createOfflineEmbeddingProvider() });
-    const registry2 = await openRegistry(":memory:", { embeddings: createOfflineEmbeddingProvider() });
+    const registry1 = await openRegistry(":memory:", {
+      embeddings: createOfflineEmbeddingProvider(),
+    });
+    const registry2 = await openRegistry(":memory:", {
+      embeddings: createOfflineEmbeddingProvider(),
+    });
     try {
       const r1 = await seedRegistry(registry1);
       const r2 = await seedRegistry(registry2);
@@ -124,7 +132,9 @@ describe("seedRegistry", () => {
   }, 30_000);
 
   it("registry.selectBlocks finds each block by its specHash after seeding", async () => {
-    const registry = await openRegistry(":memory:", { embeddings: createOfflineEmbeddingProvider() });
+    const registry = await openRegistry(":memory:", {
+      embeddings: createOfflineEmbeddingProvider(),
+    });
     try {
       const { merkleRoots } = await seedRegistry(registry);
       const { parseBlockTriplet } = await import("@yakcc/ir");
@@ -613,7 +623,9 @@ describe("end-to-end: seed → selectBlocks → getBlock → parse → compose",
   });
 
   it("seeds registry, looks up list-of-ints by specHash, retrieves block, and parses '[1,2,3]'", async () => {
-    const registry = await openRegistry(":memory:", { embeddings: createOfflineEmbeddingProvider() });
+    const registry = await openRegistry(":memory:", {
+      embeddings: createOfflineEmbeddingProvider(),
+    });
     registryInstance = registry;
 
     // Step 1: Seed the registry
@@ -647,7 +659,9 @@ describe("end-to-end: seed → selectBlocks → getBlock → parse → compose",
   });
 
   it("verifies all blocks parse successfully via parseBlockTriplet after migration", async () => {
-    const registry = await openRegistry(":memory:", { embeddings: createOfflineEmbeddingProvider() });
+    const registry = await openRegistry(":memory:", {
+      embeddings: createOfflineEmbeddingProvider(),
+    });
     registryInstance = registry;
 
     const { parseBlockTriplet } = await import("@yakcc/ir");

--- a/packages/variance/src/index.props.test.ts
+++ b/packages/variance/src/index.props.test.ts
@@ -3,8 +3,8 @@
 // Two-file pattern: this file is the thin vitest wrapper; the corpus lives in
 // the sibling index.props.ts (vitest-free, hashable as a manifest artifact).
 
-import { it } from "vitest";
 import * as fc from "fast-check";
+import { it } from "vitest";
 import {
   prop_compareDimensions_result_shape,
   prop_compareDimensions_scores_in_range,


### PR DESCRIPTION
## Summary

Pure mechanical autofix unblocking pr-ci.yml lint gate (#196 Phase 1, PR #234).

- packages/variance/src/index.props.test.ts: Biome organizeImports — 2-line import swap
- packages/seeds/src/seed.test.ts: Biome formatter — 6 multi-line wraps for long openRegistry calls

Zero semantic changes. End-to-end test of #196 Phase 1: this PR's pr-ci.yml run should be the first to pass cleanly.

## Test plan

- [x] biome check passes both files locally
- [x] Diff verified pure (orchestrator-side review)
- [ ] pr-ci.yml run on this PR completes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)