### PR TITLE
fix(ci): unblock wave-3-parity — replace hardcoded worktree path in cache.test.ts (closes #392)

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -141,6 +141,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Build full workspace (required before tests can resolve workspace deps)
+        run: pnpm -r build
+
       - name: Test affected packages (non-gating)
         # Affected filter retained for cycle-time speed (DEC-CI-FAST-PATH-PHASE-1-001).
         # Failure surfaces in PR UI but does NOT block merge (see continue-on-error

--- a/examples/v1-wave-3-wasm-lower-demo/test/cache.test.ts
+++ b/examples/v1-wave-3-wasm-lower-demo/test/cache.test.ts
@@ -12,9 +12,24 @@
 // All tests use os.tmpdir() cache paths and synthetic in-memory registries
 // so they complete in seconds without touching the real corpus.
 
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+// @decision DEC-CI-NIGHTLY-001
+// title: Derive repoRoot at runtime via import.meta.url
+// status: accepted
+// rationale: The original test hardcoded an absolute worktree path
+//   (/home/claude/yakcc/.worktrees/feature-wi-v1w4-lower-parity-cache-001) that
+//   only existed on the original author's machine.  On CI and every other
+//   developer machine those paths are missing, so regenerateCorpus received
+//   zero source files and returned zero atoms, causing the cacheMisses ≥ 1
+//   assertion to fail for 30+ consecutive CI runs.  Using
+//   fileURLToPath(new URL("../../..", import.meta.url)) pins the root to the
+//   actual location of this test file in whatever checkout is running, making
+//   the test portable across machines, worktrees, and CI environments.
+//   existsSync guards are added so a missing seed file fails loudly rather than
+//   silently producing an empty corpus that masks the real problem.
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   type BlockMerkleRoot,
   type CanonicalAstHash,
@@ -525,12 +540,29 @@ describe("regenerateCorpus — integrated determinism", () => {
 
       // Two real seed impl files (tiny source; shave completes in seconds).
       // Using digit and comma blocks — both exist in the monorepo and are ≤20 lines.
-      const repoRoot =
-        "/home/claude/yakcc/.worktrees/feature-wi-v1w4-lower-parity-cache-001";
+      //
+      // repoRoot is derived from import.meta.url so the path is correct in any
+      // checkout or CI environment (see @decision DEC-CI-NIGHTLY-001 at the top
+      // of this file).  This file lives at
+      //   examples/v1-wave-3-wasm-lower-demo/test/cache.test.ts
+      // so three levels up ("../../..") reaches the monorepo root.
+      const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
       const sourceFiles = [
         pathJoin(repoRoot, "packages/seeds/src/blocks/digit/impl.ts"),
         pathJoin(repoRoot, "packages/seeds/src/blocks/comma/impl.ts"),
       ];
+
+      // Guard: fail loudly if the seed files are missing rather than letting a
+      // silent zero-atom run hide the problem (see DEC-CI-NIGHTLY-001).
+      for (const sf of sourceFiles) {
+        if (!existsSync(sf)) {
+          throw new Error(
+            `[DEC-CI-NIGHTLY-001] Seed source file not found: ${sf}\n` +
+              `repoRoot resolved to: ${repoRoot}\n` +
+              `Ensure the monorepo checkout is complete and packages/seeds exists.`,
+          );
+        }
+      }
 
       const tempDir = mkdtempSync(pathJoin(tmpdir(), "wi119-determinism-"));
       const cacheFilePath = pathJoin(tempDir, "shave-cache.json");


### PR DESCRIPTION
## Summary

- `examples/v1-wave-3-wasm-lower-demo/test/cache.test.ts` hardcoded an absolute worktree path (`/home/claude/yakcc/.worktrees/feature-wi-v1w4-lower-parity-cache-001`) that only existed on the original implementer's box. Every CI run failed with `expected 0 to be greater than or equal to 1` because the seed source files didn't exist → `regenerateCorpus` returned zero atoms → the cold-pass `cacheMisses` assertion blew up.
- Replaced the literal with `fileURLToPath(new URL("../../..", import.meta.url))` and added an `existsSync` guard that fails loudly if the resolved seed paths are ever missing, so a silent zero-atom run can't mask the bug again.
- `@decision DEC-CI-NIGHTLY-001` annotation documents the cause and the fix.

This unblocks **30+ consecutive red runs** of the `wave-3-parity` workflow on main. Nightly CI #392 should turn green once this lands.

## Test plan

- [x] `pnpm -F v1-wave-3-wasm-lower-demo test` locally — 23 passed, 1 skipped (no regressions). Cold-then-warm integrated-determinism test passes in 1.36s.
- [ ] CI: PR checks pass; nightly turns green on the next merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)