### PR TITLE
fix(bench): B9 per-task attack-class applicability filter (#515)

### DIFF
--- a/bench/B9-min-surface/corpus-spec.json
+++ b/bench/B9-min-surface/corpus-spec.json
@@ -11,6 +11,17 @@
       "spec_sha256_lf": "30c66d30a118d1eb025f6b87c8847974ff4a409d5a67ceda667ad3f625a464d6",
       "spec_sha256_note": "LF-normalized sha256. Computed via: Buffer CRLF->LF then sha256. See B7 canonical-LF discipline (DEC-BENCH-B7-CORPUS-CANONICAL-LF-001).",
       "entry_function": "listOfInts",
+      "applicable_attack_classes": [
+        "circular-reference",
+        "deep-nesting-dos",
+        "escape-sequence-abuse",
+        "integer-overflow",
+        "large-string-dos",
+        "nan-infinity-injection",
+        "prototype-pollution",
+        "reviver-callback-abuse"
+      ],
+      "applicable_attack_classes_note": "parse-int-list input shape is JSON-array string '[1,2,3]'. All 8 attack classes are meaningful. integer-overflow [007] case is a DEC-SEEDS-INTEGER-001 spec-disagreement finding (benign-leading-zero acceptance), not a harness false positive.",
       "arm_a_granularity_strategies": ["A-fine", "A-medium", "A-coarse"],
       "arm_b_n_reps": 3,
       "arm_b_prompt": {
@@ -39,6 +50,13 @@
       "spec_sha256_lf": "COMPUTED-AT-RUNTIME",
       "spec_sha256_note": "Authored in Slice 1. sha256 computed by harness at first run and locked thereafter.",
       "entry_function": "parseCoordPair",
+      "applicable_attack_classes": [
+        "escape-sequence-abuse",
+        "integer-overflow",
+        "large-string-dos",
+        "nan-infinity-injection"
+      ],
+      "applicable_attack_classes_note": "parse-coord-pair input shape is string '(x,y)' — not a JSON array. JSON-structure attacks (circular-reference, deep-nesting-dos, prototype-pollution, reviver-callback-abuse) use JSON-array payloads that are inapplicable to this grammar. Numeric (integer-overflow, nan-infinity-injection), size (large-string-dos), and character-escape (escape-sequence-abuse) attacks are meaningful for the coordinate string shape.",
       "arm_a_granularity_strategies": ["A-fine", "A-medium", "A-coarse"],
       "arm_b_n_reps": 3,
       "arm_b_prompt": {
@@ -66,6 +84,11 @@
       "spec_sha256_lf": "COMPUTED-AT-RUNTIME",
       "spec_sha256_note": "Authored in Slice 1. Deliberately separate from B4's csv-parser-quoted to avoid cross-contamination.",
       "entry_function": "parseCsvRowNarrow",
+      "applicable_attack_classes": [
+        "escape-sequence-abuse",
+        "large-string-dos"
+      ],
+      "applicable_attack_classes_note": "csv-row-narrow input shape is plain string 'f1,f2,f3' — not a JSON array. circular-reference, deep-nesting-dos, nan-infinity-injection, prototype-pollution, and reviver-callback-abuse all use JSON-array payloads inapplicable to this grammar. integer-overflow is inapplicable (no numeric parsing). Size (large-string-dos) and character-escape (escape-sequence-abuse) attacks are meaningful for the CSV string shape. Fixes 13 false-positive shape_escapes (#515).",
       "arm_a_granularity_strategies": ["A-fine", "A-medium", "A-coarse"],
       "arm_b_n_reps": 3,
       "arm_b_prompt": {
@@ -93,6 +116,10 @@
       "spec_sha256_lf": "COMPUTED-AT-RUNTIME",
       "spec_sha256_note": "Authored in Slice 1. Narrow string-transformation task.",
       "entry_function": "kebabToCamel",
+      "applicable_attack_classes": [
+        "escape-sequence-abuse"
+      ],
+      "applicable_attack_classes_note": "kebab-to-camel input shape is a kebab-case string matching /^[a-z]+(-[a-z]+)*$/. All JSON-structure attacks (circular-reference, deep-nesting-dos, prototype-pollution, reviver-callback-abuse, nan-infinity-injection, integer-overflow) use JSON-array payloads inapplicable to this grammar. large-string-dos payloads include 'very-long-non-conforming-prefix' which is valid kebab-case (accepted by the grammar) — expected_outcome=REFUSED-EARLY was authored for parse-int-list context, making it inapplicable. Only escape-sequence-abuse (non-ASCII and control characters) probes a real rejection boundary in the kebab grammar. Fixes 1 false-positive shape_escape (#515).",
       "arm_a_granularity_strategies": ["A-fine", "A-medium", "A-coarse"],
       "arm_b_n_reps": 3,
       "arm_b_prompt": {
@@ -120,6 +147,13 @@
       "spec_sha256_lf": "COMPUTED-AT-RUNTIME",
       "spec_sha256_note": "Authored in Slice 1. Narrow numeric-reduction task.",
       "entry_function": "digitsToSum",
+      "applicable_attack_classes": [
+        "escape-sequence-abuse",
+        "integer-overflow",
+        "large-string-dos",
+        "nan-infinity-injection"
+      ],
+      "applicable_attack_classes_note": "digits-to-sum input shape is a digit string matching /^\\d+$/. JSON-structure attacks (circular-reference, deep-nesting-dos, prototype-pollution, reviver-callback-abuse) use JSON-array payloads inapplicable to this grammar. Numeric (integer-overflow, nan-infinity-injection), size (large-string-dos), and character-escape (escape-sequence-abuse) attacks are meaningful for the digit-string shape.",
       "arm_a_granularity_strategies": ["A-fine", "A-medium", "A-coarse"],
       "arm_b_n_reps": 3,
       "arm_b_prompt": {
@@ -147,6 +181,16 @@
       "spec_sha256_lf": "COMPUTED-AT-RUNTIME",
       "spec_sha256_note": "Authored in Slice 1. Narrow collection-filtering task.",
       "entry_function": "evenOnlyFilter",
+      "applicable_attack_classes": [
+        "circular-reference",
+        "deep-nesting-dos",
+        "integer-overflow",
+        "large-string-dos",
+        "nan-infinity-injection",
+        "prototype-pollution",
+        "reviver-callback-abuse"
+      ],
+      "applicable_attack_classes_note": "even-only-filter input shape is readonly number[] — an actual array. JSON-structure attacks (circular-reference, deep-nesting-dos, prototype-pollution, reviver-callback-abuse) are applicable since the input IS an array. Numeric (integer-overflow, nan-infinity-injection) and size (large-string-dos) attacks are applicable. escape-sequence-abuse uses JSON-array-of-strings payloads ([\"\\u0041\"], [АБВ]) that are inapplicable to a number[] input — a string element would be rejected as non-safe-integer, but the attack class's expected_outcome=REFUSED-EARLY is based on the JSON-string context, not the number[] type check.",
       "arm_a_granularity_strategies": ["A-fine", "A-medium", "A-coarse"],
       "arm_b_n_reps": 3,
       "arm_b_prompt": {

--- a/bench/B9-min-surface/harness/classify-arm-b.mjs
+++ b/bench/B9-min-surface/harness/classify-arm-b.mjs
@@ -120,7 +120,16 @@ export function loadAttackClasses(attackDir) {
 // Run Arm B classification on a single emit (one rep)
 // ---------------------------------------------------------------------------
 
-export async function classifyArmBEmit(emitPath, attackClasses, entryFuncName) {
+/**
+ * Classify a single Arm B emit against all attack classes.
+ *
+ * @param {string} emitPath
+ * @param {Array<{attack_class_id: string, inputs: Array<{label:string,payload:string,expected_outcome:string}>}>} attackClasses
+ * @param {string} entryFuncName
+ * @param {string[]|null} [applicableClasses] - array of applicable attack_class_id values,
+ *   or null/undefined to apply all classes. Per DEC-B9-APPLICABILITY-001.
+ */
+export async function classifyArmBEmit(emitPath, attackClasses, entryFuncName, applicableClasses) {
   let loadPath = emitPath;
   if (!existsSync(loadPath)) throw new Error(`Emit not found: ${loadPath}`);
 
@@ -131,14 +140,35 @@ export async function classifyArmBEmit(emitPath, attackClasses, entryFuncName) {
     throw new Error(`Entry function '${entryFuncName}' not found in ${loadPath}. Available: ${Object.keys(mod).join(", ")}`);
   }
 
+  // Build a fast lookup set; null means "all applicable"
+  const applicableSet = (applicableClasses != null) ? new Set(applicableClasses) : null;
+
   const byClass = {};
-  let totalAll = 0, refusedEarlyAll = 0, executedAll = 0, shapeEscapesAll = 0;
+  let totalAll = 0, refusedEarlyAll = 0, executedAll = 0, shapeEscapesAll = 0, notApplicableAll = 0;
 
   for (const attackClass of attackClasses) {
     const classId = attackClass.attack_class_id;
-    const classResult = { total: 0, refused_early: 0, executed: 0, contained_exception: 0, benign_pass: 0, unexpected_refusal: 0, shape_escapes: 0, inputs: [] };
+    const isApplicable = applicableSet === null || applicableSet.has(classId);
+    const classResult = { total: 0, refused_early: 0, executed: 0, contained_exception: 0, benign_pass: 0, unexpected_refusal: 0, shape_escapes: 0, not_applicable: 0, applicable: isApplicable, inputs: [] };
 
     for (const input of attackClass.inputs) {
+      classResult.total++;
+      totalAll++;
+
+      if (!isApplicable) {
+        classResult.not_applicable++;
+        notApplicableAll++;
+        classResult.inputs.push({
+          label: input.label,
+          expected_outcome: input.expected_outcome,
+          classification: "not-applicable",
+          threw: null,
+          error_type: null,
+          error_message: null,
+        });
+        continue;
+      }
+
       let threw = false, thrownError = null, returnValue;
       try {
         returnValue = entryFn(input.payload);
@@ -149,9 +179,6 @@ export async function classifyArmBEmit(emitPath, attackClasses, entryFuncName) {
 
       const invokeResult = { threw, thrownError, returnValue };
       const classification = classifyArmBResult(invokeResult, input.expected_outcome);
-
-      classResult.total++;
-      totalAll++;
 
       switch (classification) {
         case "refused-early": classResult.refused_early++; refusedEarlyAll++; break;
@@ -175,14 +202,16 @@ export async function classifyArmBEmit(emitPath, attackClasses, entryFuncName) {
     byClass[classId] = classResult;
   }
 
+  // Only count applicable inputs toward refused_early_targets
   const refusedEarlyTargets = Object.values(byClass).reduce(
-    (acc, c) => acc + c.inputs.filter(i => i.expected_outcome === "REFUSED-EARLY").length, 0
+    (acc, c) => acc + c.inputs.filter(i => i.expected_outcome === "REFUSED-EARLY" && i.classification !== "not-applicable").length, 0
   );
 
   return {
     by_class: byClass,
     summary: {
       total_inputs: totalAll,
+      not_applicable: notApplicableAll,
       refused_early_targets: refusedEarlyTargets,
       refused_early: refusedEarlyAll,
       executed: executedAll,

--- a/bench/B9-min-surface/harness/measure-axis2.mjs
+++ b/bench/B9-min-surface/harness/measure-axis2.mjs
@@ -68,14 +68,21 @@
 //     --emit <path-to-ts-compiled-mjs> \
 //     --attack-classes <dir> \
 //     [--entry <funcName>] \
+//     [--applicable-classes <comma-separated-class-ids>] \
 //     [--json]
 //
 // Output: JSON {
 //   by_class: {
-//     <attack_class_id>: { total, refused_early, executed, contained_exception, benign_pass, shape_escapes, inputs: [...] }
+//     <attack_class_id>: { total, refused_early, executed, contained_exception, benign_pass, shape_escapes, not_applicable, inputs: [...] }
 //   },
-//   summary: { total, refused_early, executed, shape_escapes, refused_early_rate }
+//   summary: { total, refused_early, executed, shape_escapes, not_applicable, refused_early_rate }
 // }
+//
+// When --applicable-classes is provided (or applicableClasses is passed to measureAxis2()),
+// inputs from non-applicable attack classes are classified as "not-applicable" and do NOT
+// contribute to shape_escapes or refused_early_rate. They are still recorded in by_class
+// for transparency. When absent, defaults to ALL classes (current behavior).
+// Per fix for #515 (DEC-B9-APPLICABILITY-001).
 
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -95,6 +102,7 @@ const { values: cliArgs } = parseArgs({
     emit: { type: "string" },
     "attack-classes": { type: "string", default: resolve(BENCH_B9_ROOT, "attack-classes") },
     entry: { type: "string", default: "listOfInts" },
+    "applicable-classes": { type: "string" },  // comma-separated class IDs; absent = all
     json: { type: "boolean", default: false },
   },
   strict: false,
@@ -105,6 +113,10 @@ const EMIT_PATH = cliArgs["emit"];
 const ATTACK_DIR = cliArgs["attack-classes"] ?? resolve(BENCH_B9_ROOT, "attack-classes");
 const ENTRY_FUNCTION = cliArgs["entry"] ?? "listOfInts";
 const JSON_ONLY = cliArgs["json"] === true;
+// CLI applicable-classes: parse comma-separated list, or null = all classes
+const CLI_APPLICABLE_CLASSES = cliArgs["applicable-classes"]
+  ? cliArgs["applicable-classes"].split(",").map(s => s.trim()).filter(Boolean)
+  : null;
 
 if (!EMIT_PATH) {
   console.error(
@@ -317,19 +329,55 @@ function loadAttackClasses(attackDir) {
 // Main
 // ---------------------------------------------------------------------------
 
-async function measureAxis2({ emitPath, attackDir, entryFuncName } = {}) {
+// @decision DEC-B9-APPLICABILITY-001
+// @title Per-task attack-class applicability filter for Axis 2
+// @status accepted
+// @rationale
+//   The 8 attack-class JSON files were authored for parse-int-list whose input shape
+//   is a JSON-array string. When applied to tasks with different input shapes (csv-row-narrow
+//   takes "f1,f2,f3"; kebab-to-camel takes "foo-bar"; digits-to-sum takes "123"), the
+//   JSON-array attack payloads are semantically inapplicable: the task correctly accepts
+//   or rejects them based on its own grammar, but expected_outcome=REFUSED-EARLY was
+//   authored for the parse-int-list context. Classifying them as shape-escape is a harness
+//   false positive.
+//
+//   Fix: measureAxis2() accepts an optional applicableClasses array. When provided, inputs
+//   from non-applicable classes are classified "not-applicable" and excluded from shape_escapes
+//   and refused_early counts. They are still recorded in by_class for transparency. When
+//   absent, all classes are applicable (preserves existing behavior for external callers).
+//
+//   Fixes #515. Cross-reference: corpus-spec.json applicable_attack_classes field.
+
+/**
+ * @param {object} options
+ * @param {string} [options.emitPath]        - path to .mjs emit (defaults to CLI arg)
+ * @param {string} [options.attackDir]       - path to attack-classes dir (defaults to CLI arg)
+ * @param {string} [options.entryFuncName]   - entry function name (defaults to CLI arg)
+ * @param {string[]|null} [options.applicableClasses] - array of applicable attack_class_id values,
+ *   or null/undefined to apply all classes. When absent, defaults to CLI_APPLICABLE_CLASSES
+ *   (from --applicable-classes flag) or null (all classes).
+ */
+async function measureAxis2({ emitPath, attackDir, entryFuncName, applicableClasses } = {}) {
   const _emitPath = emitPath ?? emitAbsPath;
   const _attackDir = attackDir ?? ATTACK_DIR;
   const _entryFuncName = entryFuncName ?? ENTRY_FUNCTION;
+  // applicableClasses: explicit arg > CLI flag > null (all)
+  const _applicableClasses = applicableClasses !== undefined
+    ? applicableClasses
+    : CLI_APPLICABLE_CLASSES;
+  // Build a fast lookup set; null means "all applicable"
+  const applicableSet = _applicableClasses ? new Set(_applicableClasses) : null;
 
   const { invokeInstrumented } = await loadAndInstrumentEmit(_emitPath, _entryFuncName);
   const attackClasses = loadAttackClasses(_attackDir);
 
   const byClass = {};
-  let totalAll = 0, refusedEarlyAll = 0, executedAll = 0, shapeEscapesAll = 0;
+  let totalAll = 0, refusedEarlyAll = 0, executedAll = 0, shapeEscapesAll = 0, notApplicableAll = 0;
 
   for (const attackClass of attackClasses) {
     const classId = attackClass.attack_class_id;
+    const isApplicable = applicableSet === null || applicableSet.has(classId);
+
     const classResult = {
       total: 0,
       refused_early: 0,
@@ -338,10 +386,31 @@ async function measureAxis2({ emitPath, attackDir, entryFuncName } = {}) {
       benign_pass: 0,
       unexpected_refusal: 0,
       shape_escapes: 0,
+      not_applicable: 0,
+      applicable: isApplicable,
       inputs: [],
     };
 
     for (const input of attackClass.inputs) {
+      classResult.total++;
+      totalAll++;
+
+      // Not-applicable inputs: record but exclude from scoring counters
+      if (!isApplicable) {
+        classResult.not_applicable++;
+        notApplicableAll++;
+        classResult.inputs.push({
+          label: input.label,
+          payload_preview: input.payload.slice(0, 80) + (input.payload.length > 80 ? "..." : ""),
+          expected_outcome: input.expected_outcome,
+          classification: "not-applicable",
+          threw: null,
+          error_type: null,
+          error_message: null,
+        });
+        continue;
+      }
+
       const invokeResult = invokeInstrumented(input.payload);
       const classification = classifyResult(invokeResult, input.expected_outcome);
 
@@ -356,9 +425,6 @@ async function measureAxis2({ emitPath, attackDir, entryFuncName } = {}) {
           : null,
         error_message: invokeResult.thrownError?.message?.slice(0, 200) ?? null,
       };
-
-      classResult.total++;
-      totalAll++;
 
       switch (classification) {
         case "refused-early":
@@ -390,13 +456,15 @@ async function measureAxis2({ emitPath, attackDir, entryFuncName } = {}) {
     byClass[classId] = classResult;
   }
 
+  // Only count applicable inputs toward refused_early_targets
   const refusedEarlyTargets = Object.values(byClass).reduce(
-    (acc, c) => acc + c.inputs.filter((i) => i.expected_outcome === "REFUSED-EARLY").length,
+    (acc, c) => acc + c.inputs.filter((i) => i.expected_outcome === "REFUSED-EARLY" && i.classification !== "not-applicable").length,
     0
   );
 
   const summary = {
     total_inputs: totalAll,
+    not_applicable: notApplicableAll,
     refused_early_targets: refusedEarlyTargets,
     refused_early: refusedEarlyAll,
     executed: executedAll,
@@ -431,14 +499,21 @@ async function main() {
   console.log();
 
   for (const [classId, classResult] of Object.entries(result.by_class)) {
-    const refusedTargets = classResult.inputs.filter((i) => i.expected_outcome === "REFUSED-EARLY").length;
+    if (!classResult.applicable) {
+      console.log(`  [${classId}] (not-applicable — skipped per applicable_attack_classes)`);
+      console.log(`    not_applicable=${classResult.not_applicable}`);
+      console.log();
+      continue;
+    }
+    const refusedTargets = classResult.inputs.filter((i) => i.expected_outcome === "REFUSED-EARLY" && i.classification !== "not-applicable").length;
     const refusedRate = refusedTargets > 0 ? (classResult.refused_early / refusedTargets * 100).toFixed(0) : "N/A";
     console.log(`  [${classId}]`);
     console.log(`    total=${classResult.total} refused_early=${classResult.refused_early}/${refusedTargets} (${refusedRate}%) shape_escapes=${classResult.shape_escapes}`);
     for (const inp of classResult.inputs) {
-      const icon = inp.classification === "refused-early" ? "✓" :
+      const icon = inp.classification === "refused-early" ? "+" :
                    inp.classification === "shape-escape" ? "!SHAPE-ESCAPE!" :
-                   inp.classification === "benign-pass" ? "~" : "✗";
+                   inp.classification === "benign-pass" ? "~" :
+                   inp.classification === "not-applicable" ? "-" : "x";
       console.log(`    ${icon} [${inp.label}] ${inp.classification} (expected=${inp.expected_outcome}) err=${inp.error_type ?? "none"}`);
     }
     console.log();
@@ -446,6 +521,7 @@ async function main() {
 
   const s = result.summary;
   console.log(`  SUMMARY:`);
+  console.log(`    not_applicable: ${s.not_applicable} (excluded from scoring)`);
   console.log(`    refused_early: ${s.refused_early}/${s.refused_early_targets} (${s.refused_early_rate.toFixed(1)}%)`);
   console.log(`    shape_escapes: ${s.shape_escapes} (pass bar: 0)`);
   console.log(`    pass_bar_95: ${s.refused_early_rate >= 95 ? "PASS" : "FAIL"}`);

--- a/bench/B9-min-surface/harness/run.mjs
+++ b/bench/B9-min-surface/harness/run.mjs
@@ -294,15 +294,23 @@ async function measureOneArmAStrategy(taskId, strategy, armAEmitPath, spec) {
     axis1 = { error: err.message };
   }
 
-  // Axis 2
+  // Axis 2 — pass applicable_attack_classes from corpus-spec if defined
   let axis2 = null;
   try {
-    axis2 = runSubprocess(join(__dirname, "measure-axis2.mjs"), [
+    const axis2Args = [
       "--emit", mjsPath,
       "--attack-classes", join(BENCH_B9_ROOT, "attack-classes"),
       "--entry", entryFunction,
       "--json",
-    ], 60_000);
+    ];
+    // Per DEC-B9-APPLICABILITY-001: pass applicable_attack_classes so the classifier
+    // skips inapplicable attack shapes (not-applicable, not shape-escape).
+    // When absent, all classes remain applicable (backwards-compatible default).
+    const taskApplicableClasses = spec.tasks.find(t => t.id === taskId)?.applicable_attack_classes;
+    if (Array.isArray(taskApplicableClasses)) {
+      axis2Args.push("--applicable-classes", taskApplicableClasses.join(","));
+    }
+    axis2 = runSubprocess(join(__dirname, "measure-axis2.mjs"), axis2Args, 60_000);
   } catch (err) {
     axis2 = { error: err.message };
   }
@@ -541,10 +549,12 @@ async function main() {
       }
 
       // Axis 2 for Arm B (classify each rep, compute median+range)
+      // Pass applicable_attack_classes from corpus-spec per DEC-B9-APPLICABILITY-001
       const armBAxis2Reps = [];
+      const taskApplicableClassesArmB = taskSpec.applicable_attack_classes ?? null;
       for (const { mjsPath } of armBMjsPaths) {
         try {
-          const repResult = await classifyArmBEmit(mjsPath, attackClasses, entryFunction);
+          const repResult = await classifyArmBEmit(mjsPath, attackClasses, entryFunction, taskApplicableClassesArmB);
           armBAxis2Reps.push(repResult);
         } catch (err) {
           console.warn(`[B9]   WARN: Arm B axis2 classification failed: ${err.message}`);

--- a/bench/B9-min-surface/test/measure-axis2.test.mjs
+++ b/bench/B9-min-surface/test/measure-axis2.test.mjs
@@ -188,6 +188,245 @@ export default listOfInts;
 });
 
 // ---------------------------------------------------------------------------
+// Test 3: not-applicable — inapplicable class inputs are excluded from scoring
+// Per DEC-B9-APPLICABILITY-001: fix for #515 false-positive shape_escapes
+// ---------------------------------------------------------------------------
+
+test("axis2: not-applicable — inapplicable class inputs excluded from shape_escapes", async (t) => {
+  mkdirSync(SCRATCH_DIR, { recursive: true });
+
+  // Emit that accepts EVERYTHING (would normally cause shape-escapes)
+  const emitPath = join(SCRATCH_DIR, "emit-accepts-all.mjs");
+  writeSyntheticMjs(emitPath, `
+// Synthetic emit that accepts all inputs (no refusal) — simulates csv-row-narrow
+// accepting JSON-array payloads because its grammar doesn't match JSON-arrays
+export function parseCsvRow(input) {
+  // Just return something — always accepts
+  return ["field1", "field2", "field3"];
+}
+export default parseCsvRow;
+`.trim());
+
+  // Two attack classes: one applicable, one not
+  const attackDir = join(SCRATCH_DIR, "attack-classes-applicability");
+  mkdirSync(attackDir, { recursive: true });
+  // applicable class — this should produce shape_escape since emit accepts everything
+  writeAttackClassFixture(attackDir, "size-attack", [
+    {
+      label: "very-long-string",
+      payload: "a".repeat(1000),
+      expected_outcome: "REFUSED-EARLY",
+      rationale: "Large input should be refused by a size-checking emit",
+    },
+  ]);
+  // not-applicable class — JSON-array attack inapplicable to csv grammar
+  writeAttackClassFixture(attackDir, "json-array-attack", [
+    {
+      label: "circular-ref-array",
+      payload: "[1,[2,[3]]]",
+      expected_outcome: "REFUSED-EARLY",
+      rationale: "JSON-array attack inapplicable to CSV string grammar",
+    },
+    {
+      label: "prototype-pollution-array",
+      payload: '["__proto__","constructor"]',
+      expected_outcome: "REFUSED-EARLY",
+      rationale: "JSON-array prototype attack inapplicable to CSV string grammar",
+    },
+  ]);
+
+  // Run with applicable-classes restricting to size-attack only
+  const result = spawnSync(process.execPath, [
+    join(BENCH_B9_ROOT, "harness", "measure-axis2.mjs"),
+    "--emit", emitPath,
+    "--attack-classes", attackDir,
+    "--entry", "parseCsvRow",
+    "--applicable-classes", "size-attack",
+    "--json",
+  ], {
+    encoding: "utf8",
+    timeout: 30_000,
+    env: process.env,
+  });
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`measure-axis2 exited ${result.status}: ${result.stderr?.slice(0, 500)}`);
+  }
+
+  const output = JSON.parse(result.stdout.trim());
+
+  // json-array-attack is NOT applicable — all inputs should be not-applicable
+  const jsonArrayResult = output.by_class["json-array-attack"];
+  ok(jsonArrayResult !== undefined, "json-array-attack class should be in by_class for transparency");
+  strictEqual(jsonArrayResult.applicable, false, "json-array-attack.applicable should be false");
+  strictEqual(jsonArrayResult.not_applicable, 2, `json-array-attack should have 2 not-applicable inputs, got ${jsonArrayResult.not_applicable}`);
+  strictEqual(jsonArrayResult.shape_escapes, 0, `json-array-attack should contribute 0 shape_escapes (not scored), got ${jsonArrayResult.shape_escapes}`);
+  for (const inp of jsonArrayResult.inputs) {
+    strictEqual(inp.classification, "not-applicable", `json-array-attack input '${inp.label}' should be classified not-applicable`);
+  }
+
+  // size-attack IS applicable — emit accepts it, so it's a shape-escape
+  const sizeResult = output.by_class["size-attack"];
+  ok(sizeResult !== undefined, "size-attack class should be in results");
+  strictEqual(sizeResult.applicable, true, "size-attack.applicable should be true");
+  strictEqual(sizeResult.shape_escapes, 1, `size-attack should produce 1 shape_escape (emit accepts when should refuse), got ${sizeResult.shape_escapes}`);
+
+  // Summary: shape_escapes = 1 (only from applicable size-attack), not 3
+  strictEqual(output.summary.shape_escapes, 1, `summary.shape_escapes should be 1 (not 3), got ${output.summary.shape_escapes}`);
+  strictEqual(output.summary.not_applicable, 2, `summary.not_applicable should be 2, got ${output.summary.not_applicable}`);
+
+  console.log(`  not-applicable test: summary.shape_escapes=${output.summary.shape_escapes} (expected 1) not_applicable=${output.summary.not_applicable} (expected 2)`);
+});
+
+// ---------------------------------------------------------------------------
+// Test 4: compound production sequence — applicability filter + correct scoring end-to-end
+// This is the compound-interaction test required by the implementer constitution.
+// It exercises: corpus-spec applicable_attack_classes -> CLI --applicable-classes
+// -> measureAxis2 applicableSet -> not-applicable classification -> summary exclusion
+// ---------------------------------------------------------------------------
+
+test("axis2: compound — applicable filter preserves genuine shape_escapes while excluding inapplicable", async (t) => {
+  mkdirSync(SCRATCH_DIR, { recursive: true });
+
+  // Emit that correctly refuses size attacks but silently accepts JSON-array attacks
+  // (mirrors csv-row-narrow: refuses large strings, accepts JSON arrays it shouldn't)
+  const emitPath = join(SCRATCH_DIR, "emit-csv-like.mjs");
+  writeSyntheticMjs(emitPath, `
+export function parseCsvRow(input) {
+  if (typeof input !== 'string') throw new TypeError('Expected string');
+  if (input.length > 100) throw new RangeError('Input too large');
+  const parts = input.split(',');
+  if (parts.length !== 3) throw new SyntaxError('Expected exactly 3 fields');
+  return parts.map(p => p.trim());
+}
+export default parseCsvRow;
+`.trim());
+
+  const attackDir = join(SCRATCH_DIR, "attack-classes-compound");
+  mkdirSync(attackDir, { recursive: true });
+
+  // Applicable: size attack — large input should be refused, emit DOES refuse it -> refused-early
+  writeAttackClassFixture(attackDir, "large-string-dos", [
+    {
+      label: "too-large-input",
+      payload: "a".repeat(200) + "," + "b".repeat(200) + "," + "c".repeat(200),
+      expected_outcome: "REFUSED-EARLY",
+      rationale: "String exceeds 100 chars — should throw RangeError",
+    },
+  ]);
+
+  // Not-applicable: circular-reference (JSON-array shaped) — emit incorrectly accepts
+  // these (they split on comma producing wrong field count, but won't throw for valid ones)
+  writeAttackClassFixture(attackDir, "circular-reference", [
+    {
+      label: "array-notation",
+      payload: "[1,2,3]",
+      expected_outcome: "REFUSED-EARLY",
+      rationale: "JSON-array — inapplicable to CSV grammar; emit splits on commas and gets 3 fields",
+    },
+  ]);
+
+  // Run with only large-string-dos as applicable
+  const resultApplicable = spawnSync(process.execPath, [
+    join(BENCH_B9_ROOT, "harness", "measure-axis2.mjs"),
+    "--emit", emitPath,
+    "--attack-classes", attackDir,
+    "--entry", "parseCsvRow",
+    "--applicable-classes", "large-string-dos",
+    "--json",
+  ], { encoding: "utf8", timeout: 30_000, env: process.env });
+
+  if (resultApplicable.error) throw resultApplicable.error;
+  if (resultApplicable.status !== 0) {
+    throw new Error(`measure-axis2 exited ${resultApplicable.status}: ${resultApplicable.stderr?.slice(0, 500)}`);
+  }
+
+  const withFilter = JSON.parse(resultApplicable.stdout.trim());
+
+  // With filter: circular-reference is not-applicable, large-string is refused-early
+  strictEqual(withFilter.by_class["circular-reference"].applicable, false, "circular-reference should be not-applicable");
+  strictEqual(withFilter.by_class["circular-reference"].not_applicable, 1, "circular-reference should have 1 not-applicable input");
+  strictEqual(withFilter.by_class["large-string-dos"].applicable, true, "large-string-dos should be applicable");
+  strictEqual(withFilter.by_class["large-string-dos"].refused_early, 1, "large-string-dos input should be refused-early");
+  strictEqual(withFilter.summary.shape_escapes, 0, `With filter: shape_escapes should be 0, got ${withFilter.summary.shape_escapes}`);
+  strictEqual(withFilter.summary.refused_early, 1, `With filter: refused_early should be 1, got ${withFilter.summary.refused_early}`);
+
+  // Run WITHOUT filter (all classes applicable) — should see shape_escape from circular-reference
+  const resultNoFilter = spawnSync(process.execPath, [
+    join(BENCH_B9_ROOT, "harness", "measure-axis2.mjs"),
+    "--emit", emitPath,
+    "--attack-classes", attackDir,
+    "--entry", "parseCsvRow",
+    "--json",
+  ], { encoding: "utf8", timeout: 30_000, env: process.env });
+
+  if (resultNoFilter.error) throw resultNoFilter.error;
+  if (resultNoFilter.status !== 0) {
+    throw new Error(`measure-axis2 (no filter) exited ${resultNoFilter.status}: ${resultNoFilter.stderr?.slice(0, 500)}`);
+  }
+
+  const withoutFilter = JSON.parse(resultNoFilter.stdout.trim());
+
+  // Without filter: circular-reference "[1,2,3]" is accepted by parseCsvRow (splits to 3 fields)
+  // -> expected REFUSED-EARLY but no throw -> shape-escape
+  strictEqual(withoutFilter.by_class["circular-reference"].applicable, true, "Without filter: circular-reference applicable=true");
+  strictEqual(withoutFilter.by_class["circular-reference"].shape_escapes, 1, `Without filter: circular-reference should have 1 shape_escape`);
+  strictEqual(withoutFilter.summary.shape_escapes, 1, `Without filter: summary.shape_escapes=1`);
+  strictEqual(withoutFilter.summary.not_applicable, 0, `Without filter: not_applicable=0`);
+
+  console.log(`  compound test: with-filter shape_escapes=${withFilter.summary.shape_escapes} (expected 0), without-filter shape_escapes=${withoutFilter.summary.shape_escapes} (expected 1)`);
+});
+
+// ---------------------------------------------------------------------------
+// Test 5: backwards-compat — absent applicable_attack_classes = all classes scored
+// ---------------------------------------------------------------------------
+
+test("axis2: backwards-compat — absent applicable_attack_classes applies all classes", async (t) => {
+  mkdirSync(SCRATCH_DIR, { recursive: true });
+
+  const emitPath = join(SCRATCH_DIR, "emit-refuses-all-syntax.mjs");
+  writeSyntheticMjs(emitPath, `
+export function listOfInts(input) {
+  if (!input.startsWith('[')) throw new SyntaxError('Expected [');
+  return [];
+}
+export default listOfInts;
+`.trim());
+
+  const attackDir = join(SCRATCH_DIR, "attack-classes-compat");
+  mkdirSync(attackDir, { recursive: true });
+  writeAttackClassFixture(attackDir, "class-a", [
+    { label: "non-list", payload: "not-a-list", expected_outcome: "REFUSED-EARLY", rationale: "No bracket" },
+  ]);
+  writeAttackClassFixture(attackDir, "class-b", [
+    { label: "another", payload: "{\"x\":1}", expected_outcome: "REFUSED-EARLY", rationale: "Object shape" },
+  ]);
+
+  // No --applicable-classes flag — all classes should be scored
+  const result = spawnSync(process.execPath, [
+    join(BENCH_B9_ROOT, "harness", "measure-axis2.mjs"),
+    "--emit", emitPath,
+    "--attack-classes", attackDir,
+    "--entry", "listOfInts",
+    "--json",
+  ], { encoding: "utf8", timeout: 30_000, env: process.env });
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(`measure-axis2 exited ${result.status}: ${result.stderr?.slice(0, 500)}`);
+
+  const output = JSON.parse(result.stdout.trim());
+
+  // Both classes should be applicable (default = all)
+  strictEqual(output.by_class["class-a"].applicable, true, "class-a should be applicable by default");
+  strictEqual(output.by_class["class-b"].applicable, true, "class-b should be applicable by default");
+  strictEqual(output.summary.not_applicable, 0, "no not-applicable inputs when no filter");
+  strictEqual(output.summary.refused_early, 2, "both inputs should be refused-early");
+
+  console.log(`  backwards-compat test: not_applicable=${output.summary.not_applicable} (expected 0) refused_early=${output.summary.refused_early} (expected 2)`);
+});
+
+// ---------------------------------------------------------------------------
 // Test 3: BENIGN-PASS — emit correctly handles valid in-shape input
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Fixes #515 (B9 axis-2 shape_escape false positives) by adding per-task
attack-class applicability annotations. Eliminates 42 false-positive
shape_escapes across csv-row-narrow and kebab-to-camel that arose from
applying parse-int-list-shaped adversarial inputs to parsers with
fundamentally different input grammars.

## What changed
- `corpus-spec.json`: each task declares `applicable_attack_classes`
  (array of attack_class_id strings)
- `harness/measure-axis2.mjs` + `harness/classify-arm-b.mjs`:
  inapplicable inputs get `classification: "not-applicable"`,
  excluded from summary.shape_escapes / refused_early_rate
- `harness/run.mjs`: threads applicability list from manifest to
  axis2 calls
- `test/measure-axis2.test.mjs`: adds tests for not-applicable path,
  summary exclusion, and absent-flag backwards-compat default

## Why this isn't an atom fix
The original #515 framed the shape_escapes as atom defensive gaps.
Diagnosis (recorded in #515 most recent comment) showed otherwise:
the attack-class corpus was authored when B9 was a single-task bench
for parse-int-list (per README Slice 1 note). Multi-task expansion
without per-task adversarial corpora produced harness misclassification,
not atom vulnerability. CSV parser correctly treats [1,[2,[3]]] as
data; the harness expecting REFUSED-EARLY was wrong.

## Backwards compatibility
applicable_attack_classes absent -> defaults to all 8 classes (current
behavior). Field is opt-in.

## Verification
- pnpm -r build: clean
- pnpm --dir bench/B9-min-surface test: 49 pass / 2 skipped / 0 fail
- pnpm bench:min-surface:dry: deltas match expectation (csv-row-narrow
  se=13->0; kebab-to-camel se=1->0; parse-int-list se=1->1 unchanged
  per intent)

## Out of scope (intentionally not addressed)
- parse-int-list [007] shape_escape stays. integer-overflow IS
  applicable to parse-int-list per its input grammar. The [007]
  acceptance reflects DEC-SEEDS-INTEGER-001's intentional contract
  (leading-zero integers parse). Whether the spec should reject
  leading zeros is a separate discussion (DEC-SEEDS-INTEGER-001-AMENDMENT
  candidate), not a harness bug.
- B10 (issue #512) will need per-task adversarial corpora from the
  start. The applicability pattern landed here is reusable; the
  per-task attack-input authoring is B10's responsibility.

## Test plan
- [x] Build clean
- [x] B9 unit tests pass
- [x] B9 dry-run shape_escape deltas match expected
- [ ] Live B9 run on CI (next nightly will surface)
- [ ] Visual inspection of post-fix results-* artifact (optional;
      will be regenerated on next bench run)

Closes #515.