### PR TITLE
fix(federation): SCHEMA_VERSION assertion drift 9->10 (#426)

### DIFF
--- a/packages/federation/src/mirror.test.ts
+++ b/packages/federation/src/mirror.test.ts
@@ -517,7 +517,7 @@ describe("mirrorRegistry — schema-version mismatch", () => {
     expect(caughtError).toBeInstanceOf(SchemaVersionMismatchError);
     const err = caughtError as SchemaVersionMismatchError;
     expect(err.remoteSchemaVersion).toBe(999);
-    expect(err.localSchemaVersion).toBe(9); // local SCHEMA_VERSION (bumped to 9 in issue-411-federation-drift #411)
+    expect(err.localSchemaVersion).toBe(10); // local SCHEMA_VERSION (bumped to 10 in issue-363 #363)
   });
 });
 


### PR DESCRIPTION
## Summary

One-line fix: `mirror.test.ts:520` asserted `localSchemaVersion=9`, but #363 (landed via PR #421) bumped registry `SCHEMA_VERSION` from 9 to 10. Updated the assertion and its comment.

Same mechanical pattern as #411 (8->9 fix after #355).

## Test plan

- [x] federation: 150/150 tests pass
- [x] schema-version mismatch test now exercises correct local version (10) vs synthetic remote (999)

Closes #426.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>