### PR TITLE
feat(hooks-base): WI-508 Slice 3 — telemetry-driven skip-shave tuning

### DIFF
--- a/packages/hooks-base/src/import-intercept.ts
+++ b/packages/hooks-base/src/import-intercept.ts
@@ -460,6 +460,23 @@ export async function applyImportIntercept(
     if (anyIntercepted) {
       // Matched branch: attach intercept results additively -- base response kind is unchanged.
       // The cast is safe: base.substituted is false at this call site.
+      //
+      // WI-508 Slice 3: record registry hits for skip-shave heuristic.
+      // DEC-WI508-S3-SKIP-HIT-THRESHOLD-001: hit count drives skip-shave on subsequent misses.
+      for (const result of interceptResults) {
+        if (result.intercepted) {
+          const bindingName =
+            result.binding.namedImports[0] ??
+            result.binding.defaultImport ??
+            result.binding.moduleSpecifier;
+          try {
+            const { recordImportHit } = await import("./shave-on-miss-state.js");
+            recordImportHit(result.binding.moduleSpecifier, bindingName);
+          } catch {
+            // Hit recording failure must not affect the hook path (observe-don't-mutate).
+          }
+        }
+      }
       return {
         ...base,
         importInterceptResults: interceptResults,

--- a/packages/hooks-base/src/index.ts
+++ b/packages/hooks-base/src/index.ts
@@ -699,13 +699,35 @@ export {
  * applyShaveOnMiss and awaitShaveOnMissDrain are exported for consumers and tests.
  * ShaveOnMissResult is the result type for the miss-branch entry function.
  * _resetShaveOnMissQueue is exported as a test helper (test-only; production does not call it).
+ *
+ * @decision DEC-WI508-S3-STATE-PERSIST-001
+ * WI-508 Slice 3 exports: applyPreemptivePackageShave + state management helpers.
+ * State-management symbols (_resetShaveOnMissState, recordImportHit, etc.) are test-only
+ * or called internally from import-intercept; not intended for end-user consumption.
  */
 export type { ShaveOnMissResult } from "./shave-on-miss.js";
 export {
   applyShaveOnMiss,
+  applyPreemptivePackageShave,
   awaitShaveOnMissDrain,
   resolveCorpusDir,
   resolveEntryPath,
   _resetShaveOnMissQueue,
+  _resetShaveOnMissState,
 } from "./shave-on-miss.js";
+
+// WI-508 Slice 3 -- state management surface (test-only helpers + hit recording).
+export type { ShaveOnMissState } from "./shave-on-miss-state.js";
+export {
+  resolveStatePath,
+  loadShaveOnMissState,
+  saveShaveOnMissState,
+  resolveSkipShaveHitThreshold,
+  resolvePreemptiveMissThreshold,
+  makeBindingKey,
+  listPackageBindings,
+  recordImportHit,
+  getState,
+  updateState,
+} from "./shave-on-miss-state.js";
 

--- a/packages/hooks-base/src/shave-on-miss-state.ts
+++ b/packages/hooks-base/src/shave-on-miss-state.ts
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: MIT
+// shave-on-miss-state.ts -- Persistent hot-set state for WI-508 Slice 3 skip-shave tuning.
+//
+// @decision DEC-WI508-S3-STATE-PERSIST-001
+// title: Hot-set persisted to ~/.yakcc/shave-on-miss-state.json (env-var override)
+// status: decided (WI-508 Slice 3)
+// rationale:
+//   Follows the YAKCC_TELEMETRY_DIR / YAKCC_SHAVE_ON_MISS_CORPUS_DIR env-var pattern.
+//   Single JSON file: readable, auditable, reset-able by deleting the file.
+//   Multi-process write race is accepted (per DEC-WI508-S2-IN-PROC-BACKGROUND-001: "storeBlock
+//   idempotence makes cross-process duplicates safe"). State writes are synchronous (writeFileSync)
+//   matching the telemetry append pattern (appendFileSync in telemetry.ts).
+//
+// @decision DEC-WI508-S3-KEY-FORMAT-001
+// title: State keys use "${packageName}::${binding}" not entryPath
+// status: decided (WI-508 Slice 3)
+// rationale:
+//   Binding keys are stable across corpusDir locations (different node_modules roots).
+//   Hit recording from the import-intercept path knows (packageName, binding) not entryPath,
+//   so a binding-level key avoids a corpusDir lookup at hit-recording time.
+//
+// @decision DEC-WI508-S3-SKIP-HIT-THRESHOLD-001
+// title: Default SKIP_SHAVE_HIT_THRESHOLD=2; configurable via YAKCC_SKIP_SHAVE_HIT_THRESHOLD
+// status: decided (WI-508 Slice 3)
+// rationale:
+//   N=2 means "if we've seen this binding in the registry at least twice, it is stable --
+//   skip the re-shave on the next miss." The threshold is intentionally low because:
+//   (a) The B4/B9 benchmarks will calibrate the exact value once sweep data is available
+//       (DEC-WI508-S3-THRESHOLD-CALIBRATION-PENDING-001).
+//   (b) An env-var override lets operators tune without a code change.
+//   Consecutive-vs-total hit counting is an acceptable simplification for the v1 hot-set:
+//   the hit count is a lower bound on "how stable is this atom in the registry." Calibration
+//   may shift to a sliding window in a future slice.
+//
+// @decision DEC-WI508-S3-PREEMPTIVE-MISS-THRESHOLD-001
+// title: Default PREEMPTIVE_SHAVE_MISS_THRESHOLD=3; configurable via YAKCC_PREEMPTIVE_SHAVE_MISS_THRESHOLD
+// status: decided (WI-508 Slice 3)
+// rationale:
+//   N=3 means "if we've seen 3 distinct binding misses from the same package, proactively scan
+//   and shave the package's entire lib/ directory." The rationale: 3 independent misses signal
+//   that the package is completely absent from the registry and a whole-package shave is cheaper
+//   than waiting for each binding to miss individually. The threshold is calibration-pending
+//   (DEC-WI508-S3-THRESHOLD-CALIBRATION-PENDING-001). env-var override provided.
+//
+// @decision DEC-WI508-S3-THRESHOLD-CALIBRATION-PENDING-001
+// title: SKIP_SHAVE_HIT_THRESHOLD and PREEMPTIVE_SHAVE_MISS_THRESHOLD have provisional defaults
+// status: decided (WI-508 Slice 3)
+// rationale:
+//   Both defaults (2, 3) are provisional. The B4 token-cost sweep (#188, WI-B4-MATRIX-HARNESS-V2)
+//   and B9 attack-surface benchmark (#446) are the planned data sources for calibration.
+//   Once sweep data is available, a future planner pass amends these defaults and annotates
+//   the calibration decision with a DEC-WI508-S3-THRESHOLD-CALIBRATION-FINAL-001.
+//
+// @decision DEC-WI508-S3-PREEMPTIVE-SCAN-001
+// title: Preemptive shave scans corpusDir lib/ via readdirSync; dedup handled by existing queue
+// status: decided (WI-508 Slice 3)
+// rationale:
+//   When preemptive shave fires, listPackageBindings() scans the corpus lib/ directory for
+//   .js files and returns binding names (filename minus extension). applyShaveOnMiss() is then
+//   called for each -- dedup (in-memory queue + completedBindings check) prevents re-shaving
+//   already-completed bindings. No new dedup mechanism is needed.
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join, normalize } from "node:path";
+
+// ---------------------------------------------------------------------------
+// State schema
+// ---------------------------------------------------------------------------
+
+/**
+ * Persistent hot-set state for skip-shave tuning (WI-508 Slice 3).
+ *
+ * completedBindings: set of "${packageName}::${binding}" keys that have been
+ *   successfully shaved in a prior process run. On next miss for the same key,
+ *   the enqueue is skipped (atom is already in the registry from a prior run).
+ *
+ * hitCounts: number of registry-hit events observed per binding key.
+ *   When hitCounts[key] >= SKIP_SHAVE_HIT_THRESHOLD, the enqueue is skipped
+ *   because the atom is demonstrably stable in the registry.
+ *
+ * missCounts: number of miss events observed per package name.
+ *   When missCounts[packageName] >= PREEMPTIVE_SHAVE_MISS_THRESHOLD, a whole-
+ *   package preemptive shave is triggered.
+ */
+export interface ShaveOnMissState {
+  readonly version: 1;
+  readonly completedBindings: readonly string[];
+  readonly hitCounts: Readonly<Record<string, number>>;
+  readonly missCounts: Readonly<Record<string, number>>;
+}
+
+// Mutable working copy used internally.
+type MutableState = {
+  version: 1;
+  completedBindings: string[];
+  hitCounts: Record<string, number>;
+  missCounts: Record<string, number>;
+};
+
+// ---------------------------------------------------------------------------
+// State path resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the path for the persistent shave-on-miss state file.
+ * DEC-WI508-S3-STATE-PERSIST-001.
+ */
+export function resolveStatePath(): string {
+  return (
+    process.env.YAKCC_SHAVE_ON_MISS_STATE_PATH ??
+    join(homedir(), ".yakcc", "shave-on-miss-state.json")
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Threshold resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the skip-shave hit threshold.
+ * DEC-WI508-S3-SKIP-HIT-THRESHOLD-001: default 2.
+ */
+export function resolveSkipShaveHitThreshold(): number {
+  const raw = process.env.YAKCC_SKIP_SHAVE_HIT_THRESHOLD;
+  if (raw !== undefined) {
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isNaN(parsed) && parsed > 0) return parsed;
+  }
+  return 2;
+}
+
+/**
+ * Resolve the preemptive shave miss threshold.
+ * DEC-WI508-S3-PREEMPTIVE-MISS-THRESHOLD-001: default 3.
+ */
+export function resolvePreemptiveMissThreshold(): number {
+  const raw = process.env.YAKCC_PREEMPTIVE_SHAVE_MISS_THRESHOLD;
+  if (raw !== undefined) {
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isNaN(parsed) && parsed > 0) return parsed;
+  }
+  return 3;
+}
+
+// ---------------------------------------------------------------------------
+// State I/O
+// ---------------------------------------------------------------------------
+
+function emptyState(): MutableState {
+  return { version: 1, completedBindings: [], hitCounts: {}, missCounts: {} };
+}
+
+/**
+ * Load the persistent state from disk.
+ * Returns an empty state on any read/parse error (fail-safe: missing file is normal).
+ */
+export function loadShaveOnMissState(statePath?: string): ShaveOnMissState {
+  const path = statePath ?? resolveStatePath();
+  try {
+    if (!existsSync(path)) return emptyState();
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<MutableState>;
+    return {
+      version: 1,
+      completedBindings: Array.isArray(parsed.completedBindings) ? parsed.completedBindings : [],
+      hitCounts:
+        parsed.hitCounts !== null && typeof parsed.hitCounts === "object" ? parsed.hitCounts : {},
+      missCounts:
+        parsed.missCounts !== null && typeof parsed.missCounts === "object"
+          ? parsed.missCounts
+          : {},
+    };
+  } catch {
+    return emptyState();
+  }
+}
+
+/**
+ * Save the persistent state to disk.
+ * Creates the parent directory if needed (idempotent). Errors are swallowed to prevent
+ * state persistence failures from blocking the hook path.
+ * DEC-WI508-S3-STATE-PERSIST-001.
+ */
+export function saveShaveOnMissState(state: ShaveOnMissState, statePath?: string): void {
+  const path = statePath ?? resolveStatePath();
+  try {
+    const dir = path.substring(0, Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\")));
+    if (dir.length > 0 && !existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    writeFileSync(path, JSON.stringify(state, null, 2), "utf-8");
+  } catch {
+    // State persistence failure must not block the hook path.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// State mutation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a new state with the binding key added to completedBindings.
+ * Key format: "${packageName}::${binding}" per DEC-WI508-S3-KEY-FORMAT-001.
+ */
+export function withCompletion(state: ShaveOnMissState, key: string): ShaveOnMissState {
+  if (state.completedBindings.includes(key)) return state;
+  return {
+    ...state,
+    completedBindings: [...state.completedBindings, key],
+  };
+}
+
+/**
+ * Return a new state with the hit count for the binding key incremented.
+ */
+export function withHitIncrement(state: ShaveOnMissState, key: string): ShaveOnMissState {
+  const prev = state.hitCounts[key] ?? 0;
+  return {
+    ...state,
+    hitCounts: { ...state.hitCounts, [key]: prev + 1 },
+  };
+}
+
+/**
+ * Return a new state with the miss count for the package incremented.
+ */
+export function withMissIncrement(
+  state: ShaveOnMissState,
+  packageName: string,
+): ShaveOnMissState {
+  const prev = state.missCounts[packageName] ?? 0;
+  return {
+    ...state,
+    missCounts: { ...state.missCounts, [packageName]: prev + 1 },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Binding key construction
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the binding key for a (packageName, binding) pair.
+ * DEC-WI508-S3-KEY-FORMAT-001.
+ */
+export function makeBindingKey(packageName: string, binding: string): string {
+  return `${packageName}::${binding}`;
+}
+
+// ---------------------------------------------------------------------------
+// Module-scope state cache
+// ---------------------------------------------------------------------------
+
+// Lazy-loaded once per process. Reset by _resetShaveOnMissState() in tests.
+let _cachedState: ShaveOnMissState | undefined;
+
+/**
+ * Get the current in-memory state, loading from disk on first call.
+ */
+export function getState(): ShaveOnMissState {
+  if (_cachedState === undefined) {
+    _cachedState = loadShaveOnMissState();
+  }
+  return _cachedState;
+}
+
+/**
+ * Update the in-memory state and persist to disk.
+ */
+export function updateState(newState: ShaveOnMissState): void {
+  _cachedState = newState;
+  saveShaveOnMissState(newState);
+}
+
+/** Reset the in-memory state cache. Test-only. */
+export function _resetShaveOnMissState(): void {
+  _cachedState = undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Hit recording (called from import-intercept on registry-hit)
+// ---------------------------------------------------------------------------
+
+/**
+ * Record a registry hit for a (packageName, binding) pair.
+ *
+ * Called from applyImportIntercept() when intercepted=true for a binding.
+ * Increments hitCounts[key] in the persistent state, enabling the skip-shave
+ * heuristic on subsequent misses.
+ *
+ * DEC-WI508-S3-SKIP-HIT-THRESHOLD-001.
+ *
+ * @param packageName - NPM package name (e.g. "validator").
+ * @param binding     - Named binding (e.g. "isEmail").
+ */
+export function recordImportHit(packageName: string, binding: string): void {
+  try {
+    const key = makeBindingKey(packageName, binding);
+    const updated = withHitIncrement(getState(), key);
+    updateState(updated);
+  } catch {
+    // Hit recording failure must not affect the hook path (observe-don't-mutate).
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Package corpus scanning (used by preemptive shave)
+// ---------------------------------------------------------------------------
+
+/**
+ * List all binding names (*.js basename without extension) in a package's corpus lib/ dir.
+ *
+ * Resolution order mirrors resolveEntryPath():
+ *   1. {corpusDir}/{packageName}/lib/*.js  (standard node_modules layout)
+ *   2. {corpusDir}/{packageName}-VERSION/lib/*.js  (versioned fixture layout; first sorted match)
+ *
+ * Returns an empty array when the corpus dir or lib/ is not found.
+ * DEC-WI508-S3-PREEMPTIVE-SCAN-001.
+ *
+ * @param packageName - NPM package name.
+ * @param corpusDir   - Root of the corpus (node_modules or fixture dir).
+ */
+export function listPackageBindings(packageName: string, corpusDir: string): string[] {
+  // Attempt 1: standard layout.
+  const standardLib = join(corpusDir, packageName, "lib");
+  if (existsSync(standardLib)) {
+    return _listJsBasenames(standardLib);
+  }
+
+  // Attempt 2: versioned fixture layout.
+  let entries: string[];
+  try {
+    entries = readdirSync(corpusDir);
+  } catch {
+    return [];
+  }
+
+  const prefix = `${packageName}-`;
+  const versionedDirs = entries.filter((e) => e.startsWith(prefix)).sort();
+
+  for (const dir of versionedDirs) {
+    const libDir = join(corpusDir, dir, "lib");
+    if (existsSync(libDir)) {
+      return _listJsBasenames(libDir);
+    }
+  }
+
+  return [];
+}
+
+function _listJsBasenames(libDir: string): string[] {
+  try {
+    const files = readdirSync(libDir);
+    return files
+      .filter((f) => f.endsWith(".js") && !f.endsWith(".min.js"))
+      .map((f) => basename(normalize(f), ".js"));
+  } catch {
+    return [];
+  }
+}

--- a/packages/hooks-base/src/shave-on-miss.ts
+++ b/packages/hooks-base/src/shave-on-miss.ts
@@ -71,6 +71,17 @@
 import { existsSync, readdirSync } from "node:fs";
 import { join, normalize } from "node:path";
 import type { Registry } from "@yakcc/registry";
+import {
+  _resetShaveOnMissState,
+  getState,
+  listPackageBindings,
+  makeBindingKey,
+  resolvePreemptiveMissThreshold,
+  resolveSkipShaveHitThreshold,
+  updateState,
+  withCompletion,
+  withMissIncrement,
+} from "./shave-on-miss-state.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -193,9 +204,10 @@ async function runShaveWorker(entryPath: string, registry: Registry): Promise<re
     intentStrategy: "static",
     foreignPolicy: "allow",
   });
-  return result.atoms
-    .filter((a) => a.merkleRoot !== undefined)
-    .map((a) => (a.merkleRoot as string).slice(0, 8));
+  // biome-ignore lint/suspicious/noExplicitAny: @yakcc/shave atom type is unavailable at tsc typecheck time (workspace dep not built)
+  return (result.atoms as any[])
+    .filter((a: { merkleRoot?: string }) => a.merkleRoot !== undefined)
+    .map((a: { merkleRoot?: string }) => (a.merkleRoot as string).slice(0, 8));
 }
 
 // ---------------------------------------------------------------------------
@@ -272,8 +284,25 @@ export function applyShaveOnMiss(
     return { shaveOnMissEnqueued: false, entryResolved: false, atomsCreated: [] };
   }
 
-  const key = makeQueueKey(packageName, entryPath);
-  const existing = _queue.get(key);
+  // ── WI-508 Slice 3: skip-shave heuristics (DEC-WI508-S3-SKIP-HIT-THRESHOLD-001) ──
+  // Check the persistent hot-set before touching the in-memory queue.
+  const bindingKey = makeBindingKey(packageName, binding);
+  const state = getState();
+
+  // Skip if this binding was already successfully shaved in a prior process run.
+  if (state.completedBindings.includes(bindingKey)) {
+    return { shaveOnMissEnqueued: false, entryResolved: true, atomsCreated: [] };
+  }
+
+  // Skip if we've seen N+ registry hits for this binding -- atom is stable in registry.
+  const hitCount = state.hitCounts[bindingKey] ?? 0;
+  if (hitCount >= resolveSkipShaveHitThreshold()) {
+    return { shaveOnMissEnqueued: false, entryResolved: true, atomsCreated: [] };
+  }
+
+  // ── In-memory queue dedup (DEC-WI508-S2-IN-PROC-BACKGROUND-001) ─────────────
+  const queueKey = makeQueueKey(packageName, entryPath);
+  const existing = _queue.get(queueKey);
 
   if (existing !== undefined) {
     if (existing.state === "completed") {
@@ -282,13 +311,27 @@ export function applyShaveOnMiss(
     return { shaveOnMissEnqueued: false, entryResolved: true, atomsCreated: [] };
   }
 
+  // ── Record miss and check preemptive shave trigger ────────────────────────────
+  // DEC-WI508-S3-PREEMPTIVE-MISS-THRESHOLD-001.
+  const updatedState = withMissIncrement(state, packageName);
+  updateState(updatedState);
+
+  const missCount = updatedState.missCounts[packageName] ?? 0;
+  if (missCount >= resolvePreemptiveMissThreshold()) {
+    // N+ misses for this package -- preemptively shave all known bindings.
+    // Runs in the background; dedup prevents re-shaving already-completed entries.
+    queueMicrotask(() => {
+      applyPreemptivePackageShave(packageName, ctx, registry, corpusDir);
+    });
+  }
+
   emitShaveOnMissTelemetry("shave-on-miss-enqueued", ctx.intent);
 
   let resolveDrain!: () => void;
   const drainPromise = new Promise<void>((resolve) => {
     resolveDrain = resolve;
   });
-  _queue.set(key, { state: "pending", drain: drainPromise });
+  _queue.set(queueKey, { state: "pending", drain: drainPromise });
 
   // Start the background worker. Deliberately not awaited.
   // DEC-WI508-S2-ASYNC-BACKGROUND-001.
@@ -300,18 +343,65 @@ export function applyShaveOnMiss(
   queueMicrotask(async () => {
     try {
       const atomsCreated = await runShaveWorker(entryPath, registry);
-      _queue.set(key, { state: "completed", atomsCreated });
+      _queue.set(queueKey, { state: "completed", atomsCreated });
       emitShaveOnMissTelemetry("shave-on-miss-completed", ctx.intent, { atomsCreated });
     } catch (err) {
-      _queue.set(key, { state: "error", error: err });
+      _queue.set(queueKey, { state: "error", error: err });
       const errorMsg = err instanceof Error ? err.message : String(err);
       emitShaveOnMissTelemetry("shave-on-miss-error", ctx.intent, { errorMsg });
     } finally {
+      // Persist completion regardless of success/error so future processes skip re-shaving.
+      // Rationale: if the shave errors (CJS format, missing deps, etc.), future attempts
+      // will likely also error -- recording the attempt prevents wasteful re-shave retries.
+      // Hit-count based skip (DEC-WI508-S3-SKIP-HIT-THRESHOLD-001) handles the case where
+      // the atom IS in the registry; this handles the "already tried" case.
+      // DEC-WI508-S3-STATE-PERSIST-001.
+      try {
+        updateState(withCompletion(getState(), bindingKey));
+      } catch {
+        // State update failure must not block drain resolution.
+      }
       resolveDrain();
     }
   });
 
   return { shaveOnMissEnqueued: true, entryResolved: true, atomsCreated: [] };
+}
+
+// ---------------------------------------------------------------------------
+// Preemptive package shave (WI-508 Slice 3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Enqueue background shaves for all known bindings in a package.
+ *
+ * Called when missCount[packageName] >= PREEMPTIVE_SHAVE_MISS_THRESHOLD.
+ * Scans the corpus lib/ directory and calls applyShaveOnMiss() for each binding.
+ * Existing queue dedup ensures already-queued or completed bindings are skipped.
+ *
+ * DEC-WI508-S3-PREEMPTIVE-SCAN-001.
+ * DEC-WI508-S3-PREEMPTIVE-MISS-THRESHOLD-001.
+ *
+ * @param packageName - NPM package name to scan.
+ * @param ctx         - Emission context (shared intent for telemetry).
+ * @param registry    - Registry instance.
+ * @param corpusDir   - Root of the corpus directory.
+ */
+export function applyPreemptivePackageShave(
+  packageName: string,
+  ctx: { readonly intent: string },
+  registry: Registry,
+  corpusDir: string,
+): void {
+  try {
+    const bindings = listPackageBindings(packageName, corpusDir);
+    for (const bindingName of bindings) {
+      // applyShaveOnMiss handles dedup (in-memory queue + completedBindings + hitCounts).
+      applyShaveOnMiss(packageName, bindingName, ctx, registry);
+    }
+  } catch {
+    // Preemptive shave failure must not affect the hook path.
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -356,4 +446,9 @@ export async function awaitShaveOnMissDrain(timeoutMs = 60_000): Promise<void> {
 /** Reset the module-scope queue. Test-only. */
 export function _resetShaveOnMissQueue(): void {
   _queue.clear();
+  // Also reset the persistent state cache so tests start from a clean slate.
+  // DEC-WI508-S3-STATE-PERSIST-001.
+  _resetShaveOnMissState();
 }
+
+export { _resetShaveOnMissState } from "./shave-on-miss-state.js";

--- a/packages/hooks-base/test/shave-on-miss-integration.test.ts
+++ b/packages/hooks-base/test/shave-on-miss-integration.test.ts
@@ -27,11 +27,13 @@
  *   - No new SQLite tables
  */
 
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { EmbeddingProvider } from "@yakcc/contracts";
 import { openRegistry } from "@yakcc/registry";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ImportInterceptResult } from "../src/import-intercept.js";
 import {
   type HookResponseWithSubstitution,
@@ -80,10 +82,23 @@ type ResponseWithMiss = HookResponseWithSubstitution & {
 };
 
 // ---------------------------------------------------------------------------
-// Suite teardown
+// Suite setup / teardown
 // ---------------------------------------------------------------------------
 
 const savedCorpusDir = process.env.YAKCC_SHAVE_ON_MISS_CORPUS_DIR;
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = join(tmpdir(), `shave-on-miss-integration-test-${process.pid}-${Date.now()}`);
+  mkdirSync(tempDir, { recursive: true });
+  // Isolate persistent state per test so tests never share the default
+  // ~/.yakcc/shave-on-miss-state.json path. DEC-WI508-S3-STATE-PERSIST-001.
+  process.env.YAKCC_SHAVE_ON_MISS_STATE_PATH = join(tempDir, "test-state.json");
+  // Disable preemptive shave to prevent cross-test state contamination.
+  // DEC-WI508-S3-PREEMPTIVE-MISS-THRESHOLD-001.
+  process.env.YAKCC_PREEMPTIVE_SHAVE_MISS_THRESHOLD = "999";
+});
 
 afterEach(() => {
   _resetShaveOnMissQueue();
@@ -95,6 +110,13 @@ afterEach(() => {
   }
   // biome-ignore lint/performance/noDelete: env-var removal is intentional
   delete process.env.YAKCC_HOOK_DISABLE_SUBSTITUTE;
+  // biome-ignore lint/performance/noDelete: env-var removal is intentional
+  delete process.env.YAKCC_SHAVE_ON_MISS_STATE_PATH;
+  // biome-ignore lint/performance/noDelete: env-var removal is intentional
+  delete process.env.YAKCC_PREEMPTIVE_SHAVE_MISS_THRESHOLD;
+  if (existsSync(tempDir)) {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/hooks-base/test/shave-on-miss-state.test.ts
+++ b/packages/hooks-base/test/shave-on-miss-state.test.ts
@@ -1,0 +1,410 @@
+// SPDX-License-Identifier: MIT
+/**
+ * shave-on-miss-state.test.ts -- Unit tests for WI-508 Slice 3 state management.
+ *
+ * Tests cover:
+ *   1. resolveStatePath -- env-var override and default path
+ *   2. loadShaveOnMissState -- empty state from nonexistent file
+ *   3. loadShaveOnMissState -- reads state from file
+ *   4. saveShaveOnMissState -- writes state to file; round-trip
+ *   5. withCompletion -- adds binding key to completedBindings (idempotent)
+ *   6. withHitIncrement -- increments hitCounts[key]
+ *   7. withMissIncrement -- increments missCounts[packageName]
+ *   8. resolveSkipShaveHitThreshold -- env-var override and default
+ *   9. resolvePreemptiveMissThreshold -- env-var override and default
+ *  10. listPackageBindings -- standard and versioned fixture layout
+ *  11. recordImportHit -- increments hit count and persists
+ *  12. makeBindingKey -- correct format
+ *
+ * @decision DEC-WI508-S3-STATE-PERSIST-001
+ * @decision DEC-WI508-S3-KEY-FORMAT-001
+ * @decision DEC-WI508-S3-SKIP-HIT-THRESHOLD-001
+ * @decision DEC-WI508-S3-PREEMPTIVE-MISS-THRESHOLD-001
+ */
+
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  _resetShaveOnMissState,
+  getState,
+  listPackageBindings,
+  loadShaveOnMissState,
+  makeBindingKey,
+  recordImportHit,
+  resolvePreemptiveMissThreshold,
+  resolveSkipShaveHitThreshold,
+  resolveStatePath,
+  saveShaveOnMissState,
+  updateState,
+  withCompletion,
+  withHitIncrement,
+  withMissIncrement,
+} from "../src/shave-on-miss-state.js";
+
+// ---------------------------------------------------------------------------
+// Fixture paths
+// ---------------------------------------------------------------------------
+
+const FIXTURE_DIR = join(
+  fileURLToPath(new URL(".", import.meta.url)),
+  "../../shave/src/__fixtures__/module-graph",
+);
+
+// ---------------------------------------------------------------------------
+// Temp dir helpers
+// ---------------------------------------------------------------------------
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = join(tmpdir(), `shave-on-miss-state-test-${process.pid}-${Date.now()}`);
+  mkdirSync(tempDir, { recursive: true });
+  // Reset the in-memory state cache between tests.
+  _resetShaveOnMissState();
+});
+
+afterEach(() => {
+  _resetShaveOnMissState();
+  // Remove temp dir.
+  if (existsSync(tempDir)) {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+  // Restore env vars.
+  // biome-ignore lint/performance/noDelete: env-var removal is intentional
+  delete process.env.YAKCC_SHAVE_ON_MISS_STATE_PATH;
+  // biome-ignore lint/performance/noDelete: env-var removal is intentional
+  delete process.env.YAKCC_SKIP_SHAVE_HIT_THRESHOLD;
+  // biome-ignore lint/performance/noDelete: env-var removal is intentional
+  delete process.env.YAKCC_PREEMPTIVE_SHAVE_MISS_THRESHOLD;
+});
+
+// ---------------------------------------------------------------------------
+// §1: resolveStatePath
+// ---------------------------------------------------------------------------
+
+describe("resolveStatePath", () => {
+  it("returns YAKCC_SHAVE_ON_MISS_STATE_PATH when set", () => {
+    process.env.YAKCC_SHAVE_ON_MISS_STATE_PATH = "/custom/state.json";
+    expect(resolveStatePath()).toBe("/custom/state.json");
+  });
+
+  it("returns a default path ending with shave-on-miss-state.json when env var not set", () => {
+    // biome-ignore lint/performance/noDelete: env-var removal is intentional
+    delete process.env.YAKCC_SHAVE_ON_MISS_STATE_PATH;
+    const path = resolveStatePath();
+    expect(path).toMatch(/shave-on-miss-state\.json$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §2: loadShaveOnMissState -- nonexistent file
+// ---------------------------------------------------------------------------
+
+describe("loadShaveOnMissState -- nonexistent file", () => {
+  it("returns empty state when file does not exist", () => {
+    const path = join(tempDir, "does-not-exist.json");
+    const state = loadShaveOnMissState(path);
+    expect(state.version).toBe(1);
+    expect(state.completedBindings).toHaveLength(0);
+    expect(state.hitCounts).toEqual({});
+    expect(state.missCounts).toEqual({});
+  });
+
+  it("returns empty state when file contains invalid JSON", () => {
+    const path = join(tempDir, "invalid.json");
+    writeFileSync(path, "not json", "utf-8");
+    const state = loadShaveOnMissState(path);
+    expect(state.completedBindings).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §3: loadShaveOnMissState -- existing file
+// ---------------------------------------------------------------------------
+
+describe("loadShaveOnMissState -- existing file", () => {
+  it("reads completedBindings, hitCounts, missCounts from file", () => {
+    const path = join(tempDir, "state.json");
+    const stored = {
+      version: 1,
+      completedBindings: ["validator::isEmail"],
+      hitCounts: { "validator::isEmail": 5 },
+      missCounts: { validator: 2 },
+    };
+    writeFileSync(path, JSON.stringify(stored), "utf-8");
+
+    const state = loadShaveOnMissState(path);
+    expect(state.completedBindings).toContain("validator::isEmail");
+    expect(state.hitCounts["validator::isEmail"]).toBe(5);
+    expect(state.missCounts["validator"]).toBe(2);
+  });
+
+  it("handles missing optional fields gracefully (partial state)", () => {
+    const path = join(tempDir, "partial.json");
+    writeFileSync(path, JSON.stringify({ version: 1, completedBindings: ["a::b"] }), "utf-8");
+    const state = loadShaveOnMissState(path);
+    expect(state.completedBindings).toContain("a::b");
+    expect(state.hitCounts).toEqual({});
+    expect(state.missCounts).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §4: saveShaveOnMissState -- round-trip
+// ---------------------------------------------------------------------------
+
+describe("saveShaveOnMissState", () => {
+  it("writes state to file and can be read back", () => {
+    const path = join(tempDir, "state.json");
+    const state = {
+      version: 1 as const,
+      completedBindings: ["validator::isEmail", "validator::isURL"],
+      hitCounts: { "validator::isEmail": 3 },
+      missCounts: { validator: 1 },
+    };
+    saveShaveOnMissState(state, path);
+    expect(existsSync(path)).toBe(true);
+
+    const loaded = loadShaveOnMissState(path);
+    expect(loaded.completedBindings).toEqual(state.completedBindings);
+    expect(loaded.hitCounts["validator::isEmail"]).toBe(3);
+    expect(loaded.missCounts["validator"]).toBe(1);
+  });
+
+  it("creates parent directories as needed", () => {
+    const deepPath = join(tempDir, "deep", "nested", "state.json");
+    const state = {
+      version: 1 as const,
+      completedBindings: [],
+      hitCounts: {},
+      missCounts: {},
+    };
+    saveShaveOnMissState(state, deepPath);
+    expect(existsSync(deepPath)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §5: withCompletion
+// ---------------------------------------------------------------------------
+
+describe("withCompletion", () => {
+  it("adds a new binding key to completedBindings", () => {
+    const base = { version: 1 as const, completedBindings: [], hitCounts: {}, missCounts: {} };
+    const updated = withCompletion(base, "validator::isEmail");
+    expect(updated.completedBindings).toContain("validator::isEmail");
+  });
+
+  it("is idempotent -- adding the same key twice does not duplicate", () => {
+    const base = {
+      version: 1 as const,
+      completedBindings: ["validator::isEmail"],
+      hitCounts: {},
+      missCounts: {},
+    };
+    const updated = withCompletion(base, "validator::isEmail");
+    expect(updated.completedBindings.filter((k) => k === "validator::isEmail")).toHaveLength(1);
+  });
+
+  it("does not mutate the original state", () => {
+    const base = { version: 1 as const, completedBindings: [], hitCounts: {}, missCounts: {} };
+    withCompletion(base, "validator::isEmail");
+    expect(base.completedBindings).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §6: withHitIncrement
+// ---------------------------------------------------------------------------
+
+describe("withHitIncrement", () => {
+  it("increments hitCounts[key] from 0", () => {
+    const base = { version: 1 as const, completedBindings: [], hitCounts: {}, missCounts: {} };
+    const updated = withHitIncrement(base, "validator::isEmail");
+    expect(updated.hitCounts["validator::isEmail"]).toBe(1);
+  });
+
+  it("increments hitCounts[key] from existing value", () => {
+    const base = {
+      version: 1 as const,
+      completedBindings: [],
+      hitCounts: { "validator::isEmail": 4 },
+      missCounts: {},
+    };
+    const updated = withHitIncrement(base, "validator::isEmail");
+    expect(updated.hitCounts["validator::isEmail"]).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §7: withMissIncrement
+// ---------------------------------------------------------------------------
+
+describe("withMissIncrement", () => {
+  it("increments missCounts[packageName] from 0", () => {
+    const base = { version: 1 as const, completedBindings: [], hitCounts: {}, missCounts: {} };
+    const updated = withMissIncrement(base, "validator");
+    expect(updated.missCounts["validator"]).toBe(1);
+  });
+
+  it("increments missCounts[packageName] from existing value", () => {
+    const base = {
+      version: 1 as const,
+      completedBindings: [],
+      hitCounts: {},
+      missCounts: { validator: 2 },
+    };
+    const updated = withMissIncrement(base, "validator");
+    expect(updated.missCounts["validator"]).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §8: resolveSkipShaveHitThreshold
+// ---------------------------------------------------------------------------
+
+describe("resolveSkipShaveHitThreshold", () => {
+  it("returns default 2 when env var not set", () => {
+    // biome-ignore lint/performance/noDelete: env-var removal is intentional
+    delete process.env.YAKCC_SKIP_SHAVE_HIT_THRESHOLD;
+    expect(resolveSkipShaveHitThreshold()).toBe(2);
+  });
+
+  it("returns parsed value from YAKCC_SKIP_SHAVE_HIT_THRESHOLD", () => {
+    process.env.YAKCC_SKIP_SHAVE_HIT_THRESHOLD = "5";
+    expect(resolveSkipShaveHitThreshold()).toBe(5);
+  });
+
+  it("falls back to default on invalid env var", () => {
+    process.env.YAKCC_SKIP_SHAVE_HIT_THRESHOLD = "not-a-number";
+    expect(resolveSkipShaveHitThreshold()).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §9: resolvePreemptiveMissThreshold
+// ---------------------------------------------------------------------------
+
+describe("resolvePreemptiveMissThreshold", () => {
+  it("returns default 3 when env var not set", () => {
+    // biome-ignore lint/performance/noDelete: env-var removal is intentional
+    delete process.env.YAKCC_PREEMPTIVE_SHAVE_MISS_THRESHOLD;
+    expect(resolvePreemptiveMissThreshold()).toBe(3);
+  });
+
+  it("returns parsed value from YAKCC_PREEMPTIVE_SHAVE_MISS_THRESHOLD", () => {
+    process.env.YAKCC_PREEMPTIVE_SHAVE_MISS_THRESHOLD = "10";
+    expect(resolvePreemptiveMissThreshold()).toBe(10);
+  });
+
+  it("falls back to default on invalid env var", () => {
+    process.env.YAKCC_PREEMPTIVE_SHAVE_MISS_THRESHOLD = "abc";
+    expect(resolvePreemptiveMissThreshold()).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §10: listPackageBindings
+// ---------------------------------------------------------------------------
+
+describe("listPackageBindings", () => {
+  it("returns binding names from versioned fixture layout", () => {
+    const bindings = listPackageBindings("validator", FIXTURE_DIR);
+    expect(bindings.length).toBeGreaterThan(0);
+    expect(bindings).toContain("isEmail");
+    expect(bindings).toContain("isURL");
+    expect(bindings).toContain("isUUID");
+    expect(bindings).toContain("isAlphanumeric");
+  });
+
+  it("returns empty array when package not in corpus", () => {
+    const bindings = listPackageBindings("totally-unknown-package", FIXTURE_DIR);
+    expect(bindings).toHaveLength(0);
+  });
+
+  it("returns empty array when corpus dir does not exist", () => {
+    const bindings = listPackageBindings("validator", "/nonexistent/path");
+    expect(bindings).toHaveLength(0);
+  });
+
+  it("returns binding names from standard layout (non-versioned)", () => {
+    // Standard layout: corpusDir/{packageName}/lib/*.js
+    // The versioned fixture dir acts as a standard layout package named "validator-13.15.35".
+    const bindings = listPackageBindings("validator-13.15.35", FIXTURE_DIR);
+    expect(bindings.length).toBeGreaterThan(0);
+    expect(bindings).toContain("isEmail");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §11: recordImportHit
+// ---------------------------------------------------------------------------
+
+describe("recordImportHit", () => {
+  it("increments hit count for a binding and persists to state path", () => {
+    const statePath = join(tempDir, "hits.json");
+    process.env.YAKCC_SHAVE_ON_MISS_STATE_PATH = statePath;
+
+    recordImportHit("validator", "isEmail");
+
+    const loaded = loadShaveOnMissState(statePath);
+    expect(loaded.hitCounts["validator::isEmail"]).toBe(1);
+  });
+
+  it("accumulates hit counts across multiple calls", () => {
+    const statePath = join(tempDir, "hits2.json");
+    process.env.YAKCC_SHAVE_ON_MISS_STATE_PATH = statePath;
+
+    recordImportHit("validator", "isEmail");
+    _resetShaveOnMissState(); // simulate re-load from disk
+    recordImportHit("validator", "isEmail");
+
+    const loaded = loadShaveOnMissState(statePath);
+    expect(loaded.hitCounts["validator::isEmail"]).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §12: makeBindingKey
+// ---------------------------------------------------------------------------
+
+describe("makeBindingKey", () => {
+  it("produces packageName::binding format", () => {
+    expect(makeBindingKey("validator", "isEmail")).toBe("validator::isEmail");
+    expect(makeBindingKey("zod", "z")).toBe("zod::z");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §13: getState + updateState cache
+// ---------------------------------------------------------------------------
+
+describe("getState / updateState cache", () => {
+  it("getState returns empty state when no file exists", () => {
+    process.env.YAKCC_SHAVE_ON_MISS_STATE_PATH = join(tempDir, "nope.json");
+    const state = getState();
+    expect(state.completedBindings).toHaveLength(0);
+  });
+
+  it("updateState updates the cache and saves to disk", () => {
+    const statePath = join(tempDir, "cache.json");
+    process.env.YAKCC_SHAVE_ON_MISS_STATE_PATH = statePath;
+
+    const newState = {
+      version: 1 as const,
+      completedBindings: ["validator::isEmail"],
+      hitCounts: {},
+      missCounts: {},
+    };
+    updateState(newState);
+
+    // Cache reflects the update.
+    expect(getState().completedBindings).toContain("validator::isEmail");
+    // Disk reflects the update.
+    const loaded = loadShaveOnMissState(statePath);
+    expect(loaded.completedBindings).toContain("validator::isEmail");
+  });
+});

--- a/packages/hooks-base/test/shave-on-miss.test.ts
+++ b/packages/hooks-base/test/shave-on-miss.test.ts
@@ -17,18 +17,26 @@
  * @decision DEC-WI508-S2-SHAVE-MISS-FAIL-LOUD-OFF-001
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { openRegistry } from "@yakcc/registry";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   _resetShaveOnMissQueue,
+  applyPreemptivePackageShave,
   applyShaveOnMiss,
   awaitShaveOnMissDrain,
   resolveCorpusDir,
   resolveEntryPath,
 } from "../src/shave-on-miss.js";
+import {
+  _resetShaveOnMissState,
+  loadShaveOnMissState,
+  makeBindingKey,
+  saveShaveOnMissState,
+} from "../src/shave-on-miss-state.js";
 
 // ---------------------------------------------------------------------------
 // Fixture paths
@@ -65,15 +73,41 @@ function identityEmbeddingProvider(): EmbeddingProvider {
 
 const savedCorpusDir = process.env.YAKCC_SHAVE_ON_MISS_CORPUS_DIR;
 
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = join(tmpdir(), `shave-on-miss-test-${process.pid}-${Date.now()}`);
+  mkdirSync(tempDir, { recursive: true });
+  // Point to an isolated per-test state file so tests never share the default
+  // ~/.yakcc/shave-on-miss-state.json path. Without this, miss counts accumulate
+  // across tests and trigger preemptive shave unexpectedly.
+  // DEC-WI508-S3-STATE-PERSIST-001.
+  process.env.YAKCC_SHAVE_ON_MISS_STATE_PATH = join(tempDir, "test-state.json");
+  // Disable preemptive shave by default in tests that do not specifically test it.
+  // Tests that want to test preemptive shave override this env var explicitly.
+  // DEC-WI508-S3-PREEMPTIVE-MISS-THRESHOLD-001.
+  process.env.YAKCC_PREEMPTIVE_SHAVE_MISS_THRESHOLD = "999";
+});
+
 afterEach(() => {
-  // Reset queue between tests to prevent state leakage.
+  // Reset queue and state cache between tests to prevent state leakage.
   _resetShaveOnMissQueue();
-  // Restore env var.
+  // Restore env vars.
   if (savedCorpusDir !== undefined) {
     process.env.YAKCC_SHAVE_ON_MISS_CORPUS_DIR = savedCorpusDir;
   } else {
     // biome-ignore lint/performance/noDelete: env-var removal is intentional
     delete process.env.YAKCC_SHAVE_ON_MISS_CORPUS_DIR;
+  }
+  // biome-ignore lint/performance/noDelete: env-var removal is intentional
+  delete process.env.YAKCC_SHAVE_ON_MISS_STATE_PATH;
+  // biome-ignore lint/performance/noDelete: env-var removal is intentional
+  delete process.env.YAKCC_SKIP_SHAVE_HIT_THRESHOLD;
+  // biome-ignore lint/performance/noDelete: env-var removal is intentional
+  delete process.env.YAKCC_PREEMPTIVE_SHAVE_MISS_THRESHOLD;
+  // Remove temp dir.
+  if (existsSync(tempDir)) {
+    rmSync(tempDir, { recursive: true, force: true });
   }
 });
 
@@ -281,5 +315,183 @@ describe("applyShaveOnMiss -- failure handling", () => {
 describe("awaitShaveOnMissDrain", () => {
   it("resolves immediately when queue is empty", async () => {
     await expect(awaitShaveOnMissDrain(1_000)).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §7: WI-508 Slice 3 -- skip-shave heuristics (DEC-WI508-S3-SKIP-HIT-THRESHOLD-001)
+// ---------------------------------------------------------------------------
+
+describe("applyShaveOnMiss -- Slice 3 skip-shave: completedBindings check", () => {
+  it("returns shaveOnMissEnqueued=false when binding is in completedBindings (prior run)", () => {
+    process.env.YAKCC_SHAVE_ON_MISS_CORPUS_DIR = FIXTURE_DIR;
+    // Pre-populate completed state for validator/isEmail using the per-test state path.
+    // saveShaveOnMissState imported at top of file
+    const statePath = process.env.YAKCC_SHAVE_ON_MISS_STATE_PATH as string;
+    saveShaveOnMissState(
+      {
+        version: 1,
+        completedBindings: [makeBindingKey("validator", "isEmail")],
+        hitCounts: {},
+        missCounts: {},
+      },
+      statePath,
+    );
+
+    const ctx = { intent: "validate email" };
+    const fakeRegistry = {} as import("@yakcc/registry").Registry;
+
+    const result = applyShaveOnMiss("validator", "isEmail", ctx, fakeRegistry);
+    expect(result.shaveOnMissEnqueued).toBe(false);
+    expect(result.entryResolved).toBe(true);
+  });
+
+  it("returns shaveOnMissEnqueued=false when hitCounts >= SKIP_SHAVE_HIT_THRESHOLD", () => {
+    process.env.YAKCC_SHAVE_ON_MISS_CORPUS_DIR = FIXTURE_DIR;
+    // Set threshold to 2 explicitly.
+    process.env.YAKCC_SKIP_SHAVE_HIT_THRESHOLD = "2";
+    const statePath = process.env.YAKCC_SHAVE_ON_MISS_STATE_PATH as string;
+    // saveShaveOnMissState imported at top of file
+    saveShaveOnMissState(
+      {
+        version: 1,
+        completedBindings: [],
+        hitCounts: { [makeBindingKey("validator", "isEmail")]: 2 },
+        missCounts: {},
+      },
+      statePath,
+    );
+
+    const ctx = { intent: "validate email" };
+    const fakeRegistry = {} as import("@yakcc/registry").Registry;
+
+    const result = applyShaveOnMiss("validator", "isEmail", ctx, fakeRegistry);
+    expect(result.shaveOnMissEnqueued).toBe(false);
+    expect(result.entryResolved).toBe(true);
+  });
+
+  it("enqueues when hitCounts < SKIP_SHAVE_HIT_THRESHOLD (below threshold)", () => {
+    process.env.YAKCC_SHAVE_ON_MISS_CORPUS_DIR = FIXTURE_DIR;
+    process.env.YAKCC_SKIP_SHAVE_HIT_THRESHOLD = "2";
+    const statePath = process.env.YAKCC_SHAVE_ON_MISS_STATE_PATH as string;
+    // saveShaveOnMissState imported at top of file
+    saveShaveOnMissState(
+      {
+        version: 1,
+        completedBindings: [],
+        hitCounts: { [makeBindingKey("validator", "isEmail")]: 1 },
+        missCounts: {},
+      },
+      statePath,
+    );
+
+    const registry = { storeBlock: vi.fn() } as unknown as import("@yakcc/registry").Registry;
+    const ctx = { intent: "validate email" };
+
+    const result = applyShaveOnMiss("validator", "isEmail", ctx, registry);
+    // 1 hit < threshold 2, so shave should be enqueued.
+    expect(result.shaveOnMissEnqueued).toBe(true);
+
+    // Drain so tests don't bleed into each other.
+    return awaitShaveOnMissDrain(30_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §8: WI-508 Slice 3 -- miss count increments (DEC-WI508-S3-PREEMPTIVE-MISS-THRESHOLD-001)
+// ---------------------------------------------------------------------------
+
+describe("applyShaveOnMiss -- Slice 3 miss count persistence", () => {
+  it("increments missCounts for the package on each new enqueue", async () => {
+    process.env.YAKCC_SHAVE_ON_MISS_CORPUS_DIR = FIXTURE_DIR;
+    const statePath = process.env.YAKCC_SHAVE_ON_MISS_STATE_PATH as string;
+    // Preemptive threshold is already 999 from beforeEach.
+
+    const registry = await openRegistry(":memory:", {
+      embeddings: identityEmbeddingProvider(),
+    });
+
+    const ctx1 = { intent: "validate email" };
+    const ctx2 = { intent: "validate URL" };
+
+    applyShaveOnMiss("validator", "isEmail", ctx1, registry);
+    _resetShaveOnMissState(); // simulate a second process loading state from disk
+    applyShaveOnMiss("validator", "isURL", ctx2, registry);
+
+    await awaitShaveOnMissDrain(30_000);
+
+    const state = loadShaveOnMissState(statePath);
+    // Both misses should be recorded.
+    expect(state.missCounts["validator"]).toBeGreaterThanOrEqual(2);
+
+    await registry.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §9: WI-508 Slice 3 -- completion persistence (DEC-WI508-S3-STATE-PERSIST-001)
+// ---------------------------------------------------------------------------
+
+describe("applyShaveOnMiss -- Slice 3 completion persistence", () => {
+  it("adds binding key to completedBindings after drain completes", async () => {
+    process.env.YAKCC_SHAVE_ON_MISS_CORPUS_DIR = FIXTURE_DIR;
+    const statePath = process.env.YAKCC_SHAVE_ON_MISS_STATE_PATH as string;
+
+    const registry = await openRegistry(":memory:", {
+      embeddings: identityEmbeddingProvider(),
+    });
+
+    const ctx = { intent: "validate email" };
+
+    const result = applyShaveOnMiss("validator", "isEmail", ctx, registry);
+    expect(result.shaveOnMissEnqueued).toBe(true);
+
+    await awaitShaveOnMissDrain(30_000);
+
+    const state = loadShaveOnMissState(statePath);
+    expect(state.completedBindings).toContain(makeBindingKey("validator", "isEmail"));
+
+    await registry.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §10: WI-508 Slice 3 -- applyPreemptivePackageShave
+// ---------------------------------------------------------------------------
+
+describe("applyPreemptivePackageShave", () => {
+  it("enqueues shaves for all bindings found in the corpus lib/ dir", async () => {
+    const statePath = process.env.YAKCC_SHAVE_ON_MISS_STATE_PATH as string;
+    // applyPreemptivePackageShave calls applyShaveOnMiss internally, which resolves
+    // the corpus dir from YAKCC_SHAVE_ON_MISS_CORPUS_DIR (not the corpusDir argument).
+    // Set the env var so resolveEntryPath() can find the fixture bindings.
+    process.env.YAKCC_SHAVE_ON_MISS_CORPUS_DIR = FIXTURE_DIR;
+
+    const registry = await openRegistry(":memory:", {
+      embeddings: identityEmbeddingProvider(),
+    });
+    const ctx = { intent: "preemptive scan validator" };
+
+    applyPreemptivePackageShave("validator", ctx, registry, FIXTURE_DIR);
+
+    // At least one background shave should be pending.
+    await awaitShaveOnMissDrain(30_000);
+
+    // After drain, completedBindings should contain at least one validator binding.
+    const state = loadShaveOnMissState(statePath);
+    const validatorCompleted = state.completedBindings.filter((k) => k.startsWith("validator::"));
+    expect(validatorCompleted.length).toBeGreaterThan(0);
+
+    await registry.close();
+  });
+
+  it("does nothing when package is not in corpus dir", () => {
+    const ctx = { intent: "preemptive unknown package" };
+    const fakeRegistry = {} as import("@yakcc/registry").Registry;
+
+    // Should not throw.
+    expect(() => {
+      applyPreemptivePackageShave("totally-unknown-package", ctx, fakeRegistry, FIXTURE_DIR);
+    }).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Closes #569. Implements WI-508 Slice 3: persistent hot-set state that lets the shave-on-miss hook skip redundant re-shaves and preemptively scan packages that repeatedly miss.

### What's new

**`src/shave-on-miss-state.ts`** (new file)
- `ShaveOnMissState` — versioned JSON schema: `completedBindings`, `hitCounts`, `missCounts`
- `resolveStatePath()` — `YAKCC_SHAVE_ON_MISS_STATE_PATH` override or `~/.yakcc/shave-on-miss-state.json`
- `loadShaveOnMissState` / `saveShaveOnMissState` — fail-safe I/O (missing file → empty state)
- `makeBindingKey(pkg, binding)` → `"pkg::binding"` (DEC-WI508-S3-KEY-FORMAT-001)
- `withCompletion` / `withHitIncrement` / `withMissIncrement` — pure state transformers
- `getState` / `updateState` — module-scope lazy cache + disk sync
- `recordImportHit(pkg, binding)` — called from import-intercept on registry hit
- `listPackageBindings(pkg, corpusDir)` — scans `lib/*.js`; mirrors `resolveEntryPath` resolution order
- `resolveSkipShaveHitThreshold()` — `YAKCC_SKIP_SHAVE_HIT_THRESHOLD`, default 2 (DEC-WI508-S3-SKIP-HIT-THRESHOLD-001)
- `resolvePreemptiveMissThreshold()` — `YAKCC_PREEMPTIVE_SHAVE_MISS_THRESHOLD`, default 3 (DEC-WI508-S3-PREEMPTIVE-MISS-THRESHOLD-001)

**`src/shave-on-miss.ts`** (modified)
- `applyShaveOnMiss` now checks `completedBindings` and `hitCounts` before touching the queue
- Records miss via `withMissIncrement`; triggers `applyPreemptivePackageShave` via `queueMicrotask` when `missCounts[pkg] >= threshold`
- Worker `finally` block persists completion (even on error — prevents wasteful retry storms) (DEC-WI508-S3-STATE-PERSIST-001)
- New `applyPreemptivePackageShave(pkg, ctx, registry, corpusDir)` — scans corpus and calls `applyShaveOnMiss` for each binding (DEC-WI508-S3-PREEMPTIVE-SCAN-001)

**`src/import-intercept.ts`** (modified)
- Dynamic-imports `recordImportHit` on every registry hit; fire-and-forget, failure swallowed (observe-don't-mutate)

**`src/index.ts`** (modified)
- Exports `applyPreemptivePackageShave`, `ShaveOnMissState`, and all state-management helpers

### Tests

- `test/shave-on-miss-state.test.ts` — 13 sections covering all state functions
- `test/shave-on-miss.test.ts` — 4 new sections: skip-shave via `completedBindings`, skip-shave via `hitCounts`, miss-count persistence, `applyPreemptivePackageShave`; added per-test state isolation via `beforeEach`
- `test/shave-on-miss-integration.test.ts` — added per-test state isolation to prevent cross-file state contamination

**282 / 282 tests passing.**

### Key decisions

| Decision | Description |
|---|---|
| DEC-WI508-S3-STATE-PERSIST-001 | State persisted to `~/.yakcc/shave-on-miss-state.json`; env-var override |
| DEC-WI508-S3-KEY-FORMAT-001 | Keys are `pkg::binding` (stable across corpusDir locations) |
| DEC-WI508-S3-SKIP-HIT-THRESHOLD-001 | Default threshold 2; calibration pending B4/B9 sweep |
| DEC-WI508-S3-PREEMPTIVE-MISS-THRESHOLD-001 | Default threshold 3; calibration pending |
| DEC-WI508-S3-PREEMPTIVE-SCAN-001 | Preemptive scan reuses `applyShaveOnMiss` dedup |
| DEC-WI508-S3-THRESHOLD-CALIBRATION-PENDING-001 | Both defaults provisional; B4 (#188) / B9 (#446) are calibration sources |

https://claude.ai/code/session_01VDW32nNwT1hXvoGCo94DL1

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDW32nNwT1hXvoGCo94DL1)_