### PR TITLE
fix(shave): resolve exactOptionalPropertyTypes in .props.ts (L3j fallout)

### DIFF
--- a/packages/shave/src/universalize/atom-test.props.ts
+++ b/packages/shave/src/universalize/atom-test.props.ts
@@ -183,8 +183,8 @@ export const prop_isAtom_zero_cf_empty_registry_is_always_atomic: fc.IAsyncPrope
  * the registry is consulted. A result with a different reason indicates the
  * short-circuit is broken.
  */
-export const prop_isAtom_excess_cf_returns_too_many_cf_boundaries: fc.IAsyncProperty<[undefined]> =
-  fc.asyncProperty(fc.constant(undefined), async () => {
+export const prop_isAtom_excess_cf_returns_too_many_cf_boundaries =
+  fc.asyncProperty(fc.constant<undefined>(undefined), async () => {
     // Source with exactly 2 CF boundaries (if + for): exceeds maxCF=0.
     const source =
       "function f(x: number) { if (x > 0) { for (let i = 0; i < 10; i++) {} } return 0; }";
@@ -212,8 +212,8 @@ export const prop_isAtom_excess_cf_returns_too_many_cf_boundaries: fc.IAsyncProp
  * in atom-test.ts. If this default ever changed silently, previously-atomic
  * nodes would be reclassified as non-atomic, breaking the decompose tree.
  */
-export const prop_isAtom_undefined_options_uses_default_max_cf_1: fc.IAsyncProperty<[undefined]> =
-  fc.asyncProperty(fc.constant(undefined), async () => {
+export const prop_isAtom_undefined_options_uses_default_max_cf_1 =
+  fc.asyncProperty(fc.constant<undefined>(undefined), async () => {
     // Exactly 1 CF boundary (single if) → atomic with default maxCF=1.
     const source = "function f(x: number) { if (x > 0) return x; return 0; }";
     const { file } = parseSource(source);
@@ -239,12 +239,8 @@ export const prop_isAtom_undefined_options_uses_default_max_cf_1: fc.IAsyncPrope
  * Invariant (AT-REG-1, DEC-ATOM-TEST-003): criteria 1 and 2 both pass for
  * 0-CF nodes with an empty registry. Any non-atomic result indicates a bug.
  */
-export const prop_isAtom_empty_registry_zero_cf_options_sweep_always_atomic: fc.IAsyncProperty<
-  [AtomTestOptions]
-> = fc.asyncProperty(
-  fc.record({
-    maxControlFlowBoundaries: fc.option(fc.nat({ max: 10 }), { nil: undefined }),
-  }),
+export const prop_isAtom_empty_registry_zero_cf_options_sweep_always_atomic = fc.asyncProperty(
+  fc.record({ maxControlFlowBoundaries: fc.nat({ max: 10 }) }, { requiredKeys: [] }),
   async (opts) => {
     const source = "function g(a: string): string { return a.trim(); }";
     const { file } = parseSource(source);
@@ -306,9 +302,8 @@ export const prop_isAtom_matchedPrimitive_absent_for_non_contains_reason: fc.IAs
  * Invariant (AT-REG-2, DEC-ATOM-TEST-003): criterion 2 is reachable. Without
  * this property a bug where the registry is never consulted could go unnoticed.
  */
-export const prop_isAtom_always_match_registry_triggers_contains_known_primitive: fc.IAsyncProperty<
-  [undefined]
-> = fc.asyncProperty(fc.constant(undefined), async () => {
+export const prop_isAtom_always_match_registry_triggers_contains_known_primitive =
+  fc.asyncProperty(fc.constant<undefined>(undefined), async () => {
   // Two-statement function body: first statement can match the always-match registry.
   const source = "function f(x: number) { const y = x * 2; return y + 1; }";
   const { file } = parseSource(source);

--- a/packages/shave/src/universalize/recursion.props.ts
+++ b/packages/shave/src/universalize/recursion.props.ts
@@ -239,9 +239,8 @@ export const prop_decompose_root_canonicalAstHash_is_64_char_hex: fc.IAsyncPrope
  * precedes the throw. Therefore depth > maxDepth is always true at throw time.
  * An error with depth <= maxDepth indicates the guard condition was not respected.
  */
-export const prop_RecursionDepthExceededError_depth_exceeds_maxDepth: fc.IAsyncProperty<
-  [undefined]
-> = fc.asyncProperty(fc.constant(undefined), async () => {
+export const prop_RecursionDepthExceededError_depth_exceeds_maxDepth =
+  fc.asyncProperty(fc.constant<undefined>(undefined), async () => {
   // TWO_IF_SOURCE has SourceFile with 2 CF → not atomic with maxCF=1.
   // maxDepth=0 forces the throw immediately when the recursion tries depth 1.
   let caught: RecursionDepthExceededError | undefined;
@@ -272,8 +271,8 @@ export const prop_RecursionDepthExceededError_depth_exceeds_maxDepth: fc.IAsyncP
  * where start >= end would indicate a phantom or zero-width node, which is not
  * a valid AST node kind.
  */
-export const prop_DidNotReachAtomError_node_range_is_valid: fc.IAsyncProperty<[undefined]> =
-  fc.asyncProperty(fc.constant(undefined), async () => {
+export const prop_DidNotReachAtomError_node_range_is_valid =
+  fc.asyncProperty(fc.constant<undefined>(undefined), async () => {
     // maxControlFlowBoundaries: -1 makes every node non-atomic (CF count 0 > -1).
     // ExpressionStatement has no decomposable children → DidNotReachAtomError.
     let caught: DidNotReachAtomError | undefined;
@@ -353,9 +352,8 @@ export const prop_decompose_zero_cf_always_produces_atom_root: fc.IAsyncProperty
  * invariants must hold jointly for any successful decompose() call that produces
  * a branch tree.
  */
-export const prop_compound_decompose_real_parse_branch_and_atom_invariants: fc.IAsyncProperty<
-  [undefined]
-> = fc.asyncProperty(fc.constant(undefined), async () => {
+export const prop_compound_decompose_real_parse_branch_and_atom_invariants =
+  fc.asyncProperty(fc.constant<undefined>(undefined), async () => {
   // TWO_IF_SOURCE: 2 CF boundaries at SourceFile level → branch root.
   const tree: RecursionTree = await decompose(TWO_IF_SOURCE, emptyRegistry);
 
@@ -403,9 +401,8 @@ export const prop_compound_decompose_real_parse_branch_and_atom_invariants: fc.I
  * bytes and same AST normalization → same hash on every call. Hash instability
  * would break registry lookups and cross-session provenance manifests.
  */
-export const prop_decompose_canonicalAstHash_is_stable_across_calls: fc.IAsyncProperty<
-  [undefined]
-> = fc.asyncProperty(fc.constant(undefined), async () => {
+export const prop_decompose_canonicalAstHash_is_stable_across_calls =
+  fc.asyncProperty(fc.constant<undefined>(undefined), async () => {
   const tree1 = await decompose(ONE_CF_SOURCE, emptyRegistry);
   const tree2 = await decompose(ONE_CF_SOURCE, emptyRegistry);
   return tree1.root.canonicalAstHash === tree2.root.canonicalAstHash;

--- a/packages/shave/src/universalize/slicer.props.ts
+++ b/packages/shave/src/universalize/slicer.props.ts
@@ -282,8 +282,8 @@ export const prop_slice_strict_mode_never_emits_glue_entries: fc.IAsyncProperty<
  * VariableDeclarations, and other statement kinds must not be mistaken for
  * foreign imports.
  */
-export const prop_classifyForeign_non_import_source_returns_empty: fc.IProperty<[undefined]> =
-  fc.property(fc.constant(undefined), () => {
+export const prop_classifyForeign_non_import_source_returns_empty =
+  fc.property(fc.constant<undefined>(undefined), () => {
     // Pure function with no imports — no ImportDeclaration nodes.
     const source = "function f(x: number): number { return x * 2; }";
     const entries = classifyForeign(source);
@@ -309,8 +309,8 @@ export const prop_classifyForeign_non_import_source_returns_empty: fc.IProperty<
  * are used by the provenance manifest and --foreign-policy CLI flag (L4).
  * Incorrect or missing entries would corrupt the foreign-import catalog.
  */
-export const prop_classifyForeign_foreign_named_import_returns_entry: fc.IProperty<[undefined]> =
-  fc.property(fc.constant(undefined), () => {
+export const prop_classifyForeign_foreign_named_import_returns_entry =
+  fc.property(fc.constant<undefined>(undefined), () => {
     const source = `import { readFileSync } from 'node:fs';`;
     const entries = classifyForeign(source);
     if (entries.length !== 1) return false;
@@ -341,8 +341,8 @@ export const prop_classifyForeign_foreign_named_import_returns_entry: fc.IProper
  * carry no runtime dependency. Classifying them as foreign would inject
  * spurious dependencies into the provenance manifest.
  */
-export const prop_classifyForeign_type_only_import_returns_empty: fc.IProperty<[undefined]> =
-  fc.property(fc.constant(undefined), () => {
+export const prop_classifyForeign_type_only_import_returns_empty =
+  fc.property(fc.constant<undefined>(undefined), () => {
     const source = `import type { PathLike } from 'node:fs';`;
     const entries = classifyForeign(source);
     return entries.length === 0;
@@ -366,8 +366,8 @@ export const prop_classifyForeign_type_only_import_returns_empty: fc.IProperty<[
  * break the workspace boundary assumption that drives the slicer's
  * no-synthesis-needed rule for local source.
  */
-export const prop_classifyForeign_relative_import_returns_empty: fc.IProperty<[undefined]> =
-  fc.property(fc.constant(undefined), () => {
+export const prop_classifyForeign_relative_import_returns_empty =
+  fc.property(fc.constant<undefined>(undefined), () => {
     const source = `import { helper } from './local.js';`;
     const entries = classifyForeign(source);
     return entries.length === 0;
@@ -391,8 +391,8 @@ export const prop_classifyForeign_relative_import_returns_empty: fc.IProperty<[u
  * guard. Classifying them as foreign would make all workspace consumers
  * appear as external dependencies.
  */
-export const prop_classifyForeign_workspace_import_returns_empty: fc.IProperty<[undefined]> =
-  fc.property(fc.constant(undefined), () => {
+export const prop_classifyForeign_workspace_import_returns_empty =
+  fc.property(fc.constant<undefined>(undefined), () => {
     const source = `import { slice } from '@yakcc/shave';`;
     const entries = classifyForeign(source);
     return entries.length === 0;
@@ -434,8 +434,8 @@ export const prop_classifyForeign_workspace_import_returns_empty: fc.IProperty<[
  * All six invariants must hold jointly for any valid slice call on a two-atom
  * branch tree with one matched and one unmatched atom.
  */
-export const prop_compound_slice_real_tree_joint_invariants: fc.IAsyncProperty<[undefined]> =
-  fc.asyncProperty(fc.constant(undefined), async () => {
+export const prop_compound_slice_real_tree_joint_invariants =
+  fc.asyncProperty(fc.constant<undefined>(undefined), async () => {
     const sourceX = "function add(a: number, b: number): number { return a + b; }";
     const sourceY = "function mul(a: number, b: number): number { return a * b; }";
     const hashX = "hash-compound-X";

--- a/packages/shave/src/universalize/types.props.ts
+++ b/packages/shave/src/universalize/types.props.ts
@@ -97,9 +97,10 @@ const natArb: fc.Arbitrary<number> = fc.nat({ max: 1_000 });
 // ---------------------------------------------------------------------------
 
 /** Optional non-negative integer for maxControlFlowBoundaries. */
-const atomTestOptionsArb: fc.Arbitrary<AtomTestOptions> = fc.record({
-  maxControlFlowBoundaries: fc.option(fc.nat({ max: 20 }), { nil: undefined }),
-});
+const atomTestOptionsArb: fc.Arbitrary<AtomTestOptions> = fc.record(
+  { maxControlFlowBoundaries: fc.nat({ max: 20 }) },
+  { requiredKeys: [] },
+);
 
 // ---------------------------------------------------------------------------
 // AtomTestReason arbitrary
@@ -181,10 +182,13 @@ const recursionTreeArb: fc.Arbitrary<RecursionTree> = fc
 // ---------------------------------------------------------------------------
 
 /** Arbitrary RecursionOptions. */
-const recursionOptionsArb: fc.Arbitrary<RecursionOptions> = fc.record({
-  maxControlFlowBoundaries: fc.option(fc.nat({ max: 20 }), { nil: undefined }),
-  maxDepth: fc.option(fc.integer({ min: 1, max: 64 }), { nil: undefined }),
-});
+const recursionOptionsArb: fc.Arbitrary<RecursionOptions> = fc.record(
+  {
+    maxControlFlowBoundaries: fc.nat({ max: 20 }),
+    maxDepth: fc.integer({ min: 1, max: 64 }),
+  },
+  { requiredKeys: [] },
+);
 
 // ---------------------------------------------------------------------------
 // Slicer entry arbitraries


### PR DESCRIPTION
## Summary

L3j (#221) introduced `.props.ts` files for `atom-test`/`recursion`/`slicer`/`types` that triggered `exactOptionalPropertyTypes` errors under strict tsconfig. These errors blocked downstream packages (`compile` depends on `shave`).

Two patterns fixed across 4 files (39+/43-):

- `fc.record()` with `fc.option()` producing `{ x: T|undefined }` when target type has `{ x?: T }` → replaced with `fc.record({...}, { requiredKeys: [] })`
- Overly-narrow `IAsyncProperty<[undefined]>` annotations on `fc.asyncProperty(fc.constant(undefined), ...)` → removed in favor of inference

No behavior change. 772/773 shave tests pass (1 pre-existing skip). Unblocks downstream compile slice.

Refs #87 (per-package fill precondition).

## Test plan

- [x] pnpm --filter @yakcc/shave build green
- [x] pnpm --filter @yakcc/shave test (772 pass / 1 skip)
- [ ] pnpm --filter @yakcc/compile build green (downstream verification, after merge)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)