### PR TITLE
fix(contracts): update modelId test assertion after bge-small swap (#336 follow-up)

### DIFF
--- a/packages/contracts/src/embeddings.test.ts
+++ b/packages/contracts/src/embeddings.test.ts
@@ -38,15 +38,18 @@ describe("EmbeddingProvider (local) — static metadata", () => {
   });
 
   it("modelId is non-empty and matches expected model", () => {
+    // Per DEC-EMBED-MODEL-DEFAULT-002 (PR #336, 2026-05-11): default swapped
+    // from all-MiniLM-L6-v2 to bge-small-en-v1.5 based on operator-run
+    // benchmark hitting M2=70% target. Update assertion when default changes.
     const provider = createLocalEmbeddingProvider();
-    expect(provider.modelId).toBe("Xenova/all-MiniLM-L6-v2");
+    expect(provider.modelId).toBe("Xenova/bge-small-en-v1.5");
   });
 });
 
 // ---------------------------------------------------------------------------
 // Local provider — network smoke (opt-in: YAKCC_NETWORK_TESTS=1)
 //
-// Loads the Xenova/all-MiniLM-L6-v2 ONNX model (~25 MB on cold cache).
+// Loads the Xenova/bge-small-en-v1.5 ONNX model (~25 MB on cold cache).
 // Skipped by default so CI and sandboxed runs stay offline-tolerant.
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Trailing fix from #336 — the advisory `test (affected packages)` job failed because `packages/contracts/src/embeddings.test.ts` still asserted `Xenova/all-MiniLM-L6-v2` as the expected modelId. Updates the assertion to `Xenova/bge-small-en-v1.5` per DEC-EMBED-MODEL-DEFAULT-002.

## Diff

```diff
   it("modelId is non-empty and matches expected model", () => {
+    // Per DEC-EMBED-MODEL-DEFAULT-002 (PR #336, 2026-05-11): default swapped
+    // from all-MiniLM-L6-v2 to bge-small-en-v1.5 based on operator-run
+    // benchmark hitting M2=70% target. Update assertion when default changes.
     const provider = createLocalEmbeddingProvider();
-    expect(provider.modelId).toBe("Xenova/all-MiniLM-L6-v2");
+    expect(provider.modelId).toBe("Xenova/bge-small-en-v1.5");
   });
```

Plus a parallel comment update in the network-smoke section (`Loads the Xenova/bge-small-en-v1.5 ONNX model`).

## Test plan

- [x] `pnpm --filter @yakcc/contracts test` — passes (188/189 + 1 opt-in skip)
- [x] Lint clean
- [x] No production code changed

https://claude.ai/code/session_018RFmeHWE8TTDvzT8PeotLq

---
_Generated by [Claude Code](https://claude.ai/code/session_018RFmeHWE8TTDvzT8PeotLq)_