### PR TITLE
chore(bench/B4-tokens): mark #442 Slice 1 triage complete in corpus-spec (closes #442)

### DIFF
--- a/bench/B4-tokens/corpus-spec.json
+++ b/bench/B4-tokens/corpus-spec.json
@@ -3,6 +3,14 @@
   "schema_version": 1,
   "slice": 1,
   "n_tasks": 3,
+  "triage_status": "complete",
+  "triage_completed_at": "2026-05-15",
+  "triage_summary": {
+    "kill_verdict": "withdrawn — reclassified as first data point on B4 sweep (see issue #442 comment, 2026-05-13)",
+    "csv_parser_correctness": "resolved — hook-substitution correctness regression fixed in #450 (closed 2026-05-13); arm-A oracle now matches arm-B baseline",
+    "debounce_non_engagement": "root-caused in #451, remediated in #454 (both closed 2026-05-13); timer-handle atom seeded; registry rebuild surfaces it as PARTIAL in REGISTRY_COVERAGE.md",
+    "open_items": "none — all Slice 1 triage actions landed; Slice 2 sweep continues under #167 characterisation initiative"
+  },
   "tasks": [
     {
       "id": "lru-cache-with-ttl",

--- a/bench/B4-tokens/corpus-spec.test.mjs
+++ b/bench/B4-tokens/corpus-spec.test.mjs
@@ -68,6 +68,13 @@ assert(typeof spec.description === "string", "spec has description field");
 assert(typeof spec.schema_version === "number", "spec has schema_version field");
 assert(Array.isArray(spec.tasks), "spec has tasks array");
 
+// Test 2b: Triage completion fields (added when #442 Slice 1 triage was closed)
+assert(spec.triage_status === "complete", "spec.triage_status is 'complete'");
+assert(typeof spec.triage_summary === "object" && spec.triage_summary !== null, "spec.triage_summary exists");
+assert(typeof spec.triage_summary.kill_verdict === "string", "triage_summary.kill_verdict is documented");
+assert(typeof spec.triage_summary.csv_parser_correctness === "string", "triage_summary.csv_parser_correctness is documented");
+assert(typeof spec.triage_summary.debounce_non_engagement === "string", "triage_summary.debounce_non_engagement is documented");
+
 // Test 3: debounce-with-cancel entry exists
 const debounceEntry = spec.tasks.find((t) => t.id === "debounce-with-cancel");
 assert(debounceEntry !== undefined, "tasks array contains debounce-with-cancel entry");


### PR DESCRIPTION
## Summary

- Both triage actions from the B4-tokens KILL reclassification are confirmed done: csv-parser correctness fixed by #450, debounce non-engagement root-caused in #451 and remediated by #454 (timer-handle atom seeded)
- Adds `triage_status`, `triage_completed_at`, and `triage_summary` fields to `bench/B4-tokens/corpus-spec.json` so the Slice 1 historical artifact records the resolution explicitly
- Extends `bench/B4-tokens/corpus-spec.test.mjs` with 5 new assertions validating the triage completion fields (26 total, was 21)

## Test evidence

```
============================================================
corpus-spec.json validation for B4-tokens
============================================================
  PASS: corpus-spec.json exists at bench/B4-tokens/corpus-spec.json
  PASS: corpus-spec.json is valid JSON
  PASS: spec has description field
  PASS: spec has schema_version field
  PASS: spec has tasks array
  PASS: spec.triage_status is 'complete'
  PASS: spec.triage_summary exists
  PASS: triage_summary.kill_verdict is documented
  PASS: triage_summary.csv_parser_correctness is documented
  PASS: triage_summary.debounce_non_engagement is documented
  PASS: tasks array contains debounce-with-cancel entry
  PASS: debounce-with-cancel has hook_engagement: 'none'
  ...
Results: 26 passed, 0 failed
```

Closes #442

🤖 Picked up by FuckGoblin

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2v7beBkdZ1wyyyQxLavkr)_