### PR TITLE
refactor(shave): WI-423 delegate persist loop to universalize({persist:true}) (closes #423)

### DIFF
--- a/packages/shave/src/index.ts
+++ b/packages/shave/src/index.ts
@@ -632,13 +632,12 @@ export async function universalize(
         const merkleRoot = await maybePersistNovelGlueAtom(entry, registry, {
           cacheDir: options?.cacheDir,
           parentBlockRoot,
-          // sourceFilePath is intentionally omitted: universalize() operates on a
-          // CandidateBlock (in-memory source), not on a file path. The props-file
-          // corpus extractor that consumes sourceFilePath is only meaningful in the
-          // shave() path (which forwards its sourcePath parameter). Interactive
-          // universalize() callers (e.g. assembleCandidate) have no file path.
-          // REQ-NOGO-006: sourceFilePath may be undefined -- atoms persist with null
-          // provenance, which is correct per DEC-V2-REGISTRY-SOURCE-FILE-PROVENANCE-001.
+          // sourceFilePath: forwarded from UniversalizeOptions.sourceFilePath when
+          // present (set by shave() to enable props-file corpus extraction).
+          // Undefined for interactive universalize() callers (e.g. assembleCandidate)
+          // — those atoms persist with null provenance per REQ-NOGO-006 /
+          // DEC-V2-REGISTRY-SOURCE-FILE-PROVENANCE-001.
+          sourceFilePath: options?.sourceFilePath,
           sourceContext: perAtomSourceContext,
         });
         // Surface the merkleRoot on the entry (may be undefined if intentCard absent).
@@ -739,8 +738,45 @@ export async function shave(
     hint: { name: basename(sourcePath), origin: "user" },
   };
 
-  // Step 3: Run through universalize() — errors propagate unwrapped.
-  const result = await universalize(candidate, registry, options);
+  // Step 3: Run through universalize({persist:true}) — errors propagate unwrapped.
+  //
+  // @decision DEC-V2-SHAVE-DELEGATES-UNIVERSALIZE-001
+  // title: shave() delegates atom persistence to universalize({persist:true})
+  // status: accepted (WI-423)
+  // rationale:
+  //   WI-373 (PR #419) lifted the postorder lineage-threading persist loop from
+  //   shave() into universalize() as step 6, gated on options.persist===true.
+  //   However, the WI-373 implementer copied the loop rather than refactoring
+  //   shave() to delegate — leaving two parallel persistence mechanisms (Sacred
+  //   Practice #12 violation). This WI (WI-423) closes that debt.
+  //
+  //   shave() now calls universalize({persist:true, sourceFilePath:sourcePath})
+  //   and reads merkleRoot directly from the enriched slicePlan entries returned
+  //   by universalize(). The in-line loop (DEC-ATOM-PERSIST-001 / DEC-REGISTRY-
+  //   PARENT-BLOCK-004) that previously ran here is removed — universalize() is
+  //   the single authority for atom persistence.
+  //
+  //   sourceFilePath is forwarded via UniversalizeOptions.sourceFilePath so the
+  //   props-file corpus extractor (DEC-V2-REGISTRY-SOURCE-FILE-PROVENANCE-001)
+  //   can locate the sibling <stem>.props.ts file exactly as before.
+  //
+  //   Behavior is bit-for-bit identical: T5 (DEC-UNIVERSALIZE-PERSIST-PIPELINE-001)
+  //   passes because the same maybePersistNovelGlueAtom primitives run in the same
+  //   postorder with the same parentBlockRoot chain.
+  //
+  //   Graceful degradation (read-only registry): universalize()'s step 6 is
+  //   gated on options.persist===true, and shave() always passes persist:true.
+  //   When registry.storeBlock is absent, PersistRequestedButNotSupportedError is
+  //   thrown (Sacred Practice #5 loud-fail). Previously, shave() used
+  //   maybePersistNovelGlueAtom's silent-no-op path when storeBlock was absent —
+  //   this was a silent degradation. The new behaviour preserves that: we pass
+  //   persist:true only when registry.storeBlock is present, otherwise we call
+  //   universalize without persist (maintaining the graceful-degradation contract).
+  const hasPersist = typeof registry.storeBlock === "function";
+  const result = await universalize(candidate, registry, {
+    ...options,
+    ...(hasPersist && { persist: true, sourceFilePath: sourcePath }),
+  });
 
   // Step 3b: Foreign-policy gate — enforced AFTER slice() returns, NOT inside slicer.ts.
   //
@@ -787,147 +823,33 @@ export async function shave(
   const foreignDeps: readonly ForeignRef[] | undefined =
     effectivePolicy === "tag" ? foreignRefs : undefined;
 
-  // Step 4: Persist novel atoms and translate UniversalizeResult into ShaveResult.
+  // Step 4: Translate universalize() result into ShaveResult.
   //
-  // @decision DEC-ATOM-PERSIST-001
-  // title: shave() persists NovelGlueEntries with intentCard via maybePersistNovelGlueAtom
-  // status: decided
-  // rationale:
-  //   - Persistence is opt-in: maybePersistNovelGlueAtom checks for registry.storeBlock
-  //     before doing anything. Callers with a read-only ShaveRegistryView get silent
-  //     no-ops; callers with a full Registry get atoms stored automatically.
-  //   - Only NovelGlueEntries with an intentCard persist; PointerEntries reference
-  //     existing blocks and do not produce new rows.
-  //   - Entries without intentCard (deep leaves in multi-leaf trees) return undefined
-  //     from maybePersistNovelGlueAtom; their ShavedAtomStub has no merkleRoot.
-  //   - PointerEntries do not have an intentCard slot; their stub also has no merkleRoot
-  //     (the pointer's existing registry merkleRoot is carried on the PointerEntry
-  //     itself, not propagated to ShavedAtomStub in this slice).
-  //   - property-test corpus is empty at L0 bootstrap (deferred to WI-013-03).
-  //   - effect declaration is empty (atoms pure-by-default; effect inference future).
-
-  // @decision DEC-REGISTRY-PARENT-BLOCK-004
-  // title: shave() walks SlicePlan in postorder to propagate parentBlockRoot lineage
-  // status: decided (WI-017)
-  // rationale:
-  //   The slicer emits entries in DFS (depth-first, children-before-parent) order.
-  //   By persisting sequentially rather than in parallel we guarantee that a
-  //   child's parent has already been persisted and its BlockMerkleRoot is known
-  //   before the child is written. The parent merkle root is the LITERAL value
-  //   returned by the prior maybePersistNovelGlueAtom call — no re-derivation is
-  //   performed (DEC-REGISTRY-PARENT-BLOCK-004: content-address purity).
-  //
-  //   NovelGlueEntry does not carry an explicit parent pointer (that would couple
-  //   slicer to persistence). Instead the parentBlockRoot field on PersistOptions
-  //   is populated here at the call-site. For a single-leaf plan (the common case)
-  //   the outer entry's parentBlockRoot is null — it is the root of the tree.
-  //   For a multi-entry plan the last entry is the root; all preceding entries
-  //   whose immediate structural predecessor is novel-glue forward its merkle root.
-  //
-  //   NOTE: The slicer currently emits flat plans where each NovelGlueEntry is
-  //   independent (no nesting information is carried). The "parent" here is the
-  //   immediately preceding novel-glue entry in the DFS-ordered plan when shaving
-  //   a nested function — i.e. the outer function is the parent of the inner.
-  //   For the single-leaf case the parent is always null.
-  //
-  //   Two-pass with registry update (the alternative) is excluded because
-  //   registry/storage.ts is outside this WI's scope, making tree-postorder
-  //   the only viable path (DEC-REGISTRY-PARENT-BLOCK-004).
-
-  // Persist novel-glue entries sequentially (postorder). The last novel-glue
-  // entry in the DFS slice plan is the outermost (root) function; earlier entries
-  // are its nested descendants. Each entry captures its predecessor's merkle root
-  // as its parentBlockRoot so the registry row carries the full lineage chain.
-  const merkleRoots: Array<BlockMerkleRoot | undefined> = [];
-  let lastNovelMerkleRoot: BlockMerkleRoot | undefined = undefined;
-  for (const entry of result.slicePlan) {
-    if (entry.kind === "novel-glue") {
-      // Determine parent: for the first novel-glue entry in the plan (the leaf),
-      // parentBlockRoot is null (it has no prior novel ancestor in this shave call).
-      // For subsequent novel-glue entries the preceding novel-glue's merkle root
-      // is the structural parent — it is the outer function that was just persisted.
-      const parentBlockRoot: BlockMerkleRoot | null = lastNovelMerkleRoot ?? null;
-      // @decision DEC-V2-REGISTRY-SOURCE-FILE-PROVENANCE-001
-      // sourceContext: when ShaveOptions.sourceContext is present (bootstrap mode),
-      // forward it with the per-atom sourceOffset derived from the slice plan entry's
-      // sourceRange.start. This is the byte offset within the source file at which
-      // the atom begins — used by compile-self (P2) to sort atoms back into file order.
-      // When sourceContext is absent (interactive shave), atoms are stored with null
-      // provenance, which is correct for non-bootstrap corpus production.
-      const baseSourceContext = options?.sourceContext;
-      const perAtomSourceContext =
-        baseSourceContext !== undefined
-          ? {
-              sourcePkg: baseSourceContext.sourcePkg,
-              sourceFile: baseSourceContext.sourceFile,
-              sourceOffset: entry.sourceRange.start,
-            }
-          : undefined;
-      const merkleRoot = await maybePersistNovelGlueAtom(entry, registry, {
-        ...options,
-        parentBlockRoot,
-        sourceFilePath: sourcePath,
-        sourceContext: perAtomSourceContext,
-      });
-      merkleRoots.push(merkleRoot);
-      if (merkleRoot !== undefined) {
-        lastNovelMerkleRoot = merkleRoot;
-      }
-    } else if (entry.kind === "pointer") {
-      // @decision DEC-SHAVE-POINTER-MERKLROOT-PROPAGATION-001
-      // title: PointerEntry merkleRoot propagated to ShavedAtomStub
-      // status: decided
-      // rationale:
-      //   Prior to this fix, pointer entries pushed undefined to merkleRoots[]
-      //   (the else branch here). This left ShavedAtomStub.merkleRoot=undefined
-      //   for ALL PointerEntry atoms — including those whose blocks are fully
-      //   persisted in the registry. The bootstrap's occurrence-store pass then
-      //   tried to recover the merkleRoot by calling canonicalAstHash(source,
-      //   stub.sourceRange), which fails for type-only exports and declarations
-      //   whose source ranges span multiple AST nodes. This caused 100% occurrence
-      //   drop for files like universalize/types.ts (all type-only exports).
-      //
-      //   Fix: propagate entry.merkleRoot directly. PointerEntry is the exact
-      //   place where the slicer records the registry-matched merkleRoot — it
-      //   carries the value that storeBlock already returned on a prior bootstrap.
-      //   Propagating it here makes ShavedAtomStub self-sufficient: callers (e.g.
-      //   bootstrap's occurrence-store pass) can record occurrences without
-      //   re-deriving the hash from the source text.
-      //
-      //   The ShavedAtomStub.merkleRoot type is BlockMerkleRoot|undefined;
-      //   PointerEntry.merkleRoot is BlockMerkleRoot (non-optional). No type widening
-      //   needed. The storeBlock wrapper in bootstrap.ts checks merkleRoot!==undefined
-      //   before recording, so pointer stubs are now correctly captured there instead.
-      //
-      //   Note: novel-glue entries still use merkleRoots[i] (the value returned by
-      //   maybePersistNovelGlueAtom). Only pointer entries are affected by this change.
-      merkleRoots.push(entry.merkleRoot);
-    } else {
-      // Other entry kinds (foreign-leaf, glue) — no merkleRoot in the registry.
-      merkleRoots.push(undefined);
-    }
-  }
+  // Persistence was handled by universalize({persist:true}) above
+  // (DEC-V2-SHAVE-DELEGATES-UNIVERSALIZE-001). NovelGlueEntry items in the
+  // slicePlan already carry merkleRoot when persist:true ran. PointerEntry items
+  // always carry merkleRoot (per DEC-SHAVE-POINTER-MERKLROOT-PROPAGATION-001).
+  // ForeignLeafEntry and GlueLeafEntry are excluded (per DEC-V2-GLUE-AWARE-SHAVE-001).
 
   // Each SlicePlanEntry that carries an AST hash maps to a ShavedAtomStub.
   // ForeignLeafEntry and GlueLeafEntry are intentionally excluded:
   //   - ForeignLeafEntry is an opaque leaf with no host-module sourceRange.
   //   - GlueLeafEntry is a verbatim-preserved region with no sourceRange
   //     (per DEC-V2-GLUE-LEAF-CONTRACT-001: glue is project-local, not registry-registered).
-  // The merkleRoots array was built with one slot per entry (including excluded
-  // slots, which received `undefined`), so we use flatMap with the index to skip
-  // excluded entries while keeping the merkleRoots[i] alignment intact.
   // (per DEC-SHAVE-PIPELINE-001, DEC-V2-FOREIGN-BLOCK-SCHEMA-001, DEC-V2-GLUE-AWARE-SHAVE-001)
-  const atoms = result.slicePlan.flatMap((entry, i): ShavedAtomStub[] => {
+  const atoms = result.slicePlan.flatMap((entry): ShavedAtomStub[] => {
     if (entry.kind === "foreign-leaf" || entry.kind === "glue") {
       // Excluded: foreign deps are opaque leaves; glue regions are verbatim-preserved
       // project-local code with no registry entry and no sourceRange field.
       return [];
     }
+    // novel-glue: merkleRoot populated by universalize({persist:true}) step 6.
+    // pointer: merkleRoot always present (DEC-SHAVE-POINTER-MERKLROOT-PROPAGATION-001).
     return [
       {
         placeholderId: `shave-atom-${entry.canonicalAstHash.slice(0, 8)}`,
         sourceRange: entry.sourceRange,
-        merkleRoot: merkleRoots[i],
+        merkleRoot: entry.merkleRoot,
       },
     ];
   });

--- a/packages/shave/src/persist/shave-delegates.test.ts
+++ b/packages/shave/src/persist/shave-delegates.test.ts
@@ -1,0 +1,242 @@
+/**
+ * shave-delegates.test.ts — WI-423 regression: shave() delegates persistence
+ * to universalize({persist:true}) — single authority (Sacred Practice #12).
+ *
+ * @decision DEC-V2-SHAVE-DELEGATES-UNIVERSALIZE-001 (WI-423)
+ * title: shave() delegates atom persistence to universalize({persist:true})
+ * status: accepted (WI-423)
+ * rationale:
+ *   WI-373 (PR #419) introduced universalize({persist:true}) as the canonical
+ *   persistence primitive but left shave() with a duplicate inline loop. WI-423
+ *   removes that loop and makes shave() call universalize({persist:true}).
+ *
+ *   This test suite guards against two regressions:
+ *
+ *   1. Double-persist (universalize called twice): storeBlock would be called
+ *      2N times instead of N times for N novel-glue entries. We count storeBlock
+ *      invocations on a spy registry and assert exactly N calls.
+ *
+ *   2. Zero-persist (universalize not called for persistence): storeBlock would
+ *      be called 0 times. Same assertion catches this.
+ *
+ *   Because shave() and universalize() are co-located in the same module, a
+ *   direct vi.spyOn(module, "universalize") cannot intercept the internal call.
+ *   We instead verify the delegation contract through its observable side-effect:
+ *   storeBlock call count matches novel-glue entry count exactly.
+ *
+ * Production trigger:
+ *   shave() is the primary entry point for file-level bootstrap (bootstrap.ts
+ *   walker). Every source file in the corpus passes through shave() with a full
+ *   Registry. Incorrect call count here would silently corrupt the bootstrap DB
+ *   (too many rows) or produce empty atoms (zero rows).
+ *
+ * Mocking boundary:
+ *   - storeBlock: counted via a spy wrapper around an in-memory openRegistry.
+ *     We use a real Registry so the underlying SQLite receives correct rows —
+ *     the count is measured at the shave() call boundary, not mocked away.
+ *   - Anthropic API: bypassed via intentStrategy:"static".
+ *   - Filesystem: shave() reads a tmpFile; we write ATOMIC_SOURCE to it.
+ *
+ * Air-gap compliance:
+ *   intentStrategy:"static" — no network, no API key required.
+ */
+
+import { randomUUID } from "node:crypto";
+import { rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { EmbeddingProvider } from "@yakcc/contracts";
+import { openRegistry } from "@yakcc/registry";
+import type { Registry } from "@yakcc/registry";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { shave } from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * ATOMIC_SOURCE: single-leaf source (zero CF boundaries).
+ * MIT license → passes the license gate.
+ * Produces exactly one NovelGlueEntry → exactly one storeBlock call.
+ */
+const ATOMIC_SOURCE = `// SPDX-License-Identifier: MIT
+const isDigit = (c: string): boolean => c >= "0" && c <= "9";`;
+
+/**
+ * MULTI_LEAF_SOURCE: two top-level if-statements (CF boundaries = 2 > 1).
+ * Produces multiple NovelGlueEntries → multiple storeBlock calls.
+ */
+const MULTI_LEAF_SOURCE = [
+  "// SPDX-License-Identifier: MIT",
+  "declare const a: boolean;",
+  "declare const b: boolean;",
+  'if (a) { console.log("a-branch"); }',
+  'if (b) { console.log("b-branch"); }',
+].join("\n");
+
+// ---------------------------------------------------------------------------
+// Mock embedding provider — deterministic, no ONNX required
+// ---------------------------------------------------------------------------
+
+function mockEmbeddingProvider(): EmbeddingProvider {
+  return {
+    dimension: 384,
+    modelId: "mock/test-provider-shave-delegates",
+    async embed(text: string): Promise<Float32Array> {
+      const vec = new Float32Array(384);
+      for (let i = 0; i < 384; i++) {
+        vec[i] = text.charCodeAt(i % text.length) / 128 + i * 0.001;
+      }
+      let norm = 0;
+      for (const v of vec) norm += v * v;
+      const scale = norm > 0 ? 1 / Math.sqrt(norm) : 1;
+      for (let i = 0; i < vec.length; i++) {
+        const val = vec[i];
+        if (val !== undefined) vec[i] = val * scale;
+      }
+      return vec;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-test state
+// ---------------------------------------------------------------------------
+
+let cacheDir: string;
+let tmpFilePath: string;
+let registry: Registry;
+
+beforeEach(async () => {
+  const unique = randomUUID();
+  cacheDir = join(tmpdir(), `shave-delegates-test-${unique}`);
+  tmpFilePath = join(tmpdir(), `shave-delegates-src-${unique}.ts`);
+  registry = await openRegistry(":memory:", { embeddings: mockEmbeddingProvider() });
+  // biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+  delete process.env.ANTHROPIC_API_KEY;
+});
+
+afterEach(async () => {
+  await registry.close();
+  await rm(tmpFilePath, { force: true });
+  await rm(cacheDir, { recursive: true, force: true }).catch(() => {});
+  // biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+  delete process.env.ANTHROPIC_API_KEY;
+});
+
+// ---------------------------------------------------------------------------
+// Spy registry wrapper — counts storeBlock invocations
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps a Registry's storeBlock method with a call counter.
+ * Returns the wrapped registry and a getter for the call count.
+ *
+ * Using a real registry (not a mock) ensures that:
+ * - SQLite receives correct rows (no silent corruption).
+ * - Idempotency (INSERT OR IGNORE) is exercised by the real storage layer.
+ * - The count reflects actual delegation calls, not internal retries.
+ */
+function withStoreBlockSpy(reg: Registry): {
+  spyRegistry: Registry;
+  getStoreBlockCallCount: () => number;
+} {
+  let callCount = 0;
+  const originalStoreBlock = reg.storeBlock.bind(reg);
+  const spyRegistry: Registry = {
+    ...reg,
+    storeBlock: async (row) => {
+      callCount++;
+      return originalStoreBlock(row);
+    },
+  };
+  return { spyRegistry, getStoreBlockCallCount: () => callCount };
+}
+
+// ---------------------------------------------------------------------------
+// WI-423 regression: storeBlock call count = novel-glue entry count
+//
+// If shave() calls universalize() twice (double-persist), storeBlock would be
+// called 2N times. If shave() reverts to an inline loop + universalize(), it
+// would be called 2N or more times. Exactly N calls proves single delegation.
+// ---------------------------------------------------------------------------
+
+describe("WI-423 regression: shave() delegates to universalize({persist:true}) exactly once", () => {
+  it("single-leaf source: storeBlock called exactly once (not zero, not twice)", async () => {
+    await writeFile(tmpFilePath, ATOMIC_SOURCE, "utf-8");
+
+    const { spyRegistry, getStoreBlockCallCount } = withStoreBlockSpy(registry);
+
+    const result = await shave(tmpFilePath, spyRegistry, {
+      cacheDir,
+      offline: true,
+      intentStrategy: "static",
+    });
+
+    // Exactly 1 novel-glue entry for ATOMIC_SOURCE → exactly 1 storeBlock call.
+    const novelGlueAtoms = result.atoms.filter((a) => a.merkleRoot !== undefined);
+    expect(novelGlueAtoms.length, "ATOMIC_SOURCE must produce exactly 1 persisted atom").toBe(1);
+
+    expect(
+      getStoreBlockCallCount(),
+      "storeBlock must be called exactly once — not zero (no persist) and not twice (double-persist)",
+    ).toBe(1);
+  }, 60_000);
+
+  it("multi-leaf source: storeBlock called exactly N times (one per novel-glue entry, no double-persist)", async () => {
+    await writeFile(tmpFilePath, MULTI_LEAF_SOURCE, "utf-8");
+
+    const { spyRegistry, getStoreBlockCallCount } = withStoreBlockSpy(registry);
+
+    const result = await shave(tmpFilePath, spyRegistry, {
+      cacheDir,
+      offline: true,
+      intentStrategy: "static",
+    });
+
+    const novelGlueAtoms = result.atoms.filter((a) => a.merkleRoot !== undefined);
+    expect(
+      novelGlueAtoms.length,
+      "MULTI_LEAF_SOURCE must produce > 1 persisted atoms",
+    ).toBeGreaterThan(1);
+
+    // storeBlock must be called exactly once per novel-glue entry.
+    // If the old inline loop runs in addition to universalize({persist:true}),
+    // this count would be double. If universalize is not called, it would be 0.
+    expect(
+      getStoreBlockCallCount(),
+      "storeBlock call count must equal novel-glue atom count (single delegation)",
+    ).toBe(novelGlueAtoms.length);
+  }, 60_000);
+
+  it("read-only registry (no storeBlock): shave() completes without error, zero atoms persisted", async () => {
+    // Graceful degradation: when registry.storeBlock is absent, shave() must
+    // not throw — it returns atoms with merkleRoot=undefined. This verifies
+    // that the hasPersist guard in the refactored shave() works correctly.
+    await writeFile(tmpFilePath, ATOMIC_SOURCE, "utf-8");
+
+    const readOnlyRegistry = {
+      selectBlocks: registry.selectBlocks.bind(registry),
+      getBlock: registry.getBlock.bind(registry),
+      findByCanonicalAstHash: registry.findByCanonicalAstHash?.bind(registry),
+      // storeBlock intentionally absent — read-only view
+    };
+
+    const result = await shave(tmpFilePath, readOnlyRegistry, {
+      cacheDir,
+      offline: true,
+      intentStrategy: "static",
+    });
+
+    // No atoms persisted (no storeBlock), but shave() must succeed.
+    const persistedAtoms = result.atoms.filter((a) => a.merkleRoot !== undefined);
+    expect(persistedAtoms.length, "Read-only registry: no atoms should be persisted").toBe(0);
+
+    // atoms array must still be populated (stubs exist even without persistence).
+    expect(
+      result.atoms.length,
+      "atoms array must be non-empty even without persistence",
+    ).toBeGreaterThan(0);
+  }, 60_000);
+});

--- a/packages/shave/src/types.ts
+++ b/packages/shave/src/types.ts
@@ -265,9 +265,9 @@ export interface UniversalizeResult {
  * the slice plan (postorder, lineage-threaded via parentBlockRoot) and surface
  * the resulting BlockMerkleRoot on each entry.
  *
- * `shave()` does NOT accept this type — it always persists unconditionally when
- * registry.storeBlock is present. The persist flag is exclusively meaningful for
- * universalize() callers who need opt-in persistence (e.g. assembleCandidate()).
+ * `shave()` delegates to universalize({persist:true}) and passes its file path
+ * via `sourceFilePath` so that the props-file corpus extractor can locate the
+ * sibling `.props.ts` file (WI-423: DEC-V2-SHAVE-DELEGATES-UNIVERSALIZE-001).
  *
  * @decision DEC-UNIVERSALIZE-PERSIST-API-001
  * @title UniversalizeOptions extends ShaveOptions with optional persist flag
@@ -279,8 +279,9 @@ export interface UniversalizeResult {
  *   optional and defaults to false so all existing callers are unaffected.
  *   If persist:true is requested but the registry has no storeBlock, a loud
  *   PersistRequestedButNotSupportedError is thrown (Sacred Practice #5).
- *   The shave() refactor to delegate (Sacred Practice #12 consolidation) is
- *   deferred to a follow-up WI per the plan §6 slicing recommendation.
+ *   WI-423 (DEC-V2-SHAVE-DELEGATES-UNIVERSALIZE-001) completes the consolidation:
+ *   shave() now delegates its persist loop to universalize({persist:true}) and
+ *   passes sourceFilePath so the props-file corpus path remains functional.
  *   Flag as P1 follow-up: atomize.ts in @yakcc/hooks-base also runs a parallel
  *   buildBlockRow+storeBlock loop; once universalize({persist:true}) lands, that
  *   caller should consolidate onto this path too (see WI-373 plan §7).
@@ -299,6 +300,23 @@ export interface UniversalizeOptions extends ShaveOptions {
    * Throws PersistRequestedButNotSupportedError if registry.storeBlock is absent.
    */
   readonly persist?: boolean | undefined;
+
+  /**
+   * Absolute path to the source file being processed.
+   *
+   * When provided alongside `persist: true`, this path is forwarded to
+   * maybePersistNovelGlueAtom as `sourceFilePath`, enabling the props-file
+   * corpus extractor to locate the sibling `<stem>.props.ts` file.
+   *
+   * Set by shave() from its own `sourcePath` parameter (WI-423). Interactive
+   * universalize() callers (e.g. assembleCandidate) leave this undefined, which
+   * disables the props-file source for those atoms — correct per
+   * REQ-NOGO-006: atoms persist with null provenance.
+   *
+   * @decision DEC-V2-SHAVE-DELEGATES-UNIVERSALIZE-001
+   * @scope WI-423
+   */
+  readonly sourceFilePath?: string | undefined;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

WI-373 (PR #419) added `universalize({persist:true})` as the canonical surface for in-pipeline atom persistence, but **copied** the postorder lineage-threading persist loop from `shave()` instead of refactoring `shave()` to delegate. This WI closes that Sacred Practice #12 hygiene debt.

- Remove ~72-line inline persist loop from `shave()` (`packages/shave/src/index.ts`).
- `shave()` now calls `universalize(candidate, registry, { ...options, persist: true, sourceFilePath })` once, when `registry.storeBlock` is present (graceful-degradation preserved).
- Single authority for atom persistence: `universalize()` step 6.
- `@decision DEC-V2-SHAVE-DELEGATES-UNIVERSALIZE-001` annotated at the delegation call site.

## Test plan

- [x] `pnpm --filter @yakcc/shave test` — `Test Files 56 passed | 1 skipped (57)`, `Tests 790 passed | 1 skipped (791)` (baseline was 787+1; +3 new regression tests).
- [x] New regression tests in `packages/shave/src/persist/shave-delegates.test.ts` assert `storeBlock` call count via spy wrapping a **real** SQLite registry (not a mock):
  - single-leaf: called exactly once
  - multi-leaf: called exactly N times (one per novel-glue entry)
  - read-only registry: completes without error, zero atoms persisted
- [x] `pnpm --filter @yakcc/compile test` — pre-existing non-deterministic property test failures cross-checked on main (zero regression introduced; `packages/compile/` diff is empty in this WI).
- [x] `pnpm --filter @yakcc/cli test` T7 bootstrap byte-identity: `bootstrap then bootstrap --verify produces byte-identical manifest 1163ms` — PASS.
- [x] Tester verification: high confidence CLEAN — confirmed loop removed, delegation real, spy assertions meaningful, baseline counts matched.

## Out of scope

- `atomize.ts` consolidation — tracked as separate P1 follow-up (#424).
- Public `shave()` / `universalize()` signature changes — none made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)