### PR TITLE
fix(federation): SCHEMA_VERSION assertion drift 8 to 9 (#411)

### DIFF
--- a/packages/federation/src/mirror.test.ts
+++ b/packages/federation/src/mirror.test.ts
@@ -517,7 +517,7 @@ describe("mirrorRegistry — schema-version mismatch", () => {
     expect(caughtError).toBeInstanceOf(SchemaVersionMismatchError);
     const err = caughtError as SchemaVersionMismatchError;
     expect(err.remoteSchemaVersion).toBe(999);
-    expect(err.localSchemaVersion).toBe(8); // local SCHEMA_VERSION (bumped to 8 in WI-V2-WORKSPACE-PLUMBING-GLUE-CAPTURE #333)
+    expect(err.localSchemaVersion).toBe(9); // local SCHEMA_VERSION (bumped to 9 in issue-411-federation-drift #411)
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes one-line test drift in `packages/federation/src/mirror.test.ts:520` where the schema-version mismatch assertion still expected the previous local `SCHEMA_VERSION` (8). The local version is now 9, so the assertion now reads `toBe(9)`.

No production code touched. Surface-point advisory from #408 noted; this PR is the test-only fix scoped to #411.

Closes #411

## Test plan

- [x] `bun test packages/federation/src/mirror.test.ts` passes (150/150)
- [x] Reviewer verdict: `ready_for_guardian`
- [ ] CI green on PR

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)