### PR TITLE
WI-369: vitest shave/ir workspace-source aliases (closes #369)

### DIFF
--- a/packages/hooks-base/vitest.config.ts
+++ b/packages/hooks-base/vitest.config.ts
@@ -8,12 +8,17 @@ export default defineConfig({
     alias: {
       "@yakcc/contracts": resolve(__dirname, "../contracts/src/index.ts"),
       "@yakcc/registry": resolve(__dirname, "../registry/src/index.ts"),
-      // @yakcc/shave is aliased to its pre-built dist because the shave package
-      // has a tsc error in types.props.ts that prevents building from source.
-      // The dist is committed and valid. Tests that stub atomizeEmission bypass
-      // the shave runtime entirely; tests that exercise it end-to-end use the dist.
-      // @decision DEC-HOOK-ATOM-CAPTURE-001 (shave dist alias)
-      "@yakcc/shave": resolve(__dirname, "../shave/dist/index.js"),
+      // @yakcc/shave + @yakcc/ir aliased to src/ to remove the CI dependency on
+      // a built `dist/` (which is gitignored). Matches the workspace-source alias
+      // pattern established in PR #356 for contracts/registry. Vitest uses
+      // vite/esbuild for module loading, so the TS types pre-existing in shave's
+      // source don't need to compile cleanly — only runtime imports must resolve.
+      // @decision DEC-HOOK-ATOM-CAPTURE-001 (shave dist alias) — updated: now
+      // workspace-source alias for shave + ir, matching #356 pattern.
+      // @decision DEC-HOOKS-BASE-VITEST-SHAVE-SRC-001 — shave/ir aliased to src/
+      // to remove CI dependency on built dist.
+      "@yakcc/shave": resolve(__dirname, "../shave/src/index.ts"),
+      "@yakcc/ir": resolve(__dirname, "../ir/src/index.ts"),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

- `packages/hooks-base/vitest.config.ts` aliased `@yakcc/shave` to `../shave/dist/index.js`; `dist/` is gitignored so CI bailed in 19s with 0 tests run
- Option A fix: replace the dist alias with `../shave/src/index.ts` and add a transitive `@yakcc/ir` alias pointing to `../ir/src/index.ts`
- Matches the workspace-source alias pattern established in PR #356 for `contracts`/`registry`; adds `@decision DEC-HOOKS-BASE-VITEST-SHAVE-SRC-001`

## Test plan

- [x] CI-equivalent verification: renamed `packages/shave/dist` and `packages/ir/dist` out of the way (simulating CI absent-dist state)
- [x] `pnpm --filter @yakcc/hooks-base test` → **174 passed (10 test files)**, exit 0, no skips or `.todo` assertions
- [x] Restored dist dirs, re-ran — same result
- [x] Adapter regression: `@yakcc/hooks-claude-code` 19 passed, `@yakcc/hooks-cursor` 29 passed, `@yakcc/hooks-codex` 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)