### PR TITLE
fix(B8): pin corpus JSONL to LF via .gitattributes (closes #443, #452)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# @decision DEC-BENCH-B8-SHA-001
+# @title Force LF line endings for JSONL transcript corpus files
+# @status accepted
+# @rationale
+#   B8-synthetic run.mjs computes a SHA-256 over raw bytes of the JSONL corpus files.
+#   Without this, Windows git (core.autocrlf=true) converts LF->CRLF on checkout,
+#   making the SHA-256 in corpus-spec.json (computed from LF bytes, as stored in git)
+#   not match the bytes on disk. This caused #443 / #452.
+#   Forcing eol=lf ensures all platforms see identical bytes, keeping the SHA stable.
+#   See also: bench/B8-synthetic/transcripts/corpus-spec.json _decision field.
+
+# Force LF line endings for JSONL benchmark corpus files (platform-stable SHA)
+bench/B8-synthetic/transcripts/*.jsonl text eol=lf

--- a/bench/B8-synthetic/transcripts/corpus-spec.json
+++ b/bench/B8-synthetic/transcripts/corpus-spec.json
@@ -29,6 +29,13 @@
     "SHA-256 computed over the raw bytes of all three JSONL files concatenated in the order listed in 'files'.",
     "Recompute: node -e \"const {createHash}=require('crypto'),{readFileSync}=require('fs'); const files=['bench/B8-synthetic/transcripts/substrate-001.jsonl','bench/B8-synthetic/transcripts/glue-001.jsonl','bench/B8-synthetic/transcripts/application-001.jsonl']; console.log(createHash('sha256').update(Buffer.concat(files.map(f=>readFileSync(f)))).digest('hex'))\"",
     "Slice 1 uses f=1.0 only (full corpus). Slice 2 adds f-sweep with stratified sampling.",
-    "Emission blocks are authored as a competent engineer would write them — hit/miss is measured, not pre-determined."
-  ]
+    "Emission blocks are authored as a competent engineer would write them — hit/miss is measured, not pre-determined.",
+    "IMPORTANT: The SHA is computed over LF-normalized bytes (not CRLF). .gitattributes enforces eol=lf for *.jsonl files. See DEC-BENCH-B8-SHA-001."
+  ],
+  "_decision": {
+    "id": "DEC-BENCH-B8-SHA-001",
+    "title": "Force LF line endings for JSONL corpus files to stabilize SHA across platforms",
+    "status": "accepted",
+    "rationale": "The SHA-256 in this file is computed over raw bytes of the JSONL corpus files. On Windows with core.autocrlf=true, git converts LF to CRLF on checkout, causing the SHA to drift. This was the root cause of #443 / #452. Fix: .gitattributes sets eol=lf for bench/B8-synthetic/transcripts/*.jsonl, ensuring all platforms see identical LF bytes. Path A (regen SHA) was rejected because the CRLF SHA would break on Linux CI; Path B (revert corpus) was not needed since content was not deliberately changed. The chosen path is: enforce LF via .gitattributes, keep the existing SHA which was always correct for LF-stored bytes."
+  }
 }


### PR DESCRIPTION
## Summary

- Root cause of `bench/B8-synthetic/run.mjs` SHA-256 corpus integrity failure on Windows: `core.autocrlf=true` was converting LF→CRLF on checkout, inflating the three transcript JSONL files by 10 bytes (one CR per line ending) and changing the SHA from `40788cc0…` (LF, as stored in git) to `b068fa5d…` (CRLF, on disk).
- Fix is platform-stable: new `.gitattributes` rule pins `bench/B8-synthetic/transcripts/*.jsonl text eol=lf`. Existing SHA-256 in `corpus-spec.json` stays correct — it was always right; the problem was at the encoding boundary.
- Alternative paths rejected (rationale captured in `@decision DEC-BENCH-B8-SHA-001`):
  - Path A (regenerate SHA to CRLF value) — would just break Linux CI in the opposite direction.
  - Path B (revert corpus) — content was never deliberately changed; only encoding differed on checkout.

## Files

- `.gitattributes` (new) — enforces LF for the corpus JSONLs + DEC-BENCH-B8-SHA-001 in the header comment.
- `bench/B8-synthetic/transcripts/corpus-spec.json` — adds `_decision` field referencing DEC-BENCH-B8-SHA-001 and a note about the LF requirement.

## Verification

```
Step 1: Verifying corpus integrity...
  Corpus SHA-256: 40788cc0403036ea7b562eccfa1c2be73bc812ac8dffb0fbe5c8fb355a4477a3 (OK)
  N=10 tasks across tiers: substrate=4, glue=3, application=3
```

Implementer evidence: trace `implementer-20260513-104041-ee135a`.

## Test plan

- [x] `node bench/B8-synthetic/run.mjs` passes Step 1 on Windows (post-fix) with `core.autocrlf=true`.
- [ ] Reviewer cross-check on Linux/macOS that LF normalization holds.
- [ ] Reviewer confirms `.gitattributes` does not cause re-normalization noise across the rest of the repo.

Closes #443.
Closes #452.

🤖 Generated with [Claude Code](https://claude.com/claude-code)