### PR TITLE
fix(bench/B4): WI-480 — swap BLAKE3 stub for real semantic embeddings in MCP server

### DIFF
--- a/bench/B4-tokens/harness/mcp-server.mjs
+++ b/bench/B4-tokens/harness/mcp-server.mjs
@@ -50,6 +50,25 @@
 //     no migrations (registry already exists) and the offline embedding provider
 //     is deterministic (no network calls required).
 //
+//   @decision DEC-V0-B4-EMBED-REAL-001
+//   @title Real semantic embedding provider for B4 MCP runtime path
+//   @status accepted
+//   @rationale
+//     Provider: Xenova/bge-small-en-v1.5 via @xenova/transformers (createLocalEmbeddingProvider).
+//     Dimension: 384-dim Float32Array, L2-normalized, cosine-distance compatible with vec0 index.
+//     License: MIT (confirmed, DEC-EMBED-010).
+//     Model size: ~25MB quantized ONNX; downloads from HuggingFace on first call, then cached
+//       at ~/.cache/huggingface/ (or $HF_HOME). Subsequent calls are fully local.
+//     Cache strategy: lazy singleton via closure (DEC-EMBED-SINGLETON-CLOSURE-001). The model
+//       loads on first ensureRegistry() call and is reused for the lifetime of the MCP server
+//       process. Since the server is a long-running subprocess (spawned by the harness), the
+//       per-run model-load cost (~1-2s cold, ~0s warm) is paid once per bench cell, not per query.
+//     Network behavior: outbound HuggingFace download on first cold boot ONLY. Steady-state
+//       (warm cache) is network-free. Air-gap note: see DEC-V0-B4-EMBED-SWAP-001.
+//     Why this model: Per DEC-EMBED-MODEL-DEFAULT-002, bge-small-en-v1.5 benchmarked at
+//       M2=70%, M3=100%, M4=0.823 against the yakcc seed corpus — highest semantic retrieval
+//       quality among tested 384-dim models. It is the production default for all registry paths.
+//
 // Cross-reference:
 //   bench/B4-tokens/harness/run.mjs DEC-V0-B4-HOOK-WIRING-001 (hook arm wiring)
 //   packages/seeds/src/blocks/timer-handle/ DEC-SEED-TIMER-001 (timer atom closes #454)
@@ -128,6 +147,43 @@ function logError(msg) {
 
 let registry = null;
 
+// @decision DEC-V0-B4-EMBED-SWAP-001
+// @title MCP server swaps offline BLAKE3 stub for real semantic embedding provider
+// @status accepted
+// @rationale
+//   Investigation #188 (comment 4444935370, PR #482) diagnosed that every B4 hooked-arm
+//   tool_use cycle returned {atoms:[]} because:
+//     1. Seed atoms in the registry were stored with LOCAL semantic embeddings
+//        (createLocalEmbeddingProvider → Xenova/bge-small-en-v1.5, 384-dim).
+//     2. Query text was being embedded with the BLAKE3 offline stub
+//        (createOfflineEmbeddingProvider), which produces cryptographic-hash vectors
+//        with no semantic structure whatsoever.
+//     3. Cosine similarity between a BLAKE3 vector and a transformer vector is
+//        effectively random, always landing below the 0.7 default threshold.
+//   Result: 0% substitution rate across all B4 runs — the +8.8% to +27.0% overhead
+//   measured was pure tool_use conversation overhead with zero atom reuse.
+//
+//   FIX: Use createLocalEmbeddingProvider() (Xenova/bge-small-en-v1.5) for the MCP
+//   runtime path. Query vectors are now produced by the same model that embedded the
+//   seed atoms, making cosine similarity semantically meaningful.
+//
+//   STUB PRESERVED: createOfflineEmbeddingProvider() remains exported from
+//   @yakcc/contracts for deterministic unit tests and bootstrap (air-gap) paths.
+//   The stub is intentionally NOT used here — only the MCP runtime path changes.
+//
+//   AIR-GAP NOTE (B6 compatibility): createLocalEmbeddingProvider() downloads the
+//   Xenova/bge-small-en-v1.5 model (~25MB) from HuggingFace on first use, then
+//   caches it locally. Air-gap deployments (B6) must pre-warm the model cache before
+//   going offline. The offline stub cannot replace this for semantic search — its
+//   vectors are incompatible with the seed atom embeddings in the registry.
+//   B6 workaround: YAKCC_MCP_OFFLINE=1 env var (future WI) to skip semantic search
+//   and fall back to structural matching. Track as a sub-followup on issue #480.
+//
+//   Cross-references:
+//     Issue #480 (this fix), #188 (investigation), PR #482 (instrumentation)
+//     DEC-V0-B4-EMBED-REAL-001 (provider choice)
+//     DEC-EMBED-OFFLINE-PROVIDER-001 (why stub exists)
+
 async function ensureRegistry() {
   if (registry !== null) return registry;
 
@@ -142,13 +198,17 @@ async function ensureRegistry() {
   const { openRegistry } = await import(
     new URL(`file://${resolve(REPO_ROOT, "packages/registry/dist/index.js")}`).href
   );
-  const { createOfflineEmbeddingProvider } = await import(
+  // DEC-V0-B4-EMBED-SWAP-001: use the local semantic provider (bge-small-en-v1.5),
+  // NOT createOfflineEmbeddingProvider(). The offline BLAKE3 stub produces vectors
+  // that are incompatible with the seed atom embeddings stored in the registry.
+  const { createLocalEmbeddingProvider } = await import(
     new URL(`file://${resolve(REPO_ROOT, "packages/contracts/dist/index.js")}`).href
   );
 
   log(`Opening registry at: ${REGISTRY_PATH}`);
+  log("Loading local embedding provider (Xenova/bge-small-en-v1.5) for semantic search...");
   registry = await openRegistry(REGISTRY_PATH, {
-    embeddings: createOfflineEmbeddingProvider(),
+    embeddings: createLocalEmbeddingProvider(),
   });
   log("Registry opened successfully.");
   return registry;


### PR DESCRIPTION
## Summary

- Fixes the root cause of zero B4 atom substitutions: `mcp-server.mjs` was using `createOfflineEmbeddingProvider()` (BLAKE3 cryptographic hash stub) to embed query text, while seed atoms in the registry were stored with `createLocalEmbeddingProvider()` (Xenova/bge-small-en-v1.5 transformer). Cosine similarity between BLAKE3 and transformer vectors is effectively random, always landing below the 0.7 confidence threshold.
- Swaps to `createLocalEmbeddingProvider()` in the MCP server runtime path only. The BLAKE3 stub is preserved in `@yakcc/contracts` for all unit tests and bootstrap (air-gap) paths.
- Adds `@decision DEC-V0-B4-EMBED-REAL-001` (provider choice, cache strategy, network behavior, B6 caveat) and `@decision DEC-V0-B4-EMBED-SWAP-001` (investigation finding, why the swap, stub preservation).

**One file changed:** `bench/B4-tokens/harness/mcp-server.mjs` — 62 insertions, 2 deletions.

## Investigation context

WI-479 / PR #482 instrumentation confirmed the diagnosis: every hooked-arm tool_use cycle returned `{atoms:[]}`. The registry has 20 parser combinator atoms embedded with the transformer model. The MCP server was querying with BLAKE3 vectors — cross-model cosine similarity is meaningless noise. The measured +8.8% to +27.0% token overhead was pure tool_use conversation overhead with zero substitution benefit.

## Test results

```
contracts:  13 test files, 188 passed, 1 skipped (offline network test)
registry:   16 test files, 303 passed, 19 skipped
seeds:       1 test file,  163 passed
B4 dry-run: 144/144 calls complete, exit 0, MCP server starts cleanly
```

The 4 pre-existing CLI test failures (bootstrap/cli/registry-export) are unchanged from main — verified by running `pnpm --filter @yakcc/cli test` on both branches.

## Gate 3 findings (corpus gap)

With the real embedding provider active, running `atom-lookup` against the current registry returns confidence scores in the 0.33–0.36 range for "LRU cache eviction" queries — semantically meaningful (the transformer is working) but the best match is `nonAsciiRejector` (a parser atom) rather than an LRU cache atom. This confirms the two-layer problem:

1. ✅ **Fixed here**: Wrong embedding provider (BLAKE3 stub vs. transformer)
2. ❌ **Still blocking**: No LRU cache, debounce, csv-parser, or other B4-task atoms in the registry corpus

**Recommendation: dispatch #481 (seed atoms) immediately.** The embedding fix is necessary but not sufficient for non-zero substitution rates — the corpus needs the right atoms before semantic search can yield matches above threshold.

The B4 smoke matrix (gate 3) requires ANTHROPIC_API_KEY to run. With the corpus gap, gate 3 would show zero active substitutions even with the corrected provider — which is the expected documented outcome per the issue: "If gate 3 produces zero active substitutions even with the new provider... recommend immediate #481 dispatch."

## Air-gap note (B6 compatibility)

`createLocalEmbeddingProvider()` downloads the Xenova/bge-small-en-v1.5 model (~25MB) from HuggingFace on first use, then caches locally. Air-gap deployments must pre-warm the model cache before going offline. A `YAKCC_MCP_OFFLINE=1` env-var path (future WI, tracked as sub-followup on #480) could fall back to structural matching for air-gap environments.

## Test plan

- [x] `pnpm --filter @yakcc/contracts test` — 188 passed
- [x] `pnpm --filter @yakcc/registry test` — 303 passed
- [x] `pnpm --filter @yakcc/seeds test` — 163 passed
- [x] B4 dry-run (`node bench/B4-tokens/harness/run.mjs --dry-run --tier=min`) — 144/144, exit 0
- [x] MCP atom-lookup smoke: semantic embeddings returning confidence 0.33–0.36 (transformer model confirmed active)
- [ ] Gate 3 smoke matrix (4 real API calls) — requires `ANTHROPIC_API_KEY` + corpus seeding (#481)

🤖 Generated with [Claude Code](https://claude.com/claude-code)