### PR TITLE
feat(registry): D3 Stage 3 graceful-skip on missing nonFunctional (closes #314)

### DIFF
--- a/packages/registry/src/storage.test.ts
+++ b/packages/registry/src/storage.test.ts
@@ -2193,10 +2193,9 @@ describe("findCandidatesByQuery — T2: symmetric round-trip via canonicalizeQue
     // combinedScore formula: 1 - d²/4 (DEC-V3-IMPL-QUERY-007 / DEC-V3-DISCOVERY-CALIBRATION-FIX-002).
     // vec0 returns L2 distance; for unit-normalized vectors: combinedScore = 1 - L2²/4.
     // biome-ignore lint/style/noNonNullAssertion: asserted defined above
-    const expectedScoreA = Math.max(
-      0,
-      1 - (candidateA?.cosineDistance * candidateA?.cosineDistance) / 4,
-    );
+    // biome-ignore lint/style/noNonNullAssertion: asserted defined at line 2184
+    const distA = candidateA!.cosineDistance;
+    const expectedScoreA = Math.max(0, 1 - (distA * distA) / 4);
     // biome-ignore lint/style/noNonNullAssertion: asserted defined above
     expect(candidateA!.combinedScore).toBeCloseTo(expectedScoreA, 10);
   });

--- a/packages/registry/src/storage.test.ts
+++ b/packages/registry/src/storage.test.ts
@@ -2195,7 +2195,7 @@ describe("findCandidatesByQuery — T2: symmetric round-trip via canonicalizeQue
     // biome-ignore lint/style/noNonNullAssertion: asserted defined above
     const expectedScoreA = Math.max(
       0,
-      1 - (candidateA!.cosineDistance * candidateA!.cosineDistance) / 4,
+      1 - (candidateA?.cosineDistance * candidateA?.cosineDistance) / 4,
     );
     // biome-ignore lint/style/noNonNullAssertion: asserted defined above
     expect(candidateA!.combinedScore).toBeCloseTo(expectedScoreA, 10);
@@ -2640,6 +2640,146 @@ describe("findCandidatesByQuery — T7: Stage 3 strictness filter removes purity
     const found = result.candidates.some((c) => c.block.blockMerkleRoot === row.blockMerkleRoot);
     expect(found).toBe(true);
     expect(result.nearMisses).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // T7-GRACEFUL — DEC-V3-DISCOVERY-D3-FILTER-STRICTNESS-FIX coverage
+  // -------------------------------------------------------------------------
+  // Per DEC-V3-INITIATIVE-002-DISPOSITION + #314: when candidate's spec does
+  // NOT declare nonFunctional, the Stage 3 strictness dimension is gracefully
+  // SKIPPED for that candidate. Rejection only applies when BOTH query and
+  // candidate declare the field AND candidate is strictly weaker.
+  //
+  // Empirical: #309 intent-mode A/B showed +42.5pts M2 / +20pts M3 / +0.364
+  // M4 vs query-mode (filter ON). Single-vector + corrected D3 is the
+  // production path; D1 multi-vector is paused (PR #315).
+  // -------------------------------------------------------------------------
+
+  it("graceful-skip: candidate with NO nonFunctional passes when query specifies purity", async () => {
+    const behavior = "Compute the absolute value of an integer";
+    const spec: SpecYak = {
+      name: "abs",
+      inputs: [{ name: "n", type: "number" }],
+      outputs: [{ name: "result", type: "number" }],
+      preconditions: [],
+      postconditions: [],
+      invariants: [],
+      effects: [],
+      level: "L0",
+      behavior,
+      // nonFunctional intentionally omitted — sparse-corpus shape.
+    };
+    const row = makeBlockRow(spec);
+    await registry.storeBlock(row);
+
+    const card: QueryIntentCard = {
+      behavior,
+      nonFunctional: { purity: "pure" },
+    };
+    const result = await registry.findCandidatesByQuery(card);
+
+    // Graceful-skip: candidate without NF declaration should NOT be rejected
+    // for missing nonFunctional. It should appear in candidates.
+    const found = result.candidates.some((c) => c.block.blockMerkleRoot === row.blockMerkleRoot);
+    expect(found).toBe(true);
+    // Should not surface as a strictness near-miss either.
+    const strictnessNearMiss = result.nearMisses.find(
+      (nm) => nm.failedAtLayer === "strictness" && nm.block.blockMerkleRoot === row.blockMerkleRoot,
+    );
+    expect(strictnessNearMiss).toBeUndefined();
+  });
+
+  it("graceful-skip: candidate with NO nonFunctional passes when query specifies threadSafety", async () => {
+    const behavior = "Reverse the characters of a string";
+    const spec: SpecYak = {
+      name: "reverse-string",
+      inputs: [{ name: "s", type: "string" }],
+      outputs: [{ name: "reversed", type: "string" }],
+      preconditions: [],
+      postconditions: [],
+      invariants: [],
+      effects: [],
+      level: "L0",
+      behavior,
+      // nonFunctional intentionally omitted.
+    };
+    const row = makeBlockRow(spec);
+    await registry.storeBlock(row);
+
+    const card: QueryIntentCard = {
+      behavior,
+      nonFunctional: { threadSafety: "safe" },
+    };
+    const result = await registry.findCandidatesByQuery(card);
+
+    const found = result.candidates.some((c) => c.block.blockMerkleRoot === row.blockMerkleRoot);
+    expect(found).toBe(true);
+  });
+
+  it("graceful-skip: candidate with partial NF (purity only) passes when query specifies threadSafety", async () => {
+    // declared-on-candidate-but-not-on-the-specific-dimension case
+    const behavior = "Concatenate two strings";
+    const spec: SpecYak = {
+      name: "concat",
+      inputs: [
+        { name: "a", type: "string" },
+        { name: "b", type: "string" },
+      ],
+      outputs: [{ name: "result", type: "string" }],
+      preconditions: [],
+      postconditions: [],
+      invariants: [],
+      effects: [],
+      level: "L0",
+      behavior,
+      // Partial NF — purity declared, threadSafety NOT declared.
+      nonFunctional: { purity: "pure" } as unknown as SpecYak["nonFunctional"],
+    };
+    const row = makeBlockRow(spec);
+    await registry.storeBlock(row);
+
+    const card: QueryIntentCard = {
+      behavior,
+      nonFunctional: { threadSafety: "safe" }, // candidate doesn't declare this — should skip
+    };
+    const result = await registry.findCandidatesByQuery(card);
+
+    const found = result.candidates.some((c) => c.block.blockMerkleRoot === row.blockMerkleRoot);
+    expect(found).toBe(true);
+  });
+
+  it("strict-reject: both declared and candidate strictly weaker still rejects (regression guard)", async () => {
+    // This case MUST still reject — the fix is graceful-skip on missing, NOT
+    // graceful-skip on declared-but-weaker. The strictness check is still meaningful
+    // when both query and candidate declare the field.
+    const behavior = "Hash a string using SHA-256";
+    const spec: SpecYak = {
+      name: "sha256",
+      inputs: [{ name: "input", type: "string" }],
+      outputs: [{ name: "hash", type: "string" }],
+      preconditions: [],
+      postconditions: [],
+      invariants: [],
+      effects: [],
+      level: "L0",
+      behavior,
+      nonFunctional: { purity: "io", threadSafety: "safe" }, // io < pure
+    };
+    const row = makeBlockRow(spec);
+    await registry.storeBlock(row);
+
+    const card: QueryIntentCard = {
+      behavior,
+      nonFunctional: { purity: "pure" }, // candidate purity=io < pure → strict reject
+    };
+    const result = await registry.findCandidatesByQuery(card);
+
+    const found = result.candidates.some((c) => c.block.blockMerkleRoot === row.blockMerkleRoot);
+    expect(found).toBe(false);
+    const strictnessNearMiss = result.nearMisses.find(
+      (nm) => nm.failedAtLayer === "strictness" && nm.block.blockMerkleRoot === row.blockMerkleRoot,
+    );
+    expect(strictnessNearMiss).toBeDefined();
   });
 });
 

--- a/packages/registry/src/storage.ts
+++ b/packages/registry/src/storage.ts
@@ -862,15 +862,27 @@ class SqliteRegistry implements Registry {
         const reasons: string[] = [];
         const candidateNF = item.specYak.nonFunctional;
 
+        // Graceful-skip semantics per DEC-V3-DISCOVERY-D3-FILTER-STRICTNESS-FIX
+        // (issue #314, follow-up to DEC-V3-INITIATIVE-002-DISPOSITION):
+        //   - If candidate has no nonFunctional declaration, the strictness
+        //     dimension is SKIPPED for this candidate (not a rejection).
+        //   - Rejection only applies when BOTH query and candidate declare the
+        //     field AND candidate is strictly weaker.
+        // Rationale: corpus + registry have sparse nonFunctional coverage
+        // (0/50 in stratified corpus; rare in source-shaved atoms). Treating
+        // missing-on-candidate as rejection gave intent-mode A/B +42.5pts M2
+        // / +20pts M3 / +0.364 M4 vs query-mode in #289/#309. Graceful-skip is
+        // the correct semantics: a candidate that doesn't declare the field is
+        // no worse than one that declared it and matched.
         if (candidateNF !== undefined) {
-          if (queryNF.purity !== undefined) {
+          if (queryNF.purity !== undefined && candidateNF.purity !== undefined) {
             const qRank = PURITY_RANK[queryNF.purity] ?? 0;
             const cRank = PURITY_RANK[candidateNF.purity] ?? 0;
             if (cRank < qRank) {
               reasons.push(`purity=${candidateNF.purity} but query requires ${queryNF.purity}`);
             }
           }
-          if (queryNF.threadSafety !== undefined) {
+          if (queryNF.threadSafety !== undefined && candidateNF.threadSafety !== undefined) {
             const qRank = THREAD_RANK[queryNF.threadSafety] ?? 0;
             const cRank = THREAD_RANK[candidateNF.threadSafety] ?? 0;
             if (cRank < qRank) {
@@ -879,10 +891,8 @@ class SqliteRegistry implements Registry {
               );
             }
           }
-        } else if (queryNF.purity !== undefined || queryNF.threadSafety !== undefined) {
-          // Candidate has no NF declaration — treat as failing when query requires one.
-          reasons.push("candidate has no nonFunctional declaration");
         }
+        // candidateNF === undefined → graceful skip, no reasons pushed.
 
         if (reasons.length > 0) {
           stage3Failed.push({ item, reason: reasons.join("; ") });


### PR DESCRIPTION
## Summary

Implements `WI-V3-DISCOVERY-D3-FILTER-STRICTNESS-FIX` per #314 — the operator-meaningful quality fix surfaced by FG's intent-mode A/B in #309.

(Supersedes #323 which had per-branch push rejection issues from the local proxy.)

## Root cause

`findCandidatesByQuery` Stage 3 (strictness filter) at `packages/registry/src/storage.ts:882-884` rejected candidates whose spec did NOT declare `nonFunctional` whenever the query specified a strictness constraint. Wrong on real corpora: shaved source atoms rarely populate `nonFunctional`; the stratified corpus has 0/50 entries with `nonFunctional`. Result: mass rejection of semantically-good candidates.

## Empirical evidence (from #289 / #309)

| Mode | M2 | M3 | M4 |
|---|---|---|---|
| Query (pipeline ON, pre-fix) | 20.0% | 72.5% | 0.378 |
| Intent (pipeline OFF, A/B) | 62.5% | 92.5% | 0.742 |
| Δ from disabling Stage 3 | **+42.5pts** | **+20pts** | **+0.364** |

## Fix

`packages/registry/src/storage.ts` Stage 3 strictness check now:
- **Skips** the dimension when candidate declares no `nonFunctional`
- **Skips** the dimension when candidate declares NF but not the specific field (e.g. declared purity but not threadSafety)
- **Still rejects** when both declare AND candidate is strictly weaker (e.g. candidate.purity=io vs query.purity=pure)

Per DEC-V3-INITIATIVE-002-DISPOSITION: single-vector + corrected D3 is the production path; D1 multi-vector remains paused.

## Tests added

4 new T7 tests in `storage.test.ts` covering all cases from #314 acceptance:
- `graceful-skip: candidate with NO nonFunctional passes when query specifies purity`
- `graceful-skip: candidate with NO nonFunctional passes when query specifies threadSafety`
- `graceful-skip: candidate with partial NF passes when query specifies undeclared dimension`
- `strict-reject: both declared and candidate strictly weaker still rejects (regression guard)`

Full registry suite: **272 passed / 13 skipped** (was 268 / 13).

Also fixed a pre-existing typecheck error from a prior biome auto-fix that
left `candidateA?.cosineDistance * candidateA?.cosineDistance` (optional
chaining * optional chaining = possibly undefined). Extracted to a local
non-null-asserted variable; no behavior change.

## Next step (orchestrator-action)

Re-measure with the env-var toggle from #321 (merged at b0f359f):

```sh
DISCOVERY_EVAL_PROVIDER=local DISCOVERY_EVAL_REPORT=1 \
  pnpm --filter @yakcc/registry test -- src/discovery-eval-full-corpus.test.ts
```

Default `DISCOVERY_EVAL_QUERY_MODE=query` (pipeline ON post-fix). If M2 closes to ≥70%, single-vector + corrected D3 is the production answer and v3 IMPL migration drops from the v0.5 critical path entirely → unblocks #218 → #219 → #194.

## Cornerstones preserved

- **#4** (embedding is just an index; cosine never decides correctness) untouched — Stage 3 is a strictness filter, not a similarity decider
- **#1** (single source of truth) — single edit site for the strictness logic
- **Sacred Practice #5 (loud failure)** — strict-reject case still loudly produces a near-miss with `failedAtLayer: 'strictness'` and the reason string

## Test plan

- [x] `pnpm --filter @yakcc/registry build` clean
- [x] `pnpm --filter @yakcc/registry test` → 272 passed (4 new tests added)
- [x] `pnpm -r typecheck` clean
- [x] `pnpm -r lint` clean
- [x] `pnpm bench:airgap` PASS (0 outbound)
- [ ] Operator/FG re-measures full-corpus harness with this PR to confirm M2 closes toward ≥70%

## Closes

- **#314** WI-V3-DISCOVERY-D3-FILTER-STRICTNESS-FIX

https://claude.ai/code/session_018RFmeHWE8TTDvzT8PeotLq

---
_Generated by [Claude Code](https://claude.ai/code/session_018RFmeHWE8TTDvzT8PeotLq)_