### PR TITLE
fix(variance): force fresh build artifact on every build (#440)

### DIFF
--- a/packages/variance/package.json
+++ b/packages/variance/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsc -p .",
+    "build": "rm -f tsconfig.tsbuildinfo && tsc -p .",
     "typecheck": "tsc --noEmit -p .",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
## Summary

Fixes #440. @yakcc/variance's build short-circuited on stale `tsconfig.tsbuildinfo` when `dist/` was empty (fresh install / CI runner cache), causing @yakcc/shave's TS2307 import failure on `@yakcc/variance/variance-rank`. Surfaced as the "pre-existing CI failure" on PRs #428, #430, #433, #437 and blocked #143 closer-parity-as test.

- Root cause: TypeScript composite/incremental mode uses tsbuildinfo to decide input freshness but does not verify declared output files actually exist on disk. Empty `dist/` + valid `tsbuildinfo` = tsc exits 0 with no emit.
- Fix: prefix variance's `build` script with `rm -f tsconfig.tsbuildinfo` so every build forces fresh emit. Trades sub-millisecond incremental skip for build-graph correctness.

## Change

One line in `packages/variance/package.json`:

```diff
- "build": "tsc -p ."
+ "build": "rm -f tsconfig.tsbuildinfo && tsc -p ."
```

## Verification

Local reproduction from issue #440 (fresh-install scenario):

```
rm -rf packages/variance/dist     # keep tsconfig.tsbuildinfo (the trap)
pnpm install --frozen-lockfile
pnpm -r build                     # all 19 packages green, no TS2307
```

## Test plan

- [ ] CI `pnpm -r build` succeeds on a fresh runner (no stale `node_modules` / `dist/`)
- [ ] @yakcc/shave's variance-rank import resolves (no TS2307)
- [ ] Downstream rebase: #143 closer-parity-as test can now run

Closes #440. Unblocks #143.