### PR TITLE
feat(bootstrap): expected-failures.json + reclassification for GPL fixture

### DIFF
--- a/bootstrap/expected-failures.json
+++ b/bootstrap/expected-failures.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": 1,
+  "entries": [
+    {
+      "path": "examples/v0.7-mri-demo/src/gpl-fixture.ts",
+      "errorClass": "LicenseRefusedError",
+      "rationale": "Intentional GPL-3.0-or-later fixture exercising the license gate; refusal is the test. See DESIGN.md §license-gate."
+    }
+  ]
+}

--- a/packages/cli/src/bootstrap.test.ts
+++ b/packages/cli/src/bootstrap.test.ts
@@ -452,3 +452,312 @@ describe("bootstrap --verify exits 1 with structured diff on mismatch", () => {
     expect(logger.errLines.join("\n")).toContain("committed manifest not found");
   }, 10_000);
 });
+
+// ---------------------------------------------------------------------------
+// Suite 8: expected-failures reclassification
+//
+// These tests exercise the expected-failures.json exemption mechanism without
+// running the full shave pipeline. They use a real temp-file sqlite registry
+// but a fixture project where failures are synthetic (no-SPDX header) and the
+// expected-failures.json file is written inline so we control path+errorClass.
+//
+// Production sequence exercised (Compound-Interaction requirement):
+//   bootstrap([...flags, "--expected-failures", efPath], logger)
+//   → loadExpectedFailures(efPath)
+//   → shave loop produces FileOutcomeFailure for no-SPDX file
+//   → reclassification maps it to FileOutcomeExpectedFailure via path+errorClass key
+//   → summary shows expected-failures count, exit 0
+//   → report.json contains outcome:"expected-failure"
+// ---------------------------------------------------------------------------
+
+describe("bootstrap expected-failures exemption", () => {
+  /**
+   * Build an expected-failures.json that matches a given path and errorClass.
+   * Written to a temp file; returns the path.
+   */
+  function makeExpectedFailuresFile(
+    dir: string,
+    name: string,
+    entries: Array<{ path: string; errorClass: string; rationale: string }>,
+  ): string {
+    const filePath = join(dir, name);
+    const content = {
+      schemaVersion: 1,
+      entries,
+    };
+    writeFileSync(filePath, `${JSON.stringify(content, null, 2)}\n`, "utf-8");
+    return filePath;
+  }
+
+  it("reclassifies a LicenseRefusedError failure as expected-failure and exits 0", async () => {
+    // Create a fixture project with a no-SPDX file (triggers LicenseRefusedError or
+    // similar gate failure). We also include one valid file so the bootstrap isn't empty.
+    const projDir = makeFixtureProject(suiteDir, "proj-ef-basic", [
+      {
+        relativePath: "packages/foo/src/ok.ts",
+        content: VALID_TS_SOURCE,
+      },
+      {
+        relativePath: "packages/foo/src/bad.ts",
+        content: NO_SPDX_SOURCE,
+      },
+    ]);
+
+    // Run without expected-failures first to confirm bad.ts causes a real failure.
+    const registryPath1 = join(suiteDir, "ef-basic-r1.sqlite");
+    const manifestPath1 = join(suiteDir, "ef-basic-m1.json");
+    const reportPath1 = join(suiteDir, "ef-basic-rep1.json");
+
+    const origCwd = process.cwd();
+    process.chdir(projDir);
+    let codeWithout: number;
+    let errorClassObserved: string;
+    try {
+      const logger1 = new CollectingLogger();
+      codeWithout = await bootstrap(
+        ["--registry", registryPath1, "--manifest", manifestPath1, "--report", reportPath1],
+        logger1,
+      );
+      // Must fail without the exemption.
+      expect(codeWithout).toBe(1);
+
+      // Discover the actual errorClass the shave pipeline throws for this fixture.
+      const report1 = JSON.parse(readFileSync(reportPath1, "utf-8")) as Array<{
+        outcome: string;
+        path: string;
+        errorClass?: string;
+      }>;
+      const badEntry = report1.find((r) => r.path.endsWith("bad.ts"));
+      expect(badEntry).toBeDefined();
+      expect(badEntry?.outcome).toBe("failure");
+      errorClassObserved = badEntry?.errorClass ?? "Error";
+    } finally {
+      process.chdir(origCwd);
+    }
+
+    // Write an expected-failures.json that covers bad.ts with the observed errorClass.
+    // The path in expected-failures.json must be repo-relative (matches outcomes[].path).
+    const efPath = makeExpectedFailuresFile(suiteDir, "ef-basic.json", [
+      {
+        path: "packages/foo/src/bad.ts",
+        errorClass: errorClassObserved,
+        rationale: "Test fixture: intentional license-gate failure for unit test coverage.",
+      },
+    ]);
+
+    // Run again with expected-failures — bad.ts should be reclassified, exit 0.
+    const registryPath2 = join(suiteDir, "ef-basic-r2.sqlite");
+    const manifestPath2 = join(suiteDir, "ef-basic-m2.json");
+    const reportPath2 = join(suiteDir, "ef-basic-rep2.json");
+
+    process.chdir(projDir);
+    try {
+      const logger2 = new CollectingLogger();
+      const codeWith = await bootstrap(
+        [
+          "--registry",
+          registryPath2,
+          "--manifest",
+          manifestPath2,
+          "--report",
+          reportPath2,
+          "--expected-failures",
+          efPath,
+        ],
+        logger2,
+      );
+
+      // Exit 0: the only failure is now an expected-failure.
+      expect(codeWith).toBe(0);
+
+      // Report must show outcome:"expected-failure" for bad.ts.
+      expect(existsSync(reportPath2)).toBe(true);
+      const report2 = JSON.parse(readFileSync(reportPath2, "utf-8")) as Array<{
+        outcome: string;
+        path: string;
+        errorClass?: string;
+        rationale?: string;
+      }>;
+      const efEntry = report2.find((r) => r.path.endsWith("bad.ts"));
+      expect(efEntry).toBeDefined();
+      expect(efEntry?.outcome).toBe("expected-failure");
+      expect(efEntry?.rationale).toContain("Test fixture");
+
+      // Summary output must mention expected-failures count.
+      const logOutput = logger2.logLines.join("\n");
+      expect(logOutput).toContain("expected-failures");
+      expect(logOutput).toContain("1");
+    } finally {
+      process.chdir(origCwd);
+    }
+  }, 120_000);
+
+  it("still exits 1 when a non-exempted file also fails", async () => {
+    // Two bad files; only one is in expected-failures.json. The other must still fail.
+    const projDir = makeFixtureProject(suiteDir, "proj-ef-partial", [
+      {
+        relativePath: "packages/foo/src/bad1.ts",
+        content: NO_SPDX_SOURCE,
+      },
+      {
+        relativePath: "packages/foo/src/bad2.ts",
+        content: NO_SPDX_SOURCE,
+      },
+    ]);
+
+    // First, get the errorClass for the no-SPDX files.
+    const registryPath1 = join(suiteDir, "ef-partial-r1.sqlite");
+    const manifestPath1 = join(suiteDir, "ef-partial-m1.json");
+    const reportPath1 = join(suiteDir, "ef-partial-rep1.json");
+
+    const origCwd = process.cwd();
+    process.chdir(projDir);
+    let errorClassObserved: string;
+    try {
+      const logger1 = new CollectingLogger();
+      await bootstrap(
+        ["--registry", registryPath1, "--manifest", manifestPath1, "--report", reportPath1],
+        logger1,
+      );
+      const report1 = JSON.parse(readFileSync(reportPath1, "utf-8")) as Array<{
+        outcome: string;
+        path: string;
+        errorClass?: string;
+      }>;
+      const bad1 = report1.find((r) => r.path.endsWith("bad1.ts"));
+      errorClassObserved = bad1?.errorClass ?? "Error";
+    } finally {
+      process.chdir(origCwd);
+    }
+
+    // Exempt only bad1.ts; bad2.ts remains a real failure.
+    const efPath = makeExpectedFailuresFile(suiteDir, "ef-partial.json", [
+      {
+        path: "packages/foo/src/bad1.ts",
+        errorClass: errorClassObserved,
+        rationale: "Intentional fixture.",
+      },
+    ]);
+
+    const registryPath2 = join(suiteDir, "ef-partial-r2.sqlite");
+    const manifestPath2 = join(suiteDir, "ef-partial-m2.json");
+    const reportPath2 = join(suiteDir, "ef-partial-rep2.json");
+
+    process.chdir(projDir);
+    try {
+      const logger2 = new CollectingLogger();
+      const code = await bootstrap(
+        [
+          "--registry",
+          registryPath2,
+          "--manifest",
+          manifestPath2,
+          "--report",
+          reportPath2,
+          "--expected-failures",
+          efPath,
+        ],
+        logger2,
+      );
+
+      // bad2.ts is still a real failure → exit 1.
+      expect(code).toBe(1);
+
+      const report2 = JSON.parse(readFileSync(reportPath2, "utf-8")) as Array<{
+        outcome: string;
+        path: string;
+      }>;
+      const ef1 = report2.find((r) => r.path.endsWith("bad1.ts"));
+      const f2 = report2.find((r) => r.path.endsWith("bad2.ts"));
+      expect(ef1?.outcome).toBe("expected-failure");
+      expect(f2?.outcome).toBe("failure");
+    } finally {
+      process.chdir(origCwd);
+    }
+  }, 120_000);
+
+  it("emits a warning for an untriggered expected-failure entry (path not in processed files)", async () => {
+    // A project with one valid file; expected-failures.json references a path that
+    // doesn't exist in the project. The entry is never triggered → warning, but exit 0.
+    const projDir = makeFixtureProject(suiteDir, "proj-ef-untriggered", [
+      {
+        relativePath: "packages/foo/src/ok.ts",
+        content: VALID_TS_SOURCE,
+      },
+    ]);
+
+    const efPath = makeExpectedFailuresFile(suiteDir, "ef-untriggered.json", [
+      {
+        path: "examples/v0.7-mri-demo/src/gpl-fixture.ts",
+        errorClass: "LicenseRefusedError",
+        rationale: "Intentional GPL fixture — but this fixture is not in this mini-project.",
+      },
+    ]);
+
+    const registryPath = join(suiteDir, "ef-unt-r.sqlite");
+    const manifestPath = join(suiteDir, "ef-unt-m.json");
+    const reportPath = join(suiteDir, "ef-unt-rep.json");
+
+    const origCwd = process.cwd();
+    process.chdir(projDir);
+    try {
+      const logger = new CollectingLogger();
+      const code = await bootstrap(
+        [
+          "--registry",
+          registryPath,
+          "--manifest",
+          manifestPath,
+          "--report",
+          reportPath,
+          "--expected-failures",
+          efPath,
+        ],
+        logger,
+      );
+
+      // Untriggered entry does NOT fail the bootstrap (warning only).
+      expect(code).toBe(0);
+
+      // Warning must appear in log output.
+      const logOutput = logger.logLines.join("\n");
+      expect(logOutput).toContain("warning");
+      expect(logOutput).toContain("expected-failure");
+      expect(logOutput).toContain("gpl-fixture.ts");
+    } finally {
+      process.chdir(origCwd);
+    }
+  }, 120_000);
+
+  it("exits 1 when expected-failures.json has an unsupported schemaVersion", async () => {
+    const badEfPath = join(suiteDir, "ef-badschema.json");
+    writeFileSync(badEfPath, JSON.stringify({ schemaVersion: 99, entries: [] }, null, 2), "utf-8");
+
+    const projDir = makeFixtureProject(suiteDir, "proj-ef-badschema", [
+      { relativePath: "packages/foo/src/ok.ts", content: VALID_TS_SOURCE },
+    ]);
+
+    const origCwd = process.cwd();
+    process.chdir(projDir);
+    try {
+      const logger = new CollectingLogger();
+      const code = await bootstrap(
+        [
+          "--registry",
+          join(suiteDir, "ef-badschema-r.sqlite"),
+          "--manifest",
+          join(suiteDir, "ef-badschema-m.json"),
+          "--report",
+          join(suiteDir, "ef-badschema-rep.json"),
+          "--expected-failures",
+          badEfPath,
+        ],
+        logger,
+      );
+      expect(code).toBe(1);
+      expect(logger.errLines.join("\n")).toContain("schemaVersion");
+    } finally {
+      process.chdir(origCwd);
+    }
+  }, 30_000);
+});

--- a/packages/cli/src/commands/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap.ts
@@ -48,6 +48,57 @@ import { shave as shaveImpl } from "@yakcc/shave";
 import type { Logger } from "../index.js";
 
 // ---------------------------------------------------------------------------
+// Expected-failures schema
+//
+// @decision DEC-V2-BOOT-EXPECTED-FAILURES-001
+// @title expected-failures.json documents intentional LicenseRefusedError cases
+// @status accepted
+// @rationale Some fixture files are intentionally GPL-licensed to exercise the
+//   license gate. These must not contribute to the bootstrap failure count.
+//   The expected-failures.json file (bootstrap/expected-failures.json) documents
+//   each such case with path + errorClass + rationale. Both path and errorClass
+//   must match for the reclassification to apply (path alone is insufficient —
+//   a file that fails for a different reason is a real failure). If an entry
+//   is never triggered, a WARNING is emitted: that either means the file was
+//   renamed/deleted or the underlying issue was fixed, both of which warrant
+//   removing the entry. Untriggered entries do NOT fail the bootstrap.
+// ---------------------------------------------------------------------------
+
+/** One entry in expected-failures.json. */
+interface ExpectedFailureEntry {
+  readonly path: string; // repo-relative, matches outcomes[].path
+  readonly errorClass: string; // constructor name, e.g. "LicenseRefusedError"
+  readonly rationale: string; // human-readable explanation
+}
+
+/** Top-level shape of bootstrap/expected-failures.json (schemaVersion: 1). */
+interface ExpectedFailuresFile {
+  readonly schemaVersion: 1;
+  readonly entries: readonly ExpectedFailureEntry[];
+}
+
+/**
+ * Load and parse expected-failures.json from the given path.
+ * Returns an empty entry list if the file does not exist.
+ * Throws if the file exists but is malformed (fast-fail: bad config is worse
+ * than a missed exemption).
+ */
+function loadExpectedFailures(filePath: string): readonly ExpectedFailureEntry[] {
+  if (!existsSync(filePath)) return [];
+  const raw = readFileSync(filePath, "utf-8");
+  const parsed = JSON.parse(raw) as ExpectedFailuresFile;
+  if (parsed.schemaVersion !== 1) {
+    throw new Error(
+      `expected-failures.json: unsupported schemaVersion ${String(parsed.schemaVersion)} (expected 1)`,
+    );
+  }
+  if (!Array.isArray(parsed.entries)) {
+    throw new Error("expected-failures.json: 'entries' must be an array");
+  }
+  return parsed.entries;
+}
+
+// ---------------------------------------------------------------------------
 // Argument parsing
 // ---------------------------------------------------------------------------
 
@@ -55,6 +106,7 @@ const BOOTSTRAP_PARSE_OPTIONS = {
   registry: { type: "string" as const },
   report: { type: "string" as const },
   manifest: { type: "string" as const },
+  "expected-failures": { type: "string" as const },
   verify: { type: "boolean" as const, default: false },
   help: { type: "boolean" as const, short: "h", default: false },
 } as const;
@@ -62,6 +114,7 @@ const BOOTSTRAP_PARSE_OPTIONS = {
 const DEFAULT_REGISTRY_PATH = join("bootstrap", "yakcc.registry.sqlite");
 const DEFAULT_MANIFEST_PATH = join("bootstrap", "expected-roots.json");
 const DEFAULT_REPORT_PATH = join("bootstrap", "report.json");
+const DEFAULT_EXPECTED_FAILURES_PATH = join("bootstrap", "expected-failures.json");
 
 // ---------------------------------------------------------------------------
 // File-walking helpers
@@ -187,7 +240,22 @@ interface FileOutcomeFailure {
   readonly errorMessage: string;
 }
 
-type FileOutcome = FileOutcomeSuccess | FileOutcomeFailure;
+/**
+ * A failure that was reclassified as an expected-failure because it matches an
+ * entry in expected-failures.json (path + errorClass both match).
+ * These are surfaced in the summary but do NOT count toward the failure total
+ * and do NOT cause a non-zero exit code.
+ */
+interface FileOutcomeExpectedFailure {
+  readonly path: string;
+  readonly outcome: "expected-failure";
+  readonly errorClass: string;
+  readonly errorMessage: string;
+  /** The rationale string from the matching expected-failures.json entry. */
+  readonly rationale: string;
+}
+
+type FileOutcome = FileOutcomeSuccess | FileOutcomeFailure | FileOutcomeExpectedFailure;
 
 // ---------------------------------------------------------------------------
 // VerifyDiff — structured diff result for --verify mode
@@ -407,13 +475,16 @@ export async function bootstrap(argv: ReadonlyArray<string>, logger: Logger): Pr
         "  Walk packages/*/src/**/*.ts and examples/*/src/**/*.ts, shave each file",
         "  offline, and dump the deterministic block manifest.",
         "",
-        "  --registry <path>   Registry SQLite path (default: bootstrap/yakcc.registry.sqlite)",
-        "  --manifest <path>   Manifest path: output in normal mode, committed reference in --verify",
-        "                      (default: bootstrap/expected-roots.json)",
-        "  --report   <path>   Per-file outcome report (default: bootstrap/report.json)",
-        "  --verify            Shave into :memory: registry and byte-compare against committed manifest.",
-        "                      Exit 0 on byte-identical match; exit 1 with structured diff on mismatch.",
-        "  -h, --help          Print this help and exit",
+        "  --registry           <path>  Registry SQLite path (default: bootstrap/yakcc.registry.sqlite)",
+        "  --manifest           <path>  Manifest path: output in normal mode, committed reference in --verify",
+        "                               (default: bootstrap/expected-roots.json)",
+        "  --report             <path>  Per-file outcome report (default: bootstrap/report.json)",
+        "  --expected-failures  <path>  Expected-failures exemption list (default: bootstrap/expected-failures.json)",
+        "                               Entries with matching path+errorClass are reclassified as expected-failures",
+        "                               and do NOT count toward the failure total.",
+        "  --verify                     Shave into :memory: registry and byte-compare against committed manifest.",
+        "                               Exit 0 on byte-identical match; exit 1 with structured diff on mismatch.",
+        "  -h, --help                   Print this help and exit",
       ].join("\n"),
     );
     return 0;
@@ -431,6 +502,28 @@ export async function bootstrap(argv: ReadonlyArray<string>, logger: Logger): Pr
 
   const registryPath = resolve(parsed.values.registry ?? DEFAULT_REGISTRY_PATH);
   const reportPath = resolve(parsed.values.report ?? DEFAULT_REPORT_PATH);
+
+  // Load expected-failures exemption list (DEC-V2-BOOT-EXPECTED-FAILURES-001).
+  // Resolve relative to repoRoot so the default path works regardless of cwd.
+  const expectedFailuresPath = resolve(
+    repoRoot,
+    parsed.values["expected-failures"] ?? DEFAULT_EXPECTED_FAILURES_PATH,
+  );
+  let expectedFailures: readonly ExpectedFailureEntry[];
+  try {
+    expectedFailures = loadExpectedFailures(expectedFailuresPath);
+  } catch (err) {
+    logger.error(
+      `error: failed to load expected-failures file at ${expectedFailuresPath}: ${(err as Error).message}`,
+    );
+    return 1;
+  }
+
+  // Build a lookup set keyed by "path\0errorClass" for O(1) matching.
+  const expectedFailureKeys = new Map<string, ExpectedFailureEntry>();
+  for (const entry of expectedFailures) {
+    expectedFailureKeys.set(`${entry.path}\0${entry.errorClass}`, entry);
+  }
 
   // Collect source files (lexicographic, DEC-V2-BOOT-FILE-ORDER-001).
   const sourceFiles = collectSourceFiles(repoRoot);
@@ -471,7 +564,7 @@ export async function bootstrap(argv: ReadonlyArray<string>, logger: Logger): Pr
   };
 
   // Process each file.
-  const outcomes: FileOutcome[] = [];
+  const rawOutcomes: FileOutcome[] = [];
 
   for (const absPath of sourceFiles) {
     const relPath = relative(repoRoot, absPath);
@@ -482,7 +575,7 @@ export async function bootstrap(argv: ReadonlyArray<string>, logger: Logger): Pr
         offline: true,
         intentStrategy: "static",
       });
-      outcomes.push({
+      rawOutcomes.push({
         path: relPath,
         outcome: "success",
         atomCount: result.atoms.length,
@@ -490,12 +583,39 @@ export async function bootstrap(argv: ReadonlyArray<string>, logger: Logger): Pr
       });
     } catch (err) {
       const e = err as Error;
-      outcomes.push({
+      rawOutcomes.push({
         path: relPath,
         outcome: "failure",
         errorClass: e.constructor.name,
         errorMessage: e.message,
       });
+    }
+  }
+
+  // Reclassify failures that match an expected-failures entry (DEC-V2-BOOT-EXPECTED-FAILURES-001).
+  // Track which expected-failure keys were actually triggered so we can warn about untriggered ones.
+  const triggeredKeys = new Set<string>();
+  const outcomes: FileOutcome[] = rawOutcomes.map((o) => {
+    if (o.outcome !== "failure") return o;
+    const key = `${o.path}\0${o.errorClass}`;
+    const entry = expectedFailureKeys.get(key);
+    if (entry === undefined) return o;
+    triggeredKeys.add(key);
+    return {
+      path: o.path,
+      outcome: "expected-failure" as const,
+      errorClass: o.errorClass,
+      errorMessage: o.errorMessage,
+      rationale: entry.rationale,
+    };
+  });
+
+  // Warn about untriggered expected-failure entries (they may have been fixed or renamed).
+  for (const [key, entry] of expectedFailureKeys) {
+    if (!triggeredKeys.has(key)) {
+      logger.log(
+        `warning: expected-failure entry was not triggered — either the file was fixed, renamed, or deleted. Remove or update this entry in expected-failures.json: ${entry.path} (${entry.errorClass})`,
+      );
     }
   }
 
@@ -518,14 +638,18 @@ export async function bootstrap(argv: ReadonlyArray<string>, logger: Logger): Pr
 
   // Summarise.
   const successCount = outcomes.filter((o) => o.outcome === "success").length;
+  const expectedFailureCount = outcomes.filter((o) => o.outcome === "expected-failure").length;
   const failureCount = outcomes.filter((o) => o.outcome === "failure").length;
 
   logger.log("Bootstrap complete:");
-  logger.log(`  files processed: ${outcomes.length}`);
-  logger.log(`  successful:      ${successCount}`);
-  logger.log(`  failed:          ${failureCount}`);
-  logger.log(`  manifest:        ${manifestPath} (${manifest.length} entries)`);
-  logger.log(`  report:          ${reportPath}`);
+  logger.log(`  files processed:   ${outcomes.length}`);
+  logger.log(`  successful:        ${successCount}`);
+  if (expectedFailureCount > 0) {
+    logger.log(`  expected-failures: ${expectedFailureCount} (license-refused, documented)`);
+  }
+  logger.log(`  failed:            ${failureCount}`);
+  logger.log(`  manifest:          ${manifestPath} (${manifest.length} entries)`);
+  logger.log(`  report:            ${reportPath}`);
 
   if (failureCount > 0) {
     logger.error(`error: ${failureCount} file(s) failed to shave:`);


### PR DESCRIPTION
## Summary

Closes #87 blocker 3 of 4.

Adds `bootstrap/expected-failures.json` (schemaVersion 1) documenting `examples/v0.7-mri-demo/src/gpl-fixture.ts` as an expected `LicenseRefusedError`. Updates bootstrap exit semantics so path+errorClass-matched failures are reclassified as expected-failures, excluded from the failure count, and do not cause exit 1.

## Behavior changes

- Stale entries (untriggered exemptions) emit a non-fatal warning.
- Fast-fails on malformed JSON or unsupported `schemaVersion`.
- New `--expected-failures <path>` flag (default: `bootstrap/expected-failures.json`).
- `DEC-V2-BOOT-EXPECTED-FAILURES-001` annotated at the reclassification site.

Acceptance: `yakcc bootstrap` now reports `134/135 successful + 1 expected-failure (license-refused)` against current source rather than failing.

## Test plan

- [x] 123/123 bootstrap CLI tests pass (8 pre-existing + 4 new for this slice)
- [x] Build clean against strict tsconfig
- [x] Reviewer verdict `ready_for_guardian` @ df3e74b (1 NOTE-severity finding, non-blocking, format-only)

Refs #87 (blocker 3 of 4).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>