### PR TITLE
test(registry): property-test coverage for select/search/discovery-eval-helpers/schema (#87 fill slice 1)

### DIFF
--- a/packages/registry/src/discovery-eval-helpers.props.test.ts
+++ b/packages/registry/src/discovery-eval-helpers.props.test.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for discovery-eval-helpers.props.ts
+// Two-file pattern: this file is the thin vitest wrapper; the corpus lives in
+// the sibling discovery-eval-helpers.props.ts (vitest-free, hashable as a manifest artifact).
+
+import * as fc from "fast-check";
+import { it } from "vitest";
+import {
+  prop_assignScoreBand_consistent_with_m1_threshold,
+  prop_assignScoreBand_output_is_valid,
+  prop_assignScoreBand_poor_lt_050,
+  prop_assignScoreBand_strong_ge_085,
+  prop_brierPerBand_deterministic,
+  prop_computeBrierPerBand_brier_null_iff_empty,
+  prop_computeBrierPerBand_counts_partition,
+  prop_computeHitRate_bounded,
+  prop_computeHitRate_empty_is_zero,
+  prop_computeMRR_bounded,
+  prop_computePrecisionAt1_bounded,
+  prop_computeRecallAtK_bounded,
+  prop_cosineDistance_monotone_decreasing,
+  prop_cosineDistance_output_bounded,
+  prop_cosineDistance_two_maps_to_zero,
+  prop_cosineDistance_zero_maps_to_one,
+  prop_metrics_deterministic,
+} from "./discovery-eval-helpers.props.js";
+
+// All functions are pure in-memory computation — no DB or network.
+// 200 runs provides strong coverage of the arbitrary space.
+const opts = { numRuns: 200 };
+
+it("property: prop_cosineDistance_output_bounded", () => {
+  fc.assert(prop_cosineDistance_output_bounded, opts);
+});
+
+it("property: prop_cosineDistance_monotone_decreasing", () => {
+  fc.assert(prop_cosineDistance_monotone_decreasing, opts);
+});
+
+it("property: prop_cosineDistance_zero_maps_to_one", () => {
+  fc.assert(prop_cosineDistance_zero_maps_to_one, opts);
+});
+
+it("property: prop_cosineDistance_two_maps_to_zero", () => {
+  fc.assert(prop_cosineDistance_two_maps_to_zero, opts);
+});
+
+it("property: prop_assignScoreBand_output_is_valid", () => {
+  fc.assert(prop_assignScoreBand_output_is_valid, opts);
+});
+
+it("property: prop_assignScoreBand_strong_ge_085", () => {
+  fc.assert(prop_assignScoreBand_strong_ge_085, opts);
+});
+
+it("property: prop_assignScoreBand_poor_lt_050", () => {
+  fc.assert(prop_assignScoreBand_poor_lt_050, opts);
+});
+
+it("property: prop_assignScoreBand_consistent_with_m1_threshold", () => {
+  fc.assert(prop_assignScoreBand_consistent_with_m1_threshold, opts);
+});
+
+it("property: prop_computeHitRate_bounded", () => {
+  fc.assert(prop_computeHitRate_bounded, opts);
+});
+
+it("property: prop_computeHitRate_empty_is_zero", () => {
+  fc.assert(prop_computeHitRate_empty_is_zero, opts);
+});
+
+it("property: prop_computePrecisionAt1_bounded", () => {
+  fc.assert(prop_computePrecisionAt1_bounded, opts);
+});
+
+it("property: prop_computeRecallAtK_bounded", () => {
+  fc.assert(prop_computeRecallAtK_bounded, opts);
+});
+
+it("property: prop_computeMRR_bounded", () => {
+  fc.assert(prop_computeMRR_bounded, opts);
+});
+
+it("property: prop_computeBrierPerBand_counts_partition", () => {
+  fc.assert(prop_computeBrierPerBand_counts_partition, opts);
+});
+
+it("property: prop_computeBrierPerBand_brier_null_iff_empty", () => {
+  fc.assert(prop_computeBrierPerBand_brier_null_iff_empty, opts);
+});
+
+it("property: prop_metrics_deterministic", () => {
+  fc.assert(prop_metrics_deterministic, opts);
+});
+
+it("property: prop_brierPerBand_deterministic", () => {
+  fc.assert(prop_brierPerBand_deterministic, opts);
+});

--- a/packages/registry/src/discovery-eval-helpers.props.ts
+++ b/packages/registry/src/discovery-eval-helpers.props.ts
@@ -1,0 +1,421 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-004: hand-authored property-test corpus for
+// @yakcc/registry discovery-eval-helpers.ts. Two-file pattern: this file
+// (.props.ts) is vitest-free and holds the corpus; the sibling
+// .props.test.ts is the vitest harness.
+// Status: accepted (issue-87-fill-registry)
+// Rationale: The D5 metric functions (M1–M5) have precise mathematical
+// invariants from the D5 ADR that property tests can verify exhaustively across
+// the full input domain. Example-based tests cover specific fixed values; property
+// tests verify the algebraic structure (monotonicity, boundedness, partition
+// correctness) that must hold for ALL inputs.
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for discovery-eval-helpers.ts
+//
+// Functions covered (all pure; no DB/registry/network):
+//   cosineDistanceToCombinedScore — D3 L2→combinedScore formula
+//   assignScoreBand               — D3 band boundary classifier
+//   computeHitRate                — M1: % of queries above threshold
+//   computePrecisionAt1           — M2: % of queries with correct top-1
+//   computeRecallAtK              — M3: % of queries with expected atom in top-K
+//   computeMRR                    — M4: mean reciprocal rank
+//   computeBrierPerBand           — M5: per-band calibration error
+//
+// Behaviors exercised:
+//   D1  — cosineDistanceToCombinedScore: output in [0, 1] for any L2 distance
+//   D2  — cosineDistanceToCombinedScore: monotone decreasing in distance
+//   D3  — cosineDistanceToCombinedScore: L2=0 → 1.0, L2=2 → 0.0
+//   D4  — assignScoreBand: output is always one of the four valid band names
+//   D5  — assignScoreBand: consistent with band boundary thresholds
+//   D6  — computeHitRate: output in [0, 1] for any result list
+//   D7  — computeHitRate: empty list → 0
+//   D8  — computePrecisionAt1: output in [0, 1]
+//   D9  — computeRecallAtK: output in [0, 1]
+//   D10 — computeMRR: output in [0, 1], MRR ≤ 1/min_rank
+//   D11 — computeBrierPerBand: band counts partition (sum = total results)
+//   D12 — computeBrierPerBand: brier null iff N=0 for that band
+//   D13 — metric functions are deterministic (same input → same output)
+// ---------------------------------------------------------------------------
+
+import * as fc from "fast-check";
+import {
+  M1_HIT_THRESHOLD,
+  assignScoreBand,
+  computeBrierPerBand,
+  computeHitRate,
+  computeMRR,
+  computePrecisionAt1,
+  computeRecallAtK,
+  cosineDistanceToCombinedScore,
+} from "./discovery-eval-helpers.js";
+import type { QueryResult, ScoreBand } from "./discovery-eval-helpers.js";
+
+// ---------------------------------------------------------------------------
+// Shared arbitraries
+// ---------------------------------------------------------------------------
+
+/** Arbitrary for a score in [0, 1]. */
+const scoreArb: fc.Arbitrary<number> = fc.float({
+  min: 0,
+  max: 1,
+  noNaN: true,
+  noDefaultInfinity: true,
+});
+
+/** Arbitrary for an L2 distance (vec0 output). Covers the full possible range and beyond. */
+const l2DistanceArb: fc.Arbitrary<number> = fc.float({
+  min: -0.5,
+  max: 3.0,
+  noNaN: true,
+  noDefaultInfinity: true,
+});
+
+/** Valid band names. */
+const VALID_BANDS: readonly ScoreBand[] = ["strong", "confident", "weak", "poor"];
+
+/**
+ * Arbitrary for a QueryResult with all fields generated.
+ * The top1Band is derived from top1Score so they are consistent.
+ */
+const queryResultArb: fc.Arbitrary<QueryResult> = fc
+  .record({
+    entryId: fc.string({ minLength: 1, maxLength: 10 }),
+    top1Score: scoreArb,
+    top1Atom: fc.option(fc.string({ minLength: 1, maxLength: 10 }), { nil: null }),
+    expectedAtom: fc.option(fc.string({ minLength: 1, maxLength: 10 }), { nil: null }),
+    top1Correct: fc.boolean(),
+    expectedAtomRank: fc.option(fc.integer({ min: 1, max: 10 }), { nil: null }),
+    allAtoms: fc.array(fc.string({ minLength: 1, maxLength: 10 }), {
+      minLength: 0,
+      maxLength: 5,
+    }),
+  })
+  .map(
+    ({ entryId, top1Score, top1Atom, expectedAtom, top1Correct, expectedAtomRank, allAtoms }) => ({
+      entryId,
+      expectedAtom,
+      acceptableAtoms: [],
+      top1Score,
+      top1Atom,
+      top1Band: assignScoreBand(top1Score),
+      top1Correct: expectedAtom !== null && top1Correct,
+      expectedAtomRank: expectedAtom !== null ? expectedAtomRank : null,
+      allAtoms,
+    }),
+  );
+
+/** Arbitrary for a non-empty list of QueryResults. */
+const queryResultListArb: fc.Arbitrary<readonly QueryResult[]> = fc.array(queryResultArb, {
+  minLength: 1,
+  maxLength: 10,
+});
+
+// ---------------------------------------------------------------------------
+// D1: cosineDistanceToCombinedScore output is always in [0, 1]
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_cosineDistance_output_bounded
+ *
+ * For any L2 distance value (including out-of-range inputs), the output of
+ * cosineDistanceToCombinedScore is always in [0, 1].
+ *
+ * Invariant: the function applies Math.max(0, Math.min(1, ...)) clamping, so
+ * the output is always a valid combined score regardless of input.
+ */
+export const prop_cosineDistance_output_bounded = fc.property(l2DistanceArb, (d) => {
+  const score = cosineDistanceToCombinedScore(d);
+  return score >= 0 && score <= 1;
+});
+
+// ---------------------------------------------------------------------------
+// D2: cosineDistanceToCombinedScore is monotone decreasing in distance
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_cosineDistance_monotone_decreasing
+ *
+ * For L2 distances d1 < d2 in [0, 2] (unit-sphere valid range), the score
+ * for d1 must be >= the score for d2.
+ *
+ * Invariant: closer vectors (smaller L2 distance) always produce higher
+ * combined scores. This is the fundamental correctness property of the
+ * distance-to-score mapping (DEC-V3-DISCOVERY-CALIBRATION-FIX-002).
+ */
+export const prop_cosineDistance_monotone_decreasing = fc.property(
+  fc.float({ min: 0, max: 2, noNaN: true, noDefaultInfinity: true }),
+  fc.float({ min: 0, max: 2, noNaN: true, noDefaultInfinity: true }),
+  (d1, d2) => {
+    if (d1 >= d2) return true; // skip: only test d1 < d2
+    const s1 = cosineDistanceToCombinedScore(d1);
+    const s2 = cosineDistanceToCombinedScore(d2);
+    // s1 >= s2 with small float tolerance
+    return s1 >= s2 - 1e-10;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// D3: cosineDistanceToCombinedScore boundary values
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_cosineDistance_zero_maps_to_one
+ *
+ * L2 distance of exactly 0 (identical vectors) maps to combinedScore 1.0.
+ *
+ * Invariant: 1 - 0²/4 = 1.0.
+ */
+export const prop_cosineDistance_zero_maps_to_one = fc.property(
+  fc.constant(0),
+  (d) => cosineDistanceToCombinedScore(d) === 1.0,
+);
+
+/**
+ * prop_cosineDistance_two_maps_to_zero
+ *
+ * L2 distance of exactly 2 (antipodal unit vectors) maps to combinedScore 0.0.
+ *
+ * Invariant: 1 - 2²/4 = 1 - 1 = 0.0.
+ */
+export const prop_cosineDistance_two_maps_to_zero = fc.property(
+  fc.constant(2),
+  (d) => cosineDistanceToCombinedScore(d) === 0.0,
+);
+
+// ---------------------------------------------------------------------------
+// D4: assignScoreBand output is always a valid band name
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_assignScoreBand_output_is_valid
+ *
+ * For any score in [0, 1], assignScoreBand() returns one of the four valid
+ * band names: "strong", "confident", "weak", "poor".
+ *
+ * Invariant: the four branches of assignScoreBand() are exhaustive and
+ * mutually exclusive. No score produces an undefined or invalid band.
+ */
+export const prop_assignScoreBand_output_is_valid = fc.property(scoreArb, (score) => {
+  const band = assignScoreBand(score);
+  return VALID_BANDS.includes(band);
+});
+
+// ---------------------------------------------------------------------------
+// D5: assignScoreBand is consistent with band boundary thresholds
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_assignScoreBand_strong_ge_085
+ *
+ * For any score >= 0.85, assignScoreBand() returns "strong".
+ *
+ * Invariant: D3 ADR band boundary — strong band starts at 0.85.
+ */
+export const prop_assignScoreBand_strong_ge_085 = fc.property(
+  fc.float({ min: Math.fround(0.85), max: 1.0, noNaN: true, noDefaultInfinity: true }),
+  (score) => assignScoreBand(score) === "strong",
+);
+
+/**
+ * prop_assignScoreBand_poor_lt_050
+ *
+ * For any score < 0.50, assignScoreBand() returns "poor".
+ *
+ * Invariant: D3 ADR band boundary — poor band ends at 0.50 exclusive.
+ */
+export const prop_assignScoreBand_poor_lt_050 = fc.property(
+  fc.float({ min: 0, max: Math.fround(0.4999), noNaN: true, noDefaultInfinity: true }),
+  (score) => assignScoreBand(score) === "poor",
+);
+
+/**
+ * prop_assignScoreBand_consistent_with_m1_threshold
+ *
+ * Any score >= M1_HIT_THRESHOLD (0.50) must map to a band that is at least
+ * "weak" (i.e., not "poor"). This is the D5 ADR §Q1 M1 threshold invariant.
+ *
+ * Invariant: M1_HIT_THRESHOLD equals the weak-band entry boundary.
+ * A hit (score >= threshold) must be in weak, confident, or strong band.
+ */
+export const prop_assignScoreBand_consistent_with_m1_threshold = fc.property(
+  fc.float({ min: M1_HIT_THRESHOLD, max: 1.0, noNaN: true, noDefaultInfinity: true }),
+  (score) => {
+    const band = assignScoreBand(score);
+    return band === "weak" || band === "confident" || band === "strong";
+  },
+);
+
+// ---------------------------------------------------------------------------
+// D6: computeHitRate output is in [0, 1]
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_computeHitRate_bounded
+ *
+ * For any non-empty list of QueryResults, computeHitRate() returns a value
+ * in [0, 1].
+ *
+ * Invariant: hit rate is a proportion and always lies in the unit interval.
+ */
+export const prop_computeHitRate_bounded = fc.property(queryResultListArb, (results) => {
+  const rate = computeHitRate(results);
+  return rate >= 0 && rate <= 1;
+});
+
+// ---------------------------------------------------------------------------
+// D7: computeHitRate empty list → 0
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_computeHitRate_empty_is_zero
+ *
+ * computeHitRate([]) returns exactly 0.
+ *
+ * Invariant: the empty-list guard returns 0 immediately (no division by zero).
+ */
+export const prop_computeHitRate_empty_is_zero = fc.property(
+  fc.constant([] as QueryResult[]),
+  (results) => computeHitRate(results) === 0,
+);
+
+// ---------------------------------------------------------------------------
+// D8: computePrecisionAt1 output is in [0, 1]
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_computePrecisionAt1_bounded
+ *
+ * For any list of QueryResults, computePrecisionAt1() returns a value in [0, 1].
+ *
+ * Invariant: precision is a proportion; the empty-eligible-entries guard
+ * returns 0 (no division by zero).
+ */
+export const prop_computePrecisionAt1_bounded = fc.property(queryResultListArb, (results) => {
+  const p = computePrecisionAt1(results);
+  return p >= 0 && p <= 1;
+});
+
+// ---------------------------------------------------------------------------
+// D9: computeRecallAtK output is in [0, 1]
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_computeRecallAtK_bounded
+ *
+ * For any list of QueryResults, computeRecallAtK() returns a value in [0, 1].
+ *
+ * Invariant: recall is a proportion in [0, 1].
+ */
+export const prop_computeRecallAtK_bounded = fc.property(queryResultListArb, (results) => {
+  const r = computeRecallAtK(results);
+  return r >= 0 && r <= 1;
+});
+
+// ---------------------------------------------------------------------------
+// D10: computeMRR output is in [0, 1]
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_computeMRR_bounded
+ *
+ * For any list of QueryResults, computeMRR() returns a value in [0, 1].
+ *
+ * Invariant: 1/rank is in (0, 1] for rank >= 1, and 0 for not-found.
+ * The mean of values in [0, 1] is also in [0, 1].
+ */
+export const prop_computeMRR_bounded = fc.property(queryResultListArb, (results) => {
+  const mrr = computeMRR(results);
+  return mrr >= 0 && mrr <= 1;
+});
+
+// ---------------------------------------------------------------------------
+// D11: computeBrierPerBand — band counts partition total results
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_computeBrierPerBand_counts_partition
+ *
+ * For any list of QueryResults, the sum of N across all four bands equals the
+ * total number of results.
+ *
+ * Invariant: every result is assigned to exactly one band by assignScoreBand(),
+ * so the four band counts partition the full result set.
+ */
+export const prop_computeBrierPerBand_counts_partition = fc.property(
+  queryResultListArb,
+  (results) => {
+    const brier = computeBrierPerBand(results);
+    const total = brier.strong.N + brier.confident.N + brier.weak.N + brier.poor.N;
+    return total === results.length;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// D12: computeBrierPerBand — brier is null iff N=0
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_computeBrierPerBand_brier_null_iff_empty
+ *
+ * For each band in the output of computeBrierPerBand(), brier is null if and
+ * only if N === 0 for that band.
+ *
+ * Invariant: the empty-band guard (brier=null when N=0) fires correctly and
+ * never produces brier=null for a non-empty band or brier≠null for an empty band.
+ */
+export const prop_computeBrierPerBand_brier_null_iff_empty = fc.property(
+  queryResultListArb,
+  (results) => {
+    const brier = computeBrierPerBand(results);
+    const bands = [brier.strong, brier.confident, brier.weak, brier.poor];
+    return bands.every((b) => (b.N === 0) === (b.brier === null));
+  },
+);
+
+// ---------------------------------------------------------------------------
+// D13: All metric functions are deterministic
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_metrics_deterministic
+ *
+ * Two calls to each metric function with the same input produce the same output.
+ *
+ * Invariant: M1–M5 metric functions are pure and have no hidden state or
+ * side effects.
+ */
+export const prop_metrics_deterministic = fc.property(queryResultListArb, (results) => {
+  const m1a = computeHitRate(results);
+  const m1b = computeHitRate(results);
+  const m2a = computePrecisionAt1(results);
+  const m2b = computePrecisionAt1(results);
+  const m3a = computeRecallAtK(results);
+  const m3b = computeRecallAtK(results);
+  const m4a = computeMRR(results);
+  const m4b = computeMRR(results);
+  return m1a === m1b && m2a === m2b && m3a === m3b && m4a === m4b;
+});
+
+/**
+ * prop_brierPerBand_deterministic
+ *
+ * Two calls to computeBrierPerBand() with the same input produce the same
+ * per-band N and brier values.
+ *
+ * Invariant: computeBrierPerBand() is pure and deterministic.
+ */
+export const prop_brierPerBand_deterministic = fc.property(queryResultListArb, (results) => {
+  const b1 = computeBrierPerBand(results);
+  const b2 = computeBrierPerBand(results);
+  return (
+    b1.strong.N === b2.strong.N &&
+    b1.confident.N === b2.confident.N &&
+    b1.weak.N === b2.weak.N &&
+    b1.poor.N === b2.poor.N &&
+    b1.strong.brier === b2.strong.brier &&
+    b1.confident.brier === b2.confident.brier &&
+    b1.weak.brier === b2.weak.brier &&
+    b1.poor.brier === b2.poor.brier
+  );
+});

--- a/packages/registry/src/schema.props.test.ts
+++ b/packages/registry/src/schema.props.test.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for schema.props.ts
+// Two-file pattern: this file is the thin vitest wrapper; the corpus lives in
+// the sibling schema.props.ts (vitest-free, hashable as a manifest artifact).
+
+import * as fc from "fast-check";
+import { it } from "vitest";
+import {
+  prop_applyMigrations_fresh_db_bumps_version,
+  prop_applyMigrations_idempotent_at_current_version,
+  prop_schema_version_is_positive_integer,
+} from "./schema.props.js";
+
+// applyMigrations runs against an in-memory mock DB — no SQLite, no sqlite-vec.
+// numRuns: 100 is sufficient (properties use fc.constant, so the arbitrary space is trivial).
+const opts = { numRuns: 100 };
+
+it("property: prop_schema_version_is_positive_integer", () => {
+  fc.assert(prop_schema_version_is_positive_integer, opts);
+});
+
+it("property: prop_applyMigrations_idempotent_at_current_version", () => {
+  fc.assert(prop_applyMigrations_idempotent_at_current_version, opts);
+});
+
+it("property: prop_applyMigrations_fresh_db_bumps_version", () => {
+  fc.assert(prop_applyMigrations_fresh_db_bumps_version, opts);
+});

--- a/packages/registry/src/schema.props.ts
+++ b/packages/registry/src/schema.props.ts
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-005: property-test corpus for schema.ts.
+// Status: accepted (issue-87-fill-registry)
+// Rationale: schema.ts has two testable surfaces without a real SQLite DB:
+//   (1) SCHEMA_VERSION is a positive integer constant — a simple invariant.
+//   (2) applyMigrations() is callable against a mock MigrationsDb that records
+//       SQL statements. We verify that calling it on a DB already at SCHEMA_VERSION
+//       issues no ALTER TABLE statements (idempotency) and that calling it on a
+//       fresh DB (version 0) issues DDL that bumps the version.
+// The mock DB approach is the same pattern used in schema.test.ts; it avoids
+// the sqlite-vec native module dependency at test time.
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for schema.ts
+//
+// Surfaces covered:
+//   SCHEMA_VERSION  — positive integer constant
+//   applyMigrations — migration driver (idempotency + monotonicity)
+//
+// Properties:
+//   SC1 — SCHEMA_VERSION is a positive integer
+//   SC2 — applyMigrations is idempotent: calling on an already-migrated DB
+//          issues no new migrations (no UPDATE SET version = N for N already applied)
+//   SC3 — applyMigrations on version 0 DB bumps version to SCHEMA_VERSION
+// ---------------------------------------------------------------------------
+
+import * as fc from "fast-check";
+import { SCHEMA_VERSION, applyMigrations } from "./schema.js";
+import type { MigrationsDb } from "./schema.js";
+
+// ---------------------------------------------------------------------------
+// Mock DB factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal MigrationsDb mock that:
+ * - Tracks all exec() SQL strings in `execLog`.
+ * - Tracks all run() arguments in `runLog`.
+ * - Returns `currentVersion` from SELECT version queries.
+ * - Returns undefined (no rows) from any other SELECT.
+ *
+ * This mirrors the mock pattern in schema.test.ts (if one exists), allowing
+ * applyMigrations to be tested without a live SQLite + sqlite-vec environment.
+ */
+function makeMockDb(currentVersion: number): {
+  db: MigrationsDb;
+  execLog: string[];
+  runLog: Array<{ sql: string; args: unknown[] }>;
+} {
+  const execLog: string[] = [];
+  const runLog: Array<{ sql: string; args: unknown[] }> = [];
+
+  const db: MigrationsDb = {
+    exec(sql: string) {
+      execLog.push(sql.trim());
+    },
+    prepare(sql: string) {
+      return {
+        get(..._params: unknown[]): unknown {
+          // Return a version row for the "SELECT version FROM schema_version" query.
+          if (sql.includes("SELECT version FROM schema_version")) {
+            return { version: currentVersion };
+          }
+          return undefined;
+        },
+        run(...args: unknown[]): unknown {
+          runLog.push({ sql: sql.trim(), args });
+          return undefined;
+        },
+      };
+    },
+  };
+
+  return { db, execLog, runLog };
+}
+
+// ---------------------------------------------------------------------------
+// SC1: SCHEMA_VERSION is a positive integer
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_schema_version_is_positive_integer
+ *
+ * SCHEMA_VERSION is a positive integer (>= 1). It is not zero, negative, or
+ * fractional.
+ *
+ * Invariant: schema versions are 1-based positive integers. Version 0 is the
+ * "uninitialized" sentinel (no migrations applied). SCHEMA_VERSION must always
+ * be >= 1 so that fresh DBs receive at least migration 1.
+ */
+export const prop_schema_version_is_positive_integer = fc.property(
+  fc.constant(SCHEMA_VERSION),
+  (v) => Number.isInteger(v) && v >= 1,
+);
+
+// ---------------------------------------------------------------------------
+// SC2: applyMigrations is idempotent on already-migrated DB
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_applyMigrations_idempotent_at_current_version
+ *
+ * When called on a DB already at SCHEMA_VERSION, applyMigrations() issues no
+ * UPDATE SET version = N statements (no version bumps attempted).
+ *
+ * Invariant: each migration is guarded by `if (currentVersion < N)`. When
+ * currentVersion = SCHEMA_VERSION, no migration block fires, so no version
+ * UPDATE is issued. This is the idempotency guarantee documented in the
+ * applyMigrations JSDoc.
+ */
+export const prop_applyMigrations_idempotent_at_current_version = fc.property(
+  fc.constant(SCHEMA_VERSION),
+  (version) => {
+    const { db, runLog } = makeMockDb(version);
+    applyMigrations(db);
+    // No UPDATE schema_version SET version = ? should have been issued.
+    const versionBumps = runLog.filter((r) => r.sql.includes("UPDATE schema_version"));
+    return versionBumps.length === 0;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// SC3: applyMigrations on version 0 DB bumps to SCHEMA_VERSION
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_applyMigrations_fresh_db_bumps_version
+ *
+ * When called on a DB at version 0, applyMigrations() issues at least one
+ * UPDATE SET version = ? statement, and the last such statement sets the
+ * version to SCHEMA_VERSION (or the highest version applyMigrations manages
+ * without external backfill).
+ *
+ * Note: Migration 2→3 has a two-phase split (DDL here, backfill + bump in
+ * openRegistry). applyMigrations only bumps to 2 from a version-0 start; the
+ * caller (openRegistry) performs the backfill and bumps to 3. We verify that
+ * version bumps were issued (at least one) and that no bump tries to set a
+ * version above SCHEMA_VERSION.
+ *
+ * Invariant: applyMigrations always makes forward progress on a fresh DB.
+ */
+export const prop_applyMigrations_fresh_db_bumps_version = fc.property(
+  fc.constant(0),
+  (startVersion) => {
+    const { db, runLog } = makeMockDb(startVersion);
+    applyMigrations(db);
+    const versionBumps = runLog.filter((r) => r.sql.includes("UPDATE schema_version"));
+    if (versionBumps.length === 0) return false; // must have issued at least one bump
+
+    // All bumped versions must be positive and <= SCHEMA_VERSION
+    for (const bump of versionBumps) {
+      const v = bump.args[0];
+      if (typeof v !== "number" || v < 1 || v > SCHEMA_VERSION) return false;
+    }
+    return true;
+  },
+);

--- a/packages/registry/src/search.props.test.ts
+++ b/packages/registry/src/search.props.test.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for search.props.ts
+// Two-file pattern: this file is the thin vitest wrapper; the corpus lives in
+// the sibling search.props.ts (vitest-free, hashable as a manifest artifact).
+
+import * as fc from "fast-check";
+import { it } from "vitest";
+import {
+  prop_structuralMatch_deterministic,
+  prop_structuralMatch_extra_candidate_error_returns_false,
+  prop_structuralMatch_input_count_mismatch_returns_false,
+  prop_structuralMatch_monotone_error_relaxation,
+  prop_structuralMatch_monotone_nf_relaxation,
+  prop_structuralMatch_output_count_mismatch_returns_false,
+  prop_structuralMatch_reasons_nonempty_on_false,
+  prop_structuralMatch_reflexive,
+  prop_structuralMatch_total,
+} from "./search.props.js";
+import { prop_structuralMatch_error_subset_matches } from "./search.props.js";
+
+// structuralMatch() is a pure in-memory function.
+// 200 runs gives good coverage of the arbitrary domain.
+const opts = { numRuns: 200 };
+
+it("property: prop_structuralMatch_total", () => {
+  fc.assert(prop_structuralMatch_total, opts);
+});
+
+it("property: prop_structuralMatch_deterministic", () => {
+  fc.assert(prop_structuralMatch_deterministic, opts);
+});
+
+it("property: prop_structuralMatch_reflexive", () => {
+  fc.assert(prop_structuralMatch_reflexive, opts);
+});
+
+it("property: prop_structuralMatch_input_count_mismatch_returns_false", () => {
+  fc.assert(prop_structuralMatch_input_count_mismatch_returns_false, opts);
+});
+
+it("property: prop_structuralMatch_output_count_mismatch_returns_false", () => {
+  fc.assert(prop_structuralMatch_output_count_mismatch_returns_false, opts);
+});
+
+it("property: prop_structuralMatch_error_subset_matches", () => {
+  fc.assert(prop_structuralMatch_error_subset_matches, opts);
+});
+
+it("property: prop_structuralMatch_extra_candidate_error_returns_false", () => {
+  fc.assert(prop_structuralMatch_extra_candidate_error_returns_false, opts);
+});
+
+it("property: prop_structuralMatch_monotone_error_relaxation", () => {
+  fc.assert(prop_structuralMatch_monotone_error_relaxation, opts);
+});
+
+it("property: prop_structuralMatch_monotone_nf_relaxation", () => {
+  fc.assert(prop_structuralMatch_monotone_nf_relaxation, opts);
+});
+
+it("property: prop_structuralMatch_reasons_nonempty_on_false", () => {
+  fc.assert(prop_structuralMatch_reasons_nonempty_on_false, opts);
+});

--- a/packages/registry/src/search.props.ts
+++ b/packages/registry/src/search.props.ts
@@ -1,0 +1,492 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-003: hand-authored property-test corpus for
+// @yakcc/registry search.ts. Two-file pattern: this file (.props.ts) is
+// vitest-free and holds the corpus; the sibling .props.test.ts is the vitest harness.
+// Status: accepted (issue-87-fill-registry)
+// Rationale: structuralMatch() has rich monotonicity invariants (DEC-SEARCH-STRUCTURAL-001)
+// that cannot be exhaustively enumerated by example-based tests. Property tests
+// cover totality, determinism, reflexivity, and the key monotonicity invariant:
+// relaxing a caller's requirement never turns a match into a non-match.
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for search.ts
+//
+// Functions covered:
+//   structuralMatch() — pure structural match function (DEC-SEARCH-STRUCTURAL-001)
+//
+// structuralMatch() is a pure function with no DB access. Properties are authored
+// against the exported function directly.
+//
+// Behaviors exercised:
+//   M1  — totality: never throws on valid inputs
+//   M2  — determinism: same input → same output
+//   M3  — reflexivity: a spec always matches itself
+//   M4  — input count mismatch → false with reason
+//   M5  — output count mismatch → false with reason
+//   M6  — error subset: candidate errors ⊆ caller errors → matches
+//   M7  — error superset: candidate extra errors → not matches
+//   M8  — monotonicity: relaxing error conditions never flips true → false
+//   M9  — monotonicity: relaxing nf requirements never flips true → false
+//   M10 — reasons array is non-empty on false result
+// ---------------------------------------------------------------------------
+
+import type { SpecYak } from "@yakcc/contracts";
+import * as fc from "fast-check";
+import { structuralMatch } from "./search.js";
+
+// ---------------------------------------------------------------------------
+// Shared arbitraries
+// ---------------------------------------------------------------------------
+
+/** Arbitrary for a type string — short alphanumeric tokens like "string", "number", "T". */
+const typeStringArb: fc.Arbitrary<string> = fc.constantFrom(
+  "string",
+  "number",
+  "boolean",
+  "object",
+  "unknown",
+  "T",
+  "U",
+);
+
+/** Arbitrary for a named typed parameter (one input or output slot). */
+const paramArb: fc.Arbitrary<{ name: string; type: string }> = fc.record({
+  name: fc.string({ minLength: 1, maxLength: 10 }),
+  type: typeStringArb,
+});
+
+/** Arbitrary for a list of 0–3 parameters. */
+const paramListArb: fc.Arbitrary<readonly { name: string; type: string }[]> = fc.array(paramArb, {
+  minLength: 0,
+  maxLength: 3,
+});
+
+/** Arbitrary for a purity level (DEC-SEARCH-STRUCTURAL-001 ordering). */
+const purityArb: fc.Arbitrary<"pure" | "io" | "stateful" | "nondeterministic"> = fc.constantFrom(
+  "pure" as const,
+  "io" as const,
+  "stateful" as const,
+  "nondeterministic" as const,
+);
+
+/** Arbitrary for a thread-safety level. */
+const threadSafetyArb: fc.Arbitrary<"safe" | "sequential" | "unsafe"> = fc.constantFrom(
+  "safe" as const,
+  "sequential" as const,
+  "unsafe" as const,
+);
+
+/**
+ * Arbitrary for a minimal SpecYak. Both inputs and outputs are generated;
+ * nonFunctional is included so NF checks can fire.
+ */
+const specArb: fc.Arbitrary<SpecYak> = fc
+  .record({
+    name: fc.string({ minLength: 1, maxLength: 15 }),
+    behavior: fc.string({ minLength: 1, maxLength: 30 }),
+    inputs: paramListArb,
+    outputs: paramListArb,
+    purity: purityArb,
+    threadSafety: threadSafetyArb,
+  })
+  .map(({ name, behavior, inputs, outputs, purity, threadSafety }) => ({
+    name,
+    inputs,
+    outputs,
+    preconditions: [],
+    postconditions: [],
+    invariants: [],
+    effects: [],
+    level: "L0" as const,
+    behavior,
+    guarantees: [],
+    errorConditions: [],
+    nonFunctional: { purity, threadSafety },
+    propertyTests: [],
+  }));
+
+// ---------------------------------------------------------------------------
+// M1: Totality — structuralMatch() never throws
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_structuralMatch_total
+ *
+ * For any two SpecYak values, structuralMatch() returns a MatchResult without
+ * throwing. The result is always either { matches: true } or
+ * { matches: false, reasons: [...] }.
+ *
+ * Invariant: structuralMatch() is total on any valid SpecYak pair.
+ */
+export const prop_structuralMatch_total = fc.property(specArb, specArb, (spec, candidate) => {
+  const result = structuralMatch(spec, candidate);
+  return typeof result.matches === "boolean";
+});
+
+// ---------------------------------------------------------------------------
+// M2: Determinism — same inputs → same output
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_structuralMatch_deterministic
+ *
+ * Two calls to structuralMatch() with the same arguments produce the same
+ * matches boolean.
+ *
+ * Invariant: structuralMatch() is a pure, deterministic function.
+ */
+export const prop_structuralMatch_deterministic = fc.property(
+  specArb,
+  specArb,
+  (spec, candidate) => {
+    const r1 = structuralMatch(spec, candidate);
+    const r2 = structuralMatch(spec, candidate);
+    return r1.matches === r2.matches;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// M3: Reflexivity — a spec matches itself
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_structuralMatch_reflexive
+ *
+ * For any SpecYak spec, structuralMatch(spec, spec) returns { matches: true }.
+ *
+ * Invariant: the candidate satisfying the exact same spec it was registered
+ * under always structurally matches the caller's identical spec. Input/output
+ * counts and types are identical; error conditions are a subset (equal); NF
+ * properties are at least as strong (equal).
+ */
+export const prop_structuralMatch_reflexive = fc.property(specArb, (spec) => {
+  const result = structuralMatch(spec, spec);
+  return result.matches === true;
+});
+
+// ---------------------------------------------------------------------------
+// M4: Input count mismatch → false with reason
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_structuralMatch_input_count_mismatch_returns_false
+ *
+ * When caller has N inputs and candidate has M ≠ N inputs, structuralMatch()
+ * returns { matches: false } and includes a reason string mentioning
+ * "count mismatch".
+ *
+ * Invariant: input count divergence is always caught and reported (check 1
+ * in DEC-SEARCH-V0-PRAGMATIC-001).
+ */
+export const prop_structuralMatch_input_count_mismatch_returns_false = fc.property(
+  // Generate a list of 1–3 params and a different-length list
+  fc.array(paramArb, { minLength: 1, maxLength: 3 }),
+  fc.array(paramArb, { minLength: 0, maxLength: 3 }),
+  (callerInputs, candidateInputs) => {
+    // Only test when lengths differ
+    if (callerInputs.length === candidateInputs.length) return true; // skip equal-length cases
+
+    const callerSpec: SpecYak = {
+      name: "caller",
+      inputs: callerInputs,
+      outputs: [],
+      preconditions: [],
+      postconditions: [],
+      invariants: [],
+      effects: [],
+      level: "L0",
+      behavior: "b",
+      guarantees: [],
+      errorConditions: [],
+      propertyTests: [],
+    };
+    const candidateSpec: SpecYak = { ...callerSpec, inputs: candidateInputs };
+
+    const result = structuralMatch(callerSpec, candidateSpec);
+    if (result.matches) return false;
+    return result.reasons.some((r) => r.includes("count mismatch"));
+  },
+);
+
+// ---------------------------------------------------------------------------
+// M5: Output count mismatch → false with reason
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_structuralMatch_output_count_mismatch_returns_false
+ *
+ * When caller and candidate have different output counts, structuralMatch()
+ * returns { matches: false } with a reason mentioning "count mismatch".
+ *
+ * Invariant: output count divergence is always caught and reported (check 2).
+ */
+export const prop_structuralMatch_output_count_mismatch_returns_false = fc.property(
+  fc.array(paramArb, { minLength: 1, maxLength: 3 }),
+  fc.array(paramArb, { minLength: 0, maxLength: 3 }),
+  (callerOutputs, candidateOutputs) => {
+    if (callerOutputs.length === candidateOutputs.length) return true;
+
+    const callerSpec: SpecYak = {
+      name: "caller",
+      inputs: [],
+      outputs: callerOutputs,
+      preconditions: [],
+      postconditions: [],
+      invariants: [],
+      effects: [],
+      level: "L0",
+      behavior: "b",
+      guarantees: [],
+      errorConditions: [],
+      propertyTests: [],
+    };
+    const candidateSpec: SpecYak = { ...callerSpec, outputs: candidateOutputs };
+
+    const result = structuralMatch(callerSpec, candidateSpec);
+    if (result.matches) return false;
+    return result.reasons.some((r) => r.includes("count mismatch"));
+  },
+);
+
+// ---------------------------------------------------------------------------
+// M6: Error subset — candidate errors ⊆ caller errors → match not blocked
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_structuralMatch_error_subset_matches
+ *
+ * When candidate's error conditions are a strict subset of the caller's
+ * tolerated errors (and all other checks pass), structuralMatch() returns true.
+ *
+ * Invariant: the subset-check rule (DEC-SEARCH-STRUCTURAL-001 check 3) does not
+ * produce false positives — if the candidate declares nothing unexpected, the
+ * error check passes.
+ */
+export const prop_structuralMatch_error_subset_matches = fc.property(
+  fc.array(fc.string({ minLength: 1, maxLength: 8 }), { minLength: 0, maxLength: 4 }),
+  fc.array(fc.string({ minLength: 1, maxLength: 8 }), { minLength: 0, maxLength: 4 }),
+  (candidateErrorTypes, extraCallerTypes) => {
+    const allCallerTypes = [...new Set([...candidateErrorTypes, ...extraCallerTypes])];
+    const uniqueCandidateTypes = [...new Set(candidateErrorTypes)];
+
+    const baseSpec: SpecYak = {
+      name: "s",
+      inputs: [{ name: "x", type: "string" }],
+      outputs: [{ name: "y", type: "string" }],
+      preconditions: [],
+      postconditions: [],
+      invariants: [],
+      effects: [],
+      level: "L0",
+      behavior: "b",
+      guarantees: [],
+      errorConditions: [],
+      propertyTests: [],
+    };
+
+    const callerSpec: SpecYak = {
+      ...baseSpec,
+      errorConditions: allCallerTypes.map((e) => ({ description: `Error ${e}`, errorType: e })),
+    };
+    const candidateSpec: SpecYak = {
+      ...baseSpec,
+      errorConditions: uniqueCandidateTypes.map((e) => ({
+        description: `Error ${e}`,
+        errorType: e,
+      })),
+    };
+
+    const result = structuralMatch(callerSpec, candidateSpec);
+    return result.matches === true;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// M7: Error superset — candidate extra error → false
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_structuralMatch_extra_candidate_error_returns_false
+ *
+ * When the candidate declares an error type that the caller does not tolerate,
+ * structuralMatch() returns { matches: false }.
+ *
+ * Invariant: the subset-check rejects candidates with undeclared errors. The
+ * caller would not handle such errors (DEC-SEARCH-V0-PRAGMATIC-001 check 3).
+ */
+export const prop_structuralMatch_extra_candidate_error_returns_false = fc.property(
+  fc.string({ minLength: 1, maxLength: 8 }),
+  (extraErrorType) => {
+    const baseSpec: SpecYak = {
+      name: "s",
+      inputs: [],
+      outputs: [],
+      preconditions: [],
+      postconditions: [],
+      invariants: [],
+      effects: [],
+      level: "L0",
+      behavior: "b",
+      guarantees: [],
+      errorConditions: [],
+      propertyTests: [],
+    };
+
+    const callerSpec: SpecYak = {
+      ...baseSpec,
+      errorConditions: [], // tolerates nothing
+    };
+    const candidateSpec: SpecYak = {
+      ...baseSpec,
+      errorConditions: [{ description: `Error ${extraErrorType}`, errorType: extraErrorType }],
+    };
+
+    const result = structuralMatch(callerSpec, candidateSpec);
+    return result.matches === false;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// M8: Monotonicity — relaxing error conditions never flips true → false
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_structuralMatch_monotone_error_relaxation
+ *
+ * If structuralMatch(callerA, candidate) is true, and callerB is callerA with
+ * one or more additional tolerated error types, then
+ * structuralMatch(callerB, candidate) must also be true.
+ *
+ * Invariant (DEC-SEARCH-STRUCTURAL-001): relaxing a caller requirement
+ * (adding more tolerated errors) never turns a match into a non-match.
+ */
+export const prop_structuralMatch_monotone_error_relaxation = fc.property(
+  fc.array(fc.string({ minLength: 1, maxLength: 8 }), { minLength: 0, maxLength: 3 }),
+  fc.array(fc.string({ minLength: 1, maxLength: 8 }), { minLength: 0, maxLength: 3 }),
+  (candidateErrorTypes, extraToleratedTypes) => {
+    const uniqueCandidate = [...new Set(candidateErrorTypes)];
+    // callerA tolerates all candidate errors (guaranteed to pass error check)
+    const callerAErrors = [...uniqueCandidate];
+    // callerB tolerates callerA's errors PLUS extra types (strictly more permissive)
+    const callerBErrors = [...new Set([...callerAErrors, ...extraToleratedTypes])];
+
+    const baseSpec: SpecYak = {
+      name: "s",
+      inputs: [{ name: "x", type: "string" }],
+      outputs: [{ name: "y", type: "string" }],
+      preconditions: [],
+      postconditions: [],
+      invariants: [],
+      effects: [],
+      level: "L0",
+      behavior: "b",
+      guarantees: [],
+      errorConditions: [],
+      propertyTests: [],
+    };
+
+    const candidateSpec: SpecYak = {
+      ...baseSpec,
+      errorConditions: uniqueCandidate.map((e) => ({ description: `E ${e}`, errorType: e })),
+    };
+    const callerA: SpecYak = {
+      ...baseSpec,
+      errorConditions: callerAErrors.map((e) => ({ description: `E ${e}`, errorType: e })),
+    };
+    const callerB: SpecYak = {
+      ...baseSpec,
+      errorConditions: callerBErrors.map((e) => ({ description: `E ${e}`, errorType: e })),
+    };
+
+    const resultA = structuralMatch(callerA, candidateSpec);
+    // By construction callerA tolerates all candidate errors → must match
+    if (!resultA.matches) return true; // skip (other checks may have failed; not our invariant)
+
+    const resultB = structuralMatch(callerB, candidateSpec);
+    // Relaxing callerA → callerB must not flip true → false
+    return resultB.matches === true;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// M9: Monotonicity — relaxing NF requirements never flips true → false
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_structuralMatch_monotone_nf_relaxation
+ *
+ * If a caller requires purity P and thread-safety T, and a candidate satisfies
+ * both, then relaxing the caller to require weaker purity P' < P (or weaker
+ * thread-safety T' < T) must still produce matches: true.
+ *
+ * The weakest possible requirement is nondeterministic/unsafe, which every
+ * candidate satisfies for the NF check.
+ *
+ * Invariant (DEC-SEARCH-STRUCTURAL-001): relaxing NF requirements is monotone.
+ */
+export const prop_structuralMatch_monotone_nf_relaxation = fc.property(
+  purityArb,
+  threadSafetyArb,
+  (candidatePurity, candidateThread) => {
+    const baseSpec: SpecYak = {
+      name: "s",
+      inputs: [{ name: "x", type: "string" }],
+      outputs: [{ name: "y", type: "string" }],
+      preconditions: [],
+      postconditions: [],
+      invariants: [],
+      effects: [],
+      level: "L0",
+      behavior: "b",
+      guarantees: [],
+      errorConditions: [],
+      propertyTests: [],
+    };
+
+    const candidateSpec: SpecYak = {
+      ...baseSpec,
+      nonFunctional: { purity: candidatePurity, threadSafety: candidateThread },
+    };
+
+    // callerExact: requires the exact same purity/thread as candidate → must match
+    const callerExact: SpecYak = {
+      ...baseSpec,
+      nonFunctional: { purity: candidatePurity, threadSafety: candidateThread },
+    };
+
+    // callerRelaxed: requires the weakest possible NF → must also match
+    const callerRelaxed: SpecYak = {
+      ...baseSpec,
+      nonFunctional: { purity: "nondeterministic", threadSafety: "unsafe" },
+    };
+
+    const exactResult = structuralMatch(callerExact, candidateSpec);
+    if (!exactResult.matches) return true; // skip (shouldn't happen; same NF values)
+
+    const relaxedResult = structuralMatch(callerRelaxed, candidateSpec);
+    return relaxedResult.matches === true;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// M10: Reasons non-empty on false result
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_structuralMatch_reasons_nonempty_on_false
+ *
+ * Whenever structuralMatch() returns { matches: false }, the reasons array
+ * contains at least one string explaining the divergence.
+ *
+ * Invariant: false results are always accompanied by diagnostic reasons.
+ * A false result with an empty reasons array would be a silent failure.
+ */
+export const prop_structuralMatch_reasons_nonempty_on_false = fc.property(
+  specArb,
+  specArb,
+  (spec, candidate) => {
+    const result = structuralMatch(spec, candidate);
+    if (result.matches) return true;
+    return result.reasons.length > 0;
+  },
+);

--- a/packages/registry/src/select.props.test.ts
+++ b/packages/registry/src/select.props.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+// Vitest harness for select.props.ts
+// Two-file pattern: this file is the thin vitest wrapper; the corpus lives in
+// the sibling select.props.ts (vitest-free, hashable as a manifest artifact).
+
+import * as fc from "fast-check";
+import { it } from "vitest";
+import {
+  prop_select_deterministic,
+  prop_select_empty_returns_null,
+  prop_select_irrelevant_edges_ignored,
+  prop_select_lexicographic_fallback_stable,
+  prop_select_nf_quality_tiebreak_pure_beats_stateful,
+  prop_select_provenance_tiebreak,
+  prop_select_singleton_returns_only_match,
+  prop_select_strict_candidate_wins,
+  prop_select_strict_candidate_wins_reversed_input_order,
+  prop_select_total,
+} from "./select.props.js";
+
+// select() is a pure in-memory function; 200 runs exercises the arbitrary space well.
+const opts = { numRuns: 200 };
+
+it("property: prop_select_total", () => {
+  fc.assert(prop_select_total, opts);
+});
+
+it("property: prop_select_deterministic", () => {
+  fc.assert(prop_select_deterministic, opts);
+});
+
+it("property: prop_select_empty_returns_null", () => {
+  fc.assert(prop_select_empty_returns_null, opts);
+});
+
+it("property: prop_select_singleton_returns_only_match", () => {
+  fc.assert(prop_select_singleton_returns_only_match, opts);
+});
+
+it("property: prop_select_strict_candidate_wins", () => {
+  fc.assert(prop_select_strict_candidate_wins, opts);
+});
+
+it("property: prop_select_strict_candidate_wins_reversed_input_order", () => {
+  fc.assert(prop_select_strict_candidate_wins_reversed_input_order, opts);
+});
+
+it("property: prop_select_nf_quality_tiebreak_pure_beats_stateful", () => {
+  fc.assert(prop_select_nf_quality_tiebreak_pure_beats_stateful, opts);
+});
+
+it("property: prop_select_lexicographic_fallback_stable", () => {
+  fc.assert(prop_select_lexicographic_fallback_stable, opts);
+});
+
+it("property: prop_select_irrelevant_edges_ignored", () => {
+  fc.assert(prop_select_irrelevant_edges_ignored, opts);
+});
+
+it("property: prop_select_provenance_tiebreak", () => {
+  fc.assert(prop_select_provenance_tiebreak, opts);
+});

--- a/packages/registry/src/select.props.ts
+++ b/packages/registry/src/select.props.ts
@@ -1,0 +1,523 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-V2-PROPTEST-PATH-A-002: hand-authored property-test corpus for
+// @yakcc/registry select.ts. Two-file pattern: this file (.props.ts) is
+// vitest-free and holds the corpus; the sibling .props.test.ts is the vitest harness.
+// Status: accepted (issue-87-fill-registry)
+// Rationale: select() is a pure function with a rich tiebreak chain
+// (strictness → nf-quality → passing-runs → lexicographic-root). Property tests
+// exercise invariants that example-based tests cannot enumerate exhaustively:
+// totality, determinism, strictness dominance, tiebreak monotonicity.
+
+// ---------------------------------------------------------------------------
+// Property-test corpus for select.ts
+//
+// Functions covered:
+//   select() — pure candidate-selection function (DEC-SELECT-001)
+//
+// select() is a pure function with no DB access. Properties are authored
+// against the exported select() directly — no re-implementation needed.
+//
+// Behaviors exercised:
+//   S1  — totality: never throws on any valid input
+//   S2  — determinism: same input → same output
+//   S3  — empty returns null
+//   S4  — singleton returns the only match
+//   S5  — strictness dominance: strictest candidate always wins
+//   S6  — nf-score tiebreak: higher quality score wins when no edges
+//   S7  — lexicographic fallback is stable regardless of input order
+//   S8  — irrelevant edges (roots not in match set) are ignored
+// ---------------------------------------------------------------------------
+
+import type { BlockMerkleRoot, SpecYak } from "@yakcc/contracts";
+import * as fc from "fast-check";
+import { select } from "./select.js";
+import type { CandidateProvenance, SelectMatch, StrictnessEdge } from "./select.js";
+
+// ---------------------------------------------------------------------------
+// Shared arbitraries
+// ---------------------------------------------------------------------------
+
+/**
+ * Arbitrary for a synthetic BlockMerkleRoot: 64 lowercase hex characters.
+ * We derive them from a single hex char repeated 64 times so that roots are
+ * lexicographically ordered by that character — useful for tiebreak tests.
+ */
+const hexCharArb: fc.Arbitrary<string> = fc.constantFrom(
+  "0",
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "a",
+  "b",
+  "c",
+  "d",
+  "e",
+  "f",
+);
+
+/**
+ * Arbitrary for a BlockMerkleRoot built by repeating one hex char 64 times.
+ * Root ordering is fully determined by the character (lexicographic).
+ */
+const blockRootArb: fc.Arbitrary<BlockMerkleRoot> = hexCharArb.map(
+  (c) => c.repeat(64) as BlockMerkleRoot,
+);
+
+/**
+ * Arbitrary for a SpecYak with no nonFunctional field (score 0 in nfScore).
+ * All structural required fields are populated; behavior varies across samples.
+ */
+const minimalSpecArb: fc.Arbitrary<SpecYak> = fc
+  .record({
+    name: fc.string({ minLength: 1, maxLength: 20 }),
+    behavior: fc.string({ minLength: 1, maxLength: 30 }),
+  })
+  .map(({ name, behavior }) => ({
+    name,
+    inputs: [{ name: "x", type: "string" }],
+    outputs: [{ name: "y", type: "number" }],
+    preconditions: [],
+    postconditions: [],
+    invariants: [],
+    effects: [],
+    level: "L0" as const,
+    behavior,
+    guarantees: [],
+    errorConditions: [],
+    propertyTests: [],
+  }));
+
+/**
+ * Arbitrary for a SelectMatch with a fixed root char and minimal spec.
+ * score defaults to 0.9 (irrelevant to select() logic).
+ */
+function makeMatchArb(rootChar: string): fc.Arbitrary<SelectMatch> {
+  return minimalSpecArb.map((spec) => ({
+    block: { root: rootChar.repeat(64) as BlockMerkleRoot, spec },
+    score: 0.9,
+  }));
+}
+
+/**
+ * Arbitrary for a non-empty list of SelectMatch with distinct root chars.
+ * Length 1–4 to keep tests fast.
+ */
+const distinctMatchListArb: fc.Arbitrary<readonly SelectMatch[]> = fc
+  .uniqueArray(hexCharArb, { minLength: 1, maxLength: 4 })
+  .chain((chars) =>
+    fc.tuple(...chars.map((c) => makeMatchArb(c))).map((matches) => matches as SelectMatch[]),
+  );
+
+// ---------------------------------------------------------------------------
+// S1: Totality — select() never throws on valid inputs
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_select_total
+ *
+ * For any non-empty list of SelectMatch values, any set of StrictnessEdges
+ * (including edges referencing roots not in the match set), and any provenance
+ * array, select() returns a non-null SelectMatch without throwing.
+ *
+ * Invariant: select() is total on valid inputs — it always returns a result
+ * or null (for empty lists) but never throws.
+ */
+export const prop_select_total = fc.property(
+  distinctMatchListArb,
+  fc.array(
+    fc.record({
+      stricterRoot: blockRootArb,
+      looserRoot: blockRootArb,
+    }),
+    { minLength: 0, maxLength: 5 },
+  ),
+  fc.array(
+    fc.record({
+      blockRoot: blockRootArb,
+      passingRuns: fc.integer({ min: 0, max: 100 }),
+    }),
+    { minLength: 0, maxLength: 5 },
+  ),
+  (matches, edges, provenance) => {
+    // Must not throw
+    const result = select(matches, edges, provenance);
+    // Non-empty matches → result must be non-null
+    return result !== null;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// S2: Determinism — same input produces same output
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_select_deterministic
+ *
+ * For any set of inputs, two calls to select() produce the same result
+ * (same block root or both null).
+ *
+ * Invariant: select() is a pure, deterministic function with no side effects.
+ * Multiple calls on the same inputs always agree.
+ */
+export const prop_select_deterministic = fc.property(
+  distinctMatchListArb,
+  fc.array(fc.record({ stricterRoot: blockRootArb, looserRoot: blockRootArb }), {
+    minLength: 0,
+    maxLength: 4,
+  }),
+  fc.array(fc.record({ blockRoot: blockRootArb, passingRuns: fc.integer({ min: 0, max: 50 }) }), {
+    minLength: 0,
+    maxLength: 4,
+  }),
+  (matches, edges, provenance) => {
+    const r1 = select(matches, edges, provenance);
+    const r2 = select(matches, edges, provenance);
+    return r1?.block.root === r2?.block.root;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// S3: Empty returns null
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_select_empty_returns_null
+ *
+ * select() with an empty matches array always returns null, regardless of
+ * the edges and provenance supplied.
+ *
+ * Invariant: the null path is the only permitted result for empty input.
+ */
+export const prop_select_empty_returns_null = fc.property(
+  fc.array(fc.record({ stricterRoot: blockRootArb, looserRoot: blockRootArb }), {
+    minLength: 0,
+    maxLength: 4,
+  }),
+  fc.array(fc.record({ blockRoot: blockRootArb, passingRuns: fc.integer({ min: 0, max: 50 }) }), {
+    minLength: 0,
+    maxLength: 4,
+  }),
+  (edges, provenance) => {
+    return select([], edges, provenance) === null;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// S4: Singleton returns the only match
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_select_singleton_returns_only_match
+ *
+ * When matches has exactly one element, select() returns that element,
+ * regardless of what edges or provenance are supplied.
+ *
+ * Invariant: the fast-path for length === 1 always returns that element.
+ */
+export const prop_select_singleton_returns_only_match = fc.property(
+  makeMatchArb("a"),
+  fc.array(fc.record({ stricterRoot: blockRootArb, looserRoot: blockRootArb }), {
+    minLength: 0,
+    maxLength: 3,
+  }),
+  fc.array(fc.record({ blockRoot: blockRootArb, passingRuns: fc.integer({ min: 0, max: 50 }) }), {
+    minLength: 0,
+    maxLength: 3,
+  }),
+  (match, edges, provenance) => {
+    const result = select([match], edges, provenance);
+    return result?.block.root === match.block.root;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// S5: Strictness dominance — the declared-strictest candidate wins
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_select_strict_candidate_wins
+ *
+ * When A is declared strictly stronger than B (via a StrictnessEdge), and
+ * both are in the match set, select() returns A regardless of nf-quality,
+ * provenance, or lexicographic ordering.
+ *
+ * Invariant: strictness ordering dominates all tiebreak criteria
+ * (DEC-SELECT-TIEBREAK-001 step 3 before steps 4a/4b/4c).
+ */
+export const prop_select_strict_candidate_wins = fc.property(
+  // Use two distinct chars so roots differ
+  fc.constantFrom<[string, string]>(["a", "b"], ["b", "c"], ["c", "d"], ["0", "f"]),
+  minimalSpecArb,
+  minimalSpecArb,
+  ([stricterChar, looserChar], stricterSpec, looserSpec) => {
+    const stricterRoot = stricterChar.repeat(64) as BlockMerkleRoot;
+    const looserRoot = looserChar.repeat(64) as BlockMerkleRoot;
+
+    const stricterMatch: SelectMatch = {
+      block: { root: stricterRoot, spec: stricterSpec },
+      score: 0.9,
+    };
+    const looserMatch: SelectMatch = {
+      block: { root: looserRoot, spec: looserSpec },
+      score: 0.9,
+    };
+
+    const edge: StrictnessEdge = { stricterRoot, looserRoot };
+    const result = select([stricterMatch, looserMatch], [edge], []);
+    return result?.block.root === stricterRoot;
+  },
+);
+
+/**
+ * prop_select_strict_candidate_wins_reversed_input_order
+ *
+ * The strictness dominance invariant holds regardless of input array order.
+ * select([A, B], [A > B]) and select([B, A], [A > B]) both return A.
+ *
+ * Invariant: select() does not depend on input array ordering for its
+ * strictness-based result (the candidate set is order-independent).
+ */
+export const prop_select_strict_candidate_wins_reversed_input_order = fc.property(
+  fc.constantFrom<[string, string]>(["a", "b"], ["b", "c"], ["c", "d"], ["0", "f"]),
+  minimalSpecArb,
+  minimalSpecArb,
+  ([stricterChar, looserChar], stricterSpec, looserSpec) => {
+    const stricterRoot = stricterChar.repeat(64) as BlockMerkleRoot;
+    const looserRoot = looserChar.repeat(64) as BlockMerkleRoot;
+
+    const stricterMatch: SelectMatch = {
+      block: { root: stricterRoot, spec: stricterSpec },
+      score: 0.9,
+    };
+    const looserMatch: SelectMatch = {
+      block: { root: looserRoot, spec: looserSpec },
+      score: 0.9,
+    };
+
+    const edge: StrictnessEdge = { stricterRoot, looserRoot };
+
+    const r1 = select([stricterMatch, looserMatch], [edge], []);
+    const r2 = select([looserMatch, stricterMatch], [edge], []);
+    return r1?.block.root === stricterRoot && r2?.block.root === stricterRoot;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// S6: NF-quality tiebreak — higher quality wins when no strictness edges
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_select_nf_quality_tiebreak_pure_beats_stateful
+ *
+ * When no strictness edges are declared, a candidate with higher nf-quality
+ * score (pure/safe = 32) beats one with lower score (stateful/safe = 12).
+ *
+ * Invariant: tiebreak step 4a (DEC-SELECT-TIEBREAK-001) selects by
+ * non-functional quality before consulting provenance or lexicographic order.
+ */
+export const prop_select_nf_quality_tiebreak_pure_beats_stateful = fc.property(
+  fc.constantFrom<{ pureChar: string; statefulChar: string }>(
+    { pureChar: "a", statefulChar: "b" },
+    { pureChar: "c", statefulChar: "d" },
+    { pureChar: "e", statefulChar: "f" },
+  ),
+  ({ pureChar, statefulChar }) => {
+    const pureRoot = pureChar.repeat(64) as BlockMerkleRoot;
+    const statefulRoot = statefulChar.repeat(64) as BlockMerkleRoot;
+
+    const pureSpec: SpecYak = {
+      name: "p",
+      inputs: [],
+      outputs: [],
+      preconditions: [],
+      postconditions: [],
+      invariants: [],
+      effects: [],
+      level: "L0",
+      behavior: "pure",
+      guarantees: [],
+      errorConditions: [],
+      nonFunctional: { purity: "pure", threadSafety: "safe" },
+      propertyTests: [],
+    };
+
+    const statefulSpec: SpecYak = {
+      ...pureSpec,
+      behavior: "stateful",
+      nonFunctional: { purity: "stateful", threadSafety: "safe" },
+    };
+
+    const pureMatch: SelectMatch = { block: { root: pureRoot, spec: pureSpec }, score: 0.9 };
+    const statefulMatch: SelectMatch = {
+      block: { root: statefulRoot, spec: statefulSpec },
+      score: 0.9,
+    };
+
+    const result = select([pureMatch, statefulMatch], [], []);
+    return result?.block.root === pureRoot;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// S7: Lexicographic fallback is stable and order-independent
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_select_lexicographic_fallback_stable
+ *
+ * When all candidates have identical nf-quality (no nonFunctional) and
+ * zero provenance, and no strictness edges exist, select() returns the
+ * lexicographically smallest block root — and this result is stable
+ * regardless of input array order.
+ *
+ * Invariant: the final tiebreak (DEC-SELECT-TIEBREAK-001 step 4c) is
+ * deterministic and order-independent, always yielding the smallest root.
+ */
+export const prop_select_lexicographic_fallback_stable = fc.property(
+  // Two distinct hex chars so we know the expected winner
+  fc.constantFrom<{ smallChar: string; largeChar: string }>(
+    { smallChar: "0", largeChar: "1" },
+    { smallChar: "a", largeChar: "b" },
+    { smallChar: "c", largeChar: "f" },
+    { smallChar: "1", largeChar: "9" },
+  ),
+  ({ smallChar, largeChar }) => {
+    const smallRoot = smallChar.repeat(64) as BlockMerkleRoot;
+    const largeRoot = largeChar.repeat(64) as BlockMerkleRoot;
+
+    const spec: SpecYak = {
+      name: "s",
+      inputs: [],
+      outputs: [],
+      preconditions: [],
+      postconditions: [],
+      invariants: [],
+      effects: [],
+      level: "L0",
+      behavior: "x",
+      guarantees: [],
+      errorConditions: [],
+      propertyTests: [],
+    };
+
+    const matchSmall: SelectMatch = { block: { root: smallRoot, spec }, score: 0.9 };
+    const matchLarge: SelectMatch = { block: { root: largeRoot, spec }, score: 0.9 };
+
+    const r1 = select([matchSmall, matchLarge], [], []);
+    const r2 = select([matchLarge, matchSmall], [], []);
+
+    return r1?.block.root === smallRoot && r2?.block.root === smallRoot;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// S8: Irrelevant edges (roots not in match set) are ignored
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_select_irrelevant_edges_ignored
+ *
+ * StrictnessEdges referencing roots that are not present in the candidate
+ * match set do not affect the selection result.
+ *
+ * Invariant: buildEdgeSet filters to candidateRoots before constructing the
+ * edge set, so foreign-root edges have no effect on the outcome.
+ */
+export const prop_select_irrelevant_edges_ignored = fc.property(
+  fc.constantFrom<{ charA: string; charB: string }>(
+    { charA: "a", charB: "b" },
+    { charA: "c", charB: "d" },
+  ),
+  ({ charA, charB }) => {
+    const rootA = charA.repeat(64) as BlockMerkleRoot;
+    const rootB = charB.repeat(64) as BlockMerkleRoot;
+    const foreignRoot = "f".repeat(64) as BlockMerkleRoot;
+
+    const spec: SpecYak = {
+      name: "s",
+      inputs: [],
+      outputs: [],
+      preconditions: [],
+      postconditions: [],
+      invariants: [],
+      effects: [],
+      level: "L0",
+      behavior: "x",
+      guarantees: [],
+      errorConditions: [],
+      propertyTests: [],
+    };
+
+    const matchA: SelectMatch = { block: { root: rootA, spec }, score: 0.9 };
+    const matchB: SelectMatch = { block: { root: rootB, spec }, score: 0.9 };
+
+    // Edge declaring B > A (candidate roots)
+    const relevantEdge: StrictnessEdge = { stricterRoot: rootB, looserRoot: rootA };
+    // Irrelevant edge referencing a foreign root (not in match set)
+    const irrelevantEdge: StrictnessEdge = { stricterRoot: foreignRoot, looserRoot: rootB };
+
+    const withIrrelevant = select([matchA, matchB], [relevantEdge, irrelevantEdge], []);
+    const withoutIrrelevant = select([matchA, matchB], [relevantEdge], []);
+
+    // Result should be B (stricter) in both cases
+    return withIrrelevant?.block.root === rootB && withoutIrrelevant?.block.root === rootB;
+  },
+);
+
+// ---------------------------------------------------------------------------
+// S9: Provenance tiebreak — more passing runs wins
+// ---------------------------------------------------------------------------
+
+/**
+ * prop_select_provenance_tiebreak
+ *
+ * When nf-quality scores are tied (identical specs, no nonFunctional) but
+ * provenance differs, the candidate with more passing runs wins.
+ *
+ * Invariant: tiebreak step 4b (DEC-SELECT-TIEBREAK-001) applies after 4a
+ * (nf-quality). When 4a is tied, more passing runs is decisive.
+ */
+export const prop_select_provenance_tiebreak = fc.property(
+  fc.integer({ min: 0, max: 50 }),
+  fc.integer({ min: 1, max: 100 }),
+  (fewer, more) => {
+    const rootA = "a".repeat(64) as BlockMerkleRoot;
+    const rootB = "b".repeat(64) as BlockMerkleRoot;
+
+    const spec: SpecYak = {
+      name: "s",
+      inputs: [],
+      outputs: [],
+      preconditions: [],
+      postconditions: [],
+      invariants: [],
+      effects: [],
+      level: "L0",
+      behavior: "x",
+      guarantees: [],
+      errorConditions: [],
+      propertyTests: [],
+    };
+
+    const matchA: SelectMatch = { block: { root: rootA, spec }, score: 0.9 };
+    const matchB: SelectMatch = { block: { root: rootB, spec }, score: 0.9 };
+
+    const provenance: CandidateProvenance[] = [
+      { blockRoot: rootA, passingRuns: fewer },
+      // B always has strictly more passing runs
+      { blockRoot: rootB, passingRuns: fewer + more },
+    ];
+
+    const result = select([matchA, matchB], [], provenance);
+    // B has more passing runs → B wins (when fewer < fewer+more, and lex: a < b so
+    // we need to ensure runs difference is decisive before lex kicks in).
+    // Since B has more runs, it wins over A even though lex would favor A.
+    return result?.block.root === rootB;
+  },
+);


### PR DESCRIPTION
## Summary

First per-package fill slice for #87 blocker 2. Adds `.props.ts` + `.props.test.ts` pairs covering @yakcc/registry's behavioral surfaces.

- **select.ts**: 10 properties (totality, determinism, dominance ordering, tiebreaks)
- **search.ts**: 10 properties (totality, determinism, reflexivity, monotonicity, error sets)
- **discovery-eval-helpers.ts**: 17 properties (cosineDistance bounds, scoring bands, hitRate/precision/recall/MRR/Brier metrics determinism + bounds)
- **schema.ts**: 3 properties (SCHEMA_VERSION shape, applyMigrations idempotence)

`index.ts` skipped (pure barrel re-exports, no executable behavior).

## Verification

- `pnpm --filter @yakcc/registry build`: clean
- `pnpm --filter @yakcc/registry test`: 262/278 pass (16 skipped pre-existing)

Refs #87 (per-package fill, slice 1 of N).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>