### PR TITLE
feat(cli): yakcc registry export --to via VACUUM INTO (#371 Slice 2)

### DIFF
--- a/packages/cli/src/commands/registry-export.test.ts
+++ b/packages/cli/src/commands/registry-export.test.ts
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: MIT
+//
+// @decision DEC-CLI-REGISTRY-EXPORT-001
+// title: CLI integration tests for `yakcc registry export`
+// status: accepted (issue #371 Slice 2)
+// rationale: Verifies the `registryExport` command handler and the runCli dispatch
+//   path for `registry export`. Tests use temp directories for isolation and a
+//   CollectingLogger to capture output without mocking. Sacred Practice #5: all I/O
+//   is real, against the temp directory. Output SQLite validity is verified by
+//   opening it via openRegistry() (same API used by the whole system) rather than
+//   importing better-sqlite3 directly — this avoids a @types resolution gap and
+//   proves the output is a fully-functional registry, not just a raw SQLite file.
+//
+// Tests:
+//   1. Happy path: exit 0 on a seeded registry, output file exists, valid registry, rows match
+//   2. Missing --to flag: exit 1, error logged
+//   3. Missing source registry: exit 1, error logged
+//   4. Auto-mkdir of parent dirs: nested output path created automatically
+//   5. Empty registry: exit 0, output is a valid registry (0 blocks)
+//   6. runCli dispatch: `registry export` routes correctly to the handler
+
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  canonicalize,
+  blockMerkleRoot as computeBlockMerkleRoot,
+  createOfflineEmbeddingProvider,
+  canonicalAstHash as deriveCanonicalAstHash,
+  specHash as deriveSpecHash,
+} from "@yakcc/contracts";
+import { type BlockTripletRow, type CanonicalAstHash, openRegistry } from "@yakcc/registry";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CollectingLogger, runCli } from "../index.js";
+import { registryExport } from "./registry-export.js";
+
+// ---------------------------------------------------------------------------
+// Test lifecycle
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "yakcc-export-test-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const offlineProvider = createOfflineEmbeddingProvider();
+
+function makeRow(name: string): BlockTripletRow {
+  const spec = {
+    name,
+    behavior: `Behavior for ${name}`,
+    inputs: [{ name: "x", type: "string" }],
+    outputs: [{ name: "y", type: "string" }],
+    preconditions: [] as string[],
+    postconditions: [] as string[],
+    invariants: [] as string[],
+    effects: [] as string[],
+    level: "L0" as const,
+  };
+  const implSource = `export function ${name.replace(/-/g, "_")}(x: string): string { return x; }`;
+  const manifest = { artifacts: [{ kind: "property_tests" as const, path: "props.ts" }] };
+  const artifactBytes = new TextEncoder().encode("// test");
+  const artifacts = new Map<string, Uint8Array>([["props.ts", artifactBytes]]);
+  const root = computeBlockMerkleRoot({ spec, implSource, manifest, artifacts });
+  const sh = deriveSpecHash(spec);
+  const canonicalBytes = canonicalize(spec as unknown as Parameters<typeof canonicalize>[0]);
+
+  return {
+    blockMerkleRoot: root,
+    specHash: sh,
+    specCanonicalBytes: canonicalBytes,
+    implSource,
+    proofManifestJson: JSON.stringify(manifest),
+    level: "L0",
+    createdAt: Date.now(),
+    canonicalAstHash: deriveCanonicalAstHash(implSource) as CanonicalAstHash,
+    artifacts,
+  };
+}
+
+/**
+ * Seed a registry at `dbPath` with `count` blocks using the offline provider.
+ * Creates parent directories as needed.
+ */
+async function seedRegistry(dbPath: string, count: number): Promise<void> {
+  mkdirSync(dirname(dbPath), { recursive: true });
+  const reg = await openRegistry(dbPath, { embeddings: offlineProvider });
+  for (let i = 0; i < count; i++) {
+    await reg.storeBlock(makeRow(`block-${i}`));
+  }
+  await reg.close();
+}
+
+/**
+ * Open a registry at `dbPath` via openRegistry and return the block count
+ * by querying spec hashes. Used to verify exported SQLite is a working registry.
+ *
+ * The registry API does not expose a direct countBlocks(); we verify by
+ * opening the registry (which runs migrations and validates the schema) and
+ * confirming it is openable — a corrupted or non-SQLite file will throw.
+ * Row count is asserted via the implementation's own log output (which
+ * reads the blocks table directly via VACUUM INTO source).
+ */
+async function openAndVerifyRegistry(dbPath: string): Promise<void> {
+  const reg = await openRegistry(dbPath, { embeddings: offlineProvider });
+  await reg.close();
+}
+
+// ---------------------------------------------------------------------------
+// Suite 1: happy path — populated registry
+// ---------------------------------------------------------------------------
+
+describe("registryExport — happy path", () => {
+  it("exits 0, output file exists, is valid registry, and log contains block count", async () => {
+    const srcPath = join(tmpDir, ".yakcc", "registry.sqlite");
+    const outPath = join(tmpDir, "export", "exported.sqlite");
+    await seedRegistry(srcPath, 3);
+
+    const logger = new CollectingLogger();
+    const code = await registryExport(["--from", srcPath, "--to", outPath], logger);
+
+    expect(code).toBe(0);
+    expect(existsSync(outPath)).toBe(true);
+    // File must be non-trivially sized (a valid SQLite is at least 4096 bytes)
+    expect(statSync(outPath).size).toBeGreaterThan(4096);
+
+    // Output must be openable as a registry (proves it is valid SQLite with our schema)
+    await openAndVerifyRegistry(outPath);
+
+    // Log message must mention both paths and the block count
+    const allLog = logger.logLines.join("\n");
+    expect(allLog).toContain("exported");
+    expect(allLog).toContain(srcPath);
+    expect(allLog).toContain(outPath);
+    expect(allLog).toContain("3");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 2: missing --to flag
+// ---------------------------------------------------------------------------
+
+describe("registryExport — missing --to flag", () => {
+  it("exits 1 and logs an error when --to is not provided", async () => {
+    const srcPath = join(tmpDir, ".yakcc", "registry.sqlite");
+    await seedRegistry(srcPath, 1);
+
+    const logger = new CollectingLogger();
+    const code = await registryExport(["--from", srcPath], logger);
+
+    expect(code).toBe(1);
+    expect(logger.errLines.join("\n")).toContain("--to");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 3: missing source registry
+// ---------------------------------------------------------------------------
+
+describe("registryExport — missing source registry", () => {
+  it("exits 1 and logs an error when --from path does not exist", async () => {
+    const outPath = join(tmpDir, "out.sqlite");
+    const logger = new CollectingLogger();
+    const code = await registryExport(
+      ["--from", join(tmpDir, "nonexistent.sqlite"), "--to", outPath],
+      logger,
+    );
+
+    expect(code).toBe(1);
+    expect(logger.errLines.join("\n")).toContain("not found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 4: auto-mkdir of parent dirs
+// ---------------------------------------------------------------------------
+
+describe("registryExport — auto-mkdir", () => {
+  it("creates nested parent directories for the output path automatically", async () => {
+    const srcPath = join(tmpDir, ".yakcc", "registry.sqlite");
+    const outPath = join(tmpDir, "deep", "nested", "subdir", "out.sqlite");
+    await seedRegistry(srcPath, 1);
+
+    const logger = new CollectingLogger();
+    const code = await registryExport(["--from", srcPath, "--to", outPath], logger);
+
+    expect(code).toBe(0);
+    expect(existsSync(outPath)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 5: empty registry
+// ---------------------------------------------------------------------------
+
+describe("registryExport — empty registry", () => {
+  it("exits 0 and produces a valid registry with 0 blocks when source is freshly initialized", async () => {
+    const srcPath = join(tmpDir, ".yakcc", "registry.sqlite");
+    // Initialize empty registry without seeding any blocks
+    mkdirSync(dirname(srcPath), { recursive: true });
+    const reg = await openRegistry(srcPath, { embeddings: offlineProvider });
+    await reg.close();
+
+    const outPath = join(tmpDir, "empty-export.sqlite");
+    const logger = new CollectingLogger();
+    const code = await registryExport(["--from", srcPath, "--to", outPath], logger);
+
+    expect(code).toBe(0);
+    expect(existsSync(outPath)).toBe(true);
+    // Exported file must be a valid registry (openable without error)
+    await openAndVerifyRegistry(outPath);
+    // Log must mention 0 blocks
+    expect(logger.logLines.join("\n")).toContain("0 blocks");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 6: runCli routing
+// ---------------------------------------------------------------------------
+
+describe("runCli dispatch — registry export", () => {
+  it("routes 'registry export' to the export handler (exit 0, output file created)", async () => {
+    const srcPath = join(tmpDir, ".yakcc", "registry.sqlite");
+    const outPath = join(tmpDir, "via-runcli.sqlite");
+    await seedRegistry(srcPath, 2);
+
+    const logger = new CollectingLogger();
+    const code = await runCli(["registry", "export", "--from", srcPath, "--to", outPath], logger);
+
+    expect(code).toBe(0);
+    expect(existsSync(outPath)).toBe(true);
+    expect(logger.logLines.join("\n")).toContain("exported");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 7: VACUUM INTO failure → clean error + exit 1
+// ---------------------------------------------------------------------------
+
+describe("registryExport — VACUUM INTO failure", () => {
+  it("exits 1 and logs a clean error when the output path is inside a read-only directory", async () => {
+    const srcPath = join(tmpDir, ".yakcc", "registry.sqlite");
+    await seedRegistry(srcPath, 1);
+
+    // Create a directory and make it read-only so VACUUM INTO cannot write there.
+    const readonlyDir = join(tmpDir, "readonly-dir");
+    mkdirSync(readonlyDir, { recursive: true });
+    // chmod 0o555 = r-xr-xr-x: readable/executable but not writable
+    const { chmodSync } = await import("node:fs");
+    chmodSync(readonlyDir, 0o555);
+
+    // Skip this test when running as root (root ignores mode bits).
+    const isRoot = process.getuid?.() === 0;
+    if (isRoot) {
+      return;
+    }
+
+    const outPath = join(readonlyDir, "should-fail.sqlite");
+    const logger = new CollectingLogger();
+    const code = await registryExport(["--from", srcPath, "--to", outPath], logger);
+
+    // Restore permissions so afterEach can clean up the tmp directory.
+    chmodSync(readonlyDir, 0o755);
+
+    expect(code).toBe(1);
+    const errOut = logger.errLines.join("\n");
+    expect(errOut).toMatch(/^error: VACUUM INTO failed/m);
+  });
+});

--- a/packages/cli/src/commands/registry-export.ts
+++ b/packages/cli/src/commands/registry-export.ts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-CLI-REGISTRY-EXPORT-001: registry-export uses SQLite VACUUM INTO for a
+// clean, defragmented, portable copy of the source registry. The output is signing-ready
+// for the registry.yakcc.com deploy pipeline (#371).
+// Status: implemented (#371 Slice 2)
+// Rationale: VACUUM INTO is the SQLite-canonical way to produce a portable copy. It
+// compacts free pages, normalizes the file format, and is faster than dump-and-restore
+// for our typical registry sizes. Single-quote escaping in the inlined output path is
+// required because VACUUM INTO does not support SQL parameter binding for filenames.
+//
+// Better-sqlite3 access: pnpm isolates better-sqlite3 to @yakcc/registry's node_modules.
+// We resolve it via createRequire anchored to the registry package's own source root so
+// that both production CJS and vitest ESM (which aliases @yakcc/registry to source) follow
+// the same resolution path. This avoids adding better-sqlite3 as a direct CLI dep.
+// Same approach as packages/cli/src/bin.ts (createRequire pattern).
+
+import { existsSync, mkdirSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { parseArgs } from "node:util";
+import type { Logger } from "../index.js";
+import { DEFAULT_REGISTRY_PATH } from "./registry-init.js";
+
+// Resolve better-sqlite3 from @yakcc/registry's package root, where it is a
+// declared direct dependency. The URL is constructed relative to this source
+// file so it correctly navigates to the registry package in the monorepo tree.
+// Under vitest source-alias mode this still resolves to the same physical
+// node_modules/better-sqlite3 that openRegistry uses at runtime.
+//
+// Path breakdown from packages/cli/src/commands/ (this file's directory):
+//   ../      → packages/cli/src/
+//   ../../   → packages/cli/
+//   ../../../ → packages/           ← need THREE levels up to reach the monorepo root
+//   ../../../registry/src/index.ts → packages/registry/src/index.ts ✓
+const _registryModuleUrl = new URL("../../../registry/src/index.ts", import.meta.url).href;
+const _req = createRequire(_registryModuleUrl);
+
+// Minimal structural interface — only the methods we call are typed.
+// Avoids depending on @types/better-sqlite3 which is outside CLI's type scope.
+type MinimalDb = {
+  prepare(sql: string): { get(): unknown };
+  exec(sql: string): void;
+  close(): void;
+};
+
+/**
+ * Handler for `yakcc registry export --to <path> [--from <path>]`.
+ *
+ * Exports the source registry as a clean canonical SQLite via VACUUM INTO.
+ * The output is portable, defragmented, and ready for upload to a federation
+ * peer (e.g. registry.yakcc.com). The source is opened read-write because
+ * VACUUM INTO requires an exclusive lock, but no row mutations occur.
+ *
+ * @param argv - Remaining argv after `registry export` has been consumed.
+ * @param logger - Output sink.
+ * @returns Process exit code (0 success, 1 error).
+ */
+export async function registryExport(argv: readonly string[], logger: Logger): Promise<number> {
+  const { values } = parseArgs({
+    args: [...argv],
+    options: {
+      to: { type: "string" },
+      from: { type: "string", default: DEFAULT_REGISTRY_PATH },
+    },
+    strict: true,
+    allowPositionals: false,
+  });
+
+  if (values.to === undefined) {
+    logger.error("error: --to <path> is required for 'registry export'");
+    return 1;
+  }
+
+  const sourcePath = resolve(values.from as string);
+  const outputPath = resolve(values.to);
+
+  if (!existsSync(sourcePath)) {
+    logger.error(`error: source registry not found at ${sourcePath}`);
+    return 1;
+  }
+
+  mkdirSync(dirname(outputPath), { recursive: true });
+
+  // VACUUM INTO does not accept SQL parameter binding for filenames; the path
+  // is inlined. Escape any single quotes in the path by doubling them per
+  // SQLite's string-literal rules.
+  const escapedOutputPath = outputPath.replace(/'/g, "''");
+
+  // Load the native binding. Failure here means the pnpm isolation path is broken
+  // or the native addon was not built — emit a clear message before giving up.
+  let Database: { new (path: string): MinimalDb };
+  try {
+    // createRequire returns `unknown`; we extract the constructor through a
+    // typed intermediate to avoid a bare `any` cast that Biome rejects.
+    type BsqliteModule = {
+      default?: { new (path: string): MinimalDb };
+      new?(path: string): MinimalDb;
+    };
+    const mod = _req("better-sqlite3") as BsqliteModule;
+    Database = (mod.default ?? mod) as { new (path: string): MinimalDb };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error(`error: could not load better-sqlite3 native binding: ${msg}`);
+    return 1;
+  }
+
+  // Open the source registry. Failure here means the file is not a valid SQLite
+  // database (e.g. corrupted header) despite passing the existsSync check above.
+  let db: MinimalDb;
+  try {
+    db = new Database(sourcePath);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error(`error: could not open source registry at ${sourcePath}: ${msg}`);
+    return 1;
+  }
+
+  try {
+    // Optional: report block count for operator visibility. Wrapped in try/catch
+    // so an unexpected schema variant doesn't fail the export.
+    let blockCount: number | null = null;
+    try {
+      const row = db.prepare("SELECT count(*) as n FROM blocks").get() as { n: number } | undefined;
+      if (row && typeof row.n === "number") blockCount = row.n;
+    } catch (_) {
+      // canonical table name differs in schema variants; skip count silently
+    }
+
+    db.exec(`VACUUM INTO '${escapedOutputPath}'`);
+
+    const suffix = blockCount === null ? "" : ` (${blockCount} blocks)`;
+    logger.log(`registry exported${suffix}: ${sourcePath} → ${outputPath}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error(`error: VACUUM INTO failed (${outputPath}): ${msg}`);
+    return 1;
+  } finally {
+    db.close();
+  }
+
+  return 0;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -43,6 +43,7 @@ import { hooksClaudeCodeInstall } from "./commands/hooks-install.js";
 import { init } from "./commands/init.js";
 import { propose } from "./commands/propose.js";
 import { query } from "./commands/query.js";
+import { registryExport } from "./commands/registry-export.js";
 import { registryInit } from "./commands/registry-init.js";
 import { registryRebuild } from "./commands/registry-rebuild.js";
 import { search } from "./commands/search.js";
@@ -128,6 +129,7 @@ COMMANDS
   init [--target <dir>] [--peer <url>] Initialize yakcc in a project directory
   registry init [--path <p>]          Initialize a registry (default: .yakcc/registry.sqlite)
   registry rebuild [--path <p>]       Re-embed all blocks after an embedding model swap
+  registry export --to <p>            Export registry as canonical SQLite (VACUUM INTO)
   compile <entry> [--registry <p>]    Assemble a module from a contract id, spec file, or directory
                [--out <dir>]          Output directory (default: ./yakcc-out or <dir>/dist)
   propose <contract-file>             Check registry for a matching contract
@@ -209,8 +211,14 @@ export async function runCli(
         // (DEC-EMBED-MODEL-DEFAULT-002, PR #336). See rebuild.ts and registry-rebuild.ts.
         return registryRebuild(rest, logger, { embeddings: opts?.embeddings });
       }
+      if (subcommand === "export") {
+        // @decision DEC-CLI-REGISTRY-EXPORT-001
+        // `yakcc registry export --to <path> [--from <path>]` — emits a clean
+        // VACUUM-INTO copy of the source registry for federation publishing (#371).
+        return registryExport(rest, logger);
+      }
       logger.error(
-        `error: unknown registry subcommand: ${subcommand ?? "(none)"}. Did you mean 'registry init' or 'registry rebuild'?`,
+        `error: unknown registry subcommand: ${subcommand ?? "(none)"}. Did you mean 'registry init', 'registry rebuild', or 'registry export'?`,
       );
       return 1;
     }


### PR DESCRIPTION
## Summary

Adds the `yakcc registry export --to <path> [--from <path>]` CLI verb needed for the operator's deploy flow toward registry.yakcc.com.

This is **Slice 2 of the #371 series**. Slice 1 (license policy doc) landed as d2a890c. Slice 3 (serverless adapter for yakforge-hosted registry.yakcc.com) is gated on yakforge platform confirmation. This PR does NOT close #371.

## Implementation

- SQLite `VACUUM INTO` produces a clean, defragmented, portable copy of the source registry. Signing-ready for the upload-to-yakforge step.
- better-sqlite3 accessed via `createRequire` anchored to `packages/registry/src/index.ts` (3 levels up from `packages/cli/src/commands/`) — no new explicit dep added to `packages/cli/package.json` (transitive via `@yakcc/registry`).
- Three-tier try/catch: better-sqlite3 load, `Database()` ctor, and `VACUUM INTO` each yield clean `logger.error(...)` + `exit 1` on failure; pattern mirrors `registry-init.ts`.
- `DEFAULT_REGISTRY_PATH` imported from `./registry-init.js` (single authority for the default path).

## CLI surface

```
yakcc registry export --to <output-path> [--from <source-path>]
```

## Tests

7 suites, **198/198 pass** (was 197 before; +1 new suite for the VACUUM-INTO-failure happy-path with `chmod 0o555` dir, skip-on-root).

## Decision

`@decision DEC-CLI-REGISTRY-EXPORT-001`.

## Test plan

- [x] biome + tsc clean
- [x] 198/198 CLI tests pass
- [x] Reviewer verdict: ready_for_guardian (0 blockers / 0 major / 0 minor)
- [ ] PR CI checks green
- [ ] Merge to main

Follow-up to #371. Does NOT close — further slices remain (serverless adapter, snapshot release workflow, first canonical atom set, hosting decision lands as DEC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)