### PR TITLE
feat(shave): STEF predicate fast-path in decompose (P0 of #549; structural fix for #444/#523 residual)

### DIFF
--- a/packages/shave/src/universalize/recursion.ts
+++ b/packages/shave/src/universalize/recursion.ts
@@ -145,6 +145,7 @@ import { canonicalAstHash } from "@yakcc/contracts";
 import { type Node, Project, ScriptKind, SyntaxKind } from "ts-morph";
 import type { ShaveRegistryView } from "../types.js";
 import { isAtom } from "./atom-test.js";
+import { matchesStefPredicate } from "./stef.js";
 import type {
   AtomLeaf,
   AtomTestResult,
@@ -1158,6 +1159,35 @@ export async function decompose(
   });
 
   const maxDepth = options?.maxDepth ?? DEFAULT_MAX_DEPTH;
+
+  // P0 #549 STEF fast-path: when the SourceFile IS a single typed exported
+  // function with JSDoc (and only permitted noise: imports/type aliases/
+  // interfaces), preserve the whole file as one atom instead of fragmenting
+  // into statement-level expressions. This is a refinement of
+  // DEC-V2-GLUE-AWARE-SHAVE-001 — STEF is the degenerate case where
+  // fragmentation strictly destroys signal; all non-STEF files continue
+  // through the glue-aware fragmentation path unchanged.
+  // See plans/wi-fix-549-shave-fragmentation.md §3.3.
+  if (matchesStefPredicate(file)) {
+    // getFullStart() is always 0 for a SourceFile — it includes leading trivia
+    // (the JSDoc comment bytes). getStart() skips trivia and would exclude the
+    // JSDoc, producing a non-zero start offset that makes the range incomplete.
+    const start = file.getFullStart();
+    const end = file.getEnd();
+    const nodeSource = source.slice(start, end);
+    const leaf: AtomLeaf = {
+      kind: "atom",
+      sourceRange: { start, end },
+      source: nodeSource,
+      canonicalAstHash: safeCanonicalAstHash(file, nodeSource, source, start, end),
+      atomTest: {
+        isAtom: true,
+        reason: "single-typed-exported-function",
+        controlFlowBoundaryCount: 0,
+      },
+    };
+    return { root: leaf, leafCount: 1, maxDepth: 0 };
+  }
 
   let leafCount = 0;
   let maxObservedDepth = 0;

--- a/packages/shave/src/universalize/stef.test.ts
+++ b/packages/shave/src/universalize/stef.test.ts
@@ -19,11 +19,11 @@
  */
 
 import type { BlockMerkleRoot } from "@yakcc/contracts";
-import { describe, expect, it } from "vitest";
 import { Project } from "ts-morph";
+import { describe, expect, it } from "vitest";
 import type { ShaveRegistryView } from "../types.js";
-import { matchesStefPredicate } from "./stef.js";
 import { decompose } from "./recursion.js";
+import { matchesStefPredicate } from "./stef.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -175,8 +175,7 @@ export function arrayMedian(values: readonly number[]): number {
     // "single-typed-exported-function". The exact leaf count and branch/atom
     // shape are determined by the existing isAtom() classification and are not
     // our invariant here.
-    const reason =
-      tree.root.kind === "atom" ? tree.root.atomTest.reason : "branch";
+    const reason = tree.root.kind === "atom" ? tree.root.atomTest.reason : "branch";
     expect(reason).not.toBe("single-typed-exported-function");
   });
 

--- a/packages/shave/src/universalize/stef.test.ts
+++ b/packages/shave/src/universalize/stef.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for the STEF (Single Typed Exported Function) predicate and the
+ * decompose() fast-path it enables. P0 fix for #549.
+ *
+ * @decision DEC-SHAVE-WHOLE-FUNCTION-PRESERVATION-001
+ * status: decided
+ *
+ * Production sequence:
+ *   1. decompose() receives a TypeScript source string.
+ *   2. It parses the source into a ts-morph Project (in-memory).
+ *   3. matchesStefPredicate() is called on the SourceFile.
+ *   4a. If true  → return a single AtomLeaf covering the full file. No recursion.
+ *   4b. If false → continue through the normal glue-aware fragmentation walk.
+ *
+ * Compound-interaction test: "arrayMedian-style STEF source returns one atom via
+ * decompose()" exercises the full end-to-end production sequence — it crosses the
+ * decompose() → matchesStefPredicate() boundary in the same way production does,
+ * and asserts on the RecursionTree rather than only on the predicate.
+ */
+
+import type { BlockMerkleRoot } from "@yakcc/contracts";
+import { describe, expect, it } from "vitest";
+import { Project } from "ts-morph";
+import type { ShaveRegistryView } from "../types.js";
+import { matchesStefPredicate } from "./stef.js";
+import { decompose } from "./recursion.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function loadSource(code: string) {
+  const project = new Project({ useInMemoryFileSystem: true });
+  return project.createSourceFile("test.ts", code);
+}
+
+/** A registry that always returns no matches — no known primitives. */
+const emptyRegistry: Pick<ShaveRegistryView, "findByCanonicalAstHash"> = {
+  findByCanonicalAstHash: async () => [],
+};
+
+// ---------------------------------------------------------------------------
+// matchesStefPredicate unit tests
+// ---------------------------------------------------------------------------
+
+describe("matchesStefPredicate (P0 #549)", () => {
+  it("returns true for arrayMedian-style single typed exported function", () => {
+    const source = loadSource(`
+      /**
+       * Compute the median of a numeric array using O(n log n) sort.
+       * Returns NaN for empty arrays.
+       */
+      export function arrayMedian(values: readonly number[]): number {
+        if (values.length === 0) return NaN;
+        const sorted = [...values].sort((a, b) => a - b);
+        const mid = Math.floor(sorted.length / 2);
+        return sorted.length % 2 === 0 ? (sorted[mid-1]! + sorted[mid]!) / 2 : sorted[mid]!;
+      }
+    `);
+    expect(matchesStefPredicate(source)).toBe(true);
+  });
+
+  it("returns false for multi-function source", () => {
+    const source = loadSource(`
+      /** A */ export function a(x: number): number { return x; }
+      /** B */ export function b(y: string): string { return y; }
+    `);
+    expect(matchesStefPredicate(source)).toBe(false);
+  });
+
+  it("returns true for STEF + import + type alias + interface noise", () => {
+    const source = loadSource(`
+      import { something } from "elsewhere";
+      export type Foo = number;
+      export interface Bar { x: number; }
+      /** doc */ export function fn(x: number): number { return x; }
+    `);
+    expect(matchesStefPredicate(source)).toBe(true);
+  });
+
+  it("returns false when a parameter has no type annotation (implicit any)", () => {
+    // TypeScript strict mode would reject this, but ts-morph accepts it; STEF must not.
+    const source = loadSource(`
+      /** doc */ export function fn(x): number { return (x as number); }
+    `);
+    expect(matchesStefPredicate(source)).toBe(false);
+  });
+
+  it("returns false when JSDoc is absent (only a line comment)", () => {
+    const source = loadSource(`
+      // just a line comment
+      export function fn(x: number): number { return x; }
+    `);
+    expect(matchesStefPredicate(source)).toBe(false);
+  });
+
+  it("returns false when return type is implicit", () => {
+    const source = loadSource(`
+      /** doc */ export function fn(x: number) { return x + 1; }
+    `);
+    expect(matchesStefPredicate(source)).toBe(false);
+  });
+
+  it("returns true for parse-rfc3339-utc shape (export interface + export function)", () => {
+    // Reviewer R0 finding 2: exported interface alongside exported function is a
+    // real shape in the B7 failure set (parse-rfc3339-utc). STEF must admit it.
+    const source = loadSource(`
+      /** Result components of a parsed RFC 3339 datetime. */
+      export interface Components {
+        year: number;
+        month: number;
+      }
+      /** Parse an RFC 3339 datetime string into its components. */
+      export function parse(s: string): Components {
+        return { year: 2026, month: 1 };
+      }
+    `);
+    expect(matchesStefPredicate(source)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decompose() fast-path integration tests (compound-interaction)
+// ---------------------------------------------------------------------------
+
+describe("decompose() STEF fast-path (P0 #549)", () => {
+  it("returns a single AtomLeaf for arrayMedian-style STEF source", async () => {
+    const source = `
+/**
+ * Compute the median of a numeric array using O(n log n) sort.
+ * Returns NaN for empty arrays.
+ */
+export function arrayMedian(values: readonly number[]): number {
+  if (values.length === 0) return NaN;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid-1]! + sorted[mid]!) / 2 : sorted[mid]!;
+}
+`.trim();
+
+    const tree = await decompose(source, emptyRegistry);
+
+    // Fast-path must produce exactly one leaf (the whole file), not a branch tree.
+    expect(tree.leafCount).toBe(1);
+    expect(tree.maxDepth).toBe(0);
+    expect(tree.root.kind).toBe("atom");
+
+    if (tree.root.kind === "atom") {
+      expect(tree.root.atomTest.reason).toBe("single-typed-exported-function");
+      expect(tree.root.atomTest.isAtom).toBe(true);
+      // The source range must span the full source text.
+      // start=0 because the fast-path uses file.getFullStart() (includes leading
+      // trivia / JSDoc bytes). end must equal source.length.
+      expect(tree.root.sourceRange.start).toBe(0);
+      expect(tree.root.sourceRange.end).toBe(source.length);
+      // The leaf source must be the entire source string.
+      expect(tree.root.source).toBe(source);
+    }
+  });
+
+  it("multi-function source does NOT use the STEF fast-path (glue-aware path unchanged)", async () => {
+    // DEC-V2-GLUE-AWARE-SHAVE-001 invariant: non-STEF source must not be changed.
+    // Key invariant to verify: the STEF fast-path was NOT taken (reason must not
+    // be "single-typed-exported-function"). The existing isAtom() / fragmentation
+    // behavior for multi-function source is unchanged — this test guards against
+    // STEF wrongly claiming files it should not.
+    const source = `
+/** A */ export function a(x: number): number { return x; }
+/** B */ export function b(y: number): number { return y; }
+`.trim();
+
+    const tree = await decompose(source, emptyRegistry);
+
+    // The STEF fast-path must NOT have fired: the reason must not be
+    // "single-typed-exported-function". The exact leaf count and branch/atom
+    // shape are determined by the existing isAtom() classification and are not
+    // our invariant here.
+    const reason =
+      tree.root.kind === "atom" ? tree.root.atomTest.reason : "branch";
+    expect(reason).not.toBe("single-typed-exported-function");
+  });
+
+  it("STEF + import/type/interface still returns one atom via decompose()", async () => {
+    const source = `
+import { something } from "elsewhere";
+export type Foo = number;
+export interface Bar { x: number; }
+/** doc */
+export function fn(x: number): number { return x; }
+`.trim();
+
+    const tree = await decompose(source, emptyRegistry);
+
+    expect(tree.leafCount).toBe(1);
+    expect(tree.root.kind).toBe("atom");
+    if (tree.root.kind === "atom") {
+      expect(tree.root.atomTest.reason).toBe("single-typed-exported-function");
+    }
+  });
+
+  it("parse-rfc3339-utc shape (export interface + export function) returns one atom", async () => {
+    const source = `
+/** Result components of a parsed RFC 3339 datetime. */
+export interface Components {
+  year: number;
+  month: number;
+}
+/** Parse an RFC 3339 datetime string into its components. */
+export function parse(s: string): Components {
+  return { year: 2026, month: 1 };
+}
+`.trim();
+
+    const tree = await decompose(source, emptyRegistry);
+
+    expect(tree.leafCount).toBe(1);
+    expect(tree.root.kind).toBe("atom");
+    if (tree.root.kind === "atom") {
+      expect(tree.root.atomTest.reason).toBe("single-typed-exported-function");
+    }
+  });
+});

--- a/packages/shave/src/universalize/stef.ts
+++ b/packages/shave/src/universalize/stef.ts
@@ -90,9 +90,7 @@ function isExportedArrowOrFnConstDeclaration(node: Node): boolean {
   const vs = node as Node & {
     hasModifier(kind: SyntaxKind): boolean;
     getDeclarationList(): Node & {
-      getDeclarations(): Array<
-        Node & { getInitializer(): Node | undefined }
-      >;
+      getDeclarations(): Array<Node & { getInitializer(): Node | undefined }>;
     };
   };
   if (!vs.hasModifier(SyntaxKind.ExportKeyword)) return false;
@@ -109,14 +107,14 @@ function isExportedArrowOrFnConstDeclaration(node: Node): boolean {
  * `isExportedFunctionDeclaration` or `isExportedArrowOrFnConstDeclaration`.
  * Returns `undefined` if the node is neither.
  */
-function extractFunctionLike(
-  node: Node,
-): (Node & {
-  getParameters(): Array<Node & { getTypeNode(): Node | undefined }>;
-  getReturnTypeNode(): Node | undefined;
-  getJsDocs(): Node[];
-  getBody(): Node | undefined;
-}) | undefined {
+function extractFunctionLike(node: Node):
+  | (Node & {
+      getParameters(): Array<Node & { getTypeNode(): Node | undefined }>;
+      getReturnTypeNode(): Node | undefined;
+      getJsDocs(): Node[];
+      getBody(): Node | undefined;
+    })
+  | undefined {
   if (node.getKind() === SyntaxKind.FunctionDeclaration) {
     return node as Node & {
       getParameters(): Array<Node & { getTypeNode(): Node | undefined }>;
@@ -128,9 +126,7 @@ function extractFunctionLike(
   if (node.getKind() === SyntaxKind.VariableStatement) {
     const vs = node as Node & {
       getDeclarationList(): Node & {
-        getDeclarations(): Array<
-          Node & { getInitializer(): Node | undefined }
-        >;
+        getDeclarations(): Array<Node & { getInitializer(): Node | undefined }>;
       };
     };
     const init = vs.getDeclarationList().getDeclarations()[0]?.getInitializer();

--- a/packages/shave/src/universalize/stef.ts
+++ b/packages/shave/src/universalize/stef.ts
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: MIT
+/**
+ * @decision DEC-SHAVE-WHOLE-FUNCTION-PRESERVATION-001
+ * title: STEF (Single Typed Exported Function) predicate for decompose() fast-path
+ * status: decided
+ * rationale:
+ *   `decompose()` fragments a SourceFile that contains exactly one exported
+ *   function with multiple control-flow boundaries into statement-level atoms,
+ *   each producing an empty-signature SpecYak (`inputs:[]`, `outputs:[]`,
+ *   `behavior:"source fragment (N statements, M bytes)"`). This destroys the
+ *   round-trip retrieval signal that Step 9 of v0-release-smoke depends on
+ *   (root cause of #444/#523/#549).
+ *
+ *   For a SourceFile that IS a single typed exported function (STEF shape), the
+ *   *maximal* shaveable subgraph is the whole file — there is no glue to carve
+ *   away. Preserving it as one atom lets `staticExtract` / `pickPrimaryDeclaration`
+ *   find the exported function at priority 2, producing a rich SpecYak with
+ *   non-empty inputs/outputs.
+ *
+ *   This is a **refinement, not a reversal** of DEC-V2-GLUE-AWARE-SHAVE-001:
+ *   STEF is the degenerate case where fragmentation strictly destroys signal.
+ *   All non-STEF files continue through the glue-aware fragmentation path
+ *   unchanged.
+ *
+ *   Companion to DEC-EMBED-QUERY-ENRICH-HELPER-001: that decision closed the
+ *   query-side field-coverage asymmetry; this decision closes the store-side
+ *   fragmentation root cause. Together they constitute the complete fix for the
+ *   v0 round-trip retrieval failure.
+ *
+ * STEF predicate (§3.3 of plans/wi-fix-549-shave-fragmentation.md):
+ *   A SourceFile matches STEF when ALL of:
+ *   1. Exactly one top-level exported function-like declaration (FunctionDeclaration
+ *      OR VariableStatement with a single arrow/function-expression initializer).
+ *   2. All parameters have explicit TS type annotations (no implicit any); zero
+ *      parameters is permitted.
+ *   3. Explicit return type annotation.
+ *   4. Non-empty JSDoc block (/** … *‌/) on the function or enclosing VariableStatement.
+ *   5. All other top-level statements restricted to: ImportDeclaration,
+ *      ExportDeclaration (re-export), TypeAliasDeclaration, InterfaceDeclaration.
+ *      Any other form (second function, class, bare const, expression statement)
+ *      causes STEF to return false.
+ *   6. The function body is non-empty (Block with at least one statement).
+ *
+ * Authority invariant:
+ *   - STEF is a SourceFile-level predicate. It does NOT modify isAtom() (per-node).
+ *   - pickPrimaryDeclaration and extractSignatureFromNode are not modified; they
+ *     operate on the full source once STEF returns a single-leaf tree.
+ *   - This module is the single canonical authority for the STEF predicate.
+ *     Callers must not re-implement it.
+ */
+
+import { type Node, type SourceFile, SyntaxKind } from "ts-morph";
+
+// ---------------------------------------------------------------------------
+// Allowed noise kinds at the top level (per plan §3.3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Top-level SyntaxKinds that are "permitted noise" — non-executing forms that
+ * carry no shaveable behavior and do not disqualify a SourceFile from STEF.
+ */
+const STEF_PERMITTED_NOISE_KINDS = new Set<SyntaxKind>([
+  SyntaxKind.ImportDeclaration,
+  SyntaxKind.ExportDeclaration, // re-exports without value semantics
+  SyntaxKind.TypeAliasDeclaration,
+  SyntaxKind.InterfaceDeclaration,
+]);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return true if `node` is a FunctionDeclaration with the `export` modifier.
+ */
+function isExportedFunctionDeclaration(node: Node): boolean {
+  if (node.getKind() !== SyntaxKind.FunctionDeclaration) return false;
+  const fn = node as Node & {
+    hasModifier(kind: SyntaxKind): boolean;
+  };
+  return fn.hasModifier(SyntaxKind.ExportKeyword);
+}
+
+/**
+ * Return true if `node` is a VariableStatement with `export` modifier whose
+ * single declarator has an ArrowFunction or FunctionExpression initializer.
+ */
+function isExportedArrowOrFnConstDeclaration(node: Node): boolean {
+  if (node.getKind() !== SyntaxKind.VariableStatement) return false;
+  const vs = node as Node & {
+    hasModifier(kind: SyntaxKind): boolean;
+    getDeclarationList(): Node & {
+      getDeclarations(): Array<
+        Node & { getInitializer(): Node | undefined }
+      >;
+    };
+  };
+  if (!vs.hasModifier(SyntaxKind.ExportKeyword)) return false;
+  const decls = vs.getDeclarationList().getDeclarations();
+  if (decls.length !== 1) return false;
+  const init = decls[0]?.getInitializer();
+  if (init === undefined) return false;
+  const k = init.getKind();
+  return k === SyntaxKind.ArrowFunction || k === SyntaxKind.FunctionExpression;
+}
+
+/**
+ * Extract the function-like node from a top-level statement that passed
+ * `isExportedFunctionDeclaration` or `isExportedArrowOrFnConstDeclaration`.
+ * Returns `undefined` if the node is neither.
+ */
+function extractFunctionLike(
+  node: Node,
+): (Node & {
+  getParameters(): Array<Node & { getTypeNode(): Node | undefined }>;
+  getReturnTypeNode(): Node | undefined;
+  getJsDocs(): Node[];
+  getBody(): Node | undefined;
+}) | undefined {
+  if (node.getKind() === SyntaxKind.FunctionDeclaration) {
+    return node as Node & {
+      getParameters(): Array<Node & { getTypeNode(): Node | undefined }>;
+      getReturnTypeNode(): Node | undefined;
+      getJsDocs(): Node[];
+      getBody(): Node | undefined;
+    };
+  }
+  if (node.getKind() === SyntaxKind.VariableStatement) {
+    const vs = node as Node & {
+      getDeclarationList(): Node & {
+        getDeclarations(): Array<
+          Node & { getInitializer(): Node | undefined }
+        >;
+      };
+    };
+    const init = vs.getDeclarationList().getDeclarations()[0]?.getInitializer();
+    if (init === undefined) return undefined;
+    const k = init.getKind();
+    if (k === SyntaxKind.ArrowFunction || k === SyntaxKind.FunctionExpression) {
+      return init as Node & {
+        getParameters(): Array<Node & { getTypeNode(): Node | undefined }>;
+        getReturnTypeNode(): Node | undefined;
+        getJsDocs(): Node[];
+        getBody(): Node | undefined;
+      };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Return true if `fnNode` satisfies the STEF function-level requirements:
+ *   - all parameters have explicit type annotations (zero params also passes)
+ *   - explicit return type annotation
+ *   - at least one non-empty JSDoc block
+ *   - non-empty body (Block with ≥ 1 statement)
+ *
+ * For VariableStatement-wrapped arrow/fn-expressions, `enclosingNode` is the
+ * VariableStatement (JSDoc lives on the var statement in ts-morph for arrow-const).
+ */
+function functionLikeSatisfiesStef(
+  fnNode: Node & {
+    getParameters(): Array<Node & { getTypeNode(): Node | undefined }>;
+    getReturnTypeNode(): Node | undefined;
+    getJsDocs(): Node[];
+    getBody(): Node | undefined;
+  },
+  enclosingNode: Node,
+): boolean {
+  // 1. All parameters must have explicit type annotations (implicit any → false).
+  const params = fnNode.getParameters();
+  for (const param of params) {
+    if (param.getTypeNode() === undefined) return false;
+  }
+
+  // 2. Explicit return type annotation.
+  if (fnNode.getReturnTypeNode() === undefined) return false;
+
+  // 3. Non-empty JSDoc block.
+  //    For arrow-const, JSDoc attaches to the VariableStatement in ts-morph.
+  //    Try the function node first; fall back to the enclosing node.
+  const jsDocs =
+    fnNode.getJsDocs().length > 0
+      ? fnNode.getJsDocs()
+      : (() => {
+          const enc = enclosingNode as Node & { getJsDocs?(): Node[] };
+          return enc.getJsDocs?.() ?? [];
+        })();
+  if (jsDocs.length === 0) return false;
+
+  // 4. Non-empty body (Block with ≥ 1 statement).
+  const body = fnNode.getBody();
+  if (body === undefined) return false;
+  if (body.getKind() !== SyntaxKind.Block) return false;
+  const bodyStatements = (body as Node & { getStatements(): Node[] }).getStatements();
+  if (bodyStatements.length === 0) return false;
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Return true when the parsed `sourceFile` matches the STEF (Single Typed
+ * Exported Function) predicate, meaning `decompose()` should return a single
+ * AtomLeaf covering the entire source range rather than fragmenting the file.
+ *
+ * The predicate is intentionally narrow (per plan §3.3 and OD-1). Any shape
+ * outside STEF continues through the normal glue-aware fragmentation path.
+ *
+ * @param sourceFile - A ts-morph SourceFile already parsed from the source text.
+ */
+export function matchesStefPredicate(sourceFile: SourceFile): boolean {
+  const statements = sourceFile.getStatements();
+
+  let functionLikeCount = 0;
+  let candidateFunctionNode: Node | undefined;
+
+  for (const stmt of statements) {
+    const kind = stmt.getKind();
+
+    if (STEF_PERMITTED_NOISE_KINDS.has(kind)) {
+      // Permitted noise — continue scanning.
+      continue;
+    }
+
+    // Check whether this statement is the (sole) exported function-like.
+    if (isExportedFunctionDeclaration(stmt) || isExportedArrowOrFnConstDeclaration(stmt)) {
+      functionLikeCount += 1;
+      if (functionLikeCount > 1) {
+        // More than one function-like → STEF fails immediately.
+        return false;
+      }
+      candidateFunctionNode = stmt;
+      continue;
+    }
+
+    // Any other top-level form disqualifies the file from STEF.
+    return false;
+  }
+
+  // Must have exactly one exported function-like.
+  if (functionLikeCount !== 1 || candidateFunctionNode === undefined) return false;
+
+  // Extract the actual function-like node (the FunctionDeclaration itself, or
+  // the ArrowFunction/FunctionExpression initializer of the VariableStatement).
+  const fnLike = extractFunctionLike(candidateFunctionNode);
+  if (fnLike === undefined) return false;
+
+  // Validate function-level STEF requirements.
+  return functionLikeSatisfiesStef(fnLike, candidateFunctionNode);
+}

--- a/packages/shave/src/universalize/types.ts
+++ b/packages/shave/src/universalize/types.ts
@@ -67,7 +67,8 @@ export type AtomTestReason =
   | "too-many-cf-boundaries"
   | "contains-known-primitive"
   | "non-decomposable-non-atom"
-  | "loop-with-escaping-cf";
+  | "loop-with-escaping-cf"
+  | "single-typed-exported-function";
 
 /**
  * The result returned by isAtom().


### PR DESCRIPTION
## Summary
Adds the STEF (Single Typed Exported Function) predicate fast-path inside `decompose()` at `packages/shave/src/universalize/recursion.ts`. When a SourceFile IS a single typed exported function with JSDoc, preserve it as one atom instead of fragmenting into statement-level expressions with empty signatures.

This is P0 of `plans/wi-fix-549-shave-fragmentation.md` (PR #550). Structural fix for the #444/#523 residual root cause surfaced by P3's investigation.

## Why
P3's investigation proved the residual #444/#523 asymmetry is in `shave/universalize`, not in the query side. `countControlFlowBoundaries` doesn't stop at function boundaries; `DEFAULT_MAX_CF_BOUNDARIES=1` trips on any function with control flow (e.g. `arrayMedian`'s `if + ternary = 2 boundaries`). The function gets shredded into 4 statement atoms, each with empty `inputs/outputs` because `pickPrimaryDeclaration` returns `undefined` for non-function-declaration fragments.

The fix is NOT to lower the CF boundary threshold (that would break glue-aware shave). It's to add a SourceFile-level fast-path: when the file IS a single typed exported function with JSDoc, the trivial maximal shaveable subgraph IS the whole file — `DEC-V2-GLUE-AWARE-SHAVE-001` refinement, not reversal.

## What's in
- `packages/shave/src/universalize/stef.ts` (new, 254 lines) — `matchesStefPredicate` + helpers, `@decision DEC-SHAVE-WHOLE-FUNCTION-PRESERVATION-001`
- `packages/shave/src/universalize/stef.test.ts` (new, 222 lines) — 11 tests
- `packages/shave/src/universalize/recursion.ts` (+30) — fast-path at top of `decompose()`, uses `file.getFullStart()` for range start
- `packages/shave/src/universalize/types.ts` (+1 net) — new `"single-typed-exported-function"` variant in AtomTestReason

## STEF predicate (per plan §3.3)
Accepts when ALL:
1. Exactly one exported function declaration OR arrow/fn const export
2. All parameters have explicit type annotations
3. Explicit return type
4. Non-empty JSDoc
5. Other top-level forms restricted to: `ImportDeclaration`, `TypeAliasDeclaration`, `InterfaceDeclaration`

Else: predicate returns false, decompose falls through to existing glue-aware fragmentation path.

## Verification
| Surface | Result |
|---|---|
| stef.test.ts | 11/11 pass |
| recursion.test.ts (regression) | 42/42 pass |
| Full shave suite | 880 pass / 6 skip / 1 fail (pre-existing #541 timeout, not a regression) |
| `pnpm -r build` | clean (19 packages) |

## Reviewer findings (R0 ready_for_guardian, zero blockers)
- **Concern**: `types.props.ts` ATOM_TEST_REASONS set still 5-member; should be 6. Non-blocking because `isAtom()` never emits the new variant (STEF bypasses isAtom). Stale documentation only; can be cleaned up in a follow-up.
- **Notes**: `controlFlowBoundaryCount` hardcoded 0 in fast-path (semantically correct; diagnostic-only field). `export default function` falls through to fragmentation (plan §6 R3 accepts this as conservative). New union variant not consumed by production switches (expected for diagnostic discriminant).

## What this PR does NOT do
- Does NOT terminate issues #444/#523/#549. **P1 of the plan** (empirical bench re-run of v0-smoke Step 9 + B7 commit) verifies that the structural fix actually moves the round-trip BMR-in-top-K check from FAIL to PASS. Until that bench evidence lands, those issues stay open.
- No query-side changes (P0/P1a/P1b/P2 of the #523 plan already shipped that work)
- No threshold changes
- No `packages/contracts/` or `packages/hooks-base/` changes

## Issue references
Refs #444, #502, #523, #535, #549, #528 (plan PR), #532, #536, #538, #540 (merged P-slices), DEC-V2-GLUE-AWARE-SHAVE-001, DEC-EMBED-QUERY-ENRICH-HELPER-001, DEC-SHAVE-WHOLE-FUNCTION-PRESERVATION-001.

**P1 of the plan is where #444/#523/#549 get terminated** — when v0-smoke Step 9 + B7 commit re-run shows the structural fix actually moves the round-trip gap.