### PR TITLE
fix(lint): biome auto-fix pre-existing violations across cli + shave

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -460,8 +460,8 @@ describe("hooks claude-code install", () => {
       await runCli(["hooks", "claude-code", "install", "--target", targetDir], logger);
       const raw = readFileSync(join(targetDir, ".claude", "settings.json"), "utf-8");
       const settings = JSON.parse(raw) as Record<string, unknown>;
-      const hooks = settings["hooks"] as Record<string, unknown[]>;
-      const preToolUse = hooks["PreToolUse"] as Array<{ matcher: string }>;
+      const hooks = settings.hooks as Record<string, unknown[]>;
+      const preToolUse = hooks.PreToolUse as Array<{ matcher: string }>;
       expect(preToolUse.some((e) => e.matcher === "Edit|Write|MultiEdit")).toBe(true);
     } finally {
       try {

--- a/packages/cli/src/commands/hooks-install.test.ts
+++ b/packages/cli/src/commands/hooks-install.test.ts
@@ -76,11 +76,15 @@ describe("install — fresh directory", () => {
     expect(settings).not.toBeNull();
     const hooks = settings.hooks as Record<string, unknown>;
     expect(hooks).toBeDefined();
-    const preToolUse = hooks["PreToolUse"] as Array<{ matcher: string; hooks: unknown[] }>;
+    const preToolUse = hooks.PreToolUse as Array<{ matcher: string; hooks: unknown[] }>;
     expect(Array.isArray(preToolUse)).toBe(true);
     expect(preToolUse.length).toBeGreaterThan(0);
     expect(preToolUse[0]?.matcher).toBe("Edit|Write|MultiEdit");
-    const innerHooks = preToolUse[0]?.hooks as Array<{ type: string; command: string; _yakcc: string }>;
+    const innerHooks = preToolUse[0]?.hooks as Array<{
+      type: string;
+      command: string;
+      _yakcc: string;
+    }>;
     expect(innerHooks[0]?.type).toBe("command");
     expect(innerHooks[0]?.command).toBe("yakcc hook-intercept");
     expect(innerHooks[0]?._yakcc).toBe("yakcc-hook-v1");
@@ -106,7 +110,7 @@ describe("install — idempotent re-install", () => {
 
     const settingsAfterFirst = readSettings(tmpDir) as Record<string, unknown>;
     const countAfterFirst = (
-      (settingsAfterFirst.hooks as Record<string, unknown[]>)["PreToolUse"] ?? []
+      (settingsAfterFirst.hooks as Record<string, unknown[]>).PreToolUse ?? []
     ).length;
 
     const logger2 = new CollectingLogger();
@@ -115,7 +119,7 @@ describe("install — idempotent re-install", () => {
     expect(code).toBe(0);
     const settingsAfterSecond = readSettings(tmpDir) as Record<string, unknown>;
     const countAfterSecond = (
-      (settingsAfterSecond.hooks as Record<string, unknown[]>)["PreToolUse"] ?? []
+      (settingsAfterSecond.hooks as Record<string, unknown[]>).PreToolUse ?? []
     ).length;
 
     expect(countAfterSecond).toBe(countAfterFirst);
@@ -179,9 +183,9 @@ describe("install — preserves existing settings.json", () => {
 
     expect(code).toBe(0);
     const result = readSettings(tmpDir) as Record<string, unknown>;
-    expect(result["theme"]).toBe("dark");
-    expect(Array.isArray(result["keybindings"])).toBe(true);
-    expect(result["hooks"]).toBeDefined();
+    expect(result.theme).toBe("dark");
+    expect(Array.isArray(result.keybindings)).toBe(true);
+    expect(result.hooks).toBeDefined();
   });
 
   it("appends to existing non-yakcc PreToolUse entries", async () => {
@@ -197,7 +201,7 @@ describe("install — preserves existing settings.json", () => {
     await hooksClaudeCodeInstall(["--target", tmpDir], new CollectingLogger());
 
     const result = readSettings(tmpDir) as Record<string, unknown>;
-    const preToolUse = (result["hooks"] as Record<string, unknown[]>)["PreToolUse"] as unknown[];
+    const preToolUse = (result.hooks as Record<string, unknown[]>).PreToolUse as unknown[];
     expect(preToolUse.length).toBe(2);
   });
 });
@@ -218,7 +222,7 @@ describe("--uninstall", () => {
 
     const settings = readSettings(tmpDir) as Record<string, unknown>;
     const hooks = settings?.hooks as Record<string, unknown[]> | undefined;
-    const entries = hooks?.["PreToolUse"] ?? [];
+    const entries = hooks?.PreToolUse ?? [];
     expect(entries.length).toBe(0);
   });
 
@@ -236,9 +240,9 @@ describe("--uninstall", () => {
     await hooksClaudeCodeInstall(["--target", tmpDir, "--uninstall"], new CollectingLogger());
 
     const result = readSettings(tmpDir) as Record<string, unknown>;
-    const preToolUse = (result["hooks"] as Record<string, unknown[]>)["PreToolUse"] as unknown[];
+    const preToolUse = (result.hooks as Record<string, unknown[]>).PreToolUse as unknown[];
     expect(preToolUse.length).toBe(1);
-    expect((preToolUse[0] as Record<string, unknown>)["matcher"]).toBe("Bash");
+    expect((preToolUse[0] as Record<string, unknown>).matcher).toBe("Bash");
   });
 });
 
@@ -285,10 +289,10 @@ describe("round trip", () => {
 
     expect(code).toBe(0);
     const settings = readSettings(tmpDir) as Record<string, unknown>;
-    const preToolUse = (
-      (settings.hooks as Record<string, unknown[]>)["PreToolUse"] ?? []
-    ) as Array<Record<string, unknown>>;
-    expect(preToolUse.filter((e) => e["matcher"] === "Edit|Write|MultiEdit").length).toBe(1);
+    const preToolUse = ((settings.hooks as Record<string, unknown[]>).PreToolUse ?? []) as Array<
+      Record<string, unknown>
+    >;
+    expect(preToolUse.filter((e) => e.matcher === "Edit|Write|MultiEdit").length).toBe(1);
   });
 });
 

--- a/packages/cli/src/commands/hooks-install.ts
+++ b/packages/cli/src/commands/hooks-install.ts
@@ -78,7 +78,7 @@ function readSettings(settingsPath: string): ClaudeSettings {
 }
 
 function writeSettings(settingsPath: string, settings: ClaudeSettings): void {
-  writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
+  writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, "utf-8");
 }
 
 function buildYakccHookObject(): YakccHookObject {
@@ -93,7 +93,10 @@ function isYakccEntry(entry: HookEntry): boolean {
 // Install / uninstall logic
 // ---------------------------------------------------------------------------
 
-function applyInstall(settings: ClaudeSettings): { settings: ClaudeSettings; alreadyInstalled: boolean } {
+function applyInstall(settings: ClaudeSettings): {
+  settings: ClaudeSettings;
+  alreadyInstalled: boolean;
+} {
   const hooks = settings.hooks ?? {};
   const eventHooks: HookEntry[] = hooks[HOOK_EVENT] ?? [];
 
@@ -111,7 +114,10 @@ function applyInstall(settings: ClaudeSettings): { settings: ClaudeSettings; alr
   };
 }
 
-function applyUninstall(settings: ClaudeSettings): { settings: ClaudeSettings; wasInstalled: boolean } {
+function applyUninstall(settings: ClaudeSettings): {
+  settings: ClaudeSettings;
+  wasInstalled: boolean;
+} {
   const hooks = settings.hooks ?? {};
   const eventHooks: HookEntry[] = hooks[HOOK_EVENT] ?? [];
   const filtered = eventHooks.filter((e) => !isYakccEntry(e));

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -40,9 +40,9 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createOfflineEmbeddingProvider } from "@yakcc/contracts";
 import { openRegistry } from "@yakcc/registry";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { CollectingLogger, runCli } from "../index.js";
 import { init } from "./init.js";
 
@@ -99,9 +99,9 @@ describe("init — fresh directory", () => {
     expect(code).toBe(0);
     const settings = readSettings(tmpDir);
     expect(settings).not.toBeNull();
-    const hooks = settings!["hooks"] as Record<string, unknown[]>;
+    const hooks = settings?.hooks as Record<string, unknown[]>;
     expect(hooks).toBeDefined();
-    const preToolUse = hooks["PreToolUse"] as Array<Record<string, unknown>>;
+    const preToolUse = hooks.PreToolUse as Array<Record<string, unknown>>;
     expect(Array.isArray(preToolUse)).toBe(true);
     expect(preToolUse.length).toBeGreaterThan(0);
   });
@@ -132,19 +132,19 @@ describe(".yakccrc.json content", () => {
     await init(["--target", tmpDir], new CollectingLogger());
     const rc = readRc(tmpDir);
     expect(rc).not.toBeNull();
-    expect(rc!["version"]).toBe(1);
+    expect(rc?.version).toBe(1);
   });
 
   it("registry.path matches default registry subpath", async () => {
     await init(["--target", tmpDir], new CollectingLogger());
     const rc = readRc(tmpDir);
-    expect(rc!["registry"]).toEqual({ path: ".yakcc/registry.sqlite" });
+    expect(rc?.registry).toEqual({ path: ".yakcc/registry.sqlite" });
   });
 
   it("no federation key when --peer is not provided", async () => {
     await init(["--target", tmpDir], new CollectingLogger());
     const rc = readRc(tmpDir);
-    expect(rc!["federation"]).toBeUndefined();
+    expect(rc?.federation).toBeUndefined();
   });
 });
 
@@ -186,13 +186,13 @@ describe("init — idempotent re-run", () => {
     await init(["--target", tmpDir], new CollectingLogger());
 
     const settings = readSettings(tmpDir);
-    const hooks = settings!["hooks"] as Record<string, unknown[]>;
-    const preToolUse = hooks["PreToolUse"] as unknown[];
+    const hooks = settings?.hooks as Record<string, unknown[]>;
+    const preToolUse = hooks.PreToolUse as unknown[];
     // Should still have exactly 1 yakcc entry (idempotent hook install)
     expect(
-      preToolUse.filter(
-        (e) => ((e as Record<string, unknown[]>)["hooks"] ?? []).some(
-          (h) => (h as Record<string, unknown>)["_yakcc"] === "yakcc-hook-v1",
+      preToolUse.filter((e) =>
+        ((e as Record<string, unknown[]>).hooks ?? []).some(
+          (h) => (h as Record<string, unknown>)._yakcc === "yakcc-hook-v1",
         ),
       ).length,
     ).toBe(1);
@@ -204,8 +204,8 @@ describe("init — idempotent re-run", () => {
 
     const rc = readRc(tmpDir);
     expect(rc).not.toBeNull();
-    expect(rc!["version"]).toBe(1);
-    expect((rc!["registry"] as Record<string, unknown>)["path"]).toBe(".yakcc/registry.sqlite");
+    expect(rc?.version).toBe(1);
+    expect((rc?.registry as Record<string, unknown>).path).toBe(".yakcc/registry.sqlite");
   });
 });
 
@@ -218,19 +218,16 @@ describe("init — --peer <url>", () => {
     // The mirror will fail (no real HTTP server), but init should still succeed
     // because mirror failure is non-fatal per DEC-CLI-INIT-001.
     const logger = new CollectingLogger();
-    const code = await init(
-      ["--target", tmpDir, "--peer", "http://localhost:19999"],
-      logger,
-    );
+    const code = await init(["--target", tmpDir, "--peer", "http://localhost:19999"], logger);
 
     // Exit 0 — mirror failure is a warning, not a fatal error
     expect(code).toBe(0);
     const rc = readRc(tmpDir);
     expect(rc).not.toBeNull();
-    const fed = rc!["federation"] as Record<string, unknown>;
+    const fed = rc?.federation as Record<string, unknown>;
     expect(fed).toBeDefined();
-    expect(Array.isArray(fed["peers"])).toBe(true);
-    expect((fed["peers"] as string[]).includes("http://localhost:19999")).toBe(true);
+    expect(Array.isArray(fed.peers)).toBe(true);
+    expect((fed.peers as string[]).includes("http://localhost:19999")).toBe(true);
   });
 
   it("re-run with same peer URL does not duplicate peer entry", async () => {
@@ -239,8 +236,8 @@ describe("init — --peer <url>", () => {
     await init(["--target", tmpDir, "--peer", peerUrl], new CollectingLogger());
 
     const rc = readRc(tmpDir);
-    const fed = rc!["federation"] as Record<string, unknown>;
-    const peers = fed["peers"] as string[];
+    const fed = rc?.federation as Record<string, unknown>;
+    const peers = fed.peers as string[];
     expect(peers.filter((p) => p === peerUrl).length).toBe(1);
   });
 
@@ -251,8 +248,8 @@ describe("init — --peer <url>", () => {
     await init(["--target", tmpDir, "--peer", peer2], new CollectingLogger());
 
     const rc = readRc(tmpDir);
-    const fed = rc!["federation"] as Record<string, unknown>;
-    const peers = fed["peers"] as string[];
+    const fed = rc?.federation as Record<string, unknown>;
+    const peers = fed.peers as string[];
     expect(peers.includes(peer1)).toBe(true);
     expect(peers.includes(peer2)).toBe(true);
   });

--- a/packages/shave/src/universalize/atom-test.props.ts
+++ b/packages/shave/src/universalize/atom-test.props.ts
@@ -183,8 +183,9 @@ export const prop_isAtom_zero_cf_empty_registry_is_always_atomic: fc.IAsyncPrope
  * the registry is consulted. A result with a different reason indicates the
  * short-circuit is broken.
  */
-export const prop_isAtom_excess_cf_returns_too_many_cf_boundaries =
-  fc.asyncProperty(fc.constant<undefined>(undefined), async () => {
+export const prop_isAtom_excess_cf_returns_too_many_cf_boundaries = fc.asyncProperty(
+  fc.constant<undefined>(undefined),
+  async () => {
     // Source with exactly 2 CF boundaries (if + for): exceeds maxCF=0.
     const source =
       "function f(x: number) { if (x > 0) { for (let i = 0; i < 10; i++) {} } return 0; }";
@@ -193,7 +194,8 @@ export const prop_isAtom_excess_cf_returns_too_many_cf_boundaries =
       maxControlFlowBoundaries: 0,
     });
     return result.isAtom === false && result.reason === "too-many-cf-boundaries";
-  });
+  },
+);
 
 // ---------------------------------------------------------------------------
 // AT-CF-4: undefined maxControlFlowBoundaries uses default (1)
@@ -212,8 +214,9 @@ export const prop_isAtom_excess_cf_returns_too_many_cf_boundaries =
  * in atom-test.ts. If this default ever changed silently, previously-atomic
  * nodes would be reclassified as non-atomic, breaking the decompose tree.
  */
-export const prop_isAtom_undefined_options_uses_default_max_cf_1 =
-  fc.asyncProperty(fc.constant<undefined>(undefined), async () => {
+export const prop_isAtom_undefined_options_uses_default_max_cf_1 = fc.asyncProperty(
+  fc.constant<undefined>(undefined),
+  async () => {
     // Exactly 1 CF boundary (single if) → atomic with default maxCF=1.
     const source = "function f(x: number) { if (x > 0) return x; return 0; }";
     const { file } = parseSource(source);
@@ -221,7 +224,8 @@ export const prop_isAtom_undefined_options_uses_default_max_cf_1 =
     return (
       result.isAtom === true && result.reason === "atomic" && result.controlFlowBoundaryCount === 1
     );
-  });
+  },
+);
 
 // ---------------------------------------------------------------------------
 // AT-REG-1: empty registry + options sweep → always atomic for 0-CF source
@@ -302,26 +306,28 @@ export const prop_isAtom_matchedPrimitive_absent_for_non_contains_reason: fc.IAs
  * Invariant (AT-REG-2, DEC-ATOM-TEST-003): criterion 2 is reachable. Without
  * this property a bug where the registry is never consulted could go unnoticed.
  */
-export const prop_isAtom_always_match_registry_triggers_contains_known_primitive =
-  fc.asyncProperty(fc.constant<undefined>(undefined), async () => {
-  // Two-statement function body: first statement can match the always-match registry.
-  const source = "function f(x: number) { const y = x * 2; return y + 1; }";
-  const { file } = parseSource(source);
+export const prop_isAtom_always_match_registry_triggers_contains_known_primitive = fc.asyncProperty(
+  fc.constant<undefined>(undefined),
+  async () => {
+    // Two-statement function body: first statement can match the always-match registry.
+    const source = "function f(x: number) { const y = x * 2; return y + 1; }";
+    const { file } = parseSource(source);
 
-  // Call isAtom on the FunctionDeclaration node so getTopLevelStatements
-  // returns the body's statements (not the self-recognition guard path).
-  const fnDecl = file.getFunctions()[0];
-  if (fnDecl === undefined) return false; // unexpected parse failure
+    // Call isAtom on the FunctionDeclaration node so getTopLevelStatements
+    // returns the body's statements (not the self-recognition guard path).
+    const fnDecl = file.getFunctions()[0];
+    if (fnDecl === undefined) return false; // unexpected parse failure
 
-  const result = await isAtom(fnDecl, source, alwaysMatchRegistry);
+    const result = await isAtom(fnDecl, source, alwaysMatchRegistry);
 
-  // The always-match registry returns a hit for the first sub-statement.
-  return (
-    result.isAtom === false &&
-    result.reason === "contains-known-primitive" &&
-    result.matchedPrimitive !== undefined
-  );
-});
+    // The always-match registry returns a hit for the first sub-statement.
+    return (
+      result.isAtom === false &&
+      result.reason === "contains-known-primitive" &&
+      result.matchedPrimitive !== undefined
+    );
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Compound: real parse → isAtom → result — CF-varies-by-maxCF correctness

--- a/packages/shave/src/universalize/recursion.props.ts
+++ b/packages/shave/src/universalize/recursion.props.ts
@@ -239,19 +239,21 @@ export const prop_decompose_root_canonicalAstHash_is_64_char_hex: fc.IAsyncPrope
  * precedes the throw. Therefore depth > maxDepth is always true at throw time.
  * An error with depth <= maxDepth indicates the guard condition was not respected.
  */
-export const prop_RecursionDepthExceededError_depth_exceeds_maxDepth =
-  fc.asyncProperty(fc.constant<undefined>(undefined), async () => {
-  // TWO_IF_SOURCE has SourceFile with 2 CF → not atomic with maxCF=1.
-  // maxDepth=0 forces the throw immediately when the recursion tries depth 1.
-  let caught: RecursionDepthExceededError | undefined;
-  try {
-    await decompose(TWO_IF_SOURCE, emptyRegistry, { maxDepth: 0 });
-  } catch (e) {
-    if (e instanceof RecursionDepthExceededError) caught = e;
-  }
-  if (caught === undefined) return false; // must throw
-  return caught.depth > caught.maxDepth;
-});
+export const prop_RecursionDepthExceededError_depth_exceeds_maxDepth = fc.asyncProperty(
+  fc.constant<undefined>(undefined),
+  async () => {
+    // TWO_IF_SOURCE has SourceFile with 2 CF → not atomic with maxCF=1.
+    // maxDepth=0 forces the throw immediately when the recursion tries depth 1.
+    let caught: RecursionDepthExceededError | undefined;
+    try {
+      await decompose(TWO_IF_SOURCE, emptyRegistry, { maxDepth: 0 });
+    } catch (e) {
+      if (e instanceof RecursionDepthExceededError) caught = e;
+    }
+    if (caught === undefined) return false; // must throw
+    return caught.depth > caught.maxDepth;
+  },
+);
 
 // ---------------------------------------------------------------------------
 // DEC-REC-P7: DidNotReachAtomError.node.range is a valid non-empty interval
@@ -271,8 +273,9 @@ export const prop_RecursionDepthExceededError_depth_exceeds_maxDepth =
  * where start >= end would indicate a phantom or zero-width node, which is not
  * a valid AST node kind.
  */
-export const prop_DidNotReachAtomError_node_range_is_valid =
-  fc.asyncProperty(fc.constant<undefined>(undefined), async () => {
+export const prop_DidNotReachAtomError_node_range_is_valid = fc.asyncProperty(
+  fc.constant<undefined>(undefined),
+  async () => {
     // maxControlFlowBoundaries: -1 makes every node non-atomic (CF count 0 > -1).
     // ExpressionStatement has no decomposable children → DidNotReachAtomError.
     let caught: DidNotReachAtomError | undefined;
@@ -290,7 +293,8 @@ export const prop_DidNotReachAtomError_node_range_is_valid =
       caught.node.range.start >= 0 &&
       caught.node.range.end > caught.node.range.start
     );
-  });
+  },
+);
 
 // ---------------------------------------------------------------------------
 // DEC-REC-P8: empty registry + 0-CF source → always atom root for all maxCF
@@ -352,36 +356,38 @@ export const prop_decompose_zero_cf_always_produces_atom_root: fc.IAsyncProperty
  * invariants must hold jointly for any successful decompose() call that produces
  * a branch tree.
  */
-export const prop_compound_decompose_real_parse_branch_and_atom_invariants =
-  fc.asyncProperty(fc.constant<undefined>(undefined), async () => {
-  // TWO_IF_SOURCE: 2 CF boundaries at SourceFile level → branch root.
-  const tree: RecursionTree = await decompose(TWO_IF_SOURCE, emptyRegistry);
+export const prop_compound_decompose_real_parse_branch_and_atom_invariants = fc.asyncProperty(
+  fc.constant<undefined>(undefined),
+  async () => {
+    // TWO_IF_SOURCE: 2 CF boundaries at SourceFile level → branch root.
+    const tree: RecursionTree = await decompose(TWO_IF_SOURCE, emptyRegistry);
 
-  // P3: root.kind is "atom" or "branch"
-  if (tree.root.kind !== "atom" && tree.root.kind !== "branch") return false;
+    // P3: root.kind is "atom" or "branch"
+    if (tree.root.kind !== "atom" && tree.root.kind !== "branch") return false;
 
-  // For this source the root must be a branch (2 CF > default maxCF=1).
-  if (tree.root.kind !== "branch") return false;
+    // For this source the root must be a branch (2 CF > default maxCF=1).
+    if (tree.root.kind !== "branch") return false;
 
-  // P1: leafCount >= 1
-  if (tree.leafCount < 1) return false;
+    // P1: leafCount >= 1
+    if (tree.leafCount < 1) return false;
 
-  // P2: maxDepth >= 0; for a branch tree it must be >= 1
-  if (tree.maxDepth < 1) return false;
+    // P2: maxDepth >= 0; for a branch tree it must be >= 1
+    if (tree.maxDepth < 1) return false;
 
-  // Internal consistency: count leaves matches declared leafCount.
-  if (countLeaves(tree.root) !== tree.leafCount) return false;
+    // Internal consistency: count leaves matches declared leafCount.
+    if (countLeaves(tree.root) !== tree.leafCount) return false;
 
-  // Internal consistency: computed maxDepth matches declared maxDepth.
-  if (computeMaxDepth(tree.root) !== tree.maxDepth) return false;
+    // Internal consistency: computed maxDepth matches declared maxDepth.
+    if (computeMaxDepth(tree.root) !== tree.maxDepth) return false;
 
-  // P5: root.canonicalAstHash is 64-char lowercase hex
-  const h = tree.root.canonicalAstHash;
-  if (typeof h !== "string" || h.length !== 64 || !/^[0-9a-f]+$/.test(h)) return false;
+    // P5: root.canonicalAstHash is 64-char lowercase hex
+    const h = tree.root.canonicalAstHash;
+    if (typeof h !== "string" || h.length !== 64 || !/^[0-9a-f]+$/.test(h)) return false;
 
-  // All joint invariants satisfied.
-  return true;
-});
+    // All joint invariants satisfied.
+    return true;
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Additional: canonicalAstHash stability across two calls
@@ -401,9 +407,11 @@ export const prop_compound_decompose_real_parse_branch_and_atom_invariants =
  * bytes and same AST normalization → same hash on every call. Hash instability
  * would break registry lookups and cross-session provenance manifests.
  */
-export const prop_decompose_canonicalAstHash_is_stable_across_calls =
-  fc.asyncProperty(fc.constant<undefined>(undefined), async () => {
-  const tree1 = await decompose(ONE_CF_SOURCE, emptyRegistry);
-  const tree2 = await decompose(ONE_CF_SOURCE, emptyRegistry);
-  return tree1.root.canonicalAstHash === tree2.root.canonicalAstHash;
-});
+export const prop_decompose_canonicalAstHash_is_stable_across_calls = fc.asyncProperty(
+  fc.constant<undefined>(undefined),
+  async () => {
+    const tree1 = await decompose(ONE_CF_SOURCE, emptyRegistry);
+    const tree2 = await decompose(ONE_CF_SOURCE, emptyRegistry);
+    return tree1.root.canonicalAstHash === tree2.root.canonicalAstHash;
+  },
+);

--- a/packages/shave/src/universalize/slicer.props.ts
+++ b/packages/shave/src/universalize/slicer.props.ts
@@ -282,13 +282,15 @@ export const prop_slice_strict_mode_never_emits_glue_entries: fc.IAsyncProperty<
  * VariableDeclarations, and other statement kinds must not be mistaken for
  * foreign imports.
  */
-export const prop_classifyForeign_non_import_source_returns_empty =
-  fc.property(fc.constant<undefined>(undefined), () => {
+export const prop_classifyForeign_non_import_source_returns_empty = fc.property(
+  fc.constant<undefined>(undefined),
+  () => {
     // Pure function with no imports — no ImportDeclaration nodes.
     const source = "function f(x: number): number { return x * 2; }";
     const entries = classifyForeign(source);
     return entries.length === 0;
-  });
+  },
+);
 
 // ---------------------------------------------------------------------------
 // SL-FOREIGN-2: classifyForeign on a foreign named import returns pkg + export
@@ -309,8 +311,9 @@ export const prop_classifyForeign_non_import_source_returns_empty =
  * are used by the provenance manifest and --foreign-policy CLI flag (L4).
  * Incorrect or missing entries would corrupt the foreign-import catalog.
  */
-export const prop_classifyForeign_foreign_named_import_returns_entry =
-  fc.property(fc.constant<undefined>(undefined), () => {
+export const prop_classifyForeign_foreign_named_import_returns_entry = fc.property(
+  fc.constant<undefined>(undefined),
+  () => {
     const source = `import { readFileSync } from 'node:fs';`;
     const entries = classifyForeign(source);
     if (entries.length !== 1) return false;
@@ -321,7 +324,8 @@ export const prop_classifyForeign_foreign_named_import_returns_entry =
       entry.export === "readFileSync" &&
       entry.alias === undefined
     );
-  });
+  },
+);
 
 // ---------------------------------------------------------------------------
 // SL-FOREIGN-3: classifyForeign on a type-only import returns empty array
@@ -341,12 +345,14 @@ export const prop_classifyForeign_foreign_named_import_returns_entry =
  * carry no runtime dependency. Classifying them as foreign would inject
  * spurious dependencies into the provenance manifest.
  */
-export const prop_classifyForeign_type_only_import_returns_empty =
-  fc.property(fc.constant<undefined>(undefined), () => {
+export const prop_classifyForeign_type_only_import_returns_empty = fc.property(
+  fc.constant<undefined>(undefined),
+  () => {
     const source = `import type { PathLike } from 'node:fs';`;
     const entries = classifyForeign(source);
     return entries.length === 0;
-  });
+  },
+);
 
 // ---------------------------------------------------------------------------
 // SL-FOREIGN-4: classifyForeign on a relative import returns empty array
@@ -366,12 +372,14 @@ export const prop_classifyForeign_type_only_import_returns_empty =
  * break the workspace boundary assumption that drives the slicer's
  * no-synthesis-needed rule for local source.
  */
-export const prop_classifyForeign_relative_import_returns_empty =
-  fc.property(fc.constant<undefined>(undefined), () => {
+export const prop_classifyForeign_relative_import_returns_empty = fc.property(
+  fc.constant<undefined>(undefined),
+  () => {
     const source = `import { helper } from './local.js';`;
     const entries = classifyForeign(source);
     return entries.length === 0;
-  });
+  },
+);
 
 // ---------------------------------------------------------------------------
 // SL-FOREIGN-5: classifyForeign on a workspace import returns empty array
@@ -391,12 +399,14 @@ export const prop_classifyForeign_relative_import_returns_empty =
  * guard. Classifying them as foreign would make all workspace consumers
  * appear as external dependencies.
  */
-export const prop_classifyForeign_workspace_import_returns_empty =
-  fc.property(fc.constant<undefined>(undefined), () => {
+export const prop_classifyForeign_workspace_import_returns_empty = fc.property(
+  fc.constant<undefined>(undefined),
+  () => {
     const source = `import { slice } from '@yakcc/shave';`;
     const entries = classifyForeign(source);
     return entries.length === 0;
-  });
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Compound: decompose → slice end-to-end joint invariants
@@ -434,8 +444,9 @@ export const prop_classifyForeign_workspace_import_returns_empty =
  * All six invariants must hold jointly for any valid slice call on a two-atom
  * branch tree with one matched and one unmatched atom.
  */
-export const prop_compound_slice_real_tree_joint_invariants =
-  fc.asyncProperty(fc.constant<undefined>(undefined), async () => {
+export const prop_compound_slice_real_tree_joint_invariants = fc.asyncProperty(
+  fc.constant<undefined>(undefined),
+  async () => {
     const sourceX = "function add(a: number, b: number): number { return a + b; }";
     const sourceY = "function mul(a: number, b: number): number { return a * b; }";
     const hashX = "hash-compound-X";
@@ -479,4 +490,5 @@ export const prop_compound_slice_real_tree_joint_invariants =
     if (!plan.entries.every((e) => SLICE_PLAN_ENTRY_KINDS.has(e.kind))) return false;
 
     return true;
-  });
+  },
+);


### PR DESCRIPTION
## Summary

Restores `main` to a clean lint state. Pre-existing violations slipped in during the window between WI-CI-MERGE-GATE-ENFORCEMENT Slice A1 landing (#297 / `e220f3e`) and lint being enforced as a required status check.

- `packages/shave/src/universalize/{atom-test,recursion,slicer}.props.ts` — formatter drift in fast-check property fixtures (`fc.property` arg wrapping)
- `packages/cli/src/cli.test.ts` + `commands/{hooks-install,init}.test.ts` — `useLiteralKeys` / `noNonNullAssertion` / `useTemplate` violations

All diffs are mechanical biome auto-fixes (`biome check --write [--unsafe]`). No behavioral or test-coverage changes.

PR #305 (WI-V3-DISCOVERY-EVAL-FIX) was admin-merged on top of these violations and inherited the red gate. This PR unblocks the lint gate so subsequent PRs can pass the WI-CI-MERGE-GATE-ENFORCEMENT required-status checks.

## Test plan

- [x] `pnpm -r lint` clean across all 13 packages
- [x] `pnpm -r build` clean across all 13 packages
- [x] No source logic touched — diff is mechanical biome auto-fix only

https://claude.ai/code/session_018RFmeHWE8TTDvzT8PeotLq

---
_Generated by [Claude Code](https://claude.ai/code/session_018RFmeHWE8TTDvzT8PeotLq)_