### PR TITLE
docs(551): WI-551-S1 reproduction reveals registry staleness, not M3 dedupe (closes #561, refs #551)

### DIFF
--- a/plans/wi-551-compile-self-recon-gap.md
+++ b/plans/wi-551-compile-self-recon-gap.md
@@ -1,0 +1,309 @@
+# WI-551 — Compile-self reconstruction gap: 82 divergent roots
+
+**Status:** planning (planner stage of `wi-551-compile-self-recon-gap`)
+**Issue:** [#551](https://github.com/cneckar/yakcc/issues/551)
+**Branch the runtime expected:** `feature/551-compile-self-recon-gap` (not yet created — see §10)
+**Cross-refs:** #494 (original two-pass), #520 (seed-triplet fix), #545 (props-files class, CLOSED), #543 (import-intercept CanonicalAstParseError)
+
+---
+
+## 1. Problem statement
+
+After #545 closed the props-files axis (45-46 roots) and #543 isolated the
+`import-intercept.ts` CanonicalAstParseError (1057 gap rows), the two-pass
+T3 byte-identity test still fails with **82 divergent atom roots across 10
+source files**. Divergent here means: an atom's `blockMerkleRoot` produced
+by pass-1 shave (fresh canonical source) differs from the `blockMerkleRoot`
+produced by pass-2 shave (source reconstructed by `yakcc compile-self`).
+
+The 10 files all shave successfully on both passes — unlike
+`import-intercept.ts` (#543) which fails to shave at all on pass 2. They
+produce *different* atoms because the reconstructed source differs from the
+canonical source in ways that perturb at least one atom's `implSource`
+bytes per file.
+
+| File | Roots |
+|---|---:|
+| packages/registry/src/index.ts | 29 |
+| packages/registry/src/storage.ts | 17 |
+| packages/shave/src/intent/static-extract.ts | 13 |
+| packages/shave/src/errors.ts | 6 |
+| packages/contracts/src/source-extract.ts | 6 |
+| packages/shave/src/universalize/slicer.ts | 5 |
+| packages/cli/src/commands/bootstrap.ts | 2 |
+| 3 more files | 1 each |
+| **Total** | **82** |
+
+T3 byte-identity for the whole corpus cannot reach `divergent=0` until this
+class is addressed.
+
+## 2. Investigation evidence (read-only)
+
+Captured in `tmp/wi-551-investigation/`:
+
+- `algorithm-analysis.md` — How the compile-self reconstruction algorithm
+  can produce sources that re-shave to different atom merkle roots.
+  Enumerates five mechanisms (M1–M5) and ranks them.
+- `file-profile.md` — Feature profile of the 10 hot files; rules out two
+  hypotheses from the issue body (re-export aggregation, type-system
+  reformatting) by direct inspection.
+
+No fresh `compile-self` run was executed (heavy compute, out of planner
+scope). The on-disk `dist-recompiled/` directories are stale (empty top-level
+or pre-P2 hash-keyed layout in `tmp/two-pass/`). The implementer slice
+defined in §6 carries the reproduction step.
+
+## 3. Hypothesis and categorization
+
+The cluster pattern strongly supports a single root mechanism with a long
+tail:
+
+### Primary mechanism: **M3 — atom dedupe across files with whitespace divergence**
+
+`bootstrap.ts` Pass A persists atoms via `INSERT OR IGNORE` keyed by
+`blockMerkleRoot`. `blocks.implSource` is set the **first time** the atom
+is observed in the corpus and is never overwritten. `block_occurrences`
+records the atom's position per file and is refreshed atomically per file
+on every bootstrap (`DEC-STORAGE-IDEMPOTENT-001`).
+
+Consequence: when the same canonical-AST appears in multiple files with
+slightly different surrounding bytes (different indentation, different
+whitespace at the slice boundary), all occurrences are deduped to the
+first-observed `blockMerkleRoot`. `compile-self` reconstruction emits the
+**first-observed bytes** at every occurrence in every file. Pass-2 shave
+then re-extracts the atom from the recompiled source, computes a
+`blockMerkleRoot` over the **current file's bytes**, and gets a different
+result → counted as divergent.
+
+This explains:
+
+- **Interface/class density correlation.** `registry/src/index.ts`
+  (21 interfaces) and `errors.ts` (6 classes) score highest in
+  small-declaration density. Small declarations have stable
+  canonical-AST shapes and are statistically more likely to collide at
+  `canonicalAstHash` than large function bodies.
+- **The ~2.4% rate** (82 of ~3452 atoms). M3 is not catastrophic — only
+  atoms whose dedupe target has bytewise-different surrounding context
+  diverge.
+- **The 1-root tail files.** These have a single declaration whose
+  canonical-AST matches another file's atom with different bytes.
+
+### Long-tail mechanism: **M2 — atom-end trivia attribution edge cases**
+
+For some `Node.getEnd()` cases (ASI / no-semicolon / trailing-comment
+boundaries) ts-morph can return a position that includes or excludes
+trailing trivia inconsistently. If pass-1 and pass-2 disagree on the end
+boundary, `implSource` shifts by a few bytes → new merkle root. Likely
+accounts for a small fraction of the 82.
+
+### Rejected hypotheses
+
+- **Re-export aggregation flattening** — no file uses `export *` (verified
+  by grep across all 10 named files).
+- **Type-system reformatting (conditional types, mapped types, template
+  literal types)** — no file uses `infer ` or `extends ... ?` (verified
+  by grep).
+- **`@decision` annotation stripping** — `@decision` blocks live in glue
+  (they're leading trivia for declarations and `getStart()` skips trivia
+  by default). Glue is captured verbatim by `captureSourceFileGlue` and
+  re-emitted verbatim by `compile-self`. They cannot directly cause
+  atom-byte drift, though they're abundant in the cluster.
+
+### Estimated bucket distribution (best-effort, no live diff)
+
+| Bucket | Mechanism | Estimated roots |
+|---|---|---:|
+| A | M3: atom dedupe across files with byte-different context | ~65 |
+| B | M2: atom-end trivia attribution edge cases | ~15 |
+| C | Other (unclassified until live diff) | ≤5 |
+
+§6's first slice carries the diff that will sharpen these estimates.
+
+## 4. Fix-locus decision
+
+The issue body lists four options. Recommendation:
+
+**Primary: (a) Fix `compile-self` to preserve more source fidelity.**
+
+Rationale:
+
+- **The bug is in the registry's atom-dedupe model, not in shave.** Shave
+  computes correct atoms on both passes; both atoms have the same
+  canonical-AST. The registry conflates them at `blockMerkleRoot` because
+  `INSERT OR IGNORE` accepts whichever was observed first.
+- **The two-pass test asserts byte-identity is the gate** for T3. Carving
+  out files (option c) defers the architectural fix instead of resolving
+  it — and the divergent set will silently grow as new files matching the
+  same canonical-AST collide.
+- **The fix is localized.** The dedupe model can be extended to record
+  per-occurrence `implSource` bytes when they differ from the
+  first-observed bytes, OR `compile-self` can reconstruct per-occurrence
+  bytes by reading the original source-text slice from the canonical
+  source (which means `compile-self` would need to know what the source
+  used to look like — see §6 design tradeoff).
+
+Rejected:
+
+- **(b) Make shave tolerant** — perturbs the shave invariant that
+  `implSource` is verbatim source text. Breaks proof-system assumptions
+  downstream.
+- **(c) Accept divergence + carve out** — silently grows; loses the T3
+  bar permanently for new files entering the cluster.
+- **(d) Hybrid (a)+(c)** — could be a fallback if (a) turns out to be
+  prohibitively expensive in registry storage, but should not be the
+  starting point.
+
+## 5. State-authority map (affected surfaces)
+
+| Domain | Canonical authority | Touched by fix? |
+|---|---|---|
+| Atom storage (blocks table) | `packages/registry/src/storage.ts` `storeBlock` | Yes if extending dedupe |
+| Atom occurrence (per-file position) | `block_occurrences` table; `getAtomRangesBySourceFile` | Read-only; already accurate |
+| Glue blob (per-file) | `source_file_glue` table; `captureSourceFileGlue` | Likely read-only |
+| Reconstruction | `compile-self._runPipeline` | Yes — emits the wrong bytes today |
+| Atom extraction | `packages/shave/src/universalize/recursion.ts` | Read-only |
+| Canonical-AST hash | `packages/contracts/src/canonical-ast.ts` | Read-only |
+
+**The fix bundle MUST land registry + compile-self + invariant test
+together.** No parallel authorities (Sacred Practice #12).
+
+## 6. First implementation slice (WI-551-S1)
+
+### Title
+Reproduce + confirm M3 on `packages/registry/src/index.ts` (29 roots).
+
+### Scope (bounded — 1 PR, 1 day)
+
+1. **Reproduction harness** (read-only):
+   - Run `yakcc compile-self --output tmp/wi-551-recompiled` against the
+     committed `bootstrap/yakcc.registry.sqlite`. Capture stdout +
+     manifest.json.
+   - Diff `tmp/wi-551-recompiled/packages/registry/src/index.ts` against
+     `packages/registry/src/index.ts`. Capture as
+     `tmp/wi-551-investigation/registry-index-diff.{txt,md}`.
+   - For each diff hunk, locate the affected atom's `blockMerkleRoot` via
+     `manifest.json`, query `blocks.implSource` for that root, and
+     identify the **first-observed file** that supplied those bytes.
+   - Tabulate: `(merkleRoot, current-file-bytes, first-observed-file,
+     first-observed-bytes, byte-delta-character-class)`.
+   - Confirms M3 if at least 24 of the 29 roots (~80%) are dedupes from
+     a different file with byte-different bytes.
+
+2. **Categorization deliverable**: `tmp/wi-551-investigation/m3-evidence.md`
+   tabulating the 29 roots and their dedupe sources. No fix code in this
+   slice.
+
+3. **Decide between two implementation options for the next slice (S2)**:
+   - **S2-Option-A**: Extend the `blocks` table with a per-occurrence
+     `implSource` override column, populated when dedupe finds
+     byte-different bytes. `compile-self` prefers the override when
+     present. Pros: minimal storage change. Cons: requires migration.
+   - **S2-Option-B**: `compile-self` reconstructs `implSource` per
+     occurrence by re-slicing from a per-file "atom-byte-overrides" blob
+     stored alongside the glue blob. Pros: localized to compile-self +
+     bootstrap. Cons: doubles per-file storage in worst case.
+   - Record the decision in `plans/wi-551-s1.md` as DEC-WI-551-S1-IMPL.
+
+### Acceptance (S1 only)
+
+- `tmp/wi-551-investigation/registry-index-diff.md` exists and shows the
+  29-root diff hunks against canonical source.
+- `tmp/wi-551-investigation/m3-evidence.md` tabulates each of the 29
+  roots with `first-observed-file` and `byte-delta` columns.
+- A DEC-WI-551-S1-IMPL row is appended to `plans/wi-551-s1.md` naming
+  the chosen S2 path (A or B) with rationale.
+- No source files edited under `packages/**`.
+
+### Out of scope (S1)
+
+- Building the fix itself (S2's job).
+- Reproducing for all 10 files (S1 covers the 29-root canary; if M3 is
+  confirmed there, it's confirmed for the cluster).
+- Touching the other 9 hot files' atom-extraction code.
+
+### Pre-push hygiene (S1 acceptance evidence)
+
+Per global memory `feedback_branch_must_track_origin_main`:
+
+- `git fetch origin && git diff --stat origin/main..HEAD` shows ONLY the
+  S1 investigation artifacts under `tmp/wi-551-investigation/` and
+  `plans/wi-551-s1.md`.
+- `pnpm -w lint` and `pnpm -w typecheck` pass (no source edits, so these
+  should be near-instant — but they still run in CI).
+- No `packages/**` files in the diff.
+
+## 7. Evaluation Contract (WI-551-S1)
+
+| Field | Value |
+|---|---|
+| Required tests | None (read-only investigation). Existing `examples/v2-self-shave-poc/test/two-pass-equivalence.test.ts` must still be skipped/red as before — S1 does not flip it. |
+| Required real-path checks | (a) `yakcc compile-self` executes against current registry without error. (b) `manifest.json` parses as the expected shape `Array<{outputPath, blockMerkleRoot, sourcePkg, sourceFile, sourceOffset}>`. (c) Output diff against canonical `registry/src/index.ts` is non-empty (proves the divergence is reproducible). |
+| Required authority invariants | `block_occurrences` and `blocks.implSource` are read-only during S1. No writes to the SQLite registry. |
+| Required integration points | None changed. S1 reads from `bootstrap/yakcc.registry.sqlite` and writes to `tmp/wi-551-investigation/`. |
+| Forbidden shortcuts | (1) NEVER edit any file under `packages/**` in S1. (2) NEVER write a fix that "looks plausible" without the diff evidence. (3) NEVER carve out the 10 files from the two-pass test as a stopgap — that's option (c) above and was explicitly rejected. (4) NEVER claim S1 done if the diff is empty (would mean reproduction failed; investigate why instead). |
+| Ready-for-guardian when | All three S1 acceptance artifacts (registry-index-diff.md, m3-evidence.md, DEC-WI-551-S1-IMPL row) exist, the diff is non-empty, the m3-evidence table covers all 29 roots, pre-push hygiene passes, and the implementer/reviewer agree on the S2 implementation choice. |
+
+## 8. Scope Manifest (WI-551-S1)
+
+| Field | Value |
+|---|---|
+| Allowed paths | `tmp/wi-551-investigation/**`, `tmp/wi-551-recompiled/**` (compile-self output), `plans/wi-551-s1.md` |
+| Required paths | `tmp/wi-551-investigation/registry-index-diff.md`, `tmp/wi-551-investigation/m3-evidence.md`, `plans/wi-551-s1.md` |
+| Forbidden touch points | `packages/**`, `src/**`, `.github/**`, `.claude/**`, `MASTER_PLAN.md`, `bootstrap/yakcc.registry.sqlite` (read-only — do NOT regenerate during S1) |
+| Expected state authorities touched | None (read-only on registry; writes only to tmp + plans) |
+
+## 9. Risks
+
+1. **False-negative reproduction.** If the registry on `main` has been
+   regenerated since #545 landed, the divergent set may have shifted.
+   Mitigation: S1 captures the actual current divergent count from
+   `compile-self` output and notes any delta from the issue body's 82.
+2. **M3 not confirmed.** If the diff evidence does not show cross-file
+   dedupe, the primary mechanism is wrong and S2 needs re-planning. S1
+   acceptance includes "the m3-evidence table shows the dedupe pattern"
+   — if it doesn't, S1 returns to planner with a revised hypothesis,
+   not to S2.
+3. **Compile-self fix breaks other invariants.** The S2 fix touches the
+   registry's dedupe authority. Risk: existing federation / corpus
+   distribution invariants assume single-`implSource`-per-merkle-root.
+   Mitigation: S2 plan must include an invariant audit before any code.
+4. **Storage bloat (S2-Option-A).** Per-occurrence implSource overrides
+   could in the worst case double atom storage. Probably not — the 82
+   divergent roots are a tiny fraction — but the S2 plan must measure
+   actual delta on the yakcc corpus before committing.
+
+## 10. Runtime/branch state note
+
+The ClauDEX dispatch contract names `feature/551-compile-self-recon-gap`
+as the workflow branch with worktree `.worktrees/feature-551-compile-self-recon-gap`.
+**Neither exists** on the current host at planner-stage start. This planner
+ran against the main checkout, producing only governance artifacts (this
+plan + `tmp/wi-551-investigation/`). Source edits remain forbidden on main.
+
+Before S1 implementer dispatch, Guardian provisioning must:
+
+1. Create the worktree at the runtime-named path.
+2. Set up the branch to track `origin/main` (per memory
+   `feedback_branch_must_track_origin_main`).
+3. Sync the Scope Manifest in §8 via
+   `cc-policy workflow scope-sync wi-551-compile-self-recon-gap --work-item-id wi-551-s1 --scope-file <file>`.
+
+## 11. #551 final state
+
+Multi-mechanism (M3 primary, M2 tail, possibly others). **#551 becomes the
+meta-issue.** The first slice (WI-551-S1 above) is its actionable child. The
+issue body should be updated to reflect:
+
+- Mechanism categorization from this plan
+- Link to plans/wi-551-compile-self-recon-gap.md
+- Link to the S1 child issue (to be filed by the orchestrator)
+- #551 stays OPEN until divergent count hits 0 (covers S1 confirming
+  reproduction + S2 implementing fix + S3 verifying the other 9 files)
+
+## 12. Decision log entries (this plan)
+
+| DEC-ID | Decision | Rationale |
+|---|---|---|
+| DEC-WI-551-FIX-LOCUS-001 | Primary fix locus is `compile-self` + registry dedupe model (option a), not shave tolerance or carve-out | §4 |
+| DEC-WI-551-REJECT-CARVEOUT-001 | Carving the 10 files out of T3 byte-identity is rejected | §4 — silently grows the divergent set; loses the T3 bar permanently |
+| DEC-WI-551-S2-OPTIONS-001 | S2 has two viable implementation paths (per-occurrence override column OR per-file override blob); pick in S1 based on diff evidence | §6 — need actual byte-delta data before committing to either storage shape |

--- a/plans/wi-551-s1.md
+++ b/plans/wi-551-s1.md
@@ -1,0 +1,213 @@
+# WI-551-S1: Reproduce compile-self divergence on registry/src/index.ts
+
+**Status:** complete (investigation done; finding diverges from planner hypothesis)  
+**Issue:** [#561](https://github.com/cneckar/yakcc/issues/561)  
+**Branch:** `feature/561-s1-registry-recon`  
+**Parent plan:** `plans/wi-551-compile-self-recon-gap.md`
+
+---
+
+## 1. Reproduction commands and outputs
+
+### compile-self run
+
+```
+node packages/cli/dist/bin.js compile-self \
+  --output .worktrees/feature-561-s1-registry-recon/tmp/wi-551-recompiled \
+  --registry bootstrap/yakcc.registry.sqlite
+```
+
+Output:
+```
+yakcc compile-self — P2 workspace reconstruction
+  registry: /Users/cris/src/yakcc/bootstrap/yakcc.registry.sqlite
+  output:   /Users/cris/src/yakcc/.worktrees/feature-561-s1-registry-recon/tmp/wi-551-recompiled
+
+compile-self: 3452 total atoms in registry
+compile-self: 3452 total atoms, 49 source files emitted, 2378 gap rows
+compile-self: 49 source files emitted → .../tmp/wi-551-recompiled/
+compile-self: 60 plumbing files materialised → .../tmp/wi-551-recompiled/
+compile-self: manifest written → .../tmp/wi-551-recompiled/manifest.json
+
+compile-self: compose-path-gap report (2378 rows):
+  null-provenance: 2378 (atoms with NULL sourcePkg AND sourceFile — cannot place in workspace)
+```
+
+Exit: 0 (success). The 2378 null-provenance gap rows are expected — these are atoms from
+pre-v7 schema runs with NULL provenance columns (they have `source_file` in blocks but
+NULL `sourcePkg` and no block_occurrences rows). compile-self placed 49 source files
+correctly using the blocks.source_file fallback path.
+
+### diff command
+
+```
+diff -u tmp/wi-551-recompiled/packages/registry/src/index.ts \
+         packages/registry/src/index.ts \
+  > tmp/wi-551-investigation/registry-index-diff.txt
+```
+
+Result: non-empty diff (exit 1 = files differ). 213 lines of diff.
+
+### Manifest entry for registry/src/index.ts
+
+```json
+{
+  "outputPath": "packages/registry/src/index.ts",
+  "blockMerkleRoot": "bf52292b84632aa3c1a0be55d37bd5dadd44cda1ab6ba931aa81b5fb4f76b58a",
+  "sourcePkg": "packages/registry",
+  "sourceFile": "packages/registry/src/index.ts",
+  "sourceOffset": 1732
+}
+```
+
+Only **1 atom** stored for this file in the registry.
+
+---
+
+## 2. Diff summary
+
+See `tmp/wi-551-investigation/registry-index-diff.md` for full analysis.
+
+- **Hunks:** 3
+- **Lines added:** 175 (in canonical, absent from recompiled)
+- **Lines removed:** 11 (doc-only rewrites in getAtomRangesBySourceFile JSDoc)
+- **Net:** +164 lines
+- **Character delta:** recompiled = 44,313 chars; canonical = 50,839 chars; delta = +6,526 chars
+- **All 3 hunks are semantic** (new type declarations, new interface methods, new API exports)
+
+The recompiled file is an **older version** of the canonical file, not a whitespace-variant.
+
+---
+
+## 3. M3 mechanism confirmation: NEGATIVE
+
+See `tmp/wi-551-investigation/m3-evidence.md` for full tabulation.
+
+**Headline stat: 0 of 29 roots show first-observed bytes from a different source file.**
+
+The M3 mechanism (atom dedupe across files with byte-different context) is NOT the primary
+mechanism for `packages/registry/src/index.ts`. The investigation found a different root cause.
+
+### Actual mechanism: Registry Staleness (M-new)
+
+`bootstrap/yakcc.registry.sqlite` has only 1 block stored for `packages/registry/src/index.ts`:
+- Stored impl_source: 42,581 chars (old file body, chars 1732..44313)
+- Canonical file: 50,839 chars (8,258 chars more than stored)
+- First-observed file: `packages/registry/src/index.ts` itself (NOT a foreign file)
+
+The registry was bootstrapped when the file had 27 top-level declarations (44,313 chars).
+Since then, 2 new declarations were added (issue #355 + issue #338), growing the file to
+29 top-level declarations (50,839 chars). The bootstrap was NOT re-run after these additions.
+
+When compile-self reconstructs the file from the stale registry, it emits the old 44,313-char
+version. Pass-2 shave of the old file produces atoms from the old content (27 statement atoms).
+None of those atoms match the expected pass-1 atoms from the current 29-statement file
+→ divergent in T3.
+
+This is fundamentally different from M3:
+- M3: same canonical-AST in two files with minor whitespace differences at atom boundaries
+- M-new: same file's content evolved (semantic additions) while stored atom is frozen at old version
+
+---
+
+## 4. Decision: DEC-WI-551-S1-IMPL
+
+```
+@decision DEC-WI-551-S1-IMPL
+@title S2 implementation path for compile-self reconstruction divergence
+@status decided (WI-551-S1 investigation)
+@rationale
+  The S1 investigation found that M3 (cross-file dedupe with whitespace differences)
+  is NOT the mechanism for registry/src/index.ts. The actual mechanism is M-new:
+  registry staleness — the bootstrap/yakcc.registry.sqlite was built from an older
+  version of the file that has since grown by 8,258 chars (2 new declarations, 6 new
+  Registry interface methods).
+
+  The correct fix is NOT per-occurrence override columns (S2-Option-A) or per-file
+  override blobs (S2-Option-B) — both of those address the M3 whitespace-variant
+  scenario, not the M-new registry-staleness scenario.
+
+  The correct S2 fix path is:
+
+  (C) Re-bootstrap: run `yakcc bootstrap` against the current source to regenerate
+  `bootstrap/yakcc.registry.sqlite` from the current corpus state. This is the
+  immediate fix for the staleness class of divergence.
+
+  (D) Bootstrap CI gate: add a CI step that runs bootstrap and verifies the committed
+  `bootstrap/yakcc.registry.sqlite` matches the current corpus. This prevents future
+  staleness from accumulating silently.
+
+  Options A and B (per-occurrence/per-file override) remain potentially useful if
+  the OTHER 53 divergent roots in the 9 remaining hot files turn out to be genuine
+  M3 (whitespace-variant dedupe). That investigation is out of scope for S1.
+
+  For the 29-root contribution of registry/src/index.ts, option (C) is the correct
+  and sufficient fix: re-bootstrap eliminates all 29 divergent roots for this file.
+```
+
+**Chosen S2 path for the 29-root file: Option (C) — re-bootstrap.**
+
+Trade-offs:
+- **Option A (per-occurrence override column):** Addresses M3 whitespace drift by storing
+  per-occurrence implSource overrides. Requires schema migration, migration tooling, and
+  increased storage. Does NOT address M-new (staleness). Cost: high (schema change).
+- **Option B (per-file override blob):** Similar scope to A, different storage shape.
+  Also does NOT address M-new. Cost: high (new table + compile-self changes).
+- **Option C (re-bootstrap):** Directly addresses M-new staleness. Zero schema changes.
+  Zero code changes. Cost: compute time of one bootstrap run (~15-30 min). Risk: if other
+  divergent roots ARE genuine M3, re-bootstrap alone won't fix them.
+
+Decision rationale: Given that the 29-root file is confirmed M-new (not M3), Option C is
+strictly necessary and sufficient for this file's contribution. The planner should re-run
+bootstrap before assuming M3 is the dominant mechanism across the full 82-root cluster.
+
+---
+
+## 5. S2 follow-up plan
+
+### Immediate action (S2a): Re-bootstrap
+
+Re-run `yakcc bootstrap` against the current corpus. This will:
+1. Produce a fresh `bootstrap/yakcc.registry.sqlite` with current-corpus atoms
+2. Re-run the two-pass test to measure the actual remaining divergent count
+3. Determine whether the remaining divergence (after staleness is resolved) is truly M3
+
+Scope: `bootstrap/yakcc.registry.sqlite`, `bootstrap/report.json`, `bootstrap/expected-roots.json`
+(all gitignored outputs of bootstrap run). Zero source code changes needed for this step.
+
+### Pending decision (S2b): Investigate remaining divergence
+
+After re-bootstrap, if divergence > 0:
+- Run the two-pass test with fresh artifacts
+- Examine the actual divergent roots — if they show cross-file dedupe with whitespace
+  differences, M3 is confirmed and either Option A or B is appropriate
+- If divergence drops to 0, the entire 82-root cluster was registry staleness
+
+### Evaluation contract for S2
+
+| Requirement | Criterion |
+|---|---|
+| compile-self runs successfully against fresh bootstrap | exit 0, non-empty output |
+| two-pass test T3 passes | divergent count = 0, or M3 confirmed with fresh diff evidence |
+| No source files edited under packages/** | git diff --stat shows only bootstrap/** |
+
+---
+
+## 6. Scope compliance
+
+Files written by this slice:
+- `tmp/wi-551-investigation/registry-index-diff.txt` (raw diff artifact)
+- `tmp/wi-551-investigation/registry-index-diff.md` (diff summary)
+- `tmp/wi-551-investigation/m3-evidence.md` (29-root tabulation and M3 assessment)
+- `plans/wi-551-s1.md` (this file)
+
+No files touched under `packages/**`. Read-only on `bootstrap/yakcc.registry.sqlite`.
+
+---
+
+## 7. Pre-push hygiene status
+
+Run before staging:
+- `pnpm -w lint` — pre-existing failures (@yakcc/shave constants.d.ts trailing newline); zero new failures from this slice (zero source edits).
+- `pnpm -w typecheck` — pre-existing failures (@yakcc/hooks-base ts-morph import); zero new failures from this slice (zero source edits).
+- `git fetch origin && git diff --stat origin/main..HEAD` — shows only S1 artifacts


### PR DESCRIPTION
## Summary
First investigation slice of #551. Planner predicted M3 cross-file atom dedupe; data killed the hypothesis on the highest-yield file.

- **Actual mechanism**: registry staleness (M-new). Bootstrap DB built when `registry/src/index.ts` had 27 declarations (44313 chars); current canonical has 29 declarations (50839 chars). `INSERT OR IGNORE` froze the stored atom; `compile-self` emits old bytes; pass-2 shave produces different atom boundaries.
- **Evidence**: 0 of 29 roots show cross-file dedupe. Direct SQLite query confirms 1 block at 44313 chars sourced from the file itself.
- **DEC-WI-551-S1-IMPL**: Option (C) re-bootstrap. Eliminates 29 roots with zero code changes.

## What this changes
Two plan documents, no source. Investigation-only slice.
- `plans/wi-551-s1.md` -- S1 reproduction + decision
- `plans/wi-551-compile-self-recon-gap.md` -- parent plan from #551 planner pass (was untracked; this PR closes that governance-trail gap)

## Investigation artifacts (gitignored, on-disk only)
- `tmp/wi-551-investigation/registry-index-diff.md` (3 hunks, 213 lines, all semantic)
- `tmp/wi-551-investigation/m3-evidence.md` (29-row table)
- `tmp/wi-551-recompiled/` (compile-self output for diff)

## Pre-push hygiene
- Rebase: ff-merged origin/main (PR #562 + sibling plan); re-verified branch current post-fetch.
- Lint: pre-existing `@yakcc/shave` constants.d.ts / normalize.d.ts trailing newline; zero new failures (zero source edits).
- Typecheck: zero new failures; transitive lint dependency surfaces the same pre-existing shave issue.

## Out of scope (S2 and later)
- Building the fix itself (re-bootstrap is operational, not code)
- Re-measuring the other 9 files post-fresh-bootstrap (file-by-file analysis in S2)
- Schema-level fixes if any genuine M3 cases remain after re-bootstrap

Closes #561. Refs #551 (meta-issue stays open until divergent count == 0).