### PR TITLE
test(shave): stopgap timeout bumps for nightly module-graph + validator-headline-bindings

### DIFF
--- a/packages/shave/src/universalize/module-graph.test.ts
+++ b/packages/shave/src/universalize/module-graph.test.ts
@@ -661,7 +661,7 @@ describe("shavePackage — best-effort degradation (unresolvable edge)", () => {
 describe("shavePackage — two-pass determinism (ms fixture)", () => {
   it(
     "two passes over ms produce byte-identical forest structure (moduleCount, leafCount, filePaths)",
-    { timeout: 30000 },
+    { timeout: 90000 },
     async () => {
       const pkgRoot = join(FIXTURES_DIR, "ms-2.1.3");
 

--- a/packages/shave/src/universalize/validator-headline-bindings.test.ts
+++ b/packages/shave/src/universalize/validator-headline-bindings.test.ts
@@ -160,7 +160,7 @@ function withSemanticIntentCard(
 describe("validator isEmail -- per-entry shave (WI-510 Slice 2)", () => {
   it(
     "section A -- moduleCount in [7,12], stubCount=0, forestTotalLeafCount>0 for isEmail subgraph",
-    { timeout: 120_000 },
+    { timeout: 300_000 },
     async () => {
       const forest = await shavePackage(VALIDATOR_FIXTURE_ROOT, {
         registry: emptyRegistry,
@@ -216,7 +216,7 @@ describe("validator isEmail -- per-entry shave (WI-510 Slice 2)", () => {
 
   it(
     "section D -- two-pass byte-identical determinism for isEmail subgraph",
-    { timeout: 120_000 },
+    { timeout: 300_000 },
     async () => {
       const entryPath = join(VALIDATOR_FIXTURE_ROOT, "lib", "isEmail.js");
       const forest1 = await shavePackage(VALIDATOR_FIXTURE_ROOT, {
@@ -347,7 +347,7 @@ describe("validator isURL -- per-entry shave (WI-510 Slice 2)", () => {
 
   it(
     "section D -- two-pass byte-identical determinism for isURL subgraph",
-    { timeout: 120_000 },
+    { timeout: 300_000 },
     async () => {
       const entryPath = join(VALIDATOR_FIXTURE_ROOT, "lib", "isURL.js");
       const forest1 = await shavePackage(VALIDATOR_FIXTURE_ROOT, {

--- a/plans/wi-nightly-timeouts-v2.md
+++ b/plans/wi-nightly-timeouts-v2.md
@@ -1,0 +1,66 @@
+# wi-nightly-timeouts-v2: Nightly test timeout stopgap
+
+## Problem
+
+5 nightly test failures (all timeout-class) observed in CI run:
+https://github.com/cneckar/yakcc/actions/runs/25952447737
+
+Affected tests:
+
+| File | Test | Old timeout | New timeout |
+|------|------|-------------|-------------|
+| `module-graph.test.ts` | two passes over ms produce byte-identical forest structure | 30 000 ms | 90 000 ms |
+| `validator-headline-bindings.test.ts` | section A -- moduleCount in [7,12] for isEmail subgraph | 120 000 ms | 300 000 ms |
+| `validator-headline-bindings.test.ts` | section D -- two-pass byte-identical determinism for isEmail subgraph | 120 000 ms | 300 000 ms |
+| `validator-headline-bindings.test.ts` | section D -- two-pass byte-identical determinism for isURL subgraph | 120 000 ms | 300 000 ms |
+| `validator-headline-bindings.test.ts` | all four per-entry shaves are independent, complete, and produce non-empty forests | 120 000 ms | 300 000 ms |
+
+Note: The compound interaction test (5th row) was already bumped to 300 000 ms in commit `5d8bde1`
+(WI-510 Slice 4) before this work item landed; only 4 edits were applied here.
+
+## Fix
+
+Per-test `{ timeout: N }` overrides in the two affected test files. No global
+config change — see "Why not vitest.config.ts" below.
+
+## Why NOT vitest.config.ts
+
+Issue #541 tracks the anti-pattern of using `hookTimeout` / global timeout
+config in `vitest.config.ts` as a blunt instrument. Global bumps hide slow
+tests indiscriminately and mask real regressions. Per-test overrides are
+surgical: they document exactly which tests are slow and why, and leave the
+global timeout as a canary for newly-introduced slowness.
+
+`vitest.config.ts` is explicitly **forbidden** in the scope of this work item.
+
+## Why v2
+
+v1 (`wi-nightly-test-timeouts`) hit a policy catch-22:
+- Guardian landing was denied because `evaluation_state` was pinned to an old
+  SHA after the implementer amended rather than created a fresh commit.
+- The implementer lease blocked `can_land_git` by design.
+
+v2 starts fresh from `origin/main` HEAD (`5d8bde1`) on a clean branch
+`feature/nightly-timeouts-v2`, avoiding the merge-chain dead end.
+
+## Structural fix tracker
+
+Issue #541 tracks the proper long-term fix: reducing the shave engine's
+per-call latency so these tests no longer need generous timeouts to pass
+reliably on cold CI runners.
+
+## Acceptance criteria
+
+- All 5 affected tests pass under their new budgets (4 edits applied; 1 was
+  pre-existing in current HEAD)
+- `vitest.config.ts` is NOT modified
+- No assertions weakened; no `it.skip` / `it.todo` introduced
+- Nightly CI clears the 5 timeout failures from run #25952447737
+- `git diff --stat origin/main..HEAD` shows exactly 3 files: the 2 test files
+  plus this plan doc
+
+## Rollback
+
+```
+git revert <landing-commit>
+```


### PR DESCRIPTION
## Summary
Five nightly test failures, all timeout-class. 4 edits land here (5th was already in main via WI-510 Slice 4).

- `module-graph.test.ts` two-pass determinism: 30s → 90s (2-pass was using 1-pass budget; passes in 19s)
- `validator-headline-bindings.test.ts` (3 tests): 120s → 300s (isEmail sA + sD, isURL sD)
- `compound interaction` test already at 300s in 5d8bde1 — no edit needed

## NOT touching vitest.config.ts
Per #541 anti-pattern. Only per-test `{ timeout: N }` overrides used.

## Local validation
- module-graph passes in 19s (well under 90s)
- validator-headline deferred to CI per cheap-local pattern

## Out of scope
Proper structural fix tracked in #541 (split per-binding or describe.concurrent).

Refs nightly run https://github.com/cneckar/yakcc/actions/runs/25952447737