### PR TITLE
fix(ci): force fresh workspace TS build + drop selective skip — unblocks bench-b7-commit + bootstrap (closes #449)

### DIFF
--- a/.github/workflows/bench-b7-commit.yml
+++ b/.github/workflows/bench-b7-commit.yml
@@ -79,12 +79,37 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build required packages (skip @yakcc/shave — pre-existing broken, DEC-SHAVE-SKIP-001)
-        run: |
-          pnpm --filter @yakcc/contracts build || true
-          pnpm --filter @yakcc/registry build || true
-          pnpm --filter @yakcc/hooks-base build || true
-          pnpm --filter @yakcc/cli build || true
+      - name: Build workspace (pnpm -r build)
+        # @decision DEC-CI-FRESH-BUILD-B7-001
+        # @title bench-b7-commit: replace per-package selective build with pnpm -r build
+        # @status accepted (WI-B7-WORKSPACE-RESOLUTION-FIX, issue #449)
+        # @rationale
+        #   The prior step built four packages selectively and explicitly skipped
+        #   @yakcc/shave with a stale "pre-existing broken" annotation
+        #   (DEC-SHAVE-SKIP-001 — never formally filed; shave has compiled cleanly since
+        #   PR #383/#388). This caused bench-b7-commit to be RED for 3 consecutive runs:
+        #   TS2307 errors from @yakcc/shave, @yakcc/ir, @yakcc/seeds, @yakcc/compile,
+        #   @yakcc/federation — all transitive deps of @yakcc/hooks-base that were
+        #   absent from the selective build list.
+        #
+        #   The root cause is two-layered:
+        #   (1) The selective build skipped shave, so hooks-base (which imports shave)
+        #       could never compile. The TS2307 cascade follows from this.
+        #   (2) TypeScript composite/incremental mode reads tsconfig.tsbuildinfo to
+        #       determine input freshness but does NOT verify that declared output files
+        #       actually exist. When dist/ is absent (fresh CI runner, no cache) but a
+        #       stale tsbuildinfo is present, tsc short-circuits "no inputs changed" and
+        #       exits 0 WITHOUT emitting any output files. All 9 composite packages
+        #       (contracts, registry, ir, seeds, compile, federation, cli, shave,
+        #       hooks-base) are now fixed with `rm -f tsconfig.tsbuildinfo && tsc -p .`
+        #       in their build scripts (mirroring PR #440's fix for @yakcc/variance).
+        #
+        #   Fix: replace the per-package selective build with `pnpm -r build`.
+        #   pnpm owns dependency-topological ordering; this eliminates the class of
+        #   build-order regressions that caused #390, #391, and now #449. Mirrors the
+        #   pattern from bootstrap.yml (line 96), bootstrap-accumulate.yml (line 68),
+        #   and v0-release-smoke.yml (DEC-V0-RELEASE-SMOKE-BUILD-RECURSIVE-001 / WI-391).
+        run: pnpm -r build
 
       - name: Run B7 commit-latency benchmark
         run: node bench/B7-commit/harness/run.mjs --hardware-label ubuntu-latest-node22

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "yakcc": "./dist/bin.js"
   },
   "scripts": {
-    "build": "tsc -p .",
+    "build": "rm -f tsconfig.tsbuildinfo && tsc -p .",
     "build:binary": "node scripts/build-binary.mjs",
     "typecheck": "tsc --noEmit -p .",
     "test": "vitest run",

--- a/packages/compile/package.json
+++ b/packages/compile/package.json
@@ -10,7 +10,7 @@
     ".": "./dist/index.js"
   },
   "scripts": {
-    "build": "tsc -p .",
+    "build": "rm -f tsconfig.tsbuildinfo && tsc -p .",
     "typecheck": "tsc --noEmit -p .",
     "test": "vitest run",
     "lint": "biome check src/"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -10,7 +10,7 @@
     ".": "./dist/index.js"
   },
   "scripts": {
-    "build": "tsc -p .",
+    "build": "rm -f tsconfig.tsbuildinfo && tsc -p .",
     "typecheck": "tsc --noEmit -p .",
     "test": "vitest run",
     "lint": "echo \"no lint yet\""

--- a/packages/federation/package.json
+++ b/packages/federation/package.json
@@ -10,7 +10,7 @@
     ".": "./dist/index.js"
   },
   "scripts": {
-    "build": "tsc -p .",
+    "build": "rm -f tsconfig.tsbuildinfo && tsc -p .",
     "typecheck": "tsc --noEmit -p .",
     "test": "vitest run",
     "lint": "echo \"no lint yet\""

--- a/packages/hooks-base/package.json
+++ b/packages/hooks-base/package.json
@@ -10,7 +10,7 @@
     ".": "./dist/index.js"
   },
   "scripts": {
-    "build": "tsc -p .",
+    "build": "rm -f tsconfig.tsbuildinfo && tsc -p .",
     "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "test": "vitest run",
     "lint": "echo \"no lint yet\""

--- a/packages/ir/package.json
+++ b/packages/ir/package.json
@@ -10,7 +10,7 @@
     ".": "./dist/index.js"
   },
   "scripts": {
-    "build": "tsc -p .",
+    "build": "rm -f tsconfig.tsbuildinfo && tsc -p .",
     "typecheck": "tsc --noEmit -p .",
     "test": "vitest run",
     "lint": "biome check src/",

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -10,7 +10,7 @@
     ".": "./dist/index.js"
   },
   "scripts": {
-    "build": "tsc -p .",
+    "build": "rm -f tsconfig.tsbuildinfo && tsc -p .",
     "typecheck": "tsc --noEmit -p .",
     "test": "vitest run",
     "lint": "echo \"no lint yet\""

--- a/packages/seeds/package.json
+++ b/packages/seeds/package.json
@@ -11,7 +11,7 @@
     "./blocks/*": "./dist/blocks/*/impl.js"
   },
   "scripts": {
-    "build": "tsc -p . && node src/_scripts/copy-triplets.mjs",
+    "build": "rm -f tsconfig.tsbuildinfo && tsc -p . && node src/_scripts/copy-triplets.mjs",
     "typecheck": "tsc --noEmit -p .",
     "test": "vitest run",
     "lint": "biome check src/",

--- a/packages/shave/package.json
+++ b/packages/shave/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsc -p .",
+    "build": "rm -f tsconfig.tsbuildinfo && tsc -p .",
     "typecheck": "tsc --noEmit -p .",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
## Summary

Two-layered root cause of `bench-b7-commit` RED ×3 and `bootstrap` RED ×2:

1. **Selective build dropped `@yakcc/shave` in `bench-b7-commit.yml`** — undocumented carry-over from when shave didn't compile cleanly. `hooks-base` imports shave; absent shave dist cascaded into TS2307 errors across `@yakcc/shave`, `@yakcc/ir`, `@yakcc/seeds`, `@yakcc/compile`, `@yakcc/federation` whenever any consumer ran tsc in CI. Fix: replace selective list with `pnpm -r build` (same shape as `v0-release-smoke` per DEC-V0-RELEASE-SMOKE-BUILD-RECURSIVE-001).
2. **Stale tsconfig.tsbuildinfo + absent dist short-circuits tsc** — same root cause PR #440 fixed for `variance`. Composite/incremental mode reads tsbuildinfo to decide "no inputs changed" but does NOT verify dist actually exists; on fresh CI runners tsc exits 0 without emitting. Fix: prefix each affected package's `build` script with `rm -f tsconfig.tsbuildinfo && tsc -p .`, mirroring #440 across the rest of the workspace.

## Files (10)

- `.github/workflows/bench-b7-commit.yml` — selective build → `pnpm -r build`; `@decision DEC-CI-FRESH-BUILD-B7-001` annotation.
- `packages/contracts/package.json`
- `packages/registry/package.json`
- `packages/hooks-base/package.json`
- `packages/ir/package.json`
- `packages/seeds/package.json`
- `packages/compile/package.json`
- `packages/federation/package.json`
- `packages/cli/package.json`
- `packages/shave/package.json`

Each package.json: build script becomes `rm -f tsconfig.tsbuildinfo && tsc -p . [&& post-build steps]`.

## Verification

Local — stale tsbuildinfo + absent dist scenario, fresh `pnpm -r build`:
- 19/19 packages report Done
- Zero TS2307 errors across the run
- `packages/cli/dist/bin.js` present after build

CI on this branch:
- Workspace build step GREEN: https://github.com/cneckar/yakcc/actions/runs/25813404231
- Full `bench-b7-commit` benchmark still running (~25–35 min)
- `bootstrap-accumulate` will trigger on this PR (`bootstrap` only fires on push:main, so true bootstrap verification happens post-merge)

## Test plan

- [x] Local `pnpm -r build` clean with stale tsbuildinfo + absent dist.
- [ ] CI `bench-b7-commit` workflow green to completion on the PR branch.
- [ ] CI `bootstrap-accumulate` green on this PR.
- [ ] Post-merge: `bootstrap` workflow on main green on next push.

## DEC annotations

- `DEC-CI-FRESH-BUILD-B7-001` in `.github/workflows/bench-b7-commit.yml`: rationale for dropping the selective package list in favor of `pnpm -r build`.
- Mirrors `DEC-VARIANCE-FRESH-BUILD` (from PR #440) and `DEC-V0-RELEASE-SMOKE-BUILD-RECURSIVE-001` (from WI-391).

Closes #449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)