### PR TITLE
Replace hooks-install v0 CLAUDE.md facade with real settings.json wiring (closes #203)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,21 +73,29 @@ yakcc bootstrap --verify
 
 ## IDE hook installation
 
-> **Status (2026-05-10):** the install commands listed below are **v0 facades**
-> — they write a documentation stub to `.claude/`, but do not yet wire the
-> production hook into Claude Code's integration surfaces (slash commands,
-> `.claude/settings.json` hooks, MCP server). Production wiring is in flight
-> under `WI-HOOK-LAYER` ([#194](https://github.com/cneckar/yakcc/issues/194))
-> with the CLI install replacement at [#203](https://github.com/cneckar/yakcc/issues/203),
-> a fresh-project `yakcc init` command at [#204](https://github.com/cneckar/yakcc/issues/204),
-> and an end-user walkthrough at [#205](https://github.com/cneckar/yakcc/issues/205).
-> Until those land, daily Claude-Code-with-yakcc local-dev usage is best-effort.
-
 ```sh
-yakcc hooks claude-code install   # Claude Code (v0 facade today; #203 retires it)
-yakcc hooks cursor install        # Cursor (v0 facade; WI-HOOK-LAYER Phase 4)
-yakcc hooks codex install         # Codex CLI (v0 facade; WI-HOOK-LAYER Phase 5 if justified)
+# Claude Code — writes a PreToolUse hook entry to .claude/settings.json
+# Intercepts Edit / Write / MultiEdit tool calls (DEC-HOOK-LAYER-001 D-HOOK-2)
+yakcc hooks claude-code install [--target <dir>]
+
+# Remove the hook from .claude/settings.json
+yakcc hooks claude-code install --uninstall [--target <dir>]
+
+# Cursor (WI-HOOK-LAYER Phase 4 — not yet implemented)
+# yakcc hooks cursor install
+
+# Codex CLI (WI-HOOK-LAYER Phase 5 — conditional on demand)
+# yakcc hooks codex install
 ```
+
+After installation, every `Edit`, `Write`, and `MultiEdit` tool call made by
+Claude Code will invoke `yakcc hook-intercept` before the code lands on disk.
+The hook queries the local registry for a matching atom and captures telemetry
+(local-only by default per DEC-HOOK-LAYER-001 D-HOOK-5).
+
+Re-running `install` is safe — it is idempotent and will not create duplicate
+entries. Running `--uninstall` cleanly removes the yakcc entry while leaving
+any other hook configuration untouched.
 
 ## Prerequisites
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -440,15 +440,14 @@ describe("runCli error paths", () => {
 // ---------------------------------------------------------------------------
 
 describe("hooks claude-code install", () => {
-  it("exits 0, creates .claude/CLAUDE.md in target dir, and prints confirmation", async () => {
+  it("exits 0, creates .claude/settings.json with hook entry, and prints confirmation", async () => {
     const targetDir = mkdtempSync(join(tmpdir(), "yakcc-hooks-test-"));
     try {
       const logger = new CollectingLogger();
       const code = await runCli(["hooks", "claude-code", "install", "--target", targetDir], logger);
       expect(code).toBe(0);
-      expect(existsSync(join(targetDir, ".claude", "CLAUDE.md"))).toBe(true);
-      expect(logger.logLines.some((l) => l.includes("yakcc hooks installed"))).toBe(true);
-      expect(logger.logLines.some((l) => l.includes("/yakcc"))).toBe(true);
+      expect(existsSync(join(targetDir, ".claude", "settings.json"))).toBe(true);
+      expect(logger.logLines.some((l) => l.includes("installed"))).toBe(true);
     } finally {
       try {
         rmSync(targetDir, { recursive: true, force: true });
@@ -458,14 +457,16 @@ describe("hooks claude-code install", () => {
     }
   });
 
-  it("CLAUDE.md contains the stub response message", async () => {
+  it("settings.json contains a PreToolUse hook entry for Edit|Write|MultiEdit", async () => {
     const targetDir = mkdtempSync(join(tmpdir(), "yakcc-hooks-stub-"));
     try {
       const logger = new CollectingLogger();
       await runCli(["hooks", "claude-code", "install", "--target", targetDir], logger);
-      const content = readFileSync(join(targetDir, ".claude", "CLAUDE.md"), "utf-8");
-      expect(content).toContain("v0.5 feature");
-      expect(content).toContain("/yakcc");
+      const raw = readFileSync(join(targetDir, ".claude", "settings.json"), "utf-8");
+      const settings = JSON.parse(raw) as Record<string, unknown>;
+      const hooks = settings["hooks"] as Record<string, unknown[]>;
+      const preToolUse = hooks["PreToolUse"] as Array<{ matcher: string }>;
+      expect(preToolUse.some((e) => e.matcher === "Edit|Write|MultiEdit")).toBe(true);
     } finally {
       try {
         rmSync(targetDir, { recursive: true, force: true });

--- a/packages/cli/src/commands/hooks-install.test.ts
+++ b/packages/cli/src/commands/hooks-install.test.ts
@@ -1,0 +1,324 @@
+/**
+ * hooks-install.test.ts — integration tests for `yakcc hooks claude-code install`.
+ *
+ * Production sequence exercised:
+ *   hooksClaudeCodeInstall(argv, logger)
+ *   → parseArgs → readSettings → applyInstall/applyUninstall → writeSettings
+ *   → optional rmSync(CLAUDE.md)
+ *
+ * Tests:
+ *   1. install in empty dir: creates .claude/settings.json with PreToolUse hook entry.
+ *   2. idempotent re-install: running twice yields same settings.json, exit 0.
+ *   3. --target <dir>: installs into a non-cwd directory.
+ *   4. install removes existing .claude/CLAUDE.md v0 stub.
+ *   5. install preserves existing non-yakcc settings.json content.
+ *   6. --uninstall removes the yakcc hook entry.
+ *   7. --uninstall when not installed: exit 0 with informative message.
+ *   8. --uninstall is idempotent: second uninstall also exits 0.
+ *   9. install → uninstall → re-install round trip.
+ *  10. cannot create directory: returns 1 with error message.
+ *  11. install via runCli dispatch path.
+ *
+ * @decision DEC-CLI-HOOKS-INSTALL-TEST-001
+ * title: Tests use temp directories for isolation; no real home-dir writes
+ * status: decided (WI-V05-CLI-INSTALL-RETIRE-FACADE #203)
+ * rationale: Each test creates a fresh tmpdir so test runs are isolated from
+ *   each other and from the real project .claude/ directory. CollectingLogger
+ *   captures output without mocking. Sacred Practice #5: no mocks on fs
+ *   internals — tests exercise the real file I/O against the temp directory.
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CollectingLogger, runCli } from "../index.js";
+import { hooksClaudeCodeInstall } from "./hooks-install.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "yakcc-hooks-test-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function readSettings(dir: string): unknown {
+  const p = join(dir, ".claude", "settings.json");
+  if (!existsSync(p)) return null;
+  return JSON.parse(readFileSync(p, "utf-8"));
+}
+
+function touchClaudeMd(dir: string): void {
+  const claudeDir = join(dir, ".claude");
+  mkdirSync(claudeDir, { recursive: true });
+  writeFileSync(join(claudeDir, "CLAUDE.md"), "# v0 stub\n", "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// Suite 1: fresh install
+// ---------------------------------------------------------------------------
+
+describe("install — fresh directory", () => {
+  it("creates .claude/settings.json with PreToolUse hook entry", async () => {
+    const logger = new CollectingLogger();
+    const code = await hooksClaudeCodeInstall(["--target", tmpDir], logger);
+
+    expect(code).toBe(0);
+    const settings = readSettings(tmpDir) as Record<string, unknown>;
+    expect(settings).not.toBeNull();
+    const hooks = settings.hooks as Record<string, unknown>;
+    expect(hooks).toBeDefined();
+    const preToolUse = hooks["PreToolUse"] as Array<{ matcher: string; hooks: unknown[] }>;
+    expect(Array.isArray(preToolUse)).toBe(true);
+    expect(preToolUse.length).toBeGreaterThan(0);
+    expect(preToolUse[0]?.matcher).toBe("Edit|Write|MultiEdit");
+    const innerHooks = preToolUse[0]?.hooks as Array<{ type: string; command: string; _yakcc: string }>;
+    expect(innerHooks[0]?.type).toBe("command");
+    expect(innerHooks[0]?.command).toBe("yakcc hook-intercept");
+    expect(innerHooks[0]?._yakcc).toBe("yakcc-hook-v1");
+  });
+
+  it("logs install confirmation", async () => {
+    const logger = new CollectingLogger();
+    await hooksClaudeCodeInstall(["--target", tmpDir], logger);
+
+    expect(logger.logLines.some((l) => l.includes("installed"))).toBe(true);
+    expect(logger.logLines.some((l) => l.includes("yakcc hook-intercept"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 2: idempotency
+// ---------------------------------------------------------------------------
+
+describe("install — idempotent re-install", () => {
+  it("running twice yields the same settings.json entry count", async () => {
+    const logger1 = new CollectingLogger();
+    await hooksClaudeCodeInstall(["--target", tmpDir], logger1);
+
+    const settingsAfterFirst = readSettings(tmpDir) as Record<string, unknown>;
+    const countAfterFirst = (
+      (settingsAfterFirst.hooks as Record<string, unknown[]>)["PreToolUse"] ?? []
+    ).length;
+
+    const logger2 = new CollectingLogger();
+    const code = await hooksClaudeCodeInstall(["--target", tmpDir], logger2);
+
+    expect(code).toBe(0);
+    const settingsAfterSecond = readSettings(tmpDir) as Record<string, unknown>;
+    const countAfterSecond = (
+      (settingsAfterSecond.hooks as Record<string, unknown[]>)["PreToolUse"] ?? []
+    ).length;
+
+    expect(countAfterSecond).toBe(countAfterFirst);
+    expect(logger2.logLines.some((l) => l.includes("idempotent"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 3: --target flag
+// ---------------------------------------------------------------------------
+
+describe("install — --target <dir>", () => {
+  it("installs into a non-cwd target directory", async () => {
+    const subDir = join(tmpDir, "my-project");
+    mkdirSync(subDir);
+
+    const logger = new CollectingLogger();
+    const code = await hooksClaudeCodeInstall(["--target", subDir], logger);
+
+    expect(code).toBe(0);
+    expect(existsSync(join(subDir, ".claude", "settings.json"))).toBe(true);
+    expect(existsSync(join(tmpDir, ".claude", "settings.json"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 4: v0 CLAUDE.md removal
+// ---------------------------------------------------------------------------
+
+describe("install — removes v0 CLAUDE.md stub", () => {
+  it("deletes .claude/CLAUDE.md when it exists", async () => {
+    touchClaudeMd(tmpDir);
+    expect(existsSync(join(tmpDir, ".claude", "CLAUDE.md"))).toBe(true);
+
+    const logger = new CollectingLogger();
+    await hooksClaudeCodeInstall(["--target", tmpDir], logger);
+
+    expect(existsSync(join(tmpDir, ".claude", "CLAUDE.md"))).toBe(false);
+  });
+
+  it("succeeds when .claude/CLAUDE.md does not exist", async () => {
+    const logger = new CollectingLogger();
+    const code = await hooksClaudeCodeInstall(["--target", tmpDir], logger);
+    expect(code).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 5: preserves existing settings.json content
+// ---------------------------------------------------------------------------
+
+describe("install — preserves existing settings.json", () => {
+  it("merges yakcc hook entry without clobbering unrelated keys", async () => {
+    const claudeDir = join(tmpDir, ".claude");
+    mkdirSync(claudeDir, { recursive: true });
+    const existing = { theme: "dark", keybindings: [{ key: "ctrl+s", command: "save" }] };
+    writeFileSync(join(claudeDir, "settings.json"), JSON.stringify(existing, null, 2), "utf-8");
+
+    const logger = new CollectingLogger();
+    const code = await hooksClaudeCodeInstall(["--target", tmpDir], logger);
+
+    expect(code).toBe(0);
+    const result = readSettings(tmpDir) as Record<string, unknown>;
+    expect(result["theme"]).toBe("dark");
+    expect(Array.isArray(result["keybindings"])).toBe(true);
+    expect(result["hooks"]).toBeDefined();
+  });
+
+  it("appends to existing non-yakcc PreToolUse entries", async () => {
+    const claudeDir = join(tmpDir, ".claude");
+    mkdirSync(claudeDir, { recursive: true });
+    const existing = {
+      hooks: {
+        PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "my-linter" }] }],
+      },
+    };
+    writeFileSync(join(claudeDir, "settings.json"), JSON.stringify(existing, null, 2), "utf-8");
+
+    await hooksClaudeCodeInstall(["--target", tmpDir], new CollectingLogger());
+
+    const result = readSettings(tmpDir) as Record<string, unknown>;
+    const preToolUse = (result["hooks"] as Record<string, unknown[]>)["PreToolUse"] as unknown[];
+    expect(preToolUse.length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 6: --uninstall
+// ---------------------------------------------------------------------------
+
+describe("--uninstall", () => {
+  it("removes the yakcc hook entry from settings.json", async () => {
+    await hooksClaudeCodeInstall(["--target", tmpDir], new CollectingLogger());
+
+    const logger = new CollectingLogger();
+    const code = await hooksClaudeCodeInstall(["--target", tmpDir, "--uninstall"], logger);
+
+    expect(code).toBe(0);
+    expect(logger.logLines.some((l) => l.includes("removed"))).toBe(true);
+
+    const settings = readSettings(tmpDir) as Record<string, unknown>;
+    const hooks = settings?.hooks as Record<string, unknown[]> | undefined;
+    const entries = hooks?.["PreToolUse"] ?? [];
+    expect(entries.length).toBe(0);
+  });
+
+  it("preserves non-yakcc PreToolUse entries on uninstall", async () => {
+    const claudeDir = join(tmpDir, ".claude");
+    mkdirSync(claudeDir, { recursive: true });
+    const existing = {
+      hooks: {
+        PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "my-linter" }] }],
+      },
+    };
+    writeFileSync(join(claudeDir, "settings.json"), JSON.stringify(existing, null, 2), "utf-8");
+
+    await hooksClaudeCodeInstall(["--target", tmpDir], new CollectingLogger());
+    await hooksClaudeCodeInstall(["--target", tmpDir, "--uninstall"], new CollectingLogger());
+
+    const result = readSettings(tmpDir) as Record<string, unknown>;
+    const preToolUse = (result["hooks"] as Record<string, unknown[]>)["PreToolUse"] as unknown[];
+    expect(preToolUse.length).toBe(1);
+    expect((preToolUse[0] as Record<string, unknown>)["matcher"]).toBe("Bash");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 7: --uninstall when not installed
+// ---------------------------------------------------------------------------
+
+describe("--uninstall when not installed", () => {
+  it("exits 0 with informative message when hook is not present", async () => {
+    const logger = new CollectingLogger();
+    const code = await hooksClaudeCodeInstall(["--target", tmpDir, "--uninstall"], logger);
+
+    expect(code).toBe(0);
+    expect(logger.logLines.some((l) => l.includes("not installed"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 8: --uninstall idempotent
+// ---------------------------------------------------------------------------
+
+describe("--uninstall idempotent", () => {
+  it("second uninstall also exits 0 gracefully", async () => {
+    await hooksClaudeCodeInstall(["--target", tmpDir], new CollectingLogger());
+    await hooksClaudeCodeInstall(["--target", tmpDir, "--uninstall"], new CollectingLogger());
+
+    const logger = new CollectingLogger();
+    const code = await hooksClaudeCodeInstall(["--target", tmpDir, "--uninstall"], logger);
+    expect(code).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 9: install → uninstall → re-install round trip
+// ---------------------------------------------------------------------------
+
+describe("round trip", () => {
+  it("install → uninstall → re-install produces a clean settings.json", async () => {
+    await hooksClaudeCodeInstall(["--target", tmpDir], new CollectingLogger());
+    await hooksClaudeCodeInstall(["--target", tmpDir, "--uninstall"], new CollectingLogger());
+
+    const logger = new CollectingLogger();
+    const code = await hooksClaudeCodeInstall(["--target", tmpDir], logger);
+
+    expect(code).toBe(0);
+    const settings = readSettings(tmpDir) as Record<string, unknown>;
+    const preToolUse = (
+      (settings.hooks as Record<string, unknown[]>)["PreToolUse"] ?? []
+    ) as Array<Record<string, unknown>>;
+    expect(preToolUse.filter((e) => e["matcher"] === "Edit|Write|MultiEdit").length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 10: directory creation failure (guarded by pre-existing path)
+// ---------------------------------------------------------------------------
+
+describe("error handling", () => {
+  it("returns 1 when target is a file not a directory", async () => {
+    // Create a file where .claude/ would be placed so mkdir fails.
+    writeFileSync(join(tmpDir, ".claude"), "not a directory");
+
+    const logger = new CollectingLogger();
+    const code = await hooksClaudeCodeInstall(["--target", tmpDir], logger);
+
+    expect(code).toBe(1);
+    expect(logger.errLines.some((l) => l.startsWith("error:"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 11: runCli dispatch
+// ---------------------------------------------------------------------------
+
+describe("runCli dispatch", () => {
+  it("routes hooks claude-code install correctly", async () => {
+    const logger = new CollectingLogger();
+    const code = await runCli(["hooks", "claude-code", "install", "--target", tmpDir], logger);
+
+    expect(code).toBe(0);
+    expect(existsSync(join(tmpDir, ".claude", "settings.json"))).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/hooks-install.ts
+++ b/packages/cli/src/commands/hooks-install.ts
@@ -1,55 +1,152 @@
 // SPDX-License-Identifier: MIT
-// @decision DEC-CLI-HOOKS-INSTALL-001: hooks claude-code install writes a CLAUDE.md
-// slash-command stub to the target directory's .claude/ folder. In v0 this is a
-// facade: the slash command exists and is documented, but its handler returns the
-// stubbed-flow message ("v0.5 feature") rather than performing a live registry search.
-// Status: implemented (WI-009)
-// Rationale: DEC-V0-HOOK-002 locks the install/command surface in v0 so that v0.5 is
-// a behavioral change, not an interface change. The install command must work and exit 0
-// now; the actual synthesis and registry-hit paths land in v0.5.
+// @decision DEC-CLI-HOOKS-INSTALL-002
+// title: Replace v0 CLAUDE.md facade with real settings.json hook wiring
+// status: decided (WI-V05-CLI-INSTALL-RETIRE-FACADE #203)
+// rationale:
+//   Per DEC-HOOK-LAYER-001 (docs/adr/hook-layer-architecture.md):
+//   D-HOOK-1 → Claude Code is the first IDE target.
+//   D-HOOK-2 → tool-call interception via settings.json PreToolUse hook entry
+//               for Edit|Write|MultiEdit tool calls.
+//   The install command writes the yakcc PreToolUse block to .claude/settings.json
+//   (idempotent read-modify-write) and removes the v0 .claude/CLAUDE.md stub
+//   (Sacred Practice #12 — no parallel mechanisms may coexist).
+//   The hook subprocess (yakcc hook-intercept) is provided by WI-HOOK-PHASE-1-MVP (#216).
+//   Uninstall reads settings.json and strips the yakcc-marked entry, then writes back.
+//
+// Supersedes DEC-CLI-HOOKS-INSTALL-001 (v0 CLAUDE.md stub; WI-009).
 
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import type { Logger } from "../index.js";
 
-/**
- * The v0 stub message returned when the /yakcc slash command is invoked.
- * v0.5 replaces this with real registry search + synthesis-required routing.
- */
-export const SLASH_COMMAND_STUB_MESSAGE =
-  "[yakcc v0.5 feature] Real-time registry lookup and block synthesis are not yet wired. " +
-  "Use `yakcc compile` + `yakcc seed` to assemble programs from the seed corpus manually.";
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
 
-/**
- * The CLAUDE.md content written to the target project's .claude/ directory.
- * Documents the /yakcc slash command surface so Claude Code sees it on startup.
- */
-function buildClaudeMdContent(): string {
-  return `# Yakcc slash command
+/** Claude Code settings.json hook event for pre-tool-call interception (D-HOOK-2). */
+const HOOK_EVENT = "PreToolUse";
 
-This project has Yakcc installed. The \`/yakcc\` slash command is available in
-Claude Code to look up content-addressed basic blocks from the local registry.
+/** Tool names the yakcc hook intercepts (D-HOOK-2: Edit/Write/MultiEdit). */
+const HOOK_MATCHER = "Edit|Write|MultiEdit";
 
-## /yakcc <intent>
+/** Subprocess command Claude Code spawns per intercepted tool call.
+ *  Implementation provided by WI-HOOK-PHASE-1-MVP (#216). */
+const HOOK_COMMAND = "yakcc hook-intercept";
 
-Searches the Yakcc registry for a block matching \`<intent>\`. If a registry hit
-is found, it returns the block's ContractId so you can reference it in your
-compile step. If no match is found, it starts the manual block-authoring flow.
+/** Marker placed on the inner hook object so the installer can find and remove it. */
+const YAKCC_MARKER = "yakcc-hook-v1";
 
-**v0 status:** This command is a facade. Registry search and synthesis are
-wired in v0.5. The command will acknowledge your intent and instruct you to use
-\`yakcc compile\` manually for now.
+// ---------------------------------------------------------------------------
+// Types for the settings.json shape
+// ---------------------------------------------------------------------------
 
-**Response (v0):** ${SLASH_COMMAND_STUB_MESSAGE}
-`;
+interface YakccHookObject {
+  type: string;
+  command: string;
+  _yakcc: string;
 }
 
+interface HookObject {
+  type: string;
+  command: string;
+  _yakcc?: string | undefined;
+}
+
+interface HookEntry {
+  matcher: string;
+  hooks: HookObject[];
+}
+
+interface ClaudeSettings {
+  hooks?: Record<string, HookEntry[]>;
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Settings helpers
+// ---------------------------------------------------------------------------
+
+function readSettings(settingsPath: string): ClaudeSettings {
+  if (!existsSync(settingsPath)) return {};
+  try {
+    return JSON.parse(readFileSync(settingsPath, "utf-8")) as ClaudeSettings;
+  } catch {
+    // Corrupt or non-JSON settings — start fresh rather than aborting.
+    return {};
+  }
+}
+
+function writeSettings(settingsPath: string, settings: ClaudeSettings): void {
+  writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
+}
+
+function buildYakccHookObject(): YakccHookObject {
+  return { type: "command", command: HOOK_COMMAND, _yakcc: YAKCC_MARKER };
+}
+
+function isYakccEntry(entry: HookEntry): boolean {
+  return entry.hooks.some((h) => h._yakcc === YAKCC_MARKER);
+}
+
+// ---------------------------------------------------------------------------
+// Install / uninstall logic
+// ---------------------------------------------------------------------------
+
+function applyInstall(settings: ClaudeSettings): { settings: ClaudeSettings; alreadyInstalled: boolean } {
+  const hooks = settings.hooks ?? {};
+  const eventHooks: HookEntry[] = hooks[HOOK_EVENT] ?? [];
+
+  if (eventHooks.some(isYakccEntry)) {
+    return { settings, alreadyInstalled: true };
+  }
+
+  const newEntry: HookEntry = { matcher: HOOK_MATCHER, hooks: [buildYakccHookObject()] };
+  return {
+    settings: {
+      ...settings,
+      hooks: { ...hooks, [HOOK_EVENT]: [...eventHooks, newEntry] },
+    },
+    alreadyInstalled: false,
+  };
+}
+
+function applyUninstall(settings: ClaudeSettings): { settings: ClaudeSettings; wasInstalled: boolean } {
+  const hooks = settings.hooks ?? {};
+  const eventHooks: HookEntry[] = hooks[HOOK_EVENT] ?? [];
+  const filtered = eventHooks.filter((e) => !isYakccEntry(e));
+  const wasInstalled = filtered.length < eventHooks.length;
+
+  if (!wasInstalled) {
+    return { settings, wasInstalled: false };
+  }
+
+  const newEventHooks: Record<string, HookEntry[]> = { ...hooks };
+  if (filtered.length === 0) {
+    delete newEventHooks[HOOK_EVENT];
+  } else {
+    newEventHooks[HOOK_EVENT] = filtered;
+  }
+
+  const hasRemainingHooks = Object.keys(newEventHooks).length > 0;
+  const newSettings: ClaudeSettings = hasRemainingHooks
+    ? { ...settings, hooks: newEventHooks }
+    : (({ hooks: _h, ...rest }) => rest)(settings as ClaudeSettings & { hooks: unknown });
+
+  return { settings: newSettings, wasInstalled: true };
+}
+
+// ---------------------------------------------------------------------------
+// Command handler
+// ---------------------------------------------------------------------------
+
 /**
- * Handler for `yakcc hooks claude-code install [--target <dir>]`.
+ * Handler for `yakcc hooks claude-code install [--target <dir>] [--uninstall]`.
  *
- * Writes .claude/CLAUDE.md to the target directory documenting the /yakcc
- * slash-command surface. Exits 0 on success.
+ * Install: writes a yakcc PreToolUse hook entry to .claude/settings.json
+ *   and removes the v0 .claude/CLAUDE.md stub if present.
+ * Uninstall: removes the yakcc hook entry from .claude/settings.json.
+ * Both paths are idempotent.
  *
  * @param argv - Remaining argv after `hooks claude-code install` has been consumed.
  * @param logger - Output sink.
@@ -63,6 +160,7 @@ export async function hooksClaudeCodeInstall(
     args: [...argv],
     options: {
       target: { type: "string", short: "t" },
+      uninstall: { type: "boolean" },
     },
     allowPositionals: false,
     strict: true,
@@ -70,6 +168,7 @@ export async function hooksClaudeCodeInstall(
 
   const targetDir = values.target ?? ".";
   const claudeDir = join(targetDir, ".claude");
+  const settingsPath = join(claudeDir, "settings.json");
   const claudeMdPath = join(claudeDir, "CLAUDE.md");
 
   try {
@@ -79,15 +178,47 @@ export async function hooksClaudeCodeInstall(
     return 1;
   }
 
+  // --- Uninstall path ---
+  if (values.uninstall) {
+    const { settings: updated, wasInstalled } = applyUninstall(readSettings(settingsPath));
+    if (!wasInstalled) {
+      logger.log("yakcc hook not installed — nothing to uninstall.");
+      return 0;
+    }
+    try {
+      writeSettings(settingsPath, updated);
+    } catch (err) {
+      logger.error(`error: cannot write ${settingsPath}: ${String(err)}`);
+      return 1;
+    }
+    logger.log(`yakcc hook removed from ${settingsPath}`);
+    return 0;
+  }
+
+  // --- Install path ---
+  const { settings: updated, alreadyInstalled } = applyInstall(readSettings(settingsPath));
   try {
-    writeFileSync(claudeMdPath, buildClaudeMdContent(), "utf-8");
+    writeSettings(settingsPath, updated);
   } catch (err) {
-    logger.error(`error: cannot write ${claudeMdPath}: ${String(err)}`);
+    logger.error(`error: cannot write ${settingsPath}: ${String(err)}`);
     return 1;
   }
 
-  logger.log(`yakcc hooks installed at ${claudeMdPath}`);
-  logger.log("slash command: /yakcc <intent>");
-  logger.log(`stub response: ${SLASH_COMMAND_STUB_MESSAGE}`);
+  // Remove the v0 CLAUDE.md facade stub (Sacred Practice #12 — no parallel mechanisms).
+  if (existsSync(claudeMdPath)) {
+    try {
+      rmSync(claudeMdPath);
+    } catch (err) {
+      logger.error(`warning: cannot remove v0 stub ${claudeMdPath}: ${String(err)}`);
+      // Non-fatal: the main install succeeded.
+    }
+  }
+
+  if (alreadyInstalled) {
+    logger.log(`yakcc hook already installed at ${settingsPath} (idempotent).`);
+  } else {
+    logger.log(`yakcc hook installed at ${settingsPath}`);
+    logger.log(`tool-call interception: ${HOOK_MATCHER} → ${HOOK_COMMAND}`);
+  }
   return 0;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -137,8 +137,9 @@ COMMANDS
             [--report <p>]            Per-file report (default: bootstrap/report.json)
   shave <path> [--registry <p>]       Shave a TS source file into atoms via universalize
         [--offline]
-  hooks claude-code install           Install /yakcc slash command for Claude Code
+  hooks claude-code install           Wire yakcc tool-call interception for Claude Code
                 [--target <dir>]      Target project directory (default: .)
+                [--uninstall]         Remove the yakcc hook entry
   federation serve --registry <p>     Start a read-only HTTP registry server
                 [--port <n>] [--host <h>]
   federation mirror --remote <url>    Mirror all blocks from a remote registry peer


### PR DESCRIPTION
## Summary

- Replaces the v0 `hooks-install.ts` facade (which wrote a `CLAUDE.md` documentation stub) with a real installer that writes a `PreToolUse` hook entry to `.claude/settings.json` per DEC-HOOK-LAYER-001 D-HOOK-2 (tool-call interception for `Edit|Write|MultiEdit` calls).
- Adds `--uninstall` flag that cleanly removes the yakcc hook entry while preserving other settings.json content (idempotent).
- Deletes the v0 `.claude/CLAUDE.md` stub on install (Sacred Practice #12 — no parallel mechanisms).
- Updates README `## IDE hook installation` section to reflect production wiring instead of the v0 facade caveat.
- Adds `packages/cli/src/commands/hooks-install.test.ts` with 11 test suites covering: fresh install, idempotent re-install, `--target` flag, CLAUDE.md removal, settings.json merge preservation, uninstall, uninstall-when-not-installed, idempotent uninstall, round-trip, and error paths.
- Updates two existing `cli.test.ts` assertions that tested the old CLAUDE.md facade behavior to match the new settings.json wiring.

## Test evidence

```
 RUN  v4.1.5 /home/user/yakcc/packages/cli

 Test Files  5 passed (5)
      Tests  94 passed (94)
   Start at  15:17:43
   Duration  83.64s (transform 2.39s, setup 0ms, import 7.69s, tests 112.00s, environment 1ms)
```

Closes #203

🤖 Picked up by FuckGoblin

---
_Generated by [Claude Code](https://claude.ai/code/session_0161sdLfG7PgYiEbhbn6xbPB)_