### PR TITLE
WI-AS-PHASE-2D-JSON: DEC-AS-JSON-STRATEGY-001 annotation closing #209

### DIFF
--- a/packages/compile/src/as-backend.ts
+++ b/packages/compile/src/as-backend.ts
@@ -47,6 +47,100 @@
 //   and avoids polluting the project tree. Temp files are cleaned up after each
 //   emit() call regardless of success/failure (finally block). A unique
 //   subdirectory per call (randomUUID) prevents concurrent-call collisions.
+//
+// @decision DEC-AS-JSON-STRATEGY-001
+// Title: AS-backend JSON support uses flat-memory manual integer parsers/writers
+//        (parseI32/writeI32/skipWS) rather than assemblyscript-json or native
+//        AS JSON stdlib, because both managed JSON libraries require --runtime
+//        minimal/full (GC heap, managed string type, JSON parsing internals) which
+//        are incompatible with the --runtime stub constraint used by this backend.
+// Status: decided (WI-AS-PHASE-2D-JSON, Issue #209, 2026-05-03)
+// Rationale:
+//   AS JSON library options evaluated:
+//
+//   (A) `assemblyscript-json` package (npm: assemblyscript-json):
+//       Requires AS managed types (string, GC allocation, object fields).
+//       Under --runtime stub: JSON.parse<T>() fails to compile because the stub
+//       runtime omits the GC heap and string internals. PROBE RESULT: COMPILE FAIL.
+//
+//   (B) Native AS JSON stdlib (JSON.parse / JSON.stringify built into asc):
+//       Also requires managed string type and GC allocation. Same failure mode
+//       as (A) under --runtime stub. PROBE RESULT: COMPILE FAIL.
+//       Evidence: J4/J5 probes in json-parity.test.ts confirm the compile failure.
+//
+//   (C) Flat-memory manual parsers (CHOSEN):
+//       parseI32(ptr, len): byte-by-byte ASCII decimal integer parser (atoi).
+//       writeI32(value, dstPtr): byte-by-byte ASCII decimal integer writer (itoa).
+//       skipWS(ptr, len, start): JSON whitespace-skip for token boundary detection.
+//       These use only WASM intrinsics (load<u8>, store<u8>, i32 arithmetic) with
+//       no GC dependency. Compatible with --runtime stub. PROBE RESULT: COMPILE OK.
+//
+//   Type-parameter inference at codegen time (for JSON.stringify<T>):
+//       Not applicable -- the flat-memory approach works on byte buffers, not typed
+//       AS values. The integer type (i32) is the only supported token type in v1
+//       (ASCII-ONLY CONSTRAINT per DEC-AS-JSON-LAYOUT-001). Type inference for
+//       broader JSON support (floats, strings, objects) is deferred to a future
+//       phase that adopts --runtime minimal/full.
+//
+//   JSON.parse destination type resolution:
+//       Not applicable in v1. The flat-memory parseI32 always returns i32.
+//       Destination type selection for polymorphic JSON.parse is deferred to the
+//       same future phase that enables AS managed JSON.
+//
+//   Decision: Use flat-memory approach (C) for v1. The assemblyscript-json package
+//   is NOT added as a dependency at this time -- it would only work with a GC
+//   runtime tier that is not yet adopted. A follow-up issue should track the GC
+//   runtime upgrade path and reassess JSON library adoption at that point.
+//
+// See also: DEC-AS-JSON-LAYOUT-001 in json-parity.test.ts for the byte-layout
+// specifics (JSON_BASE_PTR, DST_BASE_PTR, ASCII-ONLY CONSTRAINT).
+//
+// @decision DEC-AS-JSON-STRATEGY-001
+// Title: AS-backend JSON support uses flat-memory manual integer parsers/writers
+//        (parseI32/writeI32/skipWS) rather than assemblyscript-json or native
+//        AS JSON stdlib, because both managed JSON libraries require --runtime
+//        minimal/full (GC heap, managed string type, JSON parsing internals) which
+//        are incompatible with the --runtime stub constraint used by this backend.
+// Status: decided (WI-AS-PHASE-2D-JSON, Issue #209, 2026-05-03)
+// Rationale:
+//   AS JSON library options evaluated:
+//
+//   (A) `assemblyscript-json` package (npm: assemblyscript-json):
+//       Requires AS managed types (string, GC allocation, object fields).
+//       Under --runtime stub: JSON.parse<T>() fails to compile because the stub
+//       runtime omits the GC heap and string internals. PROBE RESULT: COMPILE FAIL.
+//
+//   (B) Native AS JSON stdlib (JSON.parse / JSON.stringify built into asc):
+//       Also requires managed string type and GC allocation. Same failure mode
+//       as (A) under --runtime stub. PROBE RESULT: COMPILE FAIL.
+//       Evidence: J4/J5 probes in json-parity.test.ts confirm the compile failure.
+//
+//   (C) Flat-memory manual parsers (CHOSEN):
+//       parseI32(ptr, len): byte-by-byte ASCII decimal integer parser (atoi).
+//       writeI32(value, dstPtr): byte-by-byte ASCII decimal integer writer (itoa).
+//       skipWS(ptr, len, start): JSON whitespace-skip for token boundary detection.
+//       These use only WASM intrinsics (load<u8>, store<u8>, i32 arithmetic) with
+//       no GC dependency. Compatible with --runtime stub. PROBE RESULT: COMPILE OK.
+//
+//   Type-parameter inference at codegen time (for JSON.stringify<T>):
+//       Not applicable -- the flat-memory approach works on byte buffers, not typed
+//       AS values. The integer type (i32) is the only supported token type in v1
+//       (ASCII-ONLY CONSTRAINT per DEC-AS-JSON-LAYOUT-001). Type inference for
+//       broader JSON support (floats, strings, objects) is deferred to a future
+//       phase that adopts --runtime minimal/full.
+//
+//   JSON.parse destination type resolution:
+//       Not applicable in v1. The flat-memory parseI32 always returns i32.
+//       Destination type selection for polymorphic JSON.parse is deferred to the
+//       same future phase that enables AS managed JSON.
+//
+//   Decision: Use flat-memory approach (C) for v1. The assemblyscript-json package
+//   is NOT added as a dependency at this time -- it would only work with a GC
+//   runtime tier that is not yet adopted. A follow-up issue should track the GC
+//   runtime upgrade path and reassess JSON library adoption at that point.
+//
+// See also: DEC-AS-JSON-LAYOUT-001 in json-parity.test.ts for the byte-layout
+// specifics (JSON_BASE_PTR, DST_BASE_PTR, ASCII-ONLY CONSTRAINT).
 
 import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";


### PR DESCRIPTION
## Summary

Closes [#209](https://github.com/cneckar/yakcc/issues/209). Code-is-Truth bookkeeping PR: adds the missing `DEC-AS-JSON-STRATEGY-001` annotation to `as-backend.ts` documenting the JSON-support strategy decision.

## Context — why this PR is small

The substantive test work for #209 already landed on main as commit [`26321b4`](https://github.com/cneckar/yakcc/commit/26321b4) (915 lines, `packages/compile/test/as-backend/json-parity.test.ts`):

- **J1 parseI32** — ASCII digit-by-digit i32 parser with leading-sign handling (20 fast-check)
- **J2 writeI32** — ASCII itoa returning byte count (20 fast-check)
- **J3 skipWS** — whitespace skipper (20 fast-check)
- **J4** — managed `JSON.parse()` PROBE: COMPILE FAIL (expected; needs GC + stdlib)
- **J5** — managed `JSON.stringify()` PROBE: COMPILE FAIL (expected; same root cause)

That commit's message said `closes #228` — a typo for `#209`. As a result GitHub didn't auto-close #209 and the issue stayed open. **#209's substantive acceptance was already met by `26321b4`** — 12/12 tests pass, ≥3 substrates, ≥15 fast-check cases each.

## What this PR adds

- **`DEC-AS-JSON-STRATEGY-001`** annotation block in `packages/compile/src/as-backend.ts` (file header), explicitly documenting:
  - **Option A (assemblyscript-json package):** rejected — fails compilation under `--runtime stub`
  - **Option B (native AS JSON stdlib):** rejected — same root cause
  - **Option C (flat-memory parseI32/writeI32/skipWS — CHOSEN):** uses only WASM intrinsics, no GC dependency, narrow but functional for i32-ASCII
- **Type-parameter inference deferral** — not applicable in v1 (i32-only, ASCII-only constraint)
- **`JSON.parse` destination type deferral** — gated on GC runtime upgrade

## Honest scope narrowing (read this carefully)

#209's original scope said `JSON.stringify(value)` + `JSON.parse(str)`. The reality:

- **AS-backend uses `--runtime stub` (no GC).** Both `assemblyscript-json` and native AS JSON stdlib require GC. So full `JSON.stringify(any)` / `JSON.parse(any)` is genuinely not implementable without first landing GC support.
- **What's deliverable today:** flat-memory integer parsers — J1/J2/J3 cover the i32-ASCII slice. These satisfy the acceptance numerically (≥3 substrates, ≥15 cases each) but NOT the spirit (full managed JSON).
- **What's deferred:** managed JSON for objects/arrays/strings, NaN, undefined, nested. Gated on GC runtime — likely covered by #213 (AS GC objects) when it lands. The J4/J5 PROBE tests are the live tracking marker for this gate.

The Sacred Practice #5 spirit is preserved: J4/J5 fail loudly with a clear documented reason, not silently.

## Files changed

- `packages/compile/src/as-backend.ts` (+94 lines, annotation only — no behavior change)

## Test plan

- [x] `pnpm --filter @yakcc/compile test` (json-parity.test.ts subset) — 12/12 pass (unchanged from main; annotation doesn't affect test execution)
- [x] `biome check` clean
- [x] No regression on existing AS-backend tests

## What this is NOT

- **Not new test coverage** — that landed in `26321b4`
- **Not new functionality** — annotation only
- **Not a substitute for managed JSON support** — that needs GC and is a separate WI

🤖 Generated with [Claude Code](https://claude.com/claude-code)