### PR TITLE
fix: atomize body-locator + locate-root Windows path check (closes #383)

### DIFF
--- a/bench/B7-commit/corpus-spec.json
+++ b/bench/B7-commit/corpus-spec.json
@@ -6,31 +6,31 @@
       "filename": "array-median.ts",
       "description": "Compute median of a numeric array (O(n log n) sort). Known-passing baseline — mirrors bench/v0-release-smoke/fixtures/novel-glue-flywheel.ts.",
       "intent": "Compute the median of a numeric array using O(n log n) sort. Returns NaN for empty arrays.",
-      "sha256": "949e392787d0a30ae5cd3b6ead8e6f2ab8c440556580ba5d5b8a8eb489380b6b"
+      "sha256": "1176eb8f9fe9ad7c92d9d78ab0a0ea62291ce96bec0ebc1d260aae9ef876728c"
     },
     {
       "filename": "iso-duration-to-seconds.ts",
       "description": "Parse ISO 8601 duration string to total seconds.",
       "intent": "Parse an ISO 8601 duration string and return the total number of seconds. Supports years (365d), months (30d), weeks, days, hours, minutes, and seconds. Returns NaN for malformed or empty input.",
-      "sha256": "19440f63e875a7bf095f45e259abaa0c5330ef0c5b9140a459c9e87b8335cefc"
+      "sha256": "54adee84eeb30e118452cbf5b97f33b71111781bce2ce0712f18b50d7f4230fc"
     },
     {
       "filename": "is-valid-ipv4.ts",
       "description": "Validate dotted-decimal IPv4 address string.",
       "intent": "Validate whether a string is a valid IPv4 address in dotted-decimal notation. Accepts addresses of the form A.B.C.D where each octet is an integer in [0, 255]. Rejects leading zeros, extra whitespace, and non-numeric characters.",
-      "sha256": "15c086844c2320376722db835c3607db23f1a2140f3e6fb26b47ada85c63ea4c"
+      "sha256": "20b6e23c457c2a1507c20c99a467c6ad8a972a6ab3f0f98deb046646b0803a75"
     },
     {
       "filename": "hamming-distance.ts",
       "description": "Compute Hamming distance between two equal-length strings.",
       "intent": "Compute the Hamming distance between two strings of equal length. The Hamming distance is the number of positions at which the corresponding characters differ. Throws a RangeError if the strings have different lengths.",
-      "sha256": "a7476bf422ed11daadb3f05661e0d1f1f7a487e9973cc01a098f92d6d4214780"
+      "sha256": "d56dd8ecb33a8e4372a866b24ba822fcffdd796b5d36ff8e61564bc4d10b43d3"
     },
     {
       "filename": "camel-to-snake-preserving-acronyms.ts",
       "description": "Convert camelCase/PascalCase to snake_case, collapsing acronyms.",
       "intent": "Convert a camelCase or PascalCase identifier to snake_case, preserving consecutive uppercase acronyms as a single lowercase segment.",
-      "sha256": "e1d1350111c5a4c2a0f307b7b44d4899b0f073592d726b2934ebb273d3a530ae"
+      "sha256": "22f0547e5d1185affd45677d4d8ccce9f0cfe65c2eb9eebdb941de5d51870193"
     }
   ]
 }

--- a/bench/B7-commit/corpus/hamming-distance.ts
+++ b/bench/B7-commit/corpus/hamming-distance.ts
@@ -8,6 +8,7 @@
  * @param a - First string.
  * @param b - Second string, must have the same length as `a`.
  * @returns The number of positions where `a` and `b` differ.
+ * @throws {RangeError} if `a` and `b` have different lengths.
  */
 export function hammingDistance(a: string, b: string): number {
   if (a.length !== b.length) {

--- a/packages/hooks-base/src/atomize.ts
+++ b/packages/hooks-base/src/atomize.ts
@@ -226,17 +226,37 @@ function detectFunctionShape(code: string): FunctionShape {
 /**
  * Count non-blank, non-comment lines in the outermost function body.
  * Used for trivial-body detection.
+ *
+ * @decision DEC-HOOK-ATOM-CAPTURE-002
+ * @title JSDoc comment stripping before body-locator string-scan
+ * @status accepted (issue #383)
+ * @rationale
+ *   The original implementation found the first `{` in the raw source string,
+ *   which caused JSDoc tags like `@throws {RangeError}`, `@returns {Promise<T>}`,
+ *   `@param {number} n`, and `@type {string}` to be mistaken for the function
+ *   body opener. The fix strips all block JSDoc comments (`/** ... *\/`) before
+ *   the scan, then locates the first `{` in the comment-free code. This is the
+ *   preferred approach over full AST parsing because:
+ *     (a) ts-morph is NOT a direct dependency of @yakcc/hooks-base (would balloon scope)
+ *     (b) JSDoc block comments have a fixed shape `/** ... *\/` — the regex is robust
+ *     (c) Strip-then-scan preserves line/offset fidelity for statement counting
+ *   Future maintainers: if ts-morph is ever added to hooks-base, consider upgrading
+ *   to `getBody()?.getStatements().length` for exact AST-level statement counting.
  */
 function countBodyStatements(code: string): number {
-  const openIdx = code.indexOf("{");
+  // Strip JSDoc and other block comments before scanning for `{`.
+  // This prevents tags like `@throws {RangeError}` from being mistaken
+  // for the function body opener (issue #383).
+  const codeWithoutBlockComments = code.replace(/\/\*[\s\S]*?\*\//g, "");
+  const openIdx = codeWithoutBlockComments.indexOf("{");
   if (openIdx === -1) return 0;
 
   let depth = 0;
   let bodyStart = -1;
   let bodyEnd = -1;
 
-  for (let i = openIdx; i < code.length; i++) {
-    const ch = code[i];
+  for (let i = openIdx; i < codeWithoutBlockComments.length; i++) {
+    const ch = codeWithoutBlockComments[i];
     if (ch === "{") {
       if (depth === 0) bodyStart = i + 1;
       depth++;
@@ -251,7 +271,7 @@ function countBodyStatements(code: string): number {
 
   if (bodyStart === -1 || bodyEnd === -1) return 0;
 
-  return code
+  return codeWithoutBlockComments
     .slice(bodyStart, bodyEnd)
     .split("\n")
     .map((l) => l.trim())

--- a/packages/hooks-base/test/atomize.test.ts
+++ b/packages/hooks-base/test/atomize.test.ts
@@ -501,6 +501,102 @@ describe("renderAtomNewComment — @atom-new comment format", () => {
 });
 
 // ---------------------------------------------------------------------------
+// A9 — JSDoc curly-brace regression (issue #383)
+//   Functions with @throws {X}, @returns {X}, @param {X}, @type {X} in JSDoc
+//   must not be falsely rejected as trivial-body.
+// ---------------------------------------------------------------------------
+
+/**
+ * Reproduction case from issue #383 (originally from B7 Slice 1 corpus).
+ * hammingDistance carries `@throws {RangeError}` — this must NOT cause a
+ * false "trivial-body" rejection from countBodyStatements().
+ */
+const JSDOC_THROWS_TAG = `// SPDX-License-Identifier: MIT
+/**
+ * Computes Hamming distance.
+ * @throws {RangeError} when strings differ in length
+ */
+export function hammingDistance(a: string, b: string): number {
+  if (a.length !== b.length) throw new RangeError("strings must be equal length");
+  let count = 0;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) count++;
+  return count;
+}`;
+
+const JSDOC_RETURNS_TAG = `// SPDX-License-Identifier: MIT
+/**
+ * Parse an integer from a string.
+ * @returns {number} The parsed integer value.
+ */
+export function parseIntStrict(s: string): number {
+  const n = parseInt(s, 10);
+  if (isNaN(n)) throw new TypeError("not a valid integer: " + s);
+  if (String(n) !== s.trim()) throw new RangeError("not a strict integer: " + s);
+  return n;
+}`;
+
+const JSDOC_PARAM_TAG = `// SPDX-License-Identifier: MIT
+/**
+ * Compute a normalised score in [0, 1] for a value within [min, max].
+ * @param {number} value - The value to normalise.
+ * @param {number} min - The lower bound of the range.
+ * @param {number} max - The upper bound of the range.
+ * @returns A number in [0, 1] representing value's position in [min, max].
+ */
+export function normalise(value: number, min: number, max: number): number {
+  if (max === min) throw new RangeError("min and max must be different");
+  const range = max - min;
+  const shifted = value - min;
+  const ratio = shifted / range;
+  if (ratio < 0) return 0;
+  if (ratio > 1) return 1;
+  return ratio;
+}`;
+
+const JSDOC_TYPE_TAG = `// SPDX-License-Identifier: MIT
+/**
+ * Format a value as a fixed-precision decimal string.
+ * @type {(value: number, decimals: number) => string}
+ */
+export function toFixed(value: number, decimals: number): string {
+  if (decimals < 0) throw new RangeError("decimals must be non-negative");
+  const factor = Math.pow(10, decimals);
+  const rounded = Math.round(value * factor) / factor;
+  return rounded.toFixed(decimals);
+}`;
+
+describe("A9 — JSDoc curly-brace regression (issue #383)", () => {
+  it("A9a: @throws {RangeError} — hammingDistance reproduction case atomizes successfully", async () => {
+    const result = await atomizeEmission(makeInput({ emittedCode: JSDOC_THROWS_TAG }));
+    // The JSDoc @throws tag must NOT cause a false trivial-body rejection.
+    expect(result.reason).not.toBe("trivial-body");
+    expect(result.atomized).toBe(true);
+    expect(result.atomsCreated.length).toBeGreaterThan(0);
+  }, 30_000);
+
+  it("A9b: @returns {number} — parseIntStrict atomizes successfully", async () => {
+    const result = await atomizeEmission(makeInput({ emittedCode: JSDOC_RETURNS_TAG }));
+    expect(result.reason).not.toBe("trivial-body");
+    expect(result.atomized).toBe(true);
+    expect(result.atomsCreated.length).toBeGreaterThan(0);
+  }, 30_000);
+
+  it("A9c: @param {number} — normalise atomizes successfully", async () => {
+    const result = await atomizeEmission(makeInput({ emittedCode: JSDOC_PARAM_TAG }));
+    expect(result.reason).not.toBe("trivial-body");
+    expect(result.atomized).toBe(true);
+    expect(result.atomsCreated.length).toBeGreaterThan(0);
+  }, 30_000);
+
+  it("A9d: @type {(value: number, decimals: number) => string} — toFixed atomizes successfully", async () => {
+    const result = await atomizeEmission(makeInput({ emittedCode: JSDOC_TYPE_TAG }));
+    expect(result.reason).not.toBe("trivial-body");
+    expect(result.atomized).toBe(true);
+    expect(result.atomsCreated.length).toBeGreaterThan(0);
+  }, 30_000);
+});
+
+// ---------------------------------------------------------------------------
 // Test-file content heuristic detection
 // ---------------------------------------------------------------------------
 

--- a/packages/shave/src/locate-root.props.ts
+++ b/packages/shave/src/locate-root.props.ts
@@ -24,7 +24,7 @@
 
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import * as os from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join, relative } from "node:path";
 import * as fc from "fast-check";
 import { locateProjectRoot } from "./locate-root.js";
 
@@ -233,13 +233,25 @@ export const prop_locateProjectRoot_compound_result_is_ancestor_of_start = fc.as
       const deepDir = await mkdirChain(rootDir, segments);
       const result = await locateProjectRoot(deepDir);
 
-      // The result must be a prefix of deepDir (ancestor or equal).
-      // On POSIX, every ancestor of /a/b/c starts with /a (inclusive).
-      // We add a trailing separator to avoid false prefix matches like
-      // '/foo-bar' being a prefix of '/foo-bar-baz'.
-      const resultNorm = result.endsWith("/") ? result : `${result}/`;
-      const deepNorm = deepDir.endsWith("/") ? deepDir : `${deepDir}/`;
-      return deepNorm.startsWith(resultNorm);
+      // The result must be an ancestor of (or equal to) deepDir.
+      //
+      // @decision DEC-SHAVE-LOCATE-ROOT-WIN-001
+      // @title Platform-aware ancestor check using path.relative()
+      // @status accepted (issue #383 Windows regression fix)
+      // @rationale
+      //   The original check normalised paths with a trailing "/" and used
+      //   String.startsWith(), which hard-codes the POSIX separator. On Windows,
+      //   node's path.join() returns "\" separators, so concatenating "/" and
+      //   calling startsWith() produced false negatives (shrunk counterexample:
+      //   seed -1876568335, segments ["0"]).
+      //
+      //   path.relative(result, deepDir) is platform-aware: it returns "" when
+      //   paths are equal, a forward-only relative path when result is an ancestor
+      //   of deepDir, and starts with ".." (or is absolute, for drive-letter
+      //   mismatches on Windows) when it is not. This covers UNC paths, Windows
+      //   drive letters, and mixed-separator inputs correctly.
+      const rel = relative(result, deepDir);
+      return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
     } finally {
       await rm(rootDir, { recursive: true, force: true }).catch(() => {});
     }


### PR DESCRIPTION
## Summary

- **Concern A (#383):** `countBodyStatements()` in `@yakcc/hooks-base/src/atomize.ts` located the function body by finding the first `{` in the raw source string. JSDoc tags like `@throws {RangeError}`, `@returns {X}`, `@param {X}`, and `@type {X}` were mistaken for the body opener, yielding a spurious 1-statement count and a false `trivial-body` rejection. Fix: strip all block comments (`/** ... */`) before the scan. Decision `DEC-HOOK-ATOM-CAPTURE-002` documents why comment-stripping was chosen over full AST parse (ts-morph is not a direct dep of `@yakcc/hooks-base`).
- **Concern B (Windows regression, surfaced in PR #387 / commit 6cd17a4):** `prop_locateProjectRoot_compound_result_is_ancestor_of_start` in `@yakcc/shave/src/locate-root.props.ts` used a POSIX-only trailing-`/` + `startsWith()` ancestor check. On Windows, `path.join()` returns `\` separators, causing false negatives (seed `-1876568335`, shrunk counterexample `[["0"], true]`). Fix: use `path.relative(result, deepDir)` — platform-aware, handles UNC paths and Windows drive-letter mismatches. Decision `DEC-SHAVE-LOCATE-ROOT-WIN-001` documented inline.

## Changes

**Commit 1 — `fix(hooks-base): countBodyStatements ignores JSDoc curly braces (closes #383)`**
- `packages/hooks-base/src/atomize.ts` — strip block comments before string-scan in `countBodyStatements()`; add `@decision DEC-HOOK-ATOM-CAPTURE-002`
- `packages/hooks-base/test/atomize.test.ts` — 4 new regression tests A9a–d covering `@throws {X}`, `@returns {X}`, `@param {X}`, `@type {X}`
- `bench/B7-commit/corpus/hamming-distance.ts` — restored `@throws {RangeError}` tag (removed as workaround in PR #382)
- `bench/B7-commit/corpus-spec.json` — recomputed SHA-256 for hamming-distance; also synced 4 pre-existing SHA drifts for the other corpus files

**Commit 2 — `fix(shave): locate-root.props ancestor check uses path.relative (Windows regression)`**
- `packages/shave/src/locate-root.props.ts` — replace POSIX-only `startsWith()` with `path.relative()`-based check; add `@decision DEC-SHAVE-LOCATE-ROOT-WIN-001`

## Verification

**hooks-base full suite:**
```
Test Files  10 passed (10)
     Tests  178 passed (178)   ← 174 original + 4 new A9 JSDoc-tag tests
  Duration  11.78s
```

**shave full suite (2nd run — flaky cache EPERM resolved):**
```
Test Files  54 passed | 1 skipped (55)
     Tests  780 passed | 1 skipped (781)
  Duration  55.02s
```
Note: one test (`cache.test.ts` concurrent rename EPERM) is a pre-existing flaky Windows race; passes when run in isolation, unrelated to this PR.

**locate-root.props — 3 consecutive runs:**
```
Run 1: Tests  5 passed (5)  Duration 340ms
Run 2: Tests  5 passed (5)  Duration 328ms
Run 3: Tests  5 passed (5)  Duration 325ms
```

**B7 harness:**
```
[B7] Corpus OK — 5 files verified.
...
[warm] hamming-distance rep 1/5... 1866ms | atomized=true bmrInTopK=true score=0.7308 candidates=3
VERDICT: PASS-aspirational — median warm ≤3 s; proceed to Slice 2
[B7] All acceptance criteria met.
```
`hamming-distance` now atomizes successfully with `@throws {RangeError}` restored. Median warm wall-clock: 1502ms.

## Test plan

- [ ] CI passes hooks-base suite (≥178 tests green)
- [ ] CI passes shave suite (780 passed, 1 skipped — pre-existing cache flake may appear under parallel load)
- [ ] locate-root.props 5/5 on Linux CI (POSIX paths)
- [ ] B7 harness: `[B7] All acceptance criteria met.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)