### PR TITLE
WI-V3-DISCOVERY-D5-HARNESS: evaluation harness + measurement-first baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ dist/
 .env.local
 .yakcc/
 tmp/
+# NOTE: tmp/discovery-eval/baseline-single-vector-2026-05-10.json and
+# tmp/discovery-eval/measurement-first-decision.md are committed via `git add --force`
+# (DEC-V3-DISCOVERY-D5-HARNESS-001: operator-facing decision input must survive reboots).
+# The `tmp/` rule above ignores them by default; git-add --force bypasses it for these files.
 .claude/
 .worktrees/
 

--- a/packages/registry/src/discovery-eval-helpers.ts
+++ b/packages/registry/src/discovery-eval-helpers.ts
@@ -1,0 +1,661 @@
+// SPDX-License-Identifier: MIT
+/**
+ * @decision DEC-V3-DISCOVERY-D5-HARNESS-001
+ * @title Evaluation harness helpers — D5 metric computation (M1..M5) + corpus schema
+ * @status accepted
+ * @rationale
+ *   This module implements the D5 ADR (docs/adr/discovery-quality-measurement.md) metric
+ *   computation functions for the discovery evaluation harness. Five decisions are captured here:
+ *
+ *   1. INLINE CORPUS SHAPE (5–10 entries, bootstrap baseline WI):
+ *      The bootstrap corpus includes 7 entries: 5 seed-derived from the 20 seed blocks
+ *      (ascii-char, digit, bracket, comma, integer) and 2 synthetic tasks (clamp + haversine
+ *      negative-space). This subset was chosen to exercise:
+ *        - The M1 "did we surface anything?" path (seed-derived positive entries)
+ *        - The M2/M4 "did top-1 match?" path (well-defined single-answer queries)
+ *        - The M5 "poor band" path (haversine negative-space ensures poor-band coverage)
+ *      Selection rationale: seed blocks chosen are the simplest, most distinctive specs in
+ *      the seed corpus; their behavior strings are maximally distinct, which matters for
+ *      BLAKE3-based offline provider testing (DEC-CI-OFFLINE-001).
+ *
+ *   2. OFFLINE PROVIDER BASELINE INTERPRETATION:
+ *      Per DEC-CI-OFFLINE-001, this harness uses the offline BLAKE3 provider for
+ *      deterministic CI runs. The offline provider produces vectors from BLAKE3 hashes, NOT
+ *      semantic embeddings — similar behavior strings do NOT produce nearby vectors. Therefore:
+ *        - M1–M4 baseline numbers with the offline provider measure hash-space proximity, not
+ *          semantic quality. They will be low (likely M1 < 0.50) because queries embedding
+ *          "Parse a digit" do not hash-close to the canonical JSON that was embedded at store time.
+ *        - The "real" M1..M5 baseline against DEC-EMBED-010 (transformers.js local provider) is
+ *          the operator-meaningful measurement. That baseline is produced by running the harness
+ *          with DISCOVERY_EVAL_PROVIDER=local (see measurement-first-decision.md).
+ *        - CI gates use offline provider for reproducibility. Local provider is operator's tool.
+ *
+ *   3. RELIABILITY DIAGRAM DEFERRAL:
+ *      The reliability diagram artifact (Q4 of D5 ADR) is implemented in this WI as the
+ *      `computeReliabilityDiagram()` function. Emission to `tmp/discovery-eval/` is gated on
+ *      the `DISCOVERY_EVAL_REPORT=1` environment variable. The actual file write is done in
+ *      `discovery-eval.test.ts` via the `emitReliabilityDiagram()` helper exported here.
+ *      Full corpus expansion (>=30 seed-derived + >=20 synthetic) defers to WI-V3-DISCOVERY-D5-CORPUS-SEED.
+ *
+ *   4. NEGATIVE-SPACE HANDLING:
+ *      Entries with `expectedAtom: null` are negative-space queries. For such entries:
+ *        - M1: top-1 combinedScore < 0.50 is the EXPECTED outcome (the system should return no hit)
+ *          but M1 counts the ACTUAL score, so a negative-space entry where top-1 >= 0.50 still
+ *          counts as a "hit" (and is a false hit — wrong behavior for the system).
+ *          Per ADR Q1, M1 measures ALL queries including negative-space ones.
+ *        - M2, M4 (MRR): skip for null expectedAtom (no correct atom exists).
+ *        - M3 (Recall@K): skip for null expectedAtom.
+ *
+ *   5. COSINE DISTANCE TO COMBINED SCORE MAPPING:
+ *      The existing `findCandidatesByIntent` path returns `cosineDistance` (lower = more similar).
+ *      The D5 ADR's M1 threshold is based on D3's `combinedScore` (in [0, 1], higher = better).
+ *      Linear mapping: combinedScore = max(0, 1 - cosineDistance/2). For unit-sphere vectors,
+ *      cosineDistance in [0, 2] maps to combinedScore in [0, 1]. The D3 band boundaries translate:
+ *        strong:    combinedScore >= 0.85
+ *        confident: combinedScore >= 0.70
+ *        weak:      combinedScore >= 0.50
+ *        poor:      combinedScore <  0.50
+ */
+
+import type { Registry } from "./index.js";
+
+// ---------------------------------------------------------------------------
+// D5 ADR corpus schema types (Q2 — verbatim from the ADR)
+// ---------------------------------------------------------------------------
+
+/**
+ * The QueryIntentCard shape used in benchmark entries.
+ * This is a structural subset of the full QueryIntentCard from D2 ADR.
+ * Only `behavior` is required; other fields are optional per D2.
+ */
+export interface BenchmarkQueryCard {
+  /** Freeform description of the desired behavior (required). */
+  readonly behavior: string;
+  /** Optional signature with named inputs/outputs. */
+  readonly signature?: {
+    readonly inputs?: ReadonlyArray<{ readonly name: string; readonly type: string }>;
+    readonly outputs?: ReadonlyArray<{ readonly name: string; readonly type: string }>;
+  };
+  /** Optional guarantees text for multi-dimensional querying. */
+  readonly guarantees?: readonly string[];
+  /** Optional error conditions for multi-dimensional querying. */
+  readonly errorConditions?: readonly string[];
+}
+
+/**
+ * One entry in a benchmark corpus file (Q2 of D5 ADR).
+ */
+export interface BenchmarkEntry {
+  /** Stable identifier; must be unique within the file. */
+  readonly id: string;
+  /** Source label; must match the file name. */
+  readonly source: "seed-derived" | "synthetic-tasks" | "captured-sessions";
+  /** The QueryIntentCard the LLM (or harness) would issue. */
+  readonly query: BenchmarkQueryCard;
+  /**
+   * The expected top-1 atom by BlockMerkleRoot.
+   * null for negative-space queries (no atom is correct).
+   */
+  readonly expectedAtom: string | null;
+  /**
+   * Optional: acceptable alternates for Recall@K.
+   * If omitted, only expectedAtom counts as correct.
+   */
+  readonly acceptableAtoms?: readonly string[];
+  /** Free-form note describing why this entry exists. */
+  readonly rationale: string;
+}
+
+/**
+ * The top-level structure of a benchmark corpus JSON file (Q2 of D5 ADR).
+ */
+export interface BenchmarkFile {
+  /** Schema version; bump on incompatible schema changes. */
+  readonly version: 1;
+  /** Source label (matches BenchmarkEntry.source for all entries). */
+  readonly source: BenchmarkEntry["source"];
+  /** Date the file was last edited (YYYY-MM-DD). */
+  readonly lastUpdated: string;
+  /** All entries in this file. */
+  readonly entries: readonly BenchmarkEntry[];
+}
+
+/**
+ * An entry in pending.json tracking registry coverage gaps (Q5 of D5 ADR).
+ */
+export interface PendingEntry {
+  /** Stable identifier (e.g. "pending-haversine-001"). */
+  readonly id: string;
+  /** The QueryIntentCard that did not produce a satisfactory result. */
+  readonly query: BenchmarkQueryCard;
+  /** Top-K candidates the system returned, captured at time of addition. */
+  readonly returnedCandidates: readonly {
+    readonly blockMerkleRoot: string;
+    readonly combinedScore: number;
+    readonly band: "strong" | "confident" | "weak" | "poor";
+    readonly perDimensionScores?: Record<string, number>;
+  }[];
+  /** CandidateNearMiss array (D3 §Q6) explaining filter failures. */
+  readonly nearMisses: readonly {
+    readonly blockMerkleRoot: string;
+    readonly failedAtLayer: "structural" | "strictness" | "property_test" | "min_score";
+    readonly failureReason: string;
+  }[];
+  /** Why this entry was added. */
+  readonly diagnosis: string;
+  /** The action that would close this entry. */
+  readonly proposedAction: string;
+  /** Date added (YYYY-MM-DD). */
+  readonly addedAt: string;
+  /** Set when gap is closed; null while still pending. */
+  readonly retiredAt: string | null;
+  /** Commit SHA or PR number that closed this entry; null while pending. */
+  readonly retiredBy: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Score band conversion (D3 ADR — cosineDistance to combinedScore)
+// ---------------------------------------------------------------------------
+
+/**
+ * Score band names as defined in D3 ADR.
+ */
+export type ScoreBand = "strong" | "confident" | "weak" | "poor";
+
+/**
+ * Convert a cosineDistance from sqlite-vec to D3's combinedScore.
+ *
+ * Linear mapping: combinedScore = max(0, 1 - cosineDistance/2).
+ * For L2-normalized unit vectors, cosineDistance in [0, 2] maps to combinedScore in [0, 1].
+ * This is consistent with the CandidateMatch.cosineDistance documentation.
+ */
+export function cosineDistanceToCombinedScore(cosineDistance: number): number {
+  return Math.max(0, Math.min(1, 1 - cosineDistance / 2));
+}
+
+/**
+ * Assign a D3 score band to a combinedScore.
+ *
+ * Band boundaries (D3 ADR §Q5):
+ *   strong:    combinedScore in [0.85, 1.00]
+ *   confident: combinedScore in [0.70, 0.85)
+ *   weak:      combinedScore in [0.50, 0.70)
+ *   poor:      combinedScore in [0.00, 0.50)
+ */
+export function assignScoreBand(combinedScore: number): ScoreBand {
+  if (combinedScore >= 0.85) return "strong";
+  if (combinedScore >= 0.7) return "confident";
+  if (combinedScore >= 0.5) return "weak";
+  return "poor";
+}
+
+/** Band midpoints as defined in D5 ADR Q1 / Q4. */
+export const BAND_MIDPOINTS: Record<ScoreBand, number> = {
+  strong: 0.925,
+  confident: 0.775,
+  weak: 0.6,
+  poor: 0.25,
+};
+
+// ---------------------------------------------------------------------------
+// Per-query result type (intermediate computation)
+// ---------------------------------------------------------------------------
+
+/** Result of running a single BenchmarkEntry through the registry. */
+export interface QueryResult {
+  readonly entryId: string;
+  readonly expectedAtom: string | null;
+  readonly acceptableAtoms: readonly string[];
+  /** combinedScore of top-1 result (0 if no results returned). */
+  readonly top1Score: number;
+  /** BlockMerkleRoot of top-1 result (null if no results returned). */
+  readonly top1Atom: string | null;
+  /** Band assigned to top-1 score. */
+  readonly top1Band: ScoreBand;
+  /** Whether top-1 is "correct": hash match or in acceptableAtoms. */
+  readonly top1Correct: boolean;
+  /** Rank of expectedAtom in results (1-based), or null if not found. */
+  readonly expectedAtomRank: number | null;
+  /** All results from findCandidatesByIntent (up to K). */
+  readonly allAtoms: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Corpus query runner
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a BenchmarkEntry's query to the IntentQuery shape expected by
+ * findCandidatesByIntent.
+ */
+function benchmarkQueryToIntentQuery(q: BenchmarkQueryCard): {
+  behavior: string;
+  inputs: ReadonlyArray<{ name: string; typeHint: string }>;
+  outputs: ReadonlyArray<{ name: string; typeHint: string }>;
+} {
+  const inputs = (q.signature?.inputs ?? []).map((p) => ({
+    name: p.name,
+    typeHint: p.type,
+  }));
+  const outputs = (q.signature?.outputs ?? []).map((p) => ({
+    name: p.name,
+    typeHint: p.type,
+  }));
+  return { behavior: q.behavior, inputs, outputs };
+}
+
+/**
+ * Run all benchmark entries against the registry and return per-entry results.
+ *
+ * @param registry - The open Registry instance to query.
+ * @param entries  - The benchmark corpus entries.
+ * @param topK     - How many candidates to retrieve (default 10, matching D2 default).
+ */
+export async function runBenchmarkEntries(
+  registry: Registry,
+  entries: readonly BenchmarkEntry[],
+  topK = 10,
+): Promise<readonly QueryResult[]> {
+  const results: QueryResult[] = [];
+
+  for (const entry of entries) {
+    const intentQuery = benchmarkQueryToIntentQuery(entry.query);
+    const candidates = await registry.findCandidatesByIntent(intentQuery, { k: topK });
+
+    const allAtoms = candidates.map((c) => c.block.blockMerkleRoot as string);
+    const top1 = candidates[0];
+
+    const top1Score = top1 !== undefined ? cosineDistanceToCombinedScore(top1.cosineDistance) : 0;
+    const top1Atom = top1 !== undefined ? (top1.block.blockMerkleRoot as string) : null;
+    const top1Band = assignScoreBand(top1Score);
+
+    const acceptableAtoms = entry.acceptableAtoms ?? [];
+    const allCorrect =
+      entry.expectedAtom !== null ? [entry.expectedAtom, ...acceptableAtoms] : acceptableAtoms;
+
+    const top1Correct = top1Atom !== null && allCorrect.length > 0 && allCorrect.includes(top1Atom);
+
+    // Find expectedAtom rank (1-based)
+    let expectedAtomRank: number | null = null;
+    if (entry.expectedAtom !== null) {
+      const idx = allAtoms.indexOf(entry.expectedAtom);
+      if (idx === -1 && acceptableAtoms.length > 0) {
+        // Check if any acceptable atom appears in results
+        for (const alt of acceptableAtoms) {
+          const altIdx = allAtoms.indexOf(alt);
+          if (altIdx !== -1 && (expectedAtomRank === null || altIdx + 1 < expectedAtomRank)) {
+            expectedAtomRank = altIdx + 1;
+          }
+        }
+      } else if (idx !== -1) {
+        expectedAtomRank = idx + 1;
+      }
+    }
+
+    results.push({
+      entryId: entry.id,
+      expectedAtom: entry.expectedAtom,
+      acceptableAtoms,
+      top1Score,
+      top1Atom,
+      top1Band,
+      top1Correct,
+      expectedAtomRank,
+      allAtoms,
+    });
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// M1: Hit rate
+// ---------------------------------------------------------------------------
+
+/**
+ * M1 — Hit rate: % of queries where top-1 combinedScore >= 0.50 (weak band entry).
+ *
+ * Per D5 ADR Q1: "% of queries where top-1 combinedScore >= 0.50".
+ * ALL entries are included (including negative-space entries with expectedAtom=null).
+ * A negative-space entry where top-1 scores >= 0.50 still counts as a "hit" (false hit).
+ * Target: >= 0.80.
+ *
+ * @param results - Per-query results from runBenchmarkEntries.
+ * @returns Hit rate in [0, 1].
+ */
+export function computeHitRate(results: readonly QueryResult[]): number {
+  if (results.length === 0) return 0;
+  const hits = results.filter((r) => r.top1Score >= 0.5).length;
+  return hits / results.length;
+}
+
+/**
+ * Return the top-N entries contributing most to hit-rate failure
+ * (those with the lowest top1Score). Used for CI diagnostics per D5 ADR Q6.
+ */
+export function worstHitRateEntries(
+  results: readonly QueryResult[],
+  n = 3,
+): readonly QueryResult[] {
+  return [...results].sort((a, b) => a.top1Score - b.top1Score).slice(0, n);
+}
+
+// ---------------------------------------------------------------------------
+// M2: Precision@1
+// ---------------------------------------------------------------------------
+
+/**
+ * M2 — Precision@1: % of queries where top-1 hash matches expectedAtom.
+ *
+ * Per D5 ADR Q1: "% of queries where top-1 candidate's BlockMerkleRoot equals expectedAtom".
+ * Only entries with expectedAtom !== null are included (negative-space entries are skipped).
+ * Target: >= 0.70.
+ *
+ * @param results - Per-query results from runBenchmarkEntries.
+ * @returns Precision@1 in [0, 1], or 0 if no eligible entries.
+ */
+export function computePrecisionAt1(results: readonly QueryResult[]): number {
+  const eligible = results.filter((r) => r.expectedAtom !== null);
+  if (eligible.length === 0) return 0;
+  const correct = eligible.filter((r) => r.top1Correct).length;
+  return correct / eligible.length;
+}
+
+/**
+ * Return the top-N entries contributing most to precision@1 failure
+ * (eligible entries where top-1 was wrong, sorted by top1Score ascending).
+ */
+export function worstPrecisionAt1Entries(
+  results: readonly QueryResult[],
+  n = 3,
+): readonly QueryResult[] {
+  return results
+    .filter((r) => r.expectedAtom !== null && !r.top1Correct)
+    .sort((a, b) => a.top1Score - b.top1Score)
+    .slice(0, n);
+}
+
+// ---------------------------------------------------------------------------
+// M3: Recall@K
+// ---------------------------------------------------------------------------
+
+/**
+ * M3 — Recall@K: % of queries where expectedAtom is in top-K candidates.
+ *
+ * Per D5 ADR Q1: "% of queries where expectedAtom is in top-10 candidates".
+ * Only entries with expectedAtom !== null are included.
+ * K should match topK used in runBenchmarkEntries (default 10).
+ * Target: >= 0.90.
+ *
+ * @param results - Per-query results from runBenchmarkEntries.
+ * @returns Recall@K in [0, 1], or 0 if no eligible entries.
+ */
+export function computeRecallAtK(results: readonly QueryResult[]): number {
+  const eligible = results.filter((r) => r.expectedAtom !== null);
+  if (eligible.length === 0) return 0;
+  const found = eligible.filter((r) => r.expectedAtomRank !== null).length;
+  return found / eligible.length;
+}
+
+/**
+ * Return the top-N entries contributing most to recall failure
+ * (eligible entries where expectedAtom was not in top-K, sorted by top1Score ascending).
+ */
+export function worstRecallEntries(results: readonly QueryResult[], n = 3): readonly QueryResult[] {
+  return results
+    .filter((r) => r.expectedAtom !== null && r.expectedAtomRank === null)
+    .sort((a, b) => a.top1Score - b.top1Score)
+    .slice(0, n);
+}
+
+// ---------------------------------------------------------------------------
+// M4: MRR (Mean Reciprocal Rank)
+// ---------------------------------------------------------------------------
+
+/**
+ * M4 — MRR: mean of 1/rank where rank is the position of expectedAtom in results.
+ *
+ * Per D5 ADR Q1: "mean of 1/rank where rank is the position of expectedAtom in the result
+ * list, or 0 if absent". Only entries with expectedAtom !== null are included.
+ * Target: >= 0.70.
+ *
+ * @param results - Per-query results from runBenchmarkEntries.
+ * @returns MRR in [0, 1], or 0 if no eligible entries.
+ */
+export function computeMRR(results: readonly QueryResult[]): number {
+  const eligible = results.filter((r) => r.expectedAtom !== null);
+  if (eligible.length === 0) return 0;
+  const sum = eligible.reduce((acc, r) => {
+    const rank = r.expectedAtomRank;
+    return acc + (rank !== null ? 1 / rank : 0);
+  }, 0);
+  return sum / eligible.length;
+}
+
+/**
+ * Return the top-N entries contributing most to MRR failure
+ * (eligible entries with worst per-entry RR, i.e. not found or low rank).
+ */
+export function worstMRREntries(results: readonly QueryResult[], n = 3): readonly QueryResult[] {
+  return results
+    .filter((r) => r.expectedAtom !== null)
+    .sort((a, b) => {
+      const rrA = a.expectedAtomRank !== null ? 1 / a.expectedAtomRank : 0;
+      const rrB = b.expectedAtomRank !== null ? 1 / b.expectedAtomRank : 0;
+      return rrA - rrB;
+    })
+    .slice(0, n);
+}
+
+// ---------------------------------------------------------------------------
+// M5: Score calibration error (per-band Brier)
+// ---------------------------------------------------------------------------
+
+/** Per-band calibration data. */
+export interface BandCalibrationData {
+  /** Number of queries whose top-1 fell in this band. */
+  readonly N: number;
+  /** Number of those queries that were also "correct" (top-1 hash match). */
+  readonly correct: number;
+  /** Observed precision in this band: correct / N. Null if N=0. */
+  readonly P: number | null;
+  /** Band midpoint as defined in D5 ADR Q4. */
+  readonly midpoint: number;
+  /** Squared deviation from midpoint: (P - midpoint)^2. Null if N=0. */
+  readonly brier: number | null;
+}
+
+/** Per-band Brier results for M5. */
+export interface BrierPerBand {
+  readonly strong: BandCalibrationData;
+  readonly confident: BandCalibrationData;
+  readonly weak: BandCalibrationData;
+  readonly poor: BandCalibrationData;
+}
+
+/**
+ * M5 — Score calibration error: Brier score per D3 band.
+ *
+ * Per D5 ADR Q1 + Q4: for each band, compute (P_b - m_b)^2 where P_b is the
+ * observed precision in that band and m_b is the band midpoint. Returns null
+ * for empty bands (N=0). The target is each err_b < 0.10.
+ *
+ * "Correct" for calibration = same predicate as M2 (top-1 hash match or in acceptableAtoms).
+ * Entries with expectedAtom=null are NOT excluded — they cannot be "correct"
+ * (null expectedAtom means no correct atom), so they contribute to the "incorrect" count.
+ *
+ * Per D5 ADR Q4: "If N_b = 0 for any band, that band contributes 0 to the calibration error
+ * and is reported as 'no data'". Callers should warn when N=0.
+ *
+ * @param results - Per-query results from runBenchmarkEntries.
+ * @returns Per-band calibration data.
+ */
+export function computeBrierPerBand(results: readonly QueryResult[]): BrierPerBand {
+  const bandCounts: Record<ScoreBand, { N: number; correct: number }> = {
+    strong: { N: 0, correct: 0 },
+    confident: { N: 0, correct: 0 },
+    weak: { N: 0, correct: 0 },
+    poor: { N: 0, correct: 0 },
+  };
+
+  for (const r of results) {
+    const band = r.top1Band;
+    const counts = bandCounts[band];
+    counts.N++;
+    // "correct" = top-1 hash match. For null expectedAtom, top1Correct is always false.
+    if (r.top1Correct) counts.correct++;
+  }
+
+  function buildData(band: ScoreBand): BandCalibrationData {
+    const { N, correct } = bandCounts[band];
+    const midpoint = BAND_MIDPOINTS[band];
+    if (N === 0) {
+      return { N: 0, correct: 0, P: null, midpoint, brier: null };
+    }
+    const P = correct / N;
+    const brier = (P - midpoint) ** 2;
+    return { N, correct, P, midpoint, brier };
+  }
+
+  return {
+    strong: buildData("strong"),
+    confident: buildData("confident"),
+    weak: buildData("weak"),
+    poor: buildData("poor"),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Reliability diagram artifact (D5 ADR Q4)
+// ---------------------------------------------------------------------------
+
+/** The reliability diagram artifact format (Q4 of D5 ADR). */
+export interface ReliabilityDiagram {
+  readonly corpus: string;
+  readonly head_sha: string;
+  readonly generated_at: string;
+  readonly provider: string;
+  readonly bands: {
+    readonly strong: BandCalibrationData;
+    readonly confident: BandCalibrationData;
+    readonly weak: BandCalibrationData;
+    readonly poor: BandCalibrationData;
+  };
+}
+
+/**
+ * Compute the reliability diagram data structure for a corpus.
+ *
+ * @param corpusSource - The corpus source label (e.g. "seed-derived").
+ * @param results      - Per-query results from runBenchmarkEntries.
+ * @param headSha      - Git HEAD SHA at time of measurement.
+ * @param provider     - Embedding provider modelId used.
+ * @returns The ReliabilityDiagram artifact (ready to JSON-serialize).
+ */
+export function computeReliabilityDiagram(
+  corpusSource: string,
+  results: readonly QueryResult[],
+  headSha: string,
+  provider: string,
+): ReliabilityDiagram {
+  const brier = computeBrierPerBand(results);
+  return {
+    corpus: corpusSource,
+    head_sha: headSha,
+    generated_at: new Date().toISOString(),
+    provider,
+    bands: brier,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Baseline JSON artifact format
+// ---------------------------------------------------------------------------
+
+/** The baseline measurement artifact written to tmp/discovery-eval/. */
+export interface BaselineMeasurement {
+  readonly version: 1;
+  readonly date: string;
+  readonly head_sha: string;
+  readonly provider: string;
+  readonly corpus_source: string;
+  readonly corpus_entries: number;
+  readonly metrics: {
+    readonly M1_hit_rate: number;
+    readonly M1_target: 0.8;
+    readonly M1_pass: boolean;
+    readonly M2_precision_at_1: number;
+    readonly M2_target: 0.7;
+    readonly M2_pass: boolean;
+    readonly M3_recall_at_10: number;
+    readonly M3_target: 0.9;
+    readonly M3_pass: boolean;
+    readonly M4_mrr: number;
+    readonly M4_target: 0.7;
+    readonly M4_pass: boolean;
+    readonly M5_brier_per_band: BrierPerBand;
+    readonly M5_target: 0.1;
+    readonly M5_pass: boolean;
+  };
+  readonly worst_entries: {
+    readonly M1: readonly string[];
+    readonly M2: readonly string[];
+    readonly M3: readonly string[];
+    readonly M4: readonly string[];
+  };
+  readonly provider_note?: string;
+}
+
+/**
+ * Compute the full baseline measurement artifact for a corpus.
+ */
+export function computeBaseline(
+  corpusSource: string,
+  entries: readonly BenchmarkEntry[],
+  results: readonly QueryResult[],
+  headSha: string,
+  provider: string,
+  providerNote?: string,
+): BaselineMeasurement {
+  const M1 = computeHitRate(results);
+  const M2 = computePrecisionAt1(results);
+  const M3 = computeRecallAtK(results);
+  const M4 = computeMRR(results);
+  const M5 = computeBrierPerBand(results);
+
+  // M5 passes if every non-empty band has brier < 0.10
+  const M5pass = Object.values(M5).every((b) => b.brier === null || b.brier < 0.1);
+
+  return {
+    version: 1,
+    date: new Date().toISOString().split("T")[0] ?? "unknown",
+    head_sha: headSha,
+    provider,
+    corpus_source: corpusSource,
+    corpus_entries: entries.length,
+    metrics: {
+      M1_hit_rate: M1,
+      M1_target: 0.8,
+      M1_pass: M1 >= 0.8,
+      M2_precision_at_1: M2,
+      M2_target: 0.7,
+      M2_pass: M2 >= 0.7,
+      M3_recall_at_10: M3,
+      M3_target: 0.9,
+      M3_pass: M3 >= 0.9,
+      M4_mrr: M4,
+      M4_target: 0.7,
+      M4_pass: M4 >= 0.7,
+      M5_brier_per_band: M5,
+      M5_target: 0.1,
+      M5_pass: M5pass,
+    },
+    worst_entries: {
+      M1: worstHitRateEntries(results, 3).map((r) => r.entryId),
+      M2: worstPrecisionAt1Entries(results, 3).map((r) => r.entryId),
+      M3: worstRecallEntries(results, 3).map((r) => r.entryId),
+      M4: worstMRREntries(results, 3).map((r) => r.entryId),
+    },
+    ...(providerNote !== undefined ? { provider_note: providerNote } : {}),
+  };
+}

--- a/packages/registry/src/discovery-eval.test.ts
+++ b/packages/registry/src/discovery-eval.test.ts
@@ -1,0 +1,981 @@
+// SPDX-License-Identifier: MIT
+/**
+ * discovery-eval.test.ts — D5 evaluation harness for v3 discovery quality measurement.
+ *
+ * WI-V3-DISCOVERY-D5-HARNESS (issue #200)
+ *
+ * PURPOSE:
+ *   This is the measurement-first guardrail per DEC-V3-INITIATIVE-001. It runs M1..M5
+ *   against the existing single-vector embedding path (findCandidatesByIntent) to determine
+ *   whether single-vector already meets the >=80% M1 target before committing to the
+ *   5x storage cost of D1's multi-dimensional schema.
+ *
+ * PROVIDER STRATEGY:
+ *   CI runs use the offline BLAKE3 provider (DEC-CI-OFFLINE-001) for determinism.
+ *   The offline provider does NOT produce semantic embeddings — it hashes text deterministically.
+ *   Therefore:
+ *     - CI tests do NOT assert M1>=0.80 against offline provider (that would always fail).
+ *     - CI tests assert that the HARNESS ITSELF is correct (metric math, corpus schema, types).
+ *     - The operator-facing baseline (real M1..M5 numbers) is produced by running with
+ *       DISCOVERY_EVAL_PROVIDER=local which uses the transformers.js semantic provider.
+ *     - The baseline JSON artifact is committed to tmp/discovery-eval/ (see acceptance criteria).
+ *
+ *   When DISCOVERY_EVAL_PROVIDER=local is set, the test spawns with the local provider and
+ *   the expect() gates use real targets. Without it, targets are skipped and only the
+ *   artifact-emission and metric-computation correctness is verified.
+ *
+ * CORPUS:
+ *   This WI ships a 9-entry bootstrap corpus (5 seed-derived + 4 synthetic).
+ *   The expectedAtom values are discovered at test runtime from the live in-memory registry —
+ *   they are NOT hardcoded hashes (which would break whenever seed blocks are regenerated).
+ *   Full corpus authoring (>=30 + >=20) is WI-V3-DISCOVERY-D5-CORPUS-SEED.
+ *
+ * DEPENDENCY NOTE:
+ *   @yakcc/seeds is NOT a dependency of @yakcc/registry (circular-dep avoidance, same grounds
+ *   as DEC-VECTOR-RETRIEVAL-004). The 5 seed-derived corpus blocks are constructed inline from
+ *   their SpecYak data using @yakcc/contracts (which IS a registry dependency). This mirrors
+ *   the pattern used by vector-search.test.ts.
+ *
+ * PRODUCTION SEQUENCE EXERCISED:
+ *   openRegistry (offline/local provider) → storeBlock ×5 →
+ *   findCandidatesByIntent ×N (corpus queries) →
+ *   computeHitRate/computePrecisionAt1/computeRecallAtK/computeMRR/computeBrierPerBand →
+ *   baseline JSON artifact emission → measurement-first-decision.md
+ */
+
+import { execSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  type CanonicalAstHash,
+  type EmbeddingProvider,
+  type ProofManifest,
+  type SpecYak,
+  blockMerkleRoot,
+  canonicalize,
+  createLocalEmbeddingProvider,
+  createOfflineEmbeddingProvider,
+  canonicalAstHash as deriveCanonicalAstHash,
+  specHash as deriveSpecHash,
+} from "@yakcc/contracts";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { BenchmarkEntry } from "./discovery-eval-helpers.js";
+import {
+  computeBaseline,
+  computeBrierPerBand,
+  computeHitRate,
+  computeMRR,
+  computePrecisionAt1,
+  computeRecallAtK,
+  computeReliabilityDiagram,
+  runBenchmarkEntries,
+  worstHitRateEntries,
+  worstMRREntries,
+  worstPrecisionAt1Entries,
+  worstRecallEntries,
+} from "./discovery-eval-helpers.js";
+import type { BlockTripletRow, Registry } from "./index.js";
+import { openRegistry } from "./storage.js";
+
+// ---------------------------------------------------------------------------
+// Provider selection
+// ---------------------------------------------------------------------------
+
+const USE_LOCAL_PROVIDER = process.env.DISCOVERY_EVAL_PROVIDER === "local";
+const EMIT_REPORT = process.env.DISCOVERY_EVAL_REPORT === "1" || USE_LOCAL_PROVIDER;
+
+// ---------------------------------------------------------------------------
+// Inline seed block specs (5 chosen from the 20 seed blocks)
+// These are verbatim copies of the spec.yak JSON from packages/seeds/src/blocks/.
+// Kept inline to avoid a circular @yakcc/seeds dependency (DEC-VECTOR-RETRIEVAL-004 rationale).
+// The 5 blocks chosen (ascii-char, digit, bracket, comma, integer) are the most
+// semantically distinct in the seed corpus, maximizing KNN separability.
+// ---------------------------------------------------------------------------
+
+const SEED_SPECS: ReadonlyArray<SpecYak & { readonly _blockName: string }> = [
+  {
+    _blockName: "ascii-char",
+    name: "ascii-char",
+    inputs: [
+      { name: "input", type: "string" },
+      { name: "position", type: "number" },
+    ],
+    outputs: [{ name: "char", type: "string" }],
+    preconditions: [],
+    postconditions: [],
+    invariants: [],
+    effects: [],
+    level: "L0",
+    behavior:
+      "Return the single ASCII character at the given zero-based position in the input string. Throws RangeError if position is out of bounds or the character code is above 127.",
+    guarantees: [
+      { id: "pure", description: "Referentially transparent; no side effects." },
+      { id: "length-1", description: "Returned string always has length 1." },
+      { id: "ascii", description: "Returned character has char code <= 127." },
+    ],
+    errorConditions: [
+      { description: "position < 0 or position >= input.length.", errorType: "RangeError" },
+      { description: "Character at position has code > 127.", errorType: "RangeError" },
+    ],
+    nonFunctional: { time: "O(1)", space: "O(1)", purity: "pure", threadSafety: "safe" },
+    propertyTests: [
+      { id: "ascii-char-first", description: "asciiChar('abc', 0) returns 'a'" },
+      { id: "ascii-char-middle", description: "asciiChar('abc', 1) returns 'b'" },
+      { id: "ascii-char-oob", description: "asciiChar('abc', 3) throws RangeError" },
+      { id: "ascii-char-negative", description: "asciiChar('abc', -1) throws RangeError" },
+      {
+        id: "ascii-char-non-ascii",
+        description: "asciiChar('aéb', 1) throws RangeError",
+      },
+    ],
+  } as SpecYak & { readonly _blockName: string },
+  {
+    _blockName: "digit",
+    name: "digit",
+    inputs: [{ name: "s", type: "string" }],
+    outputs: [{ name: "result", type: "number" }],
+    preconditions: [],
+    postconditions: [],
+    invariants: [],
+    effects: [],
+    level: "L0",
+    behavior:
+      "Parse a single ASCII digit character '0'-'9' to its integer value 0-9. Throws RangeError if the input is not exactly one character in the range '0' to '9'.",
+    guarantees: [
+      { id: "pure", description: "Referentially transparent; no side effects." },
+      { id: "range", description: "Result is an integer in the closed range [0, 9]." },
+      {
+        id: "inverse",
+        description: "digit(String.fromCharCode(48 + n)) === n for n in [0,9].",
+      },
+    ],
+    errorConditions: [
+      { description: "Input is not exactly one character.", errorType: "RangeError" },
+      { description: "Input character is not in '0'-'9'.", errorType: "RangeError" },
+    ],
+    nonFunctional: { time: "O(1)", space: "O(1)", purity: "pure", threadSafety: "safe" },
+    propertyTests: [
+      { id: "digit-zero", description: "digit('0') returns 0" },
+      { id: "digit-nine", description: "digit('9') returns 9" },
+      { id: "digit-five", description: "digit('5') returns 5" },
+      { id: "digit-non-numeric", description: "digit('a') throws RangeError" },
+      { id: "digit-empty", description: "digit('') throws RangeError" },
+      { id: "digit-multi-char", description: "digit('12') throws RangeError" },
+    ],
+  } as SpecYak & { readonly _blockName: string },
+  {
+    _blockName: "bracket",
+    name: "bracket",
+    inputs: [
+      { name: "input", type: "string" },
+      { name: "position", type: "number" },
+      { name: "kind", type: "'[' | ']'" },
+    ],
+    outputs: [{ name: "newPosition", type: "number" }],
+    preconditions: [],
+    postconditions: [],
+    invariants: [],
+    effects: [],
+    level: "L0",
+    behavior:
+      "Assert that the character at position equals kind ('[' or ']'), then return position + 1. Throws SyntaxError if the character does not match or if position is out of bounds.",
+    guarantees: [
+      { id: "pure", description: "Referentially transparent; no side effects." },
+      { id: "advance-1", description: "Returns position + 1 on success." },
+    ],
+    errorConditions: [
+      {
+        description: "Character at position does not equal kind.",
+        errorType: "SyntaxError",
+      },
+      { description: "position >= input.length (end of input).", errorType: "SyntaxError" },
+      { description: "position < 0.", errorType: "RangeError" },
+    ],
+    nonFunctional: { time: "O(1)", space: "O(1)", purity: "pure", threadSafety: "safe" },
+    propertyTests: [
+      { id: "bracket-open", description: "bracket('[abc', 0, '[') returns 1" },
+      { id: "bracket-close", description: "bracket(']', 0, ']') returns 1" },
+      { id: "bracket-mismatch", description: "bracket('[', 0, ']') throws SyntaxError" },
+      { id: "bracket-oob", description: "bracket('', 0, '[') throws SyntaxError" },
+      { id: "bracket-negative", description: "bracket('[', -1, '[') throws RangeError" },
+    ],
+  } as SpecYak & { readonly _blockName: string },
+  {
+    _blockName: "comma",
+    name: "comma",
+    inputs: [
+      { name: "input", type: "string" },
+      { name: "position", type: "number" },
+    ],
+    outputs: [{ name: "newPosition", type: "number" }],
+    preconditions: [],
+    postconditions: [],
+    invariants: [],
+    effects: [],
+    level: "L0",
+    behavior:
+      "Match a literal ',' at the given position in the input string, returning the new position after the comma. Throws SyntaxError if the character at position is not ','.",
+    guarantees: [
+      { id: "pure", description: "Referentially transparent; no side effects." },
+      { id: "advance-1", description: "Returns position + 1 on success." },
+    ],
+    errorConditions: [
+      {
+        description: "Character at position is not ','.",
+        errorType: "SyntaxError",
+      },
+    ],
+    nonFunctional: { time: "O(1)", space: "O(1)", purity: "pure", threadSafety: "safe" },
+    propertyTests: [
+      { id: "comma-match", description: "comma(',abc', 0) returns 1" },
+      { id: "comma-mismatch", description: "comma('abc', 0) throws SyntaxError" },
+    ],
+  } as SpecYak & { readonly _blockName: string },
+  {
+    _blockName: "integer",
+    name: "integer",
+    inputs: [
+      { name: "input", type: "string" },
+      { name: "position", type: "number" },
+    ],
+    outputs: [
+      { name: "value", type: "number" },
+      { name: "newPosition", type: "number" },
+    ],
+    preconditions: [],
+    postconditions: [],
+    invariants: [],
+    effects: [],
+    level: "L0",
+    behavior:
+      "Parse a sequence of ASCII digit characters starting at position in the input string and return the parsed integer value and the new position after the digits.",
+    guarantees: [
+      { id: "pure", description: "Referentially transparent; no side effects." },
+      {
+        id: "advances",
+        description: "newPosition > position when at least one digit is consumed.",
+      },
+    ],
+    errorConditions: [
+      {
+        description: "No digit character found at the given position.",
+        errorType: "SyntaxError",
+      },
+    ],
+    nonFunctional: { time: "O(n)", space: "O(1)", purity: "pure", threadSafety: "safe" },
+    propertyTests: [
+      { id: "integer-single", description: "integer('3', 0) returns {value:3, newPosition:1}" },
+      {
+        id: "integer-multi",
+        description: "integer('123', 0) returns {value:123, newPosition:3}",
+      },
+      { id: "integer-non-digit", description: "integer('abc', 0) throws SyntaxError" },
+    ],
+  } as SpecYak & { readonly _blockName: string },
+];
+
+// ---------------------------------------------------------------------------
+// Block builder (mirrors vector-search.test.ts pattern, avoids @yakcc/seeds dep)
+// ---------------------------------------------------------------------------
+
+/** Minimal L0 ProofManifest for inline test blocks. */
+function makeManifest(): ProofManifest {
+  return { artifacts: [{ kind: "property_tests", path: "property_tests.ts" }] };
+}
+
+/** Build a BlockTripletRow from a SpecYak (inline corpus construction). */
+function makeBlockRowFromSpec(spec: SpecYak): BlockTripletRow {
+  const src = `export function impl(..._args: unknown[]): unknown { /* ${spec.name} */ return undefined; }`;
+  const manifest = makeManifest();
+  const artifactBytes = new TextEncoder().encode("// property tests");
+  const artifacts = new Map<string, Uint8Array>([["property_tests.ts", artifactBytes]]);
+
+  const root = blockMerkleRoot({ spec, implSource: src, manifest, artifacts });
+  const sh = deriveSpecHash(spec);
+  const canonicalBytes = canonicalize(spec as unknown as Parameters<typeof canonicalize>[0]);
+
+  return {
+    blockMerkleRoot: root,
+    specHash: sh,
+    specCanonicalBytes: canonicalBytes,
+    implSource: src,
+    proofManifestJson: JSON.stringify(manifest),
+    level: "L0",
+    createdAt: 0,
+    canonicalAstHash: deriveCanonicalAstHash(src) as CanonicalAstHash,
+    artifacts,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test lifecycle
+// ---------------------------------------------------------------------------
+
+let registry: Registry;
+let embeddingProvider: EmbeddingProvider;
+/** BlockMerkleRoot map: seed block name → merkle root (discovered at runtime). */
+const seedRoots = new Map<string, string>();
+
+beforeAll(async () => {
+  embeddingProvider = USE_LOCAL_PROVIDER
+    ? createLocalEmbeddingProvider()
+    : createOfflineEmbeddingProvider();
+
+  registry = await openRegistry(":memory:", { embeddings: embeddingProvider });
+
+  // Store the 5 inline seed blocks and capture their merkle roots by name.
+  for (const spec of SEED_SPECS) {
+    const row = makeBlockRowFromSpec(spec);
+    await registry.storeBlock(row);
+    seedRoots.set(spec._blockName, row.blockMerkleRoot as string);
+  }
+}, 60_000); // allow time for local provider model download if needed
+
+afterAll(async () => {
+  await registry.close();
+});
+
+// ---------------------------------------------------------------------------
+// Bootstrap corpus (5 seed-derived + 4 synthetic)
+//
+// @decision DEC-V3-DISCOVERY-D5-HARNESS-001 (corpus shape):
+//   9 entries chosen for maximal discriminability with the offline BLAKE3 provider:
+//   - 5 seed-derived: behavior strings are distinct enough that BLAKE3 hash distances
+//     differ meaningfully between corpus query and stored canonical JSON embedding.
+//     ascii-char, digit, bracket, comma, integer chosen as most self-contained seeds.
+//   - 4 synthetic: clamp (positive, multi-dim), haversine-neg (negative-space, poor-band),
+//     parse-float (positive, simple), validate-email (positive, realistic LLM task).
+//   expectedAtom values are resolved at runtime from seedRoots — NOT hardcoded hashes.
+//   Full corpus (>=30 + >=20) is WI-V3-DISCOVERY-D5-CORPUS-SEED.
+// ---------------------------------------------------------------------------
+
+function buildCorpus(): readonly BenchmarkEntry[] {
+  return [
+    // --- Seed-derived (5 entries) ---
+    {
+      id: "seed-ascii-char-001",
+      source: "seed-derived",
+      query: {
+        behavior:
+          "Return the single ASCII character at the given zero-based position in the input string. Throws RangeError if position is out of bounds or the character code is above 127.",
+        signature: {
+          inputs: [
+            { name: "input", type: "string" },
+            { name: "position", type: "number" },
+          ],
+          outputs: [{ name: "char", type: "string" }],
+        },
+      },
+      expectedAtom: seedRoots.get("ascii-char") ?? null,
+      rationale:
+        "ascii-char is a canonical seed block with well-defined boundary conditions. Tests M1/M2 strong-band path with exact behavior text match.",
+    },
+    {
+      id: "seed-digit-001",
+      source: "seed-derived",
+      query: {
+        behavior:
+          "Parse a single ASCII digit character '0'-'9' to its integer value 0-9. Throws RangeError if the input is not exactly one character in the range '0' to '9'.",
+        signature: {
+          inputs: [{ name: "s", type: "string" }],
+          outputs: [{ name: "result", type: "number" }],
+        },
+      },
+      expectedAtom: seedRoots.get("digit") ?? null,
+      rationale:
+        "digit block has a distinct short behavior string. Tests M2 exact hash match and M4 MRR rank-1 path.",
+    },
+    {
+      id: "seed-bracket-001",
+      source: "seed-derived",
+      query: {
+        behavior:
+          "Assert that the character at position equals kind ('[' or ']'), then return position + 1. Throws SyntaxError if the character does not match or if position is out of bounds.",
+        signature: {
+          inputs: [
+            { name: "input", type: "string" },
+            { name: "position", type: "number" },
+            { name: "kind", type: "'[' | ']'" },
+          ],
+          outputs: [{ name: "newPosition", type: "number" }],
+        },
+      },
+      expectedAtom: seedRoots.get("bracket") ?? null,
+      rationale:
+        "bracket has a 3-input signature, exercising multi-param query path. Tests M3 recall.",
+    },
+    {
+      id: "seed-comma-001",
+      source: "seed-derived",
+      query: {
+        behavior:
+          "Match a literal ',' at the given position in the input string, returning the new position after the comma. Throws SyntaxError if the character at position is not ','.",
+      },
+      expectedAtom: seedRoots.get("comma") ?? null,
+      rationale:
+        "comma block has minimal signature (no explicit params in query), testing behavior-only query path.",
+    },
+    {
+      id: "seed-integer-001",
+      source: "seed-derived",
+      query: {
+        behavior:
+          "Parse a sequence of ASCII digit characters starting at position in the input string and return the parsed integer value and the new position after the digits.",
+        signature: {
+          inputs: [
+            { name: "input", type: "string" },
+            { name: "position", type: "number" },
+          ],
+          outputs: [
+            { name: "value", type: "number" },
+            { name: "newPosition", type: "number" },
+          ],
+        },
+      },
+      expectedAtom: seedRoots.get("integer") ?? null,
+      rationale:
+        "integer has a 2-output signature, exercising multi-output query. Tests M3/M4 with a more complex block.",
+    },
+
+    // --- Synthetic tasks (4 entries) ---
+    {
+      id: "synth-clamp-001",
+      source: "synthetic-tasks",
+      query: {
+        behavior: "clamp a number between a lower bound and upper bound",
+        signature: {
+          inputs: [
+            { name: "x", type: "number" },
+            { name: "lo", type: "number" },
+            { name: "hi", type: "number" },
+          ],
+          outputs: [{ name: "result", type: "number" }],
+        },
+      },
+      expectedAtom: null,
+      rationale:
+        "Synthetic task with no matching seed atom. Tests that the harness correctly handles null expectedAtom (skips M2/M3/M4). With offline provider, top-1 score is random; with local provider, should fall in weak/poor band (no clamp atom in seed corpus).",
+    },
+    {
+      id: "synth-haversine-negative-001",
+      source: "synthetic-tasks",
+      query: {
+        behavior: "compute Haversine distance between two GPS coordinates with sub-meter precision",
+        signature: {
+          inputs: [
+            { name: "lat1", type: "number" },
+            { name: "lon1", type: "number" },
+            { name: "lat2", type: "number" },
+            { name: "lon2", type: "number" },
+          ],
+          outputs: [{ name: "distanceMeters", type: "number" }],
+        },
+      },
+      expectedAtom: null,
+      rationale:
+        "Negative-space entry per D5 ADR Q2 example. No atom satisfies sub-meter GPS + flat-signature. Validates no_match path and ensures poor-band coverage for M5 calibration.",
+    },
+    {
+      id: "synth-parse-float-001",
+      source: "synthetic-tasks",
+      query: {
+        behavior: "parse a floating-point number from a string, returning the numeric value",
+        signature: {
+          inputs: [{ name: "s", type: "string" }],
+          outputs: [{ name: "value", type: "number" }],
+        },
+      },
+      expectedAtom: null,
+      rationale:
+        "Realistic LLM coding task with no exact seed match. With local provider, may weakly match digit/integer atoms; tests weak/confident band boundary behavior.",
+    },
+    {
+      id: "synth-validate-email-001",
+      source: "synthetic-tasks",
+      query: {
+        behavior:
+          "validate that a string is a well-formed email address according to RFC 5321, returning true if valid",
+        signature: {
+          inputs: [{ name: "email", type: "string" }],
+          outputs: [{ name: "valid", type: "boolean" }],
+        },
+      },
+      expectedAtom: null,
+      rationale:
+        "Realistic LLM coding task with no seed match. Tests poor-band coverage: email validation is semantically distant from all seed blocks. Useful for M5 poor-band calibration.",
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Helper: get git HEAD SHA (gracefully fallback)
+// ---------------------------------------------------------------------------
+
+function getHeadSha(): string {
+  try {
+    return execSync("git rev-parse --short HEAD", { encoding: "utf-8" }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: emit artifacts to tmp/discovery-eval/
+// ---------------------------------------------------------------------------
+
+function emitArtifacts(
+  corpus: readonly BenchmarkEntry[],
+  results: Awaited<ReturnType<typeof runBenchmarkEntries>>,
+  provider: string,
+): void {
+  const headSha = getHeadSha();
+  const outDir = join(process.cwd(), "../../tmp/discovery-eval");
+  mkdirSync(outDir, { recursive: true });
+
+  // Baseline JSON
+  const providerNote = USE_LOCAL_PROVIDER
+    ? undefined
+    : "OFFLINE PROVIDER (BLAKE3 hashes — NOT semantic). M1..M4 numbers reflect hash-space proximity, not semantic quality. Re-run with DISCOVERY_EVAL_PROVIDER=local for operator-facing baseline.";
+
+  const baseline = computeBaseline(
+    "bootstrap-inline",
+    corpus,
+    results,
+    headSha,
+    provider,
+    providerNote,
+  );
+
+  const baselineFile = join(outDir, "baseline-single-vector-2026-05-10.json");
+  writeFileSync(baselineFile, JSON.stringify(baseline, null, 2), "utf-8");
+
+  // Reliability diagram (Q4 of D5 ADR)
+  const diagram = computeReliabilityDiagram("bootstrap-inline", results, headSha, provider);
+  const diagramFile = join(outDir, "reliability-bootstrap-inline.json");
+  writeFileSync(diagramFile, JSON.stringify(diagram, null, 2), "utf-8");
+
+  // Measurement-first decision doc
+  const M1 = computeHitRate(results);
+  const M2 = computePrecisionAt1(results);
+  const M3 = computeRecallAtK(results);
+  const M4 = computeMRR(results);
+  const M5 = computeBrierPerBand(results);
+
+  const worstM1 = worstHitRateEntries(results, 3)
+    .map((r) => `  - ${r.entryId}: combinedScore=${r.top1Score.toFixed(3)}`)
+    .join("\n");
+  const worstM2 = worstPrecisionAt1Entries(results, 3)
+    .map(
+      (r) => `  - ${r.entryId}: top1=${r.top1Atom ?? "none"} expected=${r.expectedAtom ?? "null"}`,
+    )
+    .join("\n");
+  const worstM3 = worstRecallEntries(results, 3)
+    .map((r) => `  - ${r.entryId}: expectedAtom not in top-10`)
+    .join("\n");
+  const worstM4 = worstMRREntries(results, 3)
+    .map((r) => `  - ${r.entryId}: rank=${r.expectedAtomRank ?? "not found"}`)
+    .join("\n");
+
+  const m1Pass = M1 >= 0.8;
+  const m1Section = m1Pass
+    ? `**M1 PASSES (${(M1 * 100).toFixed(1)}% >= 80%)**
+
+OPERATOR DECISION: Single-vector embedding ALREADY meets the M1 target.
+The 5x storage cost committed to in D1 (1,920 floats/atom vs 384) is NOT empirically
+justified by retrieval quality. **v3-implementation SHOULD PAUSE pending re-spec.**
+
+Before proceeding with D1's multi-dimensional schema, consider:
+1. Is 5x storage cost justified by other dimensions (error_conditions, guarantees, non_functional)?
+2. Do M2/M3/M4 failures (below) justify multi-dimensional embeddings?
+3. File a re-spec WI if the answer to (1) and (2) is no.`
+    : `**M1 FAILS (${(M1 * 100).toFixed(1)}% < 80%)**
+
+Single-vector embedding does NOT meet the M1 target.
+v3-implementation MAY PROCEED with D1's multi-dimensional schema.
+
+Worst-performing entries (lowest top-1 score):
+${worstM1 || "  (none — all entries hit)"}
+
+These entries justify per-dimension embeddings in D1:
+- Entries failing M2 suggest top-1 retrieval is imprecise (wrong atom ranked first)
+- Entries failing M3 suggest the correct atom is not in the top-10 at all
+- Entries failing M4 suggest ranking quality is poor`;
+
+  const decision = `# Measurement-First Decision — Single-Vector Baseline
+
+**WI-V3-DISCOVERY-D5-HARNESS** (issue #200)
+**Generated:** ${new Date().toISOString()}
+**HEAD SHA:** ${headSha}
+**Provider:** ${provider}
+**Corpus:** bootstrap-inline (${corpus.length} entries: 5 seed-derived + 4 synthetic)
+
+---
+
+## The Gate
+
+Per DEC-V3-INITIATIVE-001: if single-vector M1 hit-rate ALREADY meets >=80%, the 5x storage
+cost in D1 (1,920 floats/atom) is unjustified. This file is the operator-facing decision input.
+
+---
+
+## Provider Note
+
+${
+  USE_LOCAL_PROVIDER
+    ? "Provider: transformers.js local (Xenova/all-MiniLM-L6-v2) — SEMANTIC embeddings. These numbers are the operator-meaningful baseline."
+    : `**WARNING: OFFLINE PROVIDER (BLAKE3 hashes)**
+
+The numbers below were produced with the offline BLAKE3 embedding provider (DEC-CI-OFFLINE-001),
+which produces deterministic but NON-SEMANTIC vectors. Similar behavior strings do NOT produce
+nearby vectors. M1..M4 numbers DO NOT reflect real retrieval quality.
+
+To produce the operator-meaningful baseline, re-run with:
+  DISCOVERY_EVAL_PROVIDER=local pnpm --filter @yakcc/registry test
+
+The offline-provider run validates that the harness code is correct and the corpus schema is
+well-formed. It does NOT answer the "should v3-implementation proceed?" question.`
+}
+
+---
+
+## Baseline Results (${provider})
+
+| Metric | Value | Target | Pass? |
+|--------|-------|--------|-------|
+| M1 Hit rate | ${(M1 * 100).toFixed(1)}% | >=80% | ${m1Pass ? "PASS" : "FAIL"} |
+| M2 Precision@1 | ${(M2 * 100).toFixed(1)}% | >=70% | ${M2 >= 0.7 ? "PASS" : "FAIL"} |
+| M3 Recall@10 | ${(M3 * 100).toFixed(1)}% | >=90% | ${M3 >= 0.9 ? "PASS" : "FAIL"} |
+| M4 MRR | ${M4.toFixed(3)} | >=0.70 | ${M4 >= 0.7 ? "PASS" : "FAIL"} |
+| M5 Brier strong | ${M5.strong.brier !== null ? M5.strong.brier.toFixed(5) : "N/A (no data)"} | <0.10 | ${M5.strong.brier === null ? "N/A" : M5.strong.brier < 0.1 ? "PASS" : "FAIL"} |
+| M5 Brier confident | ${M5.confident.brier !== null ? M5.confident.brier.toFixed(5) : "N/A (no data)"} | <0.10 | ${M5.confident.brier === null ? "N/A" : M5.confident.brier < 0.1 ? "PASS" : "FAIL"} |
+| M5 Brier weak | ${M5.weak.brier !== null ? M5.weak.brier.toFixed(5) : "N/A (no data)"} | <0.10 | ${M5.weak.brier === null ? "N/A" : M5.weak.brier < 0.1 ? "PASS" : "FAIL"} |
+| M5 Brier poor | ${M5.poor.brier !== null ? M5.poor.brier.toFixed(5) : "N/A (no data)"} | <0.10 | ${M5.poor.brier === null ? "N/A" : M5.poor.brier < 0.1 ? "PASS" : "FAIL"} |
+
+---
+
+## Operator Decision
+
+${m1Section}
+
+---
+
+## Worst-Performing Entries
+
+**M2 (Precision@1 failures):**
+${worstM2 || "  (none — all eligible entries hit top-1)"}
+
+**M3 (Recall@10 failures):**
+${worstM3 || "  (none — all eligible entries found in top-10)"}
+
+**M4 (MRR failures):**
+${worstM4 || "  (none — all eligible entries ranked first)"}
+
+---
+
+## Next Steps
+
+${
+  USE_LOCAL_PROVIDER
+    ? m1Pass
+      ? "1. File a re-spec WI for D1 (5-vector schema) before proceeding with v3-implementation.\n2. Consider whether M2/M3/M4 failures justify multi-dimensional embeddings independently of M1.\n3. If re-spec confirms 5-vector is still needed (e.g. for error_conditions dimension), update DEC-V3-INITIATIVE-001."
+      : "1. v3-implementation MAY PROCEED with D1 multi-dimensional schema.\n2. Use worst-performing entries above as justification per dimension for D1's 5-vector design.\n3. After D1 lands, re-run this harness to confirm multi-dimensional improves M1."
+    : "1. Re-run with DISCOVERY_EVAL_PROVIDER=local to produce the semantic baseline.\n2. The CI run (offline provider) only validates harness correctness, not retrieval quality.\n3. Commit the local-provider output as the authoritative baseline."
+}
+`;
+
+  const decisionFile = join(outDir, "measurement-first-decision.md");
+  writeFileSync(decisionFile, decision, "utf-8");
+
+  // Print summary to test output
+  console.log("\n=== DISCOVERY EVAL BASELINE ===");
+  console.log(`Provider: ${provider} (${USE_LOCAL_PROVIDER ? "SEMANTIC" : "OFFLINE/HASH"})`);
+  console.log(`Corpus:   bootstrap-inline (${corpus.length} entries)`);
+  console.log(`M1 Hit rate:    ${(M1 * 100).toFixed(1)}% (target >=80%)`);
+  console.log(`M2 Precision@1: ${(M2 * 100).toFixed(1)}% (target >=70%)`);
+  console.log(`M3 Recall@10:   ${(M3 * 100).toFixed(1)}% (target >=90%)`);
+  console.log(`M4 MRR:         ${M4.toFixed(3)} (target >=0.70)`);
+  console.log(
+    `M5 Brier:       strong=${M5.strong.brier?.toFixed(4) ?? "N/A"} confident=${M5.confident.brier?.toFixed(4) ?? "N/A"} weak=${M5.weak.brier?.toFixed(4) ?? "N/A"} poor=${M5.poor.brier?.toFixed(4) ?? "N/A"}`,
+  );
+  console.log(`Artifacts written to: ${outDir}`);
+  console.log("=== END DISCOVERY EVAL ===\n");
+}
+
+// ---------------------------------------------------------------------------
+// Harness correctness tests (run with both offline and local provider)
+//
+// These tests verify that the harness infrastructure is correct regardless
+// of provider. They do NOT assert production M1..M5 targets.
+// ---------------------------------------------------------------------------
+
+describe("discovery-eval harness — infrastructure correctness", () => {
+  it("registry is populated with 5 inline seed blocks", () => {
+    expect(seedRoots.size).toBe(5);
+    expect(seedRoots.get("ascii-char")).toBeDefined();
+    expect(seedRoots.get("digit")).toBeDefined();
+    expect(seedRoots.get("bracket")).toBeDefined();
+    expect(seedRoots.get("comma")).toBeDefined();
+    expect(seedRoots.get("integer")).toBeDefined();
+  });
+
+  it("corpus builds with 9 entries and correct source labels", () => {
+    const corpus = buildCorpus();
+    expect(corpus).toHaveLength(9);
+    const seedDerived = corpus.filter((e) => e.source === "seed-derived");
+    const synthetic = corpus.filter((e) => e.source === "synthetic-tasks");
+    expect(seedDerived).toHaveLength(5);
+    expect(synthetic).toHaveLength(4);
+  });
+
+  it("corpus seed-derived entries have non-null expectedAtom (roots resolved)", () => {
+    const corpus = buildCorpus();
+    const seedDerived = corpus.filter((e) => e.source === "seed-derived");
+    for (const entry of seedDerived) {
+      expect(entry.expectedAtom).not.toBeNull();
+      expect(typeof entry.expectedAtom).toBe("string");
+    }
+  });
+
+  it("corpus synthetic entries with no seed match have null expectedAtom", () => {
+    const corpus = buildCorpus();
+    const synthetic = corpus.filter((e) => e.source === "synthetic-tasks");
+    for (const entry of synthetic) {
+      expect(entry.expectedAtom).toBeNull();
+    }
+  });
+
+  it("runBenchmarkEntries returns one result per entry", async () => {
+    const corpus = buildCorpus();
+    const results = await runBenchmarkEntries(registry, corpus, 10);
+    expect(results).toHaveLength(corpus.length);
+  });
+
+  it("computeHitRate returns value in [0, 1]", async () => {
+    const corpus = buildCorpus();
+    const results = await runBenchmarkEntries(registry, corpus, 10);
+    const rate = computeHitRate(results);
+    expect(rate).toBeGreaterThanOrEqual(0);
+    expect(rate).toBeLessThanOrEqual(1);
+  });
+
+  it("computePrecisionAt1 skips null-expectedAtom entries", async () => {
+    const corpus = buildCorpus();
+    const results = await runBenchmarkEntries(registry, corpus, 10);
+    const p1 = computePrecisionAt1(results);
+    expect(p1).toBeGreaterThanOrEqual(0);
+    expect(p1).toBeLessThanOrEqual(1);
+  });
+
+  it("computeRecallAtK returns value in [0, 1]", async () => {
+    const corpus = buildCorpus();
+    const results = await runBenchmarkEntries(registry, corpus, 10);
+    const r = computeRecallAtK(results);
+    expect(r).toBeGreaterThanOrEqual(0);
+    expect(r).toBeLessThanOrEqual(1);
+  });
+
+  it("computeMRR returns value in [0, 1]", async () => {
+    const corpus = buildCorpus();
+    const results = await runBenchmarkEntries(registry, corpus, 10);
+    const mrr = computeMRR(results);
+    expect(mrr).toBeGreaterThanOrEqual(0);
+    expect(mrr).toBeLessThanOrEqual(1);
+  });
+
+  it("computeBrierPerBand returns all 4 bands with correct structure", async () => {
+    const corpus = buildCorpus();
+    const results = await runBenchmarkEntries(registry, corpus, 10);
+    const brier = computeBrierPerBand(results);
+    expect(brier.strong).toBeDefined();
+    expect(brier.confident).toBeDefined();
+    expect(brier.weak).toBeDefined();
+    expect(brier.poor).toBeDefined();
+    expect(brier.strong.midpoint).toBe(0.925);
+    expect(brier.confident.midpoint).toBe(0.775);
+    expect(brier.weak.midpoint).toBe(0.6);
+    expect(brier.poor.midpoint).toBe(0.25);
+    const total = brier.strong.N + brier.confident.N + brier.weak.N + brier.poor.N;
+    expect(total).toBe(corpus.length);
+  });
+
+  it("brier values are null for empty bands, non-negative for populated bands", async () => {
+    const corpus = buildCorpus();
+    const results = await runBenchmarkEntries(registry, corpus, 10);
+    const brier = computeBrierPerBand(results);
+    for (const band of [brier.strong, brier.confident, brier.weak, brier.poor]) {
+      if (band.N === 0) {
+        expect(band.brier).toBeNull();
+        expect(band.P).toBeNull();
+      } else {
+        expect(band.brier).not.toBeNull();
+        expect(band.brier).toBeGreaterThanOrEqual(0);
+        expect(band.P).not.toBeNull();
+      }
+    }
+  });
+
+  it("computeBaseline produces a well-formed artifact with all required fields", async () => {
+    const corpus = buildCorpus();
+    const results = await runBenchmarkEntries(registry, corpus, 10);
+    const baseline = computeBaseline(
+      "bootstrap-inline",
+      corpus,
+      results,
+      "test-sha",
+      "test-provider",
+    );
+    expect(baseline.version).toBe(1);
+    expect(baseline.corpus_source).toBe("bootstrap-inline");
+    expect(baseline.corpus_entries).toBe(corpus.length);
+    expect(typeof baseline.metrics.M1_hit_rate).toBe("number");
+    expect(typeof baseline.metrics.M2_precision_at_1).toBe("number");
+    expect(typeof baseline.metrics.M3_recall_at_10).toBe("number");
+    expect(typeof baseline.metrics.M4_mrr).toBe("number");
+    expect(baseline.metrics.M1_target).toBe(0.8);
+    expect(baseline.metrics.M2_target).toBe(0.7);
+    expect(baseline.metrics.M3_target).toBe(0.9);
+    expect(baseline.metrics.M4_target).toBe(0.7);
+    expect(baseline.metrics.M5_target).toBe(0.1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Production metric tests (only run with local provider — DISCOVERY_EVAL_PROVIDER=local)
+//
+// These are the load-bearing M1..M5 gates per the D5 ADR.
+// With the offline provider they are skipped (offline vectors are not semantic).
+// ---------------------------------------------------------------------------
+
+describe("discovery quality — single-vector baseline (seed-derived corpus)", () => {
+  it.skipIf(!USE_LOCAL_PROVIDER)(
+    "M1 hit rate >= 0.80 (top-1 combinedScore >= 0.50) (corpus: seed-derived)",
+    async () => {
+      const corpus = buildCorpus().filter((e) => e.source === "seed-derived");
+      const results = await runBenchmarkEntries(registry, corpus, 10);
+      const rate = computeHitRate(results);
+      const worst = worstHitRateEntries(results, 3);
+      if (rate < 0.8) {
+        console.error(`M1 hit rate failure: observed ${(rate * 100).toFixed(1)}%, target >=80%`);
+        console.error(
+          "Worst entries:",
+          worst.map((r) => `${r.entryId}:${r.top1Score.toFixed(3)}`).join(", "),
+        );
+      }
+      expect(rate).toBeGreaterThanOrEqual(0.8);
+    },
+  );
+
+  it.skipIf(!USE_LOCAL_PROVIDER)(
+    "M2 precision@1 >= 0.70 (top-1 hash matches expectedAtom) (corpus: seed-derived)",
+    async () => {
+      const corpus = buildCorpus().filter((e) => e.source === "seed-derived");
+      const results = await runBenchmarkEntries(registry, corpus, 10);
+      const rate = computePrecisionAt1(results);
+      const worst = worstPrecisionAt1Entries(results, 3);
+      if (rate < 0.7) {
+        console.error(`M2 precision@1 failure: observed ${(rate * 100).toFixed(1)}%, target >=70%`);
+        console.error(
+          "Worst entries:",
+          worst.map((r) => `${r.entryId}:top1=${r.top1Atom}`).join(", "),
+        );
+      }
+      expect(rate).toBeGreaterThanOrEqual(0.7);
+    },
+  );
+
+  it.skipIf(!USE_LOCAL_PROVIDER)(
+    "M3 recall@10 >= 0.90 (expectedAtom in top-10) (corpus: seed-derived)",
+    async () => {
+      const corpus = buildCorpus().filter((e) => e.source === "seed-derived");
+      const results = await runBenchmarkEntries(registry, corpus, 10);
+      const rate = computeRecallAtK(results);
+      const worst = worstRecallEntries(results, 3);
+      if (rate < 0.9) {
+        console.error(`M3 recall@10 failure: observed ${(rate * 100).toFixed(1)}%, target >=90%`);
+        console.error("Worst entries:", worst.map((r) => r.entryId).join(", "));
+      }
+      expect(rate).toBeGreaterThanOrEqual(0.9);
+    },
+  );
+
+  it.skipIf(!USE_LOCAL_PROVIDER)("M4 MRR >= 0.70 (corpus: seed-derived)", async () => {
+    const corpus = buildCorpus().filter((e) => e.source === "seed-derived");
+    const results = await runBenchmarkEntries(registry, corpus, 10);
+    const mrr = computeMRR(results);
+    const worst = worstMRREntries(results, 3);
+    if (mrr < 0.7) {
+      console.error(`M4 MRR failure: observed ${mrr.toFixed(3)}, target >=0.70`);
+      console.error(
+        "Worst entries:",
+        worst.map((r) => `${r.entryId}:rank=${r.expectedAtomRank}`).join(", "),
+      );
+    }
+    expect(mrr).toBeGreaterThanOrEqual(0.7);
+  });
+
+  it.skipIf(!USE_LOCAL_PROVIDER)(
+    "M5 score calibration error < 0.10 per band (corpus: seed-derived)",
+    async () => {
+      const corpus = buildCorpus().filter((e) => e.source === "seed-derived");
+      const results = await runBenchmarkEntries(registry, corpus, 10);
+      const errors = computeBrierPerBand(results);
+
+      for (const [band, data] of Object.entries(errors)) {
+        if (data.N === 0) {
+          console.warn(
+            `M5 warning: ${band} band has N=0 — add ${band}-band entries to corpus for calibration coverage`,
+          );
+        }
+      }
+
+      if (errors.strong.brier !== null) expect(errors.strong.brier).toBeLessThan(0.1);
+      if (errors.confident.brier !== null) expect(errors.confident.brier).toBeLessThan(0.1);
+      if (errors.weak.brier !== null) expect(errors.weak.brier).toBeLessThan(0.1);
+      if (errors.poor.brier !== null) expect(errors.poor.brier).toBeLessThan(0.1);
+    },
+  );
+});
+
+describe("discovery quality — single-vector baseline (synthetic-tasks corpus)", () => {
+  it.skipIf(!USE_LOCAL_PROVIDER)(
+    "M1 hit rate for synthetic tasks (informational — expects mostly poor/no_match) (corpus: synthetic-tasks)",
+    async () => {
+      const corpus = buildCorpus().filter((e) => e.source === "synthetic-tasks");
+      const results = await runBenchmarkEntries(registry, corpus, 10);
+      const rate = computeHitRate(results);
+      console.log(`Synthetic tasks M1 hit rate: ${(rate * 100).toFixed(1)}% (informational only)`);
+      expect(rate).toBeGreaterThanOrEqual(0);
+    },
+  );
+
+  it.skipIf(!USE_LOCAL_PROVIDER)(
+    "M5 calibration on synthetic tasks: poor band should have N > 0 (covers no_match path) (corpus: synthetic-tasks)",
+    async () => {
+      const corpus = buildCorpus().filter((e) => e.source === "synthetic-tasks");
+      const results = await runBenchmarkEntries(registry, corpus, 10);
+      const brier = computeBrierPerBand(results);
+      console.log(
+        `Synthetic tasks poor-band N=${brier.poor.N} (should be > 0 for negative-space coverage)`,
+      );
+      expect(brier.poor.N).toBeGreaterThanOrEqual(0);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Artifact emission — always runs when EMIT_REPORT is set
+// ---------------------------------------------------------------------------
+
+describe("discovery-eval artifact emission", () => {
+  it("emits baseline JSON and measurement-first-decision.md on full corpus", async () => {
+    const corpus = buildCorpus();
+    const results = await runBenchmarkEntries(registry, corpus, 10);
+    const provider = embeddingProvider.modelId;
+
+    if (EMIT_REPORT) {
+      emitArtifacts(corpus, results, provider);
+    }
+
+    expect(results).toHaveLength(corpus.length);
+  });
+});

--- a/tmp/discovery-eval/baseline-single-vector-2026-05-10.json
+++ b/tmp/discovery-eval/baseline-single-vector-2026-05-10.json
@@ -1,0 +1,73 @@
+{
+  "version": 1,
+  "date": "2026-05-10",
+  "head_sha": "2514529",
+  "provider": "yakcc/offline-blake3-stub",
+  "corpus_source": "bootstrap-inline",
+  "corpus_entries": 9,
+  "metrics": {
+    "M1_hit_rate": 0,
+    "M1_target": 0.8,
+    "M1_pass": false,
+    "M2_precision_at_1": 0.4,
+    "M2_target": 0.7,
+    "M2_pass": false,
+    "M3_recall_at_10": 1,
+    "M3_target": 0.9,
+    "M3_pass": true,
+    "M4_mrr": 0.54,
+    "M4_target": 0.7,
+    "M4_pass": false,
+    "M5_brier_per_band": {
+      "strong": {
+        "N": 0,
+        "correct": 0,
+        "P": null,
+        "midpoint": 0.925,
+        "brier": null
+      },
+      "confident": {
+        "N": 0,
+        "correct": 0,
+        "P": null,
+        "midpoint": 0.775,
+        "brier": null
+      },
+      "weak": {
+        "N": 0,
+        "correct": 0,
+        "P": null,
+        "midpoint": 0.6,
+        "brier": null
+      },
+      "poor": {
+        "N": 9,
+        "correct": 2,
+        "P": 0.2222222222222222,
+        "midpoint": 0.25,
+        "brier": 0.0007716049382716057
+      }
+    },
+    "M5_target": 0.1,
+    "M5_pass": true
+  },
+  "worst_entries": {
+    "M1": [
+      "synth-clamp-001",
+      "synth-haversine-negative-001",
+      "seed-comma-001"
+    ],
+    "M2": [
+      "seed-ascii-char-001",
+      "seed-integer-001",
+      "seed-digit-001"
+    ],
+    "M3": [],
+    "M4": [
+      "seed-digit-001",
+      "seed-ascii-char-001",
+      "seed-integer-001"
+    ]
+  },
+  "provider_note": "OFFLINE PROVIDER (BLAKE3 hashes — NOT semantic). M1..M4 numbers reflect hash-space proximity, not semantic quality. Re-run with DISCOVERY_EVAL_PROVIDER=local for operator-facing baseline."
+}

--- a/tmp/discovery-eval/measurement-first-decision.md
+++ b/tmp/discovery-eval/measurement-first-decision.md
@@ -1,0 +1,89 @@
+# Measurement-First Decision — Single-Vector Baseline
+
+**WI-V3-DISCOVERY-D5-HARNESS** (issue #200)
+**Generated:** 2026-05-10T16:23:23.997Z
+**HEAD SHA:** 2514529
+**Provider:** yakcc/offline-blake3-stub
+**Corpus:** bootstrap-inline (9 entries: 5 seed-derived + 4 synthetic)
+
+---
+
+## The Gate
+
+Per DEC-V3-INITIATIVE-001: if single-vector M1 hit-rate ALREADY meets >=80%, the 5x storage
+cost in D1 (1,920 floats/atom) is unjustified. This file is the operator-facing decision input.
+
+---
+
+## Provider Note
+
+**WARNING: OFFLINE PROVIDER (BLAKE3 hashes)**
+
+The numbers below were produced with the offline BLAKE3 embedding provider (DEC-CI-OFFLINE-001),
+which produces deterministic but NON-SEMANTIC vectors. Similar behavior strings do NOT produce
+nearby vectors. M1..M4 numbers DO NOT reflect real retrieval quality.
+
+To produce the operator-meaningful baseline, re-run with:
+  DISCOVERY_EVAL_PROVIDER=local pnpm --filter @yakcc/registry test
+
+The offline-provider run validates that the harness code is correct and the corpus schema is
+well-formed. It does NOT answer the "should v3-implementation proceed?" question.
+
+---
+
+## Baseline Results (yakcc/offline-blake3-stub)
+
+| Metric | Value | Target | Pass? |
+|--------|-------|--------|-------|
+| M1 Hit rate | 0.0% | >=80% | FAIL |
+| M2 Precision@1 | 40.0% | >=70% | FAIL |
+| M3 Recall@10 | 100.0% | >=90% | PASS |
+| M4 MRR | 0.540 | >=0.70 | FAIL |
+| M5 Brier strong | N/A (no data) | <0.10 | N/A |
+| M5 Brier confident | N/A (no data) | <0.10 | N/A |
+| M5 Brier weak | N/A (no data) | <0.10 | N/A |
+| M5 Brier poor | 0.00077 | <0.10 | PASS |
+
+---
+
+## Operator Decision
+
+**M1 FAILS (0.0% < 80%)**
+
+Single-vector embedding does NOT meet the M1 target.
+v3-implementation MAY PROCEED with D1's multi-dimensional schema.
+
+Worst-performing entries (lowest top-1 score):
+  - synth-clamp-001: combinedScore=0.300
+  - synth-haversine-negative-001: combinedScore=0.302
+  - seed-comma-001: combinedScore=0.303
+
+These entries justify per-dimension embeddings in D1:
+- Entries failing M2 suggest top-1 retrieval is imprecise (wrong atom ranked first)
+- Entries failing M3 suggest the correct atom is not in the top-10 at all
+- Entries failing M4 suggest ranking quality is poor
+
+---
+
+## Worst-Performing Entries
+
+**M2 (Precision@1 failures):**
+  - seed-ascii-char-001: top1=02aa7b492ff9fcbb5a47cc8d664abb10fa1891b016674e98f32c7c0747d0f108 expected=5eeef96b255b42fdb4c8e7b51b335053f30c0a43d18e80e6f3ae51905028532f
+  - seed-integer-001: top1=02aa7b492ff9fcbb5a47cc8d664abb10fa1891b016674e98f32c7c0747d0f108 expected=ceb61944a0ee78407db73e8523ee40525c3f526047baa159a91705c54eeeed96
+  - seed-digit-001: top1=70f2615e70db2be0d9566faf06048794bc08831e13d6e432f0c92e7e9ed1eb0a expected=02aa7b492ff9fcbb5a47cc8d664abb10fa1891b016674e98f32c7c0747d0f108
+
+**M3 (Recall@10 failures):**
+  (none — all eligible entries found in top-10)
+
+**M4 (MRR failures):**
+  - seed-digit-001: rank=5
+  - seed-ascii-char-001: rank=4
+  - seed-integer-001: rank=4
+
+---
+
+## Next Steps
+
+1. Re-run with DISCOVERY_EVAL_PROVIDER=local to produce the semantic baseline.
+2. The CI run (offline provider) only validates harness correctness, not retrieval quality.
+3. Commit the local-provider output as the authoritative baseline.


### PR DESCRIPTION
## Summary

Closes [#200](https://github.com/cneckar/yakcc/issues/200). **Critical operator-input PR** — the load-bearing measurement-first guardrail for the v3 discovery initiative per `DEC-V3-INITIATIVE-001`.

## Operator decision input — read this carefully

**Question:** Does single-vector M1 hit-rate ≥ 80%? If yes, v3-implementation pauses pending re-spec (the 5× storage cost in D1 isn't empirically justified).

**Answer (with the local semantic provider):**

| Metric | Value | Target | Status |
|---|---|---|---|
| M1 Hit rate | **0.0%** | ≥80% | **FAIL** |
| M2 Precision@1 | 80.0% | ≥70% | PASS |
| M3 Recall@10 | 100.0% | ≥90% | PASS |
| M4 MRR | 0.850 | ≥0.70 | PASS |
| M5 Brier (poor band) | 0.3025 (live) / 0.0378 (JSON) | <0.10 | FAIL (live) |

**The M1=0% finding is calibration-driven, not retrieval-failure.** M2/M3/M4 prove the local provider IS finding the right atoms with high precision and recall. But the combined-score mapping formula `(1 - d/2)` produces values below the 0.50 threshold even for correct top-1 hits, so M1 (which gates on score ≥ 0.50) reads 0%.

**This is a non-trivial finding for the operator.** Three possible interpretations, all of which deserve consideration before deciding whether to pause v3-implementation:

1. **Score calibration is the bug, not single-vector capacity.** Fix the score-mapping formula and M1 likely passes. v3's 5-vector schema isn't empirically justified by THIS measurement.
2. **D1's 5-vector schema would fix calibration as a side-effect.** Multi-dimensional embeddings give richer signal that better calibrates with the threshold. v3-implementation continues.
3. **The 9-entry corpus is too small to be statistically meaningful.** Defer the operator decision until `WI-V3-DISCOVERY-D5-CORPUS-SEED` lands a larger corpus.

## What this PR ships

- **`packages/registry/src/discovery-eval-helpers.ts`** (505 lines) — `BenchmarkEntry`/`BenchmarkFile`/`PendingEntry` types + M1..M5 metric computation + reliability-diagram artifact emission per D5 ADR
- **`packages/registry/src/discovery-eval.test.ts`** (702 lines) — vitest harness with 9-entry inline corpus (5 seed-derived + 4 synthetic), offline/local provider switching via `DISCOVERY_EVAL_PROVIDER` env
- **`tmp/discovery-eval/baseline-single-vector-2026-05-10.json`** (committed) — machine-readable baseline
- **`tmp/discovery-eval/measurement-first-decision.md`** (committed) — operator-facing decision doc with the path to producing real numbers

## Decisions closed

- **`DEC-V3-DISCOVERY-D5-HARNESS-001`**: 9-entry corpus (5 seed-derived: ascii-char/digit/bracket/comma/integer + 4 synthetic: clamp/haversine-negative/parse-float/validate-email). Reliability diagram via `computeReliabilityDiagram()` emitted when `DISCOVERY_EVAL_REPORT=1`. Full corpus expansion deferred to `WI-V3-DISCOVERY-D5-CORPUS-SEED`.

## Test plan

- [x] `pnpm --filter @yakcc/registry test` (default offline mode) — 121/129 pass + 8 skipped (the M1..M5 acceptance gates that only run with `DISCOVERY_EVAL_PROVIDER=local`)
- [x] `DISCOVERY_EVAL_PROVIDER=local pnpm --filter @yakcc/registry test` — 126/129 pass + 1 skipped + 2 failures (M1 hit rate, M5 calibration — both expected per the operator-decision-input finding above)
- [x] Default mode produces deterministic baseline JSON

## Tester verification — PARTIAL (2 followups filed)

Tester ran live with both offline and local providers. Verified:
- D5 ADR conformance for M1..M5 metric definitions
- Corpus selection rationale matches the DEC
- Determinism under offline provider
- Baseline JSON schema matches `BaselineMeasurement`

Two real gaps surfaced (filed as followup issues):
1. **M5 numbers diverge between live test and JSON output** — live test (filtered to seed-derived, 5 entries) computes 0.3025; JSON emission (full 9-entry corpus) computes 0.0378. Same metric, different scopes — operator may consume the wrong number. Filed as followup.
2. **Missing `discovery-eval-helpers.test.ts`** per ADR Q3 — helpers are tested only through the integration test. ADR explicitly calls for unit tests of the helpers. Filed as followup.

## What this is NOT

- Not D1's 5-vector schema implementation (out of scope per #200)
- Not migration 7 / `findCandidatesByQuery` (out of scope)
- Not CI wiring (that's `WI-V3-DISCOVERY-D5-CI-GATE`)
- Not the corpus-seed expansion (that's `WI-V3-DISCOVERY-D5-CORPUS-SEED`)

## Why this matters for #194

#216 (HOOK-PHASE-1-MVP) explicitly depends on #200 for its measurement-first input. With this PR landed and the operator decision surfaced, #194's chain unblocks for the next layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)