### PR TITLE
fix(ci): use pnpm -r build in v0-release-smoke (closes #391)

### DIFF
--- a/.github/workflows/v0-release-smoke.yml
+++ b/.github/workflows/v0-release-smoke.yml
@@ -30,10 +30,10 @@
 #   CONCURRENCY: cancel-in-progress=true — a newer nightly supersedes the prior
 #   run. Safe to cancel because each run is fully independent (no accumulated state).
 #
-#   BUILD FILTER: builds only the packages that smoke.mjs depends on.
-#   @yakcc/shave is intentionally excluded — pre-existing broken (DEC-SHAVE-SKIP-001).
-#   The smoke walkthrough doesn't need @yakcc/shave directly (atomize imports it
-#   lazily; shave is already compiled as a dep of hooks-base).
+#   BUILD: `pnpm -r build` — recursive, dep-topological order (DEC-V0-RELEASE-SMOKE-BUILD-RECURSIVE-001).
+#   Supersedes the per-package filter sequence + stale @yakcc/shave exclusion
+#   (DEC-SHAVE-SKIP-001 row was never filed; exclusion removed by WI-391 #391).
+#   Mirrors `bootstrap.yml` line 96 and `bootstrap-accumulate.yml` line 68.
 #
 #   ARTIFACT RETENTION: 90 days. Each artifact named v0-release-smoke-<run_number>
 #   for trend analysis. Windows artifacts named v0-release-smoke-windows-<run_number>.
@@ -82,22 +82,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build required packages (skip @yakcc/shave — pre-existing broken)
-        # @decision DEC-V0-RELEASE-SMOKE-BUILD-ORDER-001 / WI-V0-SMOKE-SEEDS-BUILD (#390)
-        # @yakcc/ir MUST precede @yakcc/seeds (which imports from @yakcc/ir).
-        # Surfaced post-WI-385 first smoke run on 3937873 — both ubuntu and
-        # windows jobs failed at seeds build with "Cannot find module '@yakcc/ir'".
-        # NOT switching to `pnpm -r build` because that would build @yakcc/shave
-        # (pre-existing broken; deliberately skipped per the original sequence).
-        # Follow-up to WI-339 (#339), WI-348 (#348), WI-364 (#364), WI-385 (#385).
-        run: |
-          pnpm --filter @yakcc/contracts build
-          pnpm --filter @yakcc/registry build
-          pnpm --filter @yakcc/ir build
-          pnpm --filter @yakcc/seeds build
-          pnpm --filter @yakcc/hooks-base build
-          pnpm --filter @yakcc/hooks-claude-code build
-          pnpm --filter @yakcc/cli build
+      - name: Build workspace (pnpm -r build)
+        # @decision DEC-V0-RELEASE-SMOKE-BUILD-RECURSIVE-001 / WI-391 (#391)
+        # Mirror of `bootstrap.yml` line 96 and `bootstrap-accumulate.yml` line 68.
+        # pnpm owns dependency-topological ordering; supersedes the per-package
+        # filter sequence + the stale @yakcc/shave skip. See DEC-V0-RELEASE-SMOKE-CI-001
+        # (inline supersession reference) and #390/#391.
+        run: pnpm -r build
 
       - name: Run v0-release smoke walkthrough
         id: smoke
@@ -156,22 +147,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build required packages (skip @yakcc/shave — pre-existing broken)
-        # @decision DEC-V0-RELEASE-SMOKE-BUILD-ORDER-001 / WI-V0-SMOKE-SEEDS-BUILD (#390)
-        # @yakcc/ir MUST precede @yakcc/seeds (which imports from @yakcc/ir).
-        # Surfaced post-WI-385 first smoke run on 3937873 — both ubuntu and
-        # windows jobs failed at seeds build with "Cannot find module '@yakcc/ir'".
-        # NOT switching to `pnpm -r build` because that would build @yakcc/shave
-        # (pre-existing broken; deliberately skipped per the original sequence).
-        # Follow-up to WI-339 (#339), WI-348 (#348), WI-364 (#364), WI-385 (#385).
-        run: |
-          pnpm --filter @yakcc/contracts build
-          pnpm --filter @yakcc/registry build
-          pnpm --filter @yakcc/ir build
-          pnpm --filter @yakcc/seeds build
-          pnpm --filter @yakcc/hooks-base build
-          pnpm --filter @yakcc/hooks-claude-code build
-          pnpm --filter @yakcc/cli build
+      - name: Build workspace (pnpm -r build)
+        # @decision DEC-V0-RELEASE-SMOKE-BUILD-RECURSIVE-001 / WI-391 (#391)
+        # Mirror of `bootstrap.yml` line 96 and `bootstrap-accumulate.yml` line 68.
+        # pnpm owns dependency-topological ordering; supersedes the per-package
+        # filter sequence + the stale @yakcc/shave skip. See DEC-V0-RELEASE-SMOKE-CI-001
+        # (inline supersession reference) and #390/#391.
+        run: pnpm -r build
 
       - name: Run v0-release smoke walkthrough (Windows)
         id: smoke-windows


### PR DESCRIPTION
## Summary

- Replaces the per-package build sequence in both `smoke` (ubuntu) and `smoke-windows` jobs with a single `pnpm -r build`, mirroring `bootstrap.yml` (line 96) and `bootstrap-accumulate.yml` (line 68).
- Removes the stale "skip @yakcc/shave — pre-existing broken" annotation. Shave compiles cleanly post sister merges #383/#388 (verified `tsc -p packages/shave --noEmit` exits 0 on `71ebf24`).
- Eliminates the per-package build-order regression class that produced both #390 (ir-before-seeds) and #391 (shave-skip-stale). pnpm now owns dependency-topological ordering.

## Why

Post-#390, the smoke build broke at `@yakcc/hooks-base` because `src/atomize.ts:494` uses `await import('@yakcc/shave')` and TypeScript needs shave's declarations — but the workflow deliberately skipped shave. Sister merges fixed the original "shave broken" condition; the skip annotation never caught up. Rather than re-add `pnpm --filter @yakcc/shave build` to the sequence (and wait for the next per-package ordering bug), this change adopts `pnpm -r build` uniformly with sister workflows.

## Decision annotation

`@decision DEC-V0-RELEASE-SMOKE-BUILD-RECURSIVE-001 / WI-391 (#391)`

The MASTER_PLAN.md Decision Log row for DEC-V0-RELEASE-SMOKE-BUILD-RECURSIVE-001 is added by the orchestrator post-land (tracked: #397).

## Test plan

- [x] Local diff matches reviewer evaluation @ `71ebf247...` (`ready_for_guardian`, 191/191 pass_complete)
- [x] `tsc -p packages/shave --noEmit` exits 0 on `71ebf24`
- [ ] CI v0-release-smoke ubuntu green on the next nightly run
- [ ] CI v0-release-smoke windows green on the next nightly run

Closes #391. Follow-up to WI-390 (#390 / `f489cda`).