### PR TITLE
fix(bench): correct MCP atom-lookup L2->match_confidence formula (#500)

### DIFF
--- a/bench/B4-tokens/harness/mcp-server.mjs
+++ b/bench/B4-tokens/harness/mcp-server.mjs
@@ -273,12 +273,22 @@ async function atomLookup(input) {
     return { atoms: [] };
   }
 
-  // Convert cosineDistance to match_confidence: 1 - cosineDistance/2
-  // cosineDistance in [0,2]: 0=identical, 2=opposite; maps confidence to [0,1].
+  // Convert L2 distance to match_confidence using the correct formula per
+  // DEC-V3-DISCOVERY-CALIBRATION-FIX-002 (#500).
+  //
+  // sqlite-vec vec0 returns L2 Euclidean distance by default (NOT cosine distance).
+  // For unit-normalized vectors, cosine_distance = L2² / 2, so the correct mapping
+  // from L2 distance d ∈ [0, 2] to a [0, 1] confidence score is:
+  //   match_confidence = 1 - d²/4 = (1 + cos(θ)) / 2
+  //
+  // The retracted formula (1 - d/2) treated d as cosine distance, mapping an LRU
+  // intent at L2=0.662 to 0.669 (below the 0.7 threshold). The correct formula
+  // maps it to 0.890 (above threshold). See packages/registry/src/discovery-eval-helpers.ts
+  // cosineDistanceToCombinedScore() for the canonical implementation.
   const withConfidence = candidates
     .map((c) => ({
       block: c.block,
-      match_confidence: 1 - (c.cosineDistance / 2),
+      match_confidence: Math.max(0, Math.min(1, 1 - (c.cosineDistance * c.cosineDistance) / 4)),
     }))
     .filter((c) => c.match_confidence >= effectiveThreshold)
     .slice(0, topK);


### PR DESCRIPTION
## Summary
Fix a one-line formula bug in the B4 MCP atom-lookup harness that was
causing every paid B4 cell to receive `{atoms:[]}` from atom-lookup, even
when semantically-correct top-1 candidates existed in the registry.

The MCP server inlined the retracted `1 - d/2` mapping for L2 distance →
confidence. Per `DEC-V3-DISCOVERY-CALIBRATION-FIX-002`, the registry's
`cosineDistance` field carries **L2 distance** (vec0 defaults to L2
Euclidean), so the correct mapping is `1 - d²/4` clamped to `[0,1]`.

Caught by the pre-bench verification gate this afternoon: the orchestrator
seeded a clean `.yakcc/registry.sqlite` (26 blocks, 26 embeddings, real
bge-small-en-v1.5), ran discovery dry-runs (8/8 top-1 hits via CLI), then
smoked the MCP server and observed `{atoms:[]}` despite "25 candidates
found but all below threshold 0.7". Diagnosis: bug at
`bench/B4-tokens/harness/mcp-server.mjs:281`.

## Impact
Without this fix, any paid B4 run reports 0% atom-reuse — same failure
mode as issues #188 and #497 (which previously cost ~\$11–\$15 in wasted
API spend each).

## Verification
- `pnpm -r build` clean in the feature worktree
- MCP JSON-RPC smoke against the seeded registry now returns 5 atoms for
  the LRU intent, top-1 `makeLruNode` at `match_confidence=0.890`
  (was 0.669, below threshold)
- Reviewer independently reproduced the smoke result

## Test plan
- [ ] `pnpm -r build` clean
- [ ] B4 dry-run (`pnpm bench:tokens:dry`) reaches end-of-suite
- [ ] B4 paid run (single-driver-sonnet smoke, ~\$0.10) shows non-zero
      `atoms_proposed` per hooked cell

Closes #500.