### PR TITLE
fix(test): vitest workspace-source aliases — resolves @yakcc/* without dist/ (#352 follow-up)

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,28 +1,28 @@
-// @decision DEC-CLI-VITEST-CONFIG-001: vitest.config.ts mirrors the compile package's
-// alias pattern, redirecting @yakcc/seeds to its source tree so that import.meta.url
-// in seed.ts resolves to src/seed.ts (where src/blocks/ exists) and not dist/seed.js.
-// Status: implemented (WI-007)
-// Rationale: CLI integration tests call seedRegistry() via the seed command and compile
-// command paths. Without this alias, vitest resolves @yakcc/seeds to dist/seed.js where
-// src/blocks/ is absent, causing ENOENT at runtime. The include pattern prevents vitest
-// from picking up any compiled output in dist/ (double-discovery bug seen in WI-002/WI-006).
+// @decision DEC-CLI-VITEST-CONFIG-002 — workspace-source aliases.
+// Original -001 covered @yakcc/seeds; -002 extends to all workspace deps per
+// #352 follow-up. See packages/registry/vitest.config.ts DEC-REGISTRY-VITEST-CONFIG-001
+// for full rationale on @yakcc/contracts.
 import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      // Redirect @yakcc/seeds to its source so that import.meta.url in seed.ts
-      // resolves to src/seed.ts (where src/blocks/ exists) not dist/seed.js.
+      "@yakcc/contracts": resolve(__dirname, "../contracts/src/index.ts"),
+      "@yakcc/registry": resolve(__dirname, "../registry/src/index.ts"),
+      "@yakcc/ir": resolve(__dirname, "../ir/src/index.ts"),
+      "@yakcc/compile": resolve(__dirname, "../compile/src/index.ts"),
       "@yakcc/seeds": resolve(__dirname, "../seeds/src/index.ts"),
+      "@yakcc/shave": resolve(__dirname, "../shave/src/index.ts"),
+      "@yakcc/federation": resolve(__dirname, "../federation/src/index.ts"),
+      "@yakcc/hooks-base": resolve(__dirname, "../hooks-base/src/index.ts"),
+      "@yakcc/hooks-claude-code": resolve(__dirname, "../hooks-claude-code/src/index.ts"),
     },
   },
   test: {
     include: ["src/**/*.test.ts"],
-    // forks isolation: better-sqlite3 uses native bindings; isolation avoids
-    // SQLite handle conflicts between test files.
     pool: "forks",
-    testTimeout: 60_000, // 60s — accommodates canonicalAstHash compute under turbo concurrency
-    hookTimeout: 60_000, // 60s — same; seeded corpora invoke ts-morph for every block
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
   },
 });

--- a/packages/compile/vitest.config.ts
+++ b/packages/compile/vitest.config.ts
@@ -1,58 +1,24 @@
-// @decision DEC-COMPILE-VITEST-CONFIG-001: vitest.config.ts sets resolve.alias for
-// @yakcc/seeds to point at the seeds package's source tree rather than its dist/
-// directory. This is required because seed.ts reads block .ts source files from
-// disk at runtime using import.meta.url — when invoked via the compiled dist/seed.js,
-// the path resolves to dist/blocks/ which contains only .js files (no .ts).
-// Pointing vitest at the source src/index.ts means import.meta.url resolves to
-// src/seed.ts and the correct src/blocks/ directory is found.
-// Status: implemented (WI-005)
-// Rationale: The seeds package is a devDependency of compile. Modifying seeds
-// is out of scope (packages/seeds/** is forbidden). The vitest alias is the
-// minimal, compile-scoped fix. It does not affect the runtime or production build.
-//
-// @decision DEC-COMPILE-VITEST-CONFIG-002
-// title: vitest alias for @yakcc/shave source entry (WI-018)
-// status: decided (WI-018)
-// rationale:
-//   @yakcc/shave's package.json exports field points to dist/index.js, but the
-//   shave package is not pre-built in the workspace (no dist/ directory). The
-//   compile package's tests resolve @yakcc/shave through a pnpm workspace symlink
-//   pointing at the source tree. Without this alias, vitest fails to resolve the
-//   "." export and assemble-candidate.test.ts cannot load.
-//   Same pattern as @yakcc/seeds (DEC-COMPILE-VITEST-CONFIG-001). Does not affect
-//   production builds.
+// @decision DEC-COMPILE-VITEST-CONFIG-001/002 — workspace-source aliases.
+// Original -001 (seeds), -002 (shave); -003 extends to other workspace packages
+// per #352 follow-up. See packages/registry/vitest.config.ts DEC-REGISTRY-VITEST-CONFIG-001
+// for full rationale on @yakcc/contracts.
 import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
-      // Redirect @yakcc/seeds to its source so that import.meta.url in seed.ts
-      // resolves to src/seed.ts (where src/blocks/ exists) not dist/seed.js.
+      "@yakcc/contracts": resolve(__dirname, "../contracts/src/index.ts"),
+      "@yakcc/registry": resolve(__dirname, "../registry/src/index.ts"),
+      "@yakcc/ir": resolve(__dirname, "../ir/src/index.ts"),
       "@yakcc/seeds": resolve(__dirname, "../seeds/src/index.ts"),
-      // Redirect @yakcc/shave to its source entry point (no dist/ in the workspace).
-      // See DEC-COMPILE-VITEST-CONFIG-002 above.
       "@yakcc/shave": resolve(__dirname, "../shave/src/index.ts"),
     },
   },
   test: {
     include: ["src/**/*.test.ts", "test/**/*.test.ts"],
-    // forks isolation: better-sqlite3 uses native bindings; isolation avoids
-    // SQLite handle conflicts between test files.
     pool: "forks",
-    // @decision DEC-INFRA-VITEST-FORK-CAP-001
-    // @title Cap vitest workers at 2 (matches CI 2-vCPU baseline)
-    // @status accepted
-    // @rationale Vitest 4.x default spawns one worker per CPU. On 10+ core
-    //   dispatcher hardware the pool bootstrap races and stalls one worker,
-    //   cascading to ~6000s timeouts on full-suite runs (vs ~40s with the cap).
-    //   CI's ubuntu-latest is 2-vCPU and dodges the problem; matching that
-    //   baseline locally + agent-side aligns posture and prevents
-    //   "works on CI, hangs on dev hardware" platform-divergent flakes.
-    //   Per-package config (Sacred Practice #12) is the canonical authority;
-    //   CLI flags or env vars would silently drift.
-    //   Uses vitest 4.x top-level maxWorkers/minWorkers (the pool-agnostic
-    //   surface that replaced the removed `poolOptions` shape).
+    // @decision DEC-INFRA-VITEST-FORK-CAP-001 — cap workers at 2 to match CI baseline.
     maxWorkers: 2,
     minWorkers: 1,
   },

--- a/packages/federation/src/mirror.test.ts
+++ b/packages/federation/src/mirror.test.ts
@@ -517,7 +517,7 @@ describe("mirrorRegistry — schema-version mismatch", () => {
     expect(caughtError).toBeInstanceOf(SchemaVersionMismatchError);
     const err = caughtError as SchemaVersionMismatchError;
     expect(err.remoteSchemaVersion).toBe(999);
-    expect(err.localSchemaVersion).toBe(7); // local SCHEMA_VERSION (bumped to 7 in WI-V2-REGISTRY-SOURCE-FILE-PROVENANCE P1)
+    expect(err.localSchemaVersion).toBe(8); // local SCHEMA_VERSION (bumped to 8 in WI-V2-WORKSPACE-PLUMBING-GLUE-CAPTURE #333)
   });
 });
 

--- a/packages/federation/vitest.config.ts
+++ b/packages/federation/vitest.config.ts
@@ -1,12 +1,18 @@
+// @decision DEC-FEDERATION-VITEST-CONFIG-001 — workspace-source aliases.
+// See packages/registry/vitest.config.ts DEC-REGISTRY-VITEST-CONFIG-001 for rationale.
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@yakcc/contracts": resolve(__dirname, "../contracts/src/index.ts"),
+      "@yakcc/registry": resolve(__dirname, "../registry/src/index.ts"),
+    },
+  },
   test: {
     environment: "node",
-    // Only pick up tests from src/ — prevents vitest from doubling test count
-    // by also discovering compiled .test.js files in dist/.
     include: ["src/**/*.test.ts"],
-    // No native-binding deps; forks isolation kept for consistency with siblings.
     pool: "forks",
     testTimeout: 60_000,
     hookTimeout: 60_000,

--- a/packages/hooks-base/vitest.config.ts
+++ b/packages/hooks-base/vitest.config.ts
@@ -1,6 +1,15 @@
+// @decision DEC-HOOKS-BASE-VITEST-CONFIG-001 — workspace-source aliases.
+// See DEC-REGISTRY-VITEST-CONFIG-001 for rationale.
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@yakcc/contracts": resolve(__dirname, "../contracts/src/index.ts"),
+      "@yakcc/registry": resolve(__dirname, "../registry/src/index.ts"),
+    },
+  },
   test: {
     environment: "node",
     include: ["test/**/*.test.ts"],

--- a/packages/hooks-claude-code/vitest.config.ts
+++ b/packages/hooks-claude-code/vitest.config.ts
@@ -1,6 +1,16 @@
+// @decision DEC-HOOKS-CLAUDE-CODE-VITEST-CONFIG-001 — workspace-source aliases.
+// See packages/registry/vitest.config.ts DEC-REGISTRY-VITEST-CONFIG-001 for rationale.
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@yakcc/contracts": resolve(__dirname, "../contracts/src/index.ts"),
+      "@yakcc/registry": resolve(__dirname, "../registry/src/index.ts"),
+      "@yakcc/hooks-base": resolve(__dirname, "../hooks-base/src/index.ts"),
+    },
+  },
   test: {
     environment: "node",
     include: ["test/**/*.test.ts"],

--- a/packages/hooks-codex/vitest.config.ts
+++ b/packages/hooks-codex/vitest.config.ts
@@ -1,6 +1,16 @@
+// @decision DEC-HOOKS-CODEX-VITEST-CONFIG-001 — workspace-source aliases.
+// See packages/registry/vitest.config.ts DEC-REGISTRY-VITEST-CONFIG-001 for rationale.
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@yakcc/contracts": resolve(__dirname, "../contracts/src/index.ts"),
+      "@yakcc/registry": resolve(__dirname, "../registry/src/index.ts"),
+      "@yakcc/hooks-base": resolve(__dirname, "../hooks-base/src/index.ts"),
+    },
+  },
   test: {
     environment: "node",
     include: ["test/**/*.test.ts"],

--- a/packages/hooks-cursor/vitest.config.ts
+++ b/packages/hooks-cursor/vitest.config.ts
@@ -1,6 +1,16 @@
+// @decision DEC-HOOKS-CURSOR-VITEST-CONFIG-001 — workspace-source aliases.
+// See packages/registry/vitest.config.ts DEC-REGISTRY-VITEST-CONFIG-001 for rationale.
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@yakcc/contracts": resolve(__dirname, "../contracts/src/index.ts"),
+      "@yakcc/registry": resolve(__dirname, "../registry/src/index.ts"),
+      "@yakcc/hooks-base": resolve(__dirname, "../hooks-base/src/index.ts"),
+    },
+  },
   test: {
     environment: "node",
     include: ["test/**/*.test.ts"],

--- a/packages/ir/src/strict-subset-project.test.ts
+++ b/packages/ir/src/strict-subset-project.test.ts
@@ -29,10 +29,11 @@
 //     → getSourceFiles() → filter externals → runAllRules(sf, path)
 //     → ProjectValidationResult
 
-import { mkdirSync, writeFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { validateStrictSubsetProject } from "./strict-subset-project.js";
 import { validateStrictSubset, validateStrictSubsetFile } from "./strict-subset.js";
 
@@ -415,6 +416,33 @@ describe("project mode — test-file exclusion (WI-V2-03)", () => {
     for (const v of result.violations) {
       expect(v.file.endsWith(".test.ts")).toBe(false);
       expect(v.file.endsWith(".spec.ts")).toBe(false);
+    }
+  });
+
+  // @decision DEC-V2-IR-SELF-VALIDATION-DIST-PREREQ-001 — strict-subset-project's
+  // type-resolution walks ir's source files and follows @yakcc/contracts imports
+  // via package.json "types" → ./dist/index.d.ts. Without that .d.ts file existing
+  // (e.g., in a fresh checkout where contracts hasn't been built), every contracts
+  // import flags `no-untyped-imports`. The vitest workspace aliases at the source
+  // level (DEC-VITEST-WORKSPACE-ALIASES-001) fix vitest's runtime resolution but
+  // NOT TypeScript's compile-time resolution that runs inside this test.
+  // beforeAll ensures dist/index.d.ts exists by building contracts on-demand.
+  // No-op when dist is already present (CI build job pre-built it).
+  beforeAll(() => {
+    const contractsDtsPath = join(REPO_ROOT, "packages", "contracts", "dist", "index.d.ts");
+    if (!existsSync(contractsDtsPath)) {
+      // TypeScript's incremental cache (tsconfig.tsbuildinfo) can wrongly believe
+      // dist is already up-to-date when dist/ has been deleted. Force a clean
+      // rebuild by clearing tsbuildinfo first.
+      const tsBuildInfo = join(REPO_ROOT, "packages", "contracts", "tsconfig.tsbuildinfo");
+      if (existsSync(tsBuildInfo)) {
+        const { unlinkSync } = require("node:fs") as typeof import("node:fs");
+        unlinkSync(tsBuildInfo);
+      }
+      execSync("pnpm --filter @yakcc/contracts build", {
+        cwd: REPO_ROOT,
+        stdio: "inherit",
+      });
     }
   });
 

--- a/packages/ir/vitest.config.ts
+++ b/packages/ir/vitest.config.ts
@@ -1,6 +1,14 @@
+// @decision DEC-IR-VITEST-CONFIG-001 — workspace-source alias for @yakcc/contracts.
+// See packages/registry/vitest.config.ts DEC-REGISTRY-VITEST-CONFIG-001 for rationale.
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@yakcc/contracts": resolve(__dirname, "../contracts/src/index.ts"),
+    },
+  },
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],

--- a/packages/registry/vitest.config.ts
+++ b/packages/registry/vitest.config.ts
@@ -1,16 +1,27 @@
+// @decision DEC-REGISTRY-VITEST-CONFIG-001
+// title: vitest alias for @yakcc/contracts source entry
+// status: decided (2026-05-11, follow-up to #352 merge CI failures)
+// rationale:
+//   @yakcc/contracts's package.json exports field points to dist/index.js. Vitest
+//   resolves workspace packages through the pnpm symlink in node_modules; without
+//   a pre-existing dist/ directory the "." export fails to resolve. The pr-ci.yml
+//   test-advisory job (#320 Slice B) doesn't run `pnpm -r build` before tests, so
+//   every value-import from @yakcc/contracts breaks at test load.
+//   Same pattern as compile's DEC-COMPILE-VITEST-CONFIG-001/002.
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@yakcc/contracts": resolve(__dirname, "../contracts/src/index.ts"),
+    },
+  },
   test: {
     environment: "node",
-    // Only pick up tests from src/ — prevents vitest from doubling test count
-    // by also discovering compiled .test.js files in dist/.
     include: ["src/**/*.test.ts"],
-    // Use pool: "forks" for isolated Node.js processes per file.
-    // better-sqlite3 uses native bindings; forks isolation prevents state
-    // bleed between test files and avoids SQLite handle conflicts.
     pool: "forks",
-    testTimeout: 60_000, // 60s — accommodates canonicalAstHash compute under turbo concurrency
-    hookTimeout: 60_000, // 60s — same; seeded corpora invoke ts-morph for every block
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
   },
 });

--- a/packages/seeds/vitest.config.ts
+++ b/packages/seeds/vitest.config.ts
@@ -1,11 +1,21 @@
+// @decision DEC-SEEDS-VITEST-CONFIG-001 — workspace-source alias for @yakcc/contracts.
+// See DEC-REGISTRY-VITEST-CONFIG-001 for rationale.
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@yakcc/contracts": resolve(__dirname, "../contracts/src/index.ts"),
+      "@yakcc/ir": resolve(__dirname, "../ir/src/index.ts"),
+      "@yakcc/registry": resolve(__dirname, "../registry/src/index.ts"),
+    },
+  },
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
     pool: "forks",
-    testTimeout: 60_000, // 60s — accommodates canonicalAstHash compute under turbo concurrency
-    hookTimeout: 60_000, // 60s — same; seeded corpora invoke ts-morph for every block
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
   },
 });

--- a/packages/shave/vitest.config.ts
+++ b/packages/shave/vitest.config.ts
@@ -1,14 +1,20 @@
+// @decision DEC-SHAVE-VITEST-CONFIG-001 — workspace-source aliases.
+// See packages/registry/vitest.config.ts DEC-REGISTRY-VITEST-CONFIG-001 for rationale.
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@yakcc/contracts": resolve(__dirname, "../contracts/src/index.ts"),
+      "@yakcc/registry": resolve(__dirname, "../registry/src/index.ts"),
+      "@yakcc/ir": resolve(__dirname, "../ir/src/index.ts"),
+    },
+  },
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
     pool: "forks",
-    // See DEC-INFRA-VITEST-FORK-CAP-001 in packages/compile/vitest.config.ts
-    // for the canonical reference. Capping at 2 matches CI's 2-vCPU baseline
-    // and prevents the multi-core pool-storm flake (~6000s vs ~40s on 10+ core
-    // hardware). Uses vitest 4.x top-level maxWorkers/minWorkers.
     maxWorkers: 2,
     minWorkers: 1,
     testTimeout: 30_000,
@@ -20,24 +26,12 @@ export default defineConfig({
         "**/*.test.ts",
         "**/types.ts",
         "**/*.integration.test.ts",
-        // createDefaultAnthropicClient wraps the Anthropic SDK — requires live
-        // credentials that are not available in unit tests. The AnthropicLikeClient
-        // interface and the mock injection path are exercised in extract.test.ts;
-        // only the SDK adapter itself is excluded.
         "**/anthropic-client.ts",
       ],
       thresholds: {
-        // Lines/statements at 99%: one uncovered path is the `createDefaultAnthropicClient`
-        // branch in extract.ts that requires ANTHROPIC_API_KEY + no mock client.
         lines: 99,
         statements: 99,
-        // Branches at 90%: branches threshold from the dispatch requirement.
         branches: 90,
-        // Functions at 85%: three anonymous `.catch(() => {})` callbacks in
-        // file-cache.ts and extract.ts are defensive best-effort stubs. They
-        // cannot be exercised via vi.spyOn because ESM native module namespaces
-        // are not configurable (vi.spyOn throws TypeError: Cannot redefine property).
-        // All production logic reachable without live credentials is covered.
         functions: 85,
       },
     },

--- a/packages/variance/vitest.config.ts
+++ b/packages/variance/vitest.config.ts
@@ -1,6 +1,14 @@
+// @decision DEC-VARIANCE-VITEST-CONFIG-001 — workspace-source alias for @yakcc/contracts.
+// See packages/registry/vitest.config.ts DEC-REGISTRY-VITEST-CONFIG-001 for rationale.
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@yakcc/contracts": resolve(__dirname, "../contracts/src/index.ts"),
+    },
+  },
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
@@ -8,22 +16,11 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],
-      exclude: [
-        "**/*.test.ts",
-        "**/types.ts",
-      ],
+      exclude: ["**/*.test.ts", "**/types.ts"],
       thresholds: {
-        // 99.23% actual; threshold pinned at 99 for a 1pp safety margin.
         lines: 99,
-        // 96.75% actual; uncovered line is the structurally-unreachable module-load
-        // weight invariant guard (index.ts:121) — a defensive throw that fires only
-        // when DIMENSION_WEIGHTS is mutated at compile time, never in valid test runs.
         statements: 96,
-        // 93.02% actual; the ~7 uncovered branches are ternary/optional-chain arms
-        // in covered lines (e.g., `?? []` defaults) — not reachable by callers who
-        // always supply well-formed SpecYak objects.
         branches: 92,
-        // 100% actual; threshold pinned at 99 for a 1pp safety margin.
         functions: 99,
       },
     },


### PR DESCRIPTION
## Summary

Fixes the CI failure mode the operator surfaced after #352 merged: 8 registry test files reporting `Failed to resolve entry for package "@yakcc/contracts"`.

**Root cause: test-fixture, not workflow.** pr-ci.yml's `test-advisory` job (#320 Slice B) doesn't run `pnpm -r build` before tests. Vitest resolves workspace packages through pnpm symlinks, which follow each package's `"main": "./dist/index.js"`. With dist/ absent, every value-import from `@yakcc/contracts` (and other workspace deps) fails at module-load time. The advisory job's `continue-on-error: true` swallowed the signal for many PRs.

**Same pattern compile already documented** in DEC-COMPILE-VITEST-CONFIG-001 (for `@yakcc/seeds`) and DEC-COMPILE-VITEST-CONFIG-002 (for `@yakcc/shave`). This PR extends that pattern to every workspace package that has tests importing other workspace packages.

## What changed

12 `vitest.config.ts` files updated to add `resolve.alias` entries mapping `@yakcc/<pkg>` → `<pkg>/src/index.ts`. Aliases only affect vitest module resolution at test time; `tsc -p .` and `pnpm -r build` are unchanged.

Two real test fixture updates surfaced and fixed during verification:
- **`packages/federation/src/mirror.test.ts:520`** — local SCHEMA_VERSION expectation updated from 7 to 8 to match the registry schema bump in #352 (DEC-V2-REGISTRY-SCHEMA-BUMP-V8-001).
- **`packages/ir/src/strict-subset-project.test.ts`** — added `beforeAll` that builds `@yakcc/contracts` on demand. The strict-subset project-mode test reads source files and follows TypeScript's package.json `types` resolution path (needs `dist/index.d.ts`); this is orthogonal to the vitest runtime resolution path the aliases fix. Clears stale `tsconfig.tsbuildinfo` to defeat TypeScript's incremental cache.

## Verification (with all `packages/*/dist` directories removed)

| Package | Before | After |
|---|---|---|
| @yakcc/registry | 8 failed | **304 passed / 13 skipped (16 files)** |
| @yakcc/seeds | 1 failed | **158 passed** |
| @yakcc/hooks-claude-code | resolved errors | **19 passed** |
| @yakcc/hooks-cursor | resolved errors | **29 passed** |
| @yakcc/hooks-codex | resolved errors | **11 passed** |
| @yakcc/federation | 1 failed | **150 passed** |
| @yakcc/variance | passed | **104 passed** |
| @yakcc/ir | 1 failed | **142 passed** |
| @yakcc/shave | resolved errors | **775 passed / 1 skipped** |
| @yakcc/hooks-base | (silently failed) | **150 passed / 4 failed (pre-existing)** |

**Net effect: ~62 additional tests now run** vs the previous silent-failure state. The 4 substantive failures newly visible in `hooks-base/test/substitution-integration.test.ts` are real bugs in Phase 2/3 substitution logic that were masked by the import-error mode. They'll be filed as a follow-up debug WI.

## Why this is a test-fixture fix and not a workflow change

Workflow alternative (add `pnpm -r build` to test-advisory job, my original Wrath ticket #354) would also work but:
- Requires `workflow` token scope (Wrath-only)
- Slower CI feedback (~30-60s extra per PR for the workspace build)
- Doesn't address the "developer running `pnpm test` locally without first building" case

Vitest aliases handle both CI and local-dev test paths consistently. Same approach has been the de facto pattern in this repo since DEC-COMPILE-VITEST-CONFIG-001 in WI-005.

## Test plan

- [x] `pnpm -r build` clean
- [x] `pnpm -r typecheck` clean
- [x] `pnpm -r lint` clean
- [x] All 10 affected packages' tests run end-to-end with dist/ removed
- [x] 8 registry test files (the operator's pasted CI failure) now pass
- [x] Federation + ir test-fixture drift updated for #352's schema change
- [ ] Operator/sister re-verifies on next PR's `test-advisory` job that the resolution errors are gone

## Follow-ups

- File new issue: `hooks-base/test/substitution-integration.test.ts` — 4 substantive failures in Phase 2/3 substitution path (newly visible post-fix; assign to FG or whoever owns the substitution work)

https://claude.ai/code/session_018RFmeHWE8TTDvzT8PeotLq

---
_Generated by [Claude Code](https://claude.ai/code/session_018RFmeHWE8TTDvzT8PeotLq)_