### PR TITLE
fix(wasm-backend): replace duplicate inline valtypeByte arrow with reference

### DIFF
--- a/packages/compile/src/wasm-backend.ts
+++ b/packages/compile/src/wasm-backend.ts
@@ -688,7 +688,7 @@ function emitTypeLoweredModule(
     let type5: Uint8Array;
     if (paramDomains !== undefined && paramDomains.length !== 2) {
       // Build (p0 p1 ... pN-1) → retVt from per-parameter domains.
-      const paramVts = paramDomains.map((d) => (d === "i64" ? I64 : d === "f64" ? F64 : I32));
+      const paramVts = paramDomains.map(valtypeByte);
       type5 = concat(
         new Uint8Array([FUNCTYPE]),
         uleb128(paramVts.length),


### PR DESCRIPTION
## Summary

Closes #263. Replaces the non-atomic inline arrow at `packages/compile/src/wasm-backend.ts` line 691 with a reference to the existing `valtypeByte` import — eliminating the duplicate `(d) => d === "i64" ? I64 : d === "f64" ? F64 : I32` mapping that was already provided by `valtypeByte` (imported at line 78, used at line 604).

```diff
-      const paramVts = paramDomains.map((d) => (d === "i64" ? I64 : d === "f64" ? F64 : I32));
+      const paramVts = paramDomains.map(valtypeByte);
```

Behavior-preserving: byte-identical mapping. `valtypeByte` returns the same `I64 | F64 | I32` byte for the same `"i64" | "f64" | "i32"` input.

## Why

Refs #87 (acceptance gate prerequisite). After this lands, yakcc bootstrap should reach `134/135 successful + 1 expected-failure (gpl-fixture.ts)` once the next re-bootstrap runs.

## Test plan

- [x] `pnpm -r build` green at HEAD `3c18f8b`
- [x] @yakcc/compile suite passing for the changed file (21/21)
- [x] Reviewer verdict: `ready_for_guardian`, 0 blockers / 0 major / 0 minor (2 NOTE-severity findings, both pre-existing, neither blocks)
- [ ] Post-merge: re-bootstrap reaches 134/135 successful (out of scope here; tracked under #87)

🤖 Generated with [Claude Code](https://claude.com/claude-code)