### PR TITLE
fix(ci): bump pr-ci test-advisory timeout 10->20 min (closes #422 partial)

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -125,7 +125,7 @@ jobs:
   test-advisory:
     name: test (affected packages, advisory)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Bumps the `test-advisory` job timeout in `.github/workflows/pr-ci.yml` from 10 to 20 minutes. Single-line, non-source CI config change.

## Why

Empirical evidence from PR #419 (WI-373 universalize-persist) CI run [25771588880](https://github.com/cneckar/yakcc/actions/runs/25771588880): the test job hit the 10-minute timeout with the `compile` package mid-flight and downstream packages (`hooks-claude-code`, `hooks-cursor`, `hooks-codex`, `ir`, `registry`, `contracts`, `seeds`, `cli`, `examples`) unstarted.

Per-package runtime observed:

| Package | Time |
|---------|------|
| shave | 101s (787 passed, 1 skipped — includes new 22s `isAtom` property test) |
| federation | 10s |
| hooks-base | 50s |
| compile | >6min (not finished at timeout) |
| downstream | ~3-5min estimated |

Total nominal runtime ~13-15min; 20-min budget gives 5-7min headroom without masking legitimate hangs.

## Why this is safe

- `test-advisory` has `continue-on-error: true` and is NOT in branch protection's `required_status_checks` list — the timeout never blocked merges, but tripped UNSTABLE merge state on every PR touching multiple packages, which operators interpreted as broken CI.
- All other timeouts preserved unchanged: lint=5, typecheck=5, build=10, branch-hygiene=3, B6a=15.
- `continue-on-error: true` on `test-advisory` unchanged.
- DEC-CI-FAST-PATH-PHASE-1-001 and DEC-CI-MERGE-GATE-ENFORCE-001 invariants intact.

## Scope split

This closes the **timeout-bump portion** of issue #422. The separate CF2 `sumToN` fast-check flake in `packages/compile/test/as-backend/control-flow-parity.test.ts` (added by commit 572ea9e for WI-AS-PHASE-2G) remains a separate open follow-up — see the issue body for the partial-close split.

## Test plan
- [x] Reviewer verdict: `ready_for_guardian` (0 blockers, 0 major, 0 minor)
- [x] No source code touched; test-state `pass_complete` at evaluated SHA
- [ ] pr-ci.yml syntax validated on PR (this PR itself runs through pr-ci)
- [ ] Verify next PR with broad scope completes `test-advisory` within new 20-min budget

Closes #422 (timeout bump portion; flake deferred).

Refs #419.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)