### PR TITLE
WI-AS-PHASE-2C-EXCEPTIONS: DEC-AS-EXCEPTIONS-STRATEGY-001 annotation closing #207

### DIFF
--- a/packages/compile/src/as-backend.ts
+++ b/packages/compile/src/as-backend.ts
@@ -141,6 +141,55 @@
 //
 // See also: DEC-AS-JSON-LAYOUT-001 in json-parity.test.ts for the byte-layout
 // specifics (JSON_BASE_PTR, DST_BASE_PTR, ASCII-ONLY CONSTRAINT).
+//
+// @decision DEC-AS-EXCEPTIONS-STRATEGY-001
+// Title: AS-backend exception/error handling uses primitive abort(), flat-memory error
+//        codes (store<u8>(errPtr, code)), and sentinel return values rather than
+//        try/catch exception dispatch, because try/catch requires exception-table
+//        support absent from --runtime stub (asc 0.28.x). Bare throw new Error()
+//        (no enclosing try/catch) compiles under stub — an unexpected finding.
+// Status: decided (WI-AS-PHASE-2C-EXCEPTIONS, Issue #207, 2026-05-10)
+// Rationale:
+//   AS exception handling options evaluated:
+//
+//   (A) Managed try/catch exception dispatch:
+//       Requires exception-table support in the WASM binary — catch routing,
+//       finalizer calls, and stack unwinding to the matching catch block.
+//       Under --runtime stub, asc refuses to compile `try { throw } catch {}`.
+//       PROBE RESULT (E5): COMPILE FAIL. asc error: exception-table absent.
+//
+//   (B) Managed throw new Error("msg") with catch:
+//       Same failure mode as (A) when enclosed in a try/catch. The Error object
+//       constructor itself does not require GC under stub; it is the catch-dispatch
+//       mechanism that fails. PROBE RESULT: COMPILE FAIL (when try/catch present).
+//
+//   (C) Flat-memory error protocol (CHOSEN):
+//       Three complementary patterns, all WASM-intrinsic compatible:
+//         abort():           AS primitive; traps the WASM instance on error.
+//                            No GC or exception-table needed.
+//         errPtr (i32):      Caller passes a pointer into WASM linear memory.
+//                            store<u8>(errPtr, code) writes error code byte.
+//                            load<u8>(errPtr) lets host read error state.
+//                            ERR_BASE_PTR=512: above AS stub header,
+//                            below STR_BASE_PTR=1024 (strings-parity ABI).
+//         Sentinel values:   Return -1 (or other out-of-band integer) on error.
+//                            Mirrors S4/indexOfByte pattern from strings-parity.
+//       All three patterns use only load<u8>/store<u8>/i32 arithmetic — no GC.
+//       Compatible with --runtime stub. PROBE RESULT: COMPILE OK.
+//
+//   FINDING (E4 — UNEXPECTED): bare `throw new Error("msg")` with NO enclosing
+//   try/catch DOES compile under asc 0.28.x --runtime stub and passes
+//   WebAssembly.validate(). The Error constructor is more stub-permissive than
+//   initially assumed; it is the catch-dispatch that requires the exception-table.
+//   The non-negative pass-through path is verified at runtime (E4 probe test).
+//
+//   Decision: Use flat-memory approach (C) for v1. try/catch exception dispatch
+//   is deferred until a future phase adopts --runtime minimal/full (GC tier).
+//   A follow-up issue should track the GC runtime upgrade path and reassess
+//   native AS exception handling at that point.
+//
+// See also: DEC-AS-EXCEPTION-LAYOUT-001 in exceptions-parity.test.ts for the
+// full substrate inventory (E1-E5), ERR_BASE_PTR layout, and probe methodology.
 
 import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";


### PR DESCRIPTION
## Summary

Closes [#207](https://github.com/cneckar/yakcc/issues/207). Code-is-Truth bookkeeping PR analogous to [#247](https://github.com/cneckar/yakcc/pull/247) (which closed #209): adds the missing `DEC-AS-EXCEPTIONS-STRATEGY-001` annotation to `as-backend.ts` documenting the runtime-constraint analysis and chosen strategy.

## Context — same pattern as #209

The substantive test work for #207 already landed on main as commit [`8240a20`](https://github.com/cneckar/yakcc/commit/8240a20) (PR #244, `packages/compile/test/as-backend/exceptions-parity.test.ts`):

- **E1 abort** — `abort()` host call
- **E2 errPtr** — `errPtr store<u8>` sentinel propagation
- **E3 sentinel** — `-1` sentinel return
- **E4** — bare `throw new Error()` PROBE: COMPILE OK (asc 0.28.x stub unexpectedly accepts unguarded throws)
- **E5** — `try/catch` PROBE: COMPILE FAIL expected (exception-table absent under `--runtime stub`)

That commit's message said `closes #227` — a typo for `#207`. As a result GitHub didn't auto-close #207 and the issue stayed open. **#207's substantive acceptance was already met by `8240a20`** — 12/12 tests pass, ≥4 substrates, ≥15 fast-check cases.

This PR is the missing strategy annotation.

## What this PR adds

- **`DEC-AS-EXCEPTIONS-STRATEGY-001`** annotation block in `packages/compile/src/as-backend.ts` (lines 145-192), documenting:
  - **Option A (managed `try/catch`):** rejected — exception-table absent under `--runtime stub`
  - **Option B (managed `throw new Error()` + catch):** rejected — same root cause
  - **Option C (flat-memory: `abort()` + `errPtr store<u8>` + sentinel `-1` — CHOSEN):** uses only WASM intrinsics, no GC
  - **E4 finding:** bare `throw new Error()` without try/catch unexpectedly COMPILES OK under asc 0.28.x stub (no GC required for unguarded throws)
  - **try/catch dispatch deferred** to GC runtime tier (likely #213 AS GC objects)

## Honest scope narrowing (same shape as #209's narrowing)

#207's original scope said `try/catch` + `throw new Error()` + error message propagation. The reality:

- **AS-backend uses `--runtime stub` (no GC).** Managed try/catch + caught-error-message access requires GC. Genuinely not implementable without first landing GC support.
- **What's deliverable today:** flat-memory abort + sentinel propagation. E1/E2/E3 cover this slice. Numerically satisfies acceptance (≥4 substrates, ≥15 cases — 12 tests with multiple property runs each).
- **What's deferred:** managed try/catch dispatch and `e.message` access. Gated on GC runtime — same gate as #209's managed JSON.
- **Quirky finding:** bare `throw new Error()` outside any try/catch DOES compile under stub (E4). Documented honestly.

Sacred Practice #5 preserved: E5 fails loudly with a clear documented reason.

## Files changed

- `packages/compile/src/as-backend.ts` (+49 lines, annotation only — no behavior change)

## Test plan

- [x] `pnpm --filter @yakcc/compile test` (exceptions-parity.test.ts subset) — 12/12 pass (unchanged from main)
- [x] `biome check` clean
- [x] No regression on existing AS-backend tests

## What this is NOT

- **Not new test coverage** — that landed in `8240a20` (PR #244)
- **Not new functionality** — annotation only
- **Not a substitute for managed try/catch** — that needs GC and is deferred to a separate WI

🤖 Generated with [Claude Code](https://claude.com/claude-code)