### PR TITLE
docs(shave): reconcile stale comments with shipped WI-031 per-leaf intent (closes #375)

### DIFF
--- a/packages/shave/src/index.ts
+++ b/packages/shave/src/index.ts
@@ -413,11 +413,10 @@ import type { ForeignLeafEntry, NovelGlueEntry, SlicePlanEntry } from "./univers
  *
  * Intent card attachment: for single-leaf trees (root is an AtomLeaf), the
  * extracted intent card is attached to the one NovelGlueEntry that covers the
- * root. For multi-leaf trees, per-leaf intent extraction would require calling
- * extractIntent once per leaf — this is deferred to a future work item. Entries
- * for non-root leaves are emitted without an intentCard (the field is optional).
- * TODO(future-WI): call extractIntent per leaf and populate intentCard on each
- * NovelGlueEntry for multi-leaf trees.
+ * root. For multi-leaf trees, per-leaf intentCard population is implemented by
+ * WI-031 (commit `8dfb44b`, merge `3049ec3`, 2026-05-01) — see
+ * `DEC-UNIVERSALIZE-MULTI-LEAF-INTENT-001` for the live decision and the
+ * per-leaf extractIntent loop at lines ~542-573.
  *
  * "decomposition" is removed from diagnostics.stubbed — decomposition is now
  * live. "license-gate" is removed — gate is now live (WI-013-02).

--- a/packages/shave/src/persist/atom-persist.props.ts
+++ b/packages/shave/src/persist/atom-persist.props.ts
@@ -140,10 +140,12 @@ function makeStoreStub(): {
  * When the NovelGlueEntry has no intentCard, persistNovelGlueAtom returns
  * undefined and never calls storeBlock.
  *
- * Invariant (AP1.1, DEC-ATOM-PERSIST-001): deep-leaf entries (multi-leaf trees
- * without per-leaf intent extraction) are silently skipped — no error, no
- * persistence. This preserves backward-compatibility while future WIs add
- * per-leaf extraction.
+ * Invariant (AP1.1, DEC-ATOM-PERSIST-001): entries without an intentCard are
+ * silently skipped — no error, no persistence. This is the safety net for
+ * non-NovelGlue kinds (PointerEntry, ForeignLeafEntry). Per WI-031
+ * (DEC-UNIVERSALIZE-MULTI-LEAF-INTENT-001), novel-glue entries in multi-leaf
+ * trees carry per-leaf cards; intentCard optionality is preserved for
+ * forward-compat with entry kinds that carry no intent slot.
  */
 export const prop_persistNovelGlueAtom_skips_no_intent_card = fc.asyncProperty(
   novelGlueEntryNoCardArb,

--- a/packages/shave/src/persist/atom-persist.ts
+++ b/packages/shave/src/persist/atom-persist.ts
@@ -9,9 +9,12 @@
 //     be used without modification.
 //   - Only NovelGlueEntries with an intentCard persist; PointerEntries reference
 //     existing blocks in the registry and do not produce new rows.
-//   - Entries without an intentCard (deep leaves in multi-leaf trees per
-//     DEC-UNIVERSALIZE-WIRING-001) are skipped. Future work: per-leaf intent
-//     extraction for multi-leaf trees.
+//   - Entries without an intentCard are skipped. For NovelGlueEntries this
+//     should not occur in practice: WI-031 (commit `8dfb44b`, 2026-05-01)
+//     calls extractIntent per novel-glue entry for multi-leaf trees (see
+//     DEC-UNIVERSALIZE-MULTI-LEAF-INTENT-001). The intentCard field remains
+//     optional on NovelGlueEntry for forward-compat with PointerEntry /
+//     ForeignLeafEntry kinds that carry no intent slot.
 //   - WI-016: Property-test corpus is extracted via extractCorpus() before buildTriplet().
 //     The CorpusResult is passed to buildTriplet() as the canonical artifact source.
 //     The bootstrap placeholder (empty bytes) is no longer the silent default.
@@ -137,8 +140,11 @@ export async function persistNovelGlueAtom(
   registry: Registry,
   options?: PersistOptions,
 ): Promise<BlockMerkleRoot | undefined> {
-  // Skip atoms without an intent card — deep leaves in multi-leaf trees do not
-  // carry one (per DEC-UNIVERSALIZE-WIRING-001; future WI populates per-leaf cards).
+  // Skip atoms without an intent card — this is the defensive safety net for
+  // non-NovelGlue entry kinds (PointerEntry, ForeignLeafEntry) that have no
+  // intentCard slot. Per WI-031 (DEC-UNIVERSALIZE-MULTI-LEAF-INTENT-001),
+  // novel-glue entries in multi-leaf trees DO carry per-leaf cards; this branch
+  // is not expected to fire for them in the normal pipeline.
   const intentCard: IntentCard | undefined = entry.intentCard;
   if (intentCard === undefined) {
     return undefined;


### PR DESCRIPTION
## Summary

Pure prose reconciliation — no behavior change. Per-leaf `extractIntent` for multi-leaf shaves was actually shipped on **2026-05-01 by WI-031** (commit `8dfb44b`, merge `3049ec3`, decision `DEC-UNIVERSALIZE-MULTI-LEAF-INTENT-001`). Four spots in `packages/shave/src/` still described the wiring as deferred / future-work, surfaced by the 2026-05-12 build-vs-design audit (#375 b-010).

This PR updates only the prose to match the shipped behavior:

1. **`packages/shave/src/index.ts:413-420`** — `DEC-UNIVERSALIZE-WIRING-001` header's `TODO(future-WI)` clause replaced with a pointer to `DEC-UNIVERSALIZE-MULTI-LEAF-INTENT-001` and the live per-leaf loop at lines ~542-573.
2. **`packages/shave/src/persist/atom-persist.ts:12-14`** — file header's *"Future work: per-leaf intent extraction"* reframed: the field stays optional for forward-compat with `PointerEntry` / `ForeignLeafEntry` kinds (which carry no intent slot), but per-leaf extraction is now the active behavior for NovelGlueEntries.
3. **`packages/shave/src/persist/atom-persist.ts:140-141`** — *"future WI populates per-leaf cards"* inline comment updated to note the live population by WI-031; the defensive `if (intentCard === undefined)` safety net for non-NovelGlue entries is preserved.
4. **`packages/shave/src/persist/atom-persist.props.ts:145`** — cosmetic *"future WIs add"* phrase updated to match.

## What this is NOT

- Not a behavior change. Zero runtime semantics modified.
- Not a re-implementation. WI-031 already shipped the feature.
- Not a test change. Same 687/687 baseline as `main` (11 pre-existing failures unchanged — variance build artifact + better-sqlite3 native module in worktree's `node_modules`).

## Test plan

- [x] `git diff --stat`: 3 files, 21 insertions, 14 deletions — all in comment blocks
- [x] All target stale comments still exist verbatim in `origin/main` (no conflict with intervening merges of #431 WI-423 / #432 WI-V2-09)
- [x] Reviewer evaluated `031039b8` as `ready_for_guardian` (0 blockers / 0 major / 0 minor)
- [x] Test-state `pass_complete` at same SHA
- [x] Live decision remains `DEC-UNIVERSALIZE-MULTI-LEAF-INTENT-001`

Closes #375.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)