### PR TITLE
docs(bench): WI-464 relabel B1/B5/B6/B7/B8 KILL→directional-target pe…

### DIFF
--- a/bench/B1-latency/README.md
+++ b/bench/B1-latency/README.md
@@ -1,5 +1,14 @@
 # B1 — Latency / Substrate Throughput Benchmark
 
+<!--
+@decision DEC-V0-BENCH-SLICE3-RELABEL-001
+@title B1-latency pass-bars are directional targets only pre-characterisation-data
+@status accepted
+@rationale Per WI-BENCHMARK-SUITE-CHARACTERISATION-PASS, pass-bars are directional targets only pre-characterisation-data.
+-->
+
+> **Note (WI-BENCHMARK-SUITE-CHARACTERISATION-PASS / PR #448):** This bench is part of the `WI-BENCHMARK-SUITE-CHARACTERISATION-PASS` initiative (PR #448). Pass-bars are directional targets only; no measurement triggers a project-level KILL pre-data. Pass-bar revision happens after the characterisation distributions are in.
+
 **Issue:** [#185](https://github.com/cneckar/yakcc/issues/185)  
 **Parent:** WI-BENCHMARK-SUITE (#167)
 
@@ -58,13 +67,13 @@ WASM is from the CPU's peak throughput — informational context, not the verdic
 
 See `integer-math/algorithm.md` for full rationale.
 
-## Pass / Kill Bars (from issue #185)
+## Pass / Directional Target Bars (from issue #185)
 
 | Result | Verdict |
 |--------|---------|
 | yakcc-as degradation vs rust-software **≤ 15%** | **PASS** |
 | degradation **15%–40%** | **WARN** — concerning, review AS initiative |
-| degradation **> 40%** | **KILL** — triggers re-plan of #143 AS initiative |
+| degradation **> 40%** | **Directional target (no KILL pre-data)** — would prompt re-plan of #143 AS initiative post-characterisation |
 
 Degradation = `(yakcc_mean_ms - rust_software_mean_ms) / rust_software_mean_ms * 100`.
 
@@ -75,7 +84,7 @@ Degradation = `(yakcc_mean_ms - rust_software_mean_ms) / rust_software_mean_ms *
 Results on other platforms are **informational only**:
 - Windows development machines: SHA-NI availability varies; Node V8 JIT behavior differs
 - macOS (Apple Silicon): ARM SHA extensions, different WASM JIT characteristics
-- Cross-architecture results should not be used to make pass/kill decisions
+- Cross-architecture results should not be used to make pass-bar verdict decisions
 
 The result JSON includes an `environment` block (platform, arch, CPU model, Node version,
 Rust version, yakcc git HEAD) so results can be correlated with hardware context.
@@ -143,7 +152,7 @@ Written to `tmp/B1-latency/integer-math-<timestamp>.json`:
   "verdict": {
     "primary_comparison": "yakcc-as vs rust-software",
     "yakcc_vs_rust_software_degradation_pct": ...,
-    "vs_pass_bar_15pct": "pass" | "warn" | "kill" | "blocker",
+    "vs_pass_bar_15pct": "pass" | "warn" | "kill" | "blocker", // "kill" reserved for post-characterisation; never emitted by Tester pre-data
     "ceiling_reference": {
       "rust_accelerated_throughput_mb_per_sec": ...,
       "speedup_vs_software_pct": ...,
@@ -165,7 +174,7 @@ This decision captures:
 - The 3-slice strategy (B1 split for incremental delivery)
 - The dual-comparator discipline (apples-to-apples gate vs ceiling reference)
 - The methodology (100 warm-up + 1000 measured, per-process isolation)
-- This commit's measurement results and pass/warn/kill verdict
+- This commit's measurement results and pass/warn/directional-target verdict
 
 ---
 
@@ -190,13 +199,13 @@ All four comparators exclude JSON parsing from the timing loop:
 - ts-node: `JSON.parse` result cached before timing
 - yakcc-as: flat binary tagged-union serialized into WASM memory before timing
 
-### Slice 2 Pass/Kill Bars
+### Slice 2 Directional Target Bars
 
 | Result | Verdict |
 |--------|---------|
 | yakcc-as degradation vs rust-software **≤ 15%** | **PASS** |
 | degradation **15%–40%** | **WARN** |
-| degradation **> 40%** | **KILL** |
+| degradation **> 40%** | **Directional target (no KILL pre-data)** |
 
 ### How to Run Slice 2
 
@@ -246,15 +255,15 @@ Query distribution: 70% static hit, 25% param hit, 5% miss.
 Note: for HTTP routing, there is no hardware-acceleration analog. Both Rust bins are
 structurally identical — the dual-target pattern is kept for consistency with Slices 1+2.
 
-### Slice 3 Pass/Kill Bars
+### Slice 3 Directional Target Bars
 
 | Result | Verdict |
 |--------|---------|
 | yakcc-as degradation vs rust-software **≤ 25%** | **PASS** (glue-heavy relaxed bar) |
 | degradation **25%–40%** | **WARN** |
-| degradation **> 40%** | **KILL** |
+| degradation **> 40%** | **Directional target (no KILL pre-data)** |
 
-The kill bar is the same across all workload types. The pass bar is relaxed from 15% to 25%
+The directional target bar is the same across all workload types. The pass bar is relaxed from 15% to 25%
 to account for WASM's inherent indirect-call dispatch overhead on branching-heavy workloads.
 
 ### How to Run Slice 3

--- a/bench/B1-latency/http-routing/algorithm.md
+++ b/bench/B1-latency/http-routing/algorithm.md
@@ -1,5 +1,14 @@
 # B1 Slice 3 — HTTP Routing Algorithm
 
+<!--
+@decision DEC-V0-BENCH-SLICE3-RELABEL-001
+@title B1 HTTP routing pass-bars are directional targets only pre-characterisation-data
+@status accepted
+@rationale Per WI-BENCHMARK-SUITE-CHARACTERISATION-PASS, pass-bars are directional targets only pre-characterisation-data.
+-->
+
+> **Note (WI-BENCHMARK-SUITE-CHARACTERISATION-PASS / PR #448):** This bench is part of the `WI-BENCHMARK-SUITE-CHARACTERISATION-PASS` initiative (PR #448). Pass-bars are directional targets only; no measurement triggers a project-level KILL pre-data. Pass-bar revision happens after the characterisation distributions are in.
+
 **Issue:** [#185](https://github.com/cneckar/yakcc/issues/185)  
 **Workload class:** Glue-heavy (dispatch/branching intensive, low arithmetic depth)
 
@@ -86,7 +95,7 @@ the WASM flat encoding is equivalent to what Rust lays out in memory for a Vec<N
 - For yakcc-as: pre-flatten trie + pre-hash: EXCLUDED from timing loop
 - Inner loop: 100,000-query match phase, 100 warm-up + 1,000 measured iterations
 
-### Pass/Kill Bars for Glue-Heavy Workload
+### Directional Target Bars for Glue-Heavy Workload
 
 Per issue #185: glue-heavy workloads have a relaxed bar because WASM's indirect branching
 overhead is inherent and not an AS-backend-specific deficiency.
@@ -95,9 +104,9 @@ overhead is inherent and not an AS-backend-specific deficiency.
 |---------|-----------|
 | PASS | yakcc-as degradation vs rust-software ≤ 25% |
 | WARN | degradation 25%–40% |
-| KILL | degradation > 40% |
+| Directional target (no KILL pre-data) | degradation > 40% |
 
-The kill bar remains the same across all workload types (>40% = re-plan AS initiative).
+The directional target bar is the same across all workload types (>40% would prompt re-plan of AS initiative post-characterisation).
 The pass bar is relaxed from 15% (substrate-heavy) to 25% (glue-heavy) to account for
 the inherent WASM dispatch overhead that is not present in native code.
 

--- a/bench/B1-latency/integer-math/algorithm.md
+++ b/bench/B1-latency/integer-math/algorithm.md
@@ -1,5 +1,14 @@
 # Algorithm Choice: SHA-256 over 100MB Buffer
 
+<!--
+@decision DEC-V0-BENCH-SLICE3-RELABEL-001
+@title B1 integer-math pass-bars are directional targets only pre-characterisation-data
+@status accepted
+@rationale Per WI-BENCHMARK-SUITE-CHARACTERISATION-PASS, pass-bars are directional targets only pre-characterisation-data.
+-->
+
+> **Note (WI-BENCHMARK-SUITE-CHARACTERISATION-PASS / PR #448):** This bench is part of the `WI-BENCHMARK-SUITE-CHARACTERISATION-PASS` initiative (PR #448). Pass-bars are directional targets only; no measurement triggers a project-level KILL pre-data. Pass-bar revision happens after the characterisation distributions are in.
+
 ## Why SHA-256
 
 SHA-256 is chosen as the integer-math kernel for the following reasons:
@@ -58,12 +67,12 @@ The verdict gate is **yakcc-as vs rust-software**, not yakcc-as vs rust-accelera
 The 15%/40% bars measure the WASM JIT overhead — the cost of running the same algorithm
 in a sandboxed runtime vs native Rust. Hardware acceleration is irrelevant to this question.
 
-## Pass/Kill Bars (from issue #185)
+## Directional Target Bars (from issue #185)
 
 | Result | Verdict |
 |--------|---------|
 | yakcc-as degradation vs rust-software ≤ 15% | PASS |
 | degradation 15%–40% | WARN |
-| degradation > 40% | KILL (triggers re-plan of #143 AS initiative) |
+| degradation > 40% | Directional target (no KILL pre-data) — would prompt re-plan of #143 AS initiative post-characterisation |
 
 Degradation = `(yakcc_mean_ms - rust_software_mean_ms) / rust_software_mean_ms * 100`.

--- a/bench/B1-latency/json-transformer/algorithm.md
+++ b/bench/B1-latency/json-transformer/algorithm.md
@@ -1,5 +1,14 @@
 # Algorithm Choice: Sum-of-All-Numeric-Leaves over ~100MB JSON Corpus
 
+<!--
+@decision DEC-V0-BENCH-SLICE3-RELABEL-001
+@title B1 json-transformer pass-bars are directional targets only pre-characterisation-data
+@status accepted
+@rationale Per WI-BENCHMARK-SUITE-CHARACTERISATION-PASS, pass-bars are directional targets only pre-characterisation-data.
+-->
+
+> **Note (WI-BENCHMARK-SUITE-CHARACTERISATION-PASS / PR #448):** This bench is part of the `WI-BENCHMARK-SUITE-CHARACTERISATION-PASS` initiative (PR #448). Pass-bars are directional targets only; no measurement triggers a project-level KILL pre-data. Pass-bar revision happens after the characterisation distributions are in.
+
 ## Algorithm Selected: Sum-of-All-Numeric-Leaves (DFS)
 
 The primary candidate for Slice 2 was a **string-keys-to-camelCase recursive normalization**.
@@ -72,12 +81,12 @@ Before timing, all 4 comparators run on a fixed 10KB test input. Their outputs (
 numeric sum as a serialized float) must be byte-identical. Without this check the
 measurement compares different algorithms. Any mismatch is a hard fail in run.mjs.
 
-## Pass/Kill Bars (from issue #185, same as Slice 1)
+## Directional Target Bars (from issue #185, same as Slice 1)
 
 | Result | Verdict |
 |--------|---------|
 | yakcc-as degradation vs rust-software ≤ 15% | PASS |
 | degradation 15%–40% | WARN |
-| degradation > 40% | KILL (triggers re-plan of #143 AS initiative) |
+| degradation > 40% | Directional target (no KILL pre-data) — would prompt re-plan of #143 AS initiative post-characterisation |
 
 Degradation = `(yakcc_mean_ms - rust_software_mean_ms) / rust_software_mean_ms * 100`.

--- a/bench/B5-coherence/README.md
+++ b/bench/B5-coherence/README.md
@@ -1,5 +1,14 @@
 ﻿# B5 — Hallucination Rebound / Multi-Turn Coherence Benchmark
 
+<!--
+@decision DEC-V0-BENCH-SLICE3-RELABEL-001
+@title B5-coherence pass-bars are directional targets only pre-characterisation-data
+@status accepted
+@rationale Per WI-BENCHMARK-SUITE-CHARACTERISATION-PASS, pass-bars are directional targets only pre-characterisation-data.
+-->
+
+> **Note (WI-BENCHMARK-SUITE-CHARACTERISATION-PASS / PR #448):** This bench is part of the `WI-BENCHMARK-SUITE-CHARACTERISATION-PASS` initiative (PR #448). Pass-bars are directional targets only; no measurement triggers a project-level KILL pre-data. Pass-bar revision happens after the characterisation distributions are in.
+
 **Issue:** [#189](https://github.com/cneckar/yakcc/issues/189)
 **Parent:** WI-BENCHMARK-SUITE (#167)
 **Track:** B5 of 8
@@ -23,7 +32,7 @@ B5 verifies that yakcc's hook interception does not break the LLM's coherence ac
 **Goal:** Build the infrastructure that Slices 2 and 3 plug into.
 
 **What's implemented:**
-- `RUBRIC.md` — authoritative scoring spec (0–5 per turn, 4 failure modes, pass/KILL bars)
+- `RUBRIC.md` — authoritative scoring spec (0–5 per turn, 4 failure modes, pass/directional-target bars)
 - `conversations.jsonl` — N=10 adversarial conversation seeds, 2 per shape category
 - `harness/run-conversation.mjs` — runs hook-enabled and hook-disabled arms using offline simulation (no real LLM)
 - `rubric-eval.mjs` — programmatic offline classifier implementing the rubric mechanically
@@ -58,7 +67,7 @@ B5 verifies that yakcc's hook interception does not break the LLM's coherence ac
 
 ### Slice 3 — Cross-arm blind verdict
 
-**Goal:** Produce the final B5 verdict against the pass/KILL bars.
+**Goal:** Produce the final B5 verdict against the pass/directional-target bars.
 
 **What gets added:**
 - Full blind verdict: final comparison of hook-enabled vs hook-disabled arms
@@ -153,7 +162,7 @@ The programmatic classifier is structurally blind: it scores by pattern matching
 
 ### Sample size
 
-Slice 1: N=10 (calibration). Slice 2: N=50 (per #189 spec). The pass/KILL bars are designed for N=50. Slice 1 scores on N=10 are indicative only.
+Slice 1: N=10 (calibration). Slice 2: N=50 (per #189 spec). The pass/directional-target bars are designed for N=50. Slice 1 scores on N=10 are indicative only.
 
 ---
 
@@ -176,25 +185,25 @@ Arm assignment is randomized per run (for blind-eval discipline). The scores wit
 
 ## Falsifiability statement
 
-B5 CAN return KILL. The KILL criterion is explicit and binary:
+B5 has explicit directional failure criteria (no KILL pre-data). The criteria are:
 - Mean coherence < 2.5 on the hook-enabled arm, OR
 - Catastrophic failures > 15% of scored turns
 
-If KILL triggers, the conclusion is: **atom references break LLM context; the hook cannot ship in its current form**. This would trigger redesign of the contract-surfacing mechanism (D-HOOK-4).
+If these criteria trigger post-characterisation, the conclusion is: **atom references break LLM context; the hook cannot ship in its current form**. This would trigger redesign of the contract-surfacing mechanism (D-HOOK-4).
 
-The Slice 1 offline classifier will generally NOT trigger KILL on the `assistant_emission_target` seeds because those seeds were authored to represent correct behavior. Slice 2 with real LLM emission is where divergence from the expected behavior can surface a genuine KILL.
+The Slice 1 offline classifier will generally NOT reach these thresholds on the `assistant_emission_target` seeds because those seeds were authored to represent correct behavior. Slice 2 with real LLM emission is where divergence from the expected behavior can surface genuine threshold violations.
 
 ---
 
-## Pass/KILL bars (from #189)
+## Pass / Directional Target Bars (from #189)
 
-| Metric | Pass | KILL |
-|--------|------|------|
+| Metric | Pass | Directional target (no KILL pre-data) |
+|--------|------|--------------------------------------|
 | Mean coherence score | ≥ 4.0 | < 2.5 |
 | Subsequent-turn coherence rate (score ≥ 4) | ≥ 90% | — |
 | Catastrophic failures (score 0–1) | ≤ 5% of turns | > 15% |
 
-KILL triggers on **either** condition: mean < 2.5 **OR** catastrophic > 15%.
+Directional target triggers on **either** condition: mean < 2.5 **OR** catastrophic > 15%. No measurement triggers a project-level KILL pre-characterisation-data.
 
 ---
 

--- a/bench/B5-coherence/RUBRIC.md
+++ b/bench/B5-coherence/RUBRIC.md
@@ -1,5 +1,14 @@
 # B5 Coherence Rubric
 
+<!--
+@decision DEC-V0-BENCH-SLICE3-RELABEL-001
+@title B5-coherence rubric bars are directional targets only pre-characterisation-data
+@status accepted
+@rationale Per WI-BENCHMARK-SUITE-CHARACTERISATION-PASS, pass-bars are directional targets only pre-characterisation-data.
+-->
+
+> **Note (WI-BENCHMARK-SUITE-CHARACTERISATION-PASS / PR #448):** This bench is part of the `WI-BENCHMARK-SUITE-CHARACTERISATION-PASS` initiative (PR #448). Pass-bars are directional targets only; no measurement triggers a project-level KILL pre-data. Pass-bar revision happens after the characterisation distributions are in.
+
 **Issue:** [#189](https://github.com/cneckar/yakcc/issues/189)
 **Benchmark:** B5 — Hallucination Rebound / Multi-Turn Coherence
 **Authoritative version:** This file is the single source of truth for B5 scoring.
@@ -115,7 +124,7 @@ Four categorical failure modes are tracked independently of per-turn scores:
 The LLM treats a yakcc atom reference as an opaque token (the hash is present but unused semantically). Score 3 turns are classified here. Indicates the hook's contract comment (D-HOOK-4) is insufficient — the LLM cannot infer the atom's semantics from the substitution context alone.
 
 ### `hallucinated`
-The LLM invents atom semantics that contradict the registered spec. Score 2 turns are classified here. Indicates the LLM is not grounding its reasoning in the atom's contract — a contract-surfacing failure. B5 KILL criterion applies if this failure mode exceeds thresholds.
+The LLM invents atom semantics that contradict the registered spec. Score 2 turns are classified here. Indicates the LLM is not grounding its reasoning in the atom's contract — a contract-surfacing failure. B5 directional-target criterion applies if this failure mode exceeds thresholds.
 
 ### `re-emission`
 The LLM re-emits the atom's body verbatim. Score 1 turns are classified here. Indicates the hook's substitution is not "sticking" — the LLM ignores the reference and regenerates from its training context. Most serious coherence failure short of catastrophic.
@@ -125,17 +134,17 @@ The conversation derails entirely. Score 0 turns are classified here. Indicates 
 
 ---
 
-## Pass/KILL Bars (from #189)
+## Pass / Directional Target Bars (from #189)
 
-| Metric | Pass | KILL |
-|--------|------|------|
+| Metric | Pass | Directional target (no KILL pre-data) |
+|--------|------|--------------------------------------|
 | Mean coherence score | ≥ 4.0 | < 2.5 |
 | Subsequent-turn coherence rate (score ≥ 4) | ≥ 90% | — |
 | Catastrophic failures (score 0–1) | ≤ 5% of turns | > 15% |
 
-KILL triggers on **either** condition: mean < 2.5 **OR** catastrophic > 15%.
+Directional target triggers on **either** condition: mean < 2.5 **OR** catastrophic > 15%. No measurement triggers a project-level KILL pre-characterisation-data.
 
-**KILL meaning:** atom references break LLM context; cannot ship hook in current shape. Triggers redesign of hook contract-surfacing mechanism (D-HOOK-4).
+**Post-characterisation meaning if thresholds are crossed:** atom references break LLM context; cannot ship hook in current shape. Would trigger redesign of hook contract-surfacing mechanism (D-HOOK-4).
 
 ---
 

--- a/bench/B6-airgap/README.md
+++ b/bench/B6-airgap/README.md
@@ -1,5 +1,14 @@
 # B6 — Air-Gapped / Network-Locality Benchmark
 
+<!--
+@decision DEC-V0-BENCH-SLICE3-RELABEL-001
+@title B6-airgap pass-bars are directional targets only pre-characterisation-data
+@status accepted
+@rationale Per WI-BENCHMARK-SUITE-CHARACTERISATION-PASS, pass-bars are directional targets only pre-characterisation-data.
+-->
+
+> **Note (WI-BENCHMARK-SUITE-CHARACTERISATION-PASS / PR #448):** This bench is part of the `WI-BENCHMARK-SUITE-CHARACTERISATION-PASS` initiative (PR #448). Pass-bars are directional targets only; no measurement triggers a project-level KILL pre-data. Pass-bar revision happens after the characterisation distributions are in.
+
 **Issue:** [#190](https://github.com/cneckar/yakcc/issues/190)  
 **Parent:** WI-BENCHMARK-SUITE (#167)
 
@@ -9,8 +18,8 @@ Two sub-benchmarks:
 
 | Sub-benchmark | Mode | Bar | Description |
 |---|---|---|---|
-| B6a | Offline (air-gapped) | **ZERO outbound connections** | Full 7-step developer flow with `createOfflineEmbeddingProvider()` (BLAKE3-based, no network). Any outbound connection is a KILL — cannot claim air-gapped viability. |
-| B6b | Networked | Only allowlisted destinations | Same flow with live Anthropic API embeddings. Every outbound destination must appear in `allowlist.json`. Any unlisted destination is a KILL. |
+| B6a | Offline (air-gapped) | **ZERO outbound connections** | Full 7-step developer flow with `createOfflineEmbeddingProvider()` (BLAKE3-based, no network). Any outbound connection is a directional-target failure (no KILL pre-data) — cannot claim air-gapped viability. |
+| B6b | Networked | Only allowlisted destinations | Same flow with live Anthropic API embeddings. Every outbound destination must appear in `allowlist.json`. Any unlisted destination is a directional-target failure (no KILL pre-data). |
 
 ## How to run
 

--- a/bench/B7-commit/README.md
+++ b/bench/B7-commit/README.md
@@ -1,5 +1,14 @@
 # B7 — Time-to-Commit: Novel-Glue Flywheel Latency
 
+<!--
+@decision DEC-V0-BENCH-SLICE3-RELABEL-001
+@title B7-commit pass-bars are directional targets only pre-characterisation-data
+@status accepted
+@rationale Per WI-BENCHMARK-SUITE-CHARACTERISATION-PASS, pass-bars are directional targets only pre-characterisation-data.
+-->
+
+> **Note (WI-BENCHMARK-SUITE-CHARACTERISATION-PASS / PR #448):** This bench is part of the `WI-BENCHMARK-SUITE-CHARACTERISATION-PASS` initiative (PR #448). Pass-bars are directional targets only; no measurement triggers a project-level KILL pre-data. Pass-bar revision happens after the characterisation distributions are in.
+
 **Issue:** [#396](https://github.com/cneckar/yakcc/issues/396) — WI-B7-SLICE-3: Multi-hardware + subprocess isolation + DEC-BENCH-B7-001  
 **Predecessors:** [#381](https://github.com/cneckar/yakcc/issues/381) (Slice 1), [#389](https://github.com/cneckar/yakcc/issues/389) (Slice 2)  
 **Parent:** [#191](https://github.com/cneckar/yakcc/issues/191) — WI-BENCHMARK-B7: Time-to-commit for novel glue  
@@ -51,7 +60,7 @@ Two cache states are measured per utility:
 | ≤3 s | PASS-aspirational |
 | 3–10 s | PASS-hard-cap |
 | 10–15 s | WARN |
-| >15 s | **KILL** — file `WI-FAST-PATH-VERIFIER` immediately |
+| >15 s | **Directional target (no KILL pre-data)** — would file `WI-FAST-PATH-VERIFIER` post-characterisation |
 | >5 s (any) | File `WI-FAST-PATH-VERIFIER` with empirical baseline |
 
 ## Slice 3 methodology
@@ -106,7 +115,7 @@ Results written to `tmp/B7-commit/slice3-<timestamp>.json`. Artifact contains:
 - `measurements[]`: per-rep records with `cacheState`, `utilityName`, timing fields, `atomized`, `bmrInTopK`, `combinedScore`
 - `aggregate`: `{ warm, cold, qualifyingWarm }` each with `median_ms`, `p95_ms`, `p99_ms`, `n`
 - `atomizedCount`: number of utilities that atomized on their warm seed rep (should = 32)
-- `verdict`: one of `PASS-aspirational` | `PASS-hard-cap` | `WARN` | `KILL`
+- `verdict`: one of `PASS-aspirational` | `PASS-hard-cap` | `WARN` | `KILL` <!-- "KILL" reserved for post-characterisation; never emitted by Tester pre-data -->
 
 ## Architecture
 

--- a/bench/B8-synthetic/README.md
+++ b/bench/B8-synthetic/README.md
@@ -1,5 +1,14 @@
 # B8-SYNTHETIC — Pre-hook Scaling-Curve Prototype via Transcript Replay
 
+<!--
+@decision DEC-V0-BENCH-SLICE3-RELABEL-001
+@title B8-synthetic pass-bars are directional targets only pre-characterisation-data
+@status accepted
+@rationale Per WI-BENCHMARK-SUITE-CHARACTERISATION-PASS, pass-bars are directional targets only pre-characterisation-data.
+-->
+
+> **Note (WI-BENCHMARK-SUITE-CHARACTERISATION-PASS / PR #448):** This bench is part of the `WI-BENCHMARK-SUITE-CHARACTERISATION-PASS` initiative (PR #448). Pass-bars are directional targets only; no measurement triggers a project-level KILL pre-data. Pass-bar revision happens after the characterisation distributions are in.
+
 **Parent issue:** [#192](https://github.com/cneckar/yakcc/issues/192)  
 **Parent suite:** [#167](https://github.com/cneckar/yakcc/issues/167) (WI-BENCHMARK-SUITE)  
 **Decision:** `DEC-BENCH-B8-SYNTHETIC-SLICE1-001`  
@@ -45,8 +54,8 @@ Token savings heuristic (per hit block):
 
 ### Falsifiability
 
-The benchmark has explicit KILL criteria (see `RUBRIC.md`):
-- **Asymptote < 50%** → architecture fundamentally limited; triggers replanning
+The benchmark has explicit directional criteria (see `RUBRIC.md`; no KILL pre-data):
+- **Asymptote < 50%** → architecture fundamentally limited; would trigger replanning post-characterisation
 - **Non-monotonic curve** (Slice 2) → simulation bug; not publishable
 
 ---
@@ -115,7 +124,7 @@ Expected: `40788cc0403036ea7b562eccfa1c2be73bc812ac8dffb0fbe5c8fb355a4477a3`
 ```
 bench/B8-synthetic/
 ├── README.md                    # this file
-├── RUBRIC.md                    # pass/kill bars verbatim from #192 + #167 DQ-5/6/7/9
+├── RUBRIC.md                    # pass/directional-target bars verbatim from #192 + #167 DQ-5/6/7/9
 ├── transcripts/
 │   ├── corpus-spec.json         # SHA-256 of the transcript set
 │   ├── substrate-001.jsonl      # substrate-heavy task transcripts (4 fixtures)

--- a/bench/B8-synthetic/RUBRIC.md
+++ b/bench/B8-synthetic/RUBRIC.md
@@ -1,5 +1,14 @@
 # B8-SYNTHETIC Benchmark Rubric
 
+<!--
+@decision DEC-V0-BENCH-SLICE3-RELABEL-001
+@title B8-synthetic rubric bars are directional targets only pre-characterisation-data
+@status accepted
+@rationale Per WI-BENCHMARK-SUITE-CHARACTERISATION-PASS, pass-bars are directional targets only pre-characterisation-data.
+-->
+
+> **Note (WI-BENCHMARK-SUITE-CHARACTERISATION-PASS / PR #448):** This bench is part of the `WI-BENCHMARK-SUITE-CHARACTERISATION-PASS` initiative (PR #448). Pass-bars are directional targets only; no measurement triggers a project-level KILL pre-data. Pass-bar revision happens after the characterisation distributions are in.
+
 **Source:** #192 (WI-BENCHMARK-B8-SYNTHETIC) + #167 (WI-BENCHMARK-SUITE DQ-5/6/7/9)
 
 ---
@@ -14,11 +23,11 @@
 
 ---
 
-## KILL Bars (per #192 + #167 DQ-5)
+## Directional Target Bars (per #192 + #167 DQ-5; no KILL pre-characterisation-data)
 
 | Bar | Condition | Consequence |
 |-----|-----------|-------------|
-| **Asymptote < 50%** | mean savings % at f=1.0 < 50% | Architecture fundamentally limited; production cannot exceed this ceiling; triggers replanning before production B8 starts |
+| **Asymptote < 50%** | mean savings % at f=1.0 < 50% | Architecture fundamentally limited; production cannot exceed this ceiling; would trigger replanning post-characterisation |
 | **Non-monotonic curve** | any decreasing savings as f increases | Bug in simulation; not safe to publish; requires investigation |
 
 ---
@@ -70,7 +79,7 @@ B8 numbers can only be equal to or worse than the synthetic ceiling.
 |------------------------------|----------------|
 | ≥ 80% | PASS — ceiling is viable; production worth pursuing |
 | 50% – 79% | WARN — ceiling is marginal; investigate corpus composition |
-| < 50% | KILL — ceiling too low; architecture needs replanning |
+| < 50% | Directional target (no KILL pre-data) — ceiling too low; architecture would need replanning post-characterisation |
 
 ---
 


### PR DESCRIPTION
…r characterisation reframing

Per WI-BENCHMARK-SUITE-CHARACTERISATION-PASS (PR #448): pass-bars across all bench docs are directional targets only; no measurement triggers a project-level KILL pre-data. Relabels applied to B1-latency (README + 3 algorithm.md files), B5-coherence (README + RUBRIC), B6-airgap (README), B7-commit (README), and B8-synthetic (README + RUBRIC).

Changes per file:
- Added DEC-V0-BENCH-SLICE3-RELABEL-001 annotation block at top of each file
- Added initiative note paragraph at top of each README/RUBRIC
- Renamed "Pass/Kill Bars" table headers → "Pass / Directional Target Bars"
- Replaced KILL verdict rows with "Directional target (no KILL pre-data)"
- Preserved "kill" enum values in JSON result schemas with adjacent inline comment
- Updated narrative KILL framing to post-characterisation conditional language

Harness code (*/harness/*.mjs, */run.mjs) untouched; no PASS/WARN bars removed.

Closes #464