### PR TITLE
docs(hooks): enforce specific-first descent-and-compose pattern in discovery prompt (closes #578)

### DIFF
--- a/docs/adr/discovery-llm-interaction.md
+++ b/docs/adr/discovery-llm-interaction.md
@@ -430,6 +430,61 @@ rank-1 is surfaced.
 
 ---
 
+### Q8: Descent-and-Compose Discipline — WI-578 prompt rewrite (2026-05-15)
+
+**Decision:** Rewrite `docs/system-prompts/yakcc-discovery.md` from a polite suggestion into an
+imperative descent-and-compose discipline. This is a D4 ADR revision as required by the authority
+comment at the top of the prompt file.
+
+**What changed:**
+
+The original Q4 prompt (locked in this ADR) offered soft guidance:
+
+- "first call `yakcc_resolve` with a structured intent"
+- "Reserve hand-written code for project-specific business logic"
+- "(a) widen the query … and re-issue" on `no_match`
+
+The revised prompt (`docs/system-prompts/yakcc-discovery.md` as of WI-578) replaces that
+guidance with imperative rules:
+
+- "You MUST start every search with the most specific intent you can articulate"
+- "You MUST NOT widen an intent to make a search hit"
+- "There are NO carve-outs"
+- A mandatory self-check step before every `yakcc_resolve` call
+- Descent-on-miss rule: decompose, query each piece, compose upward
+- A verbatim URL-parser walkthrough as the canonical protocol
+- Explicit `refuse` instruction for single-word or vague intents
+
+**Why:** GH #578 (label: `load-bearing`) documented that the original prompt produced loose
+initial intents in practice — "validation," "parser," "helper" — resulting in oversized atoms
+that carry unused capabilities. The soft-suggestion framing allowed LLMs to rationalize skipping
+discovery by treating generic operations as "business logic." The imperative rewrite closes that
+escape hatch.
+
+**Invariants verified (grep-level, DEC-HOOK-PROMPT-DESCENT-001):**
+- `grep -c "You MUST" docs/system-prompts/yakcc-discovery.md` ≥ 4
+- `grep -c "You MUST NOT" docs/system-prompts/yakcc-discovery.md` ≥ 1
+- `grep -c "NO carve-outs" docs/system-prompts/yakcc-discovery.md` ≥ 1
+- `grep -ci "self-check" docs/system-prompts/yakcc-discovery.md` ≥ 1
+- `grep -c "URL parser" docs/system-prompts/yakcc-discovery.md` ≥ 1
+- `grep -c "You SHOULD consider\|Try to\|When possible\|Reserve hand-written code"` = 0
+- `grep -ci "business logic\|one-off\|application-specific"` = 0
+
+**What is NOT changed:** The D4 design decisions Q1–Q7 remain in force. The tool call shape,
+evidence rendering contract, 4-band protocol, `status` enum, `ConfidenceMode` type, failure mode
+shapes, and D4/D5 boundary are all unchanged. Only the system-prompt text (previously locked
+verbatim in Q4) is updated. The Q4 "locked text" section above is now superseded by the revised
+file at `docs/system-prompts/yakcc-discovery.md`.
+
+**Rollback:** `git revert` the WI-578 landing commit. The prompt file reverts to its previous
+49-line form; behavior reverts to the pre-#578 baseline.
+
+**Issue:** https://github.com/cneckar/yakcc/issues/578
+**Decision ID:** DEC-HOOK-PROMPT-DESCENT-001
+**Date:** 2026-05-15
+
+---
+
 ### Q7: Boundary with D5 (quality measurement)
 
 **Decision:** D4 pins **interaction shape** in v1; D5 measures and tunes **calibration knobs**.
@@ -835,6 +890,7 @@ The implementation split follows the WI assignments established by D1, D2, and D
 
 ## References
 
+- Issue #578 (WI-578 — Descent-and-Compose prompt rewrite; D4 ADR revision in Q8)
 - Issue #154 (this work item — V3-DISCOVERY-D4)
 - Issue #153 (D3 — V3-DISCOVERY-D3)
 - Issue #152 (D2 — V3-DISCOVERY-D2)

--- a/docs/system-prompts/yakcc-discovery.md
+++ b/docs/system-prompts/yakcc-discovery.md
@@ -1,49 +1,111 @@
 # Authority: DEC-V3-DISCOVERY-D4-001 (docs/adr/discovery-llm-interaction.md) — changes to this file require a D4 ADR revision.
 
-You have access to the yakcc discovery system via the `yakcc_resolve` tool.
+You have access to the yakcc discovery system via the `yakcc_resolve` tool. The
+rules below are not suggestions. They define the only acceptable way to write
+generic operations in this project.
 
-When you need to write code that performs a generic operation — parsing,
-validating, transforming, computing, formatting, hashing, comparing —
-first call `yakcc_resolve` with a structured intent describing what the
-code should do.
+## The rule
 
-Build the intent as:
+You MUST start every search with the most specific intent you can articulate
+for the immediate need. A loose initial intent is a defect — it produces
+oversized atoms that carry unused capabilities into the project. Unused code is
+attack surface, complexity debt, and reasoning load.
 
-  - behavior: a one-line natural-language description of what the code does.
-  - guarantees: an array of specific properties the code must satisfy.
-                Be specific. "rejects non-integer values" disambiguates from
-                "rejects non-numeric values."
-  - signature: input/output types as { name?, type } pairs.
-                Names are optional; types are required.
-  - errorConditions, propertyTests, nonFunctional: optional dimensions you
-                can populate to narrow the search.
-  - weights: optional per-dimension floats. Higher = more important. Omit
-                for equal weighting.
+You MUST NOT widen an intent to make a search hit. Widening is the failure
+mode this prompt exists to prevent. If you catch yourself reaching for a
+broader phrasing because "the narrow one missed," stop and apply the descent
+rule below.
 
-The system returns up to topK candidate atoms — pre-tested, pre-verified
-implementations from the registry. Each candidate carries a combinedScore
-in [0, 1] and a band classification:
+There are NO carve-outs. Project-specific logic, single-use operations, and
+premature-abstraction concerns are not valid reasons to skip discovery.
+
+## Self-check before every `yakcc_resolve` call
+
+Before you submit a query, answer these two questions silently:
+
+  1. Is this intent the most specific I can articulate for what the immediate
+     caller needs? If no — narrow it now and re-check.
+  2. Could a smaller piece of this intent already exist as its own atom? If
+     yes — search for that smaller piece first.
+
+If either answer leaves you submitting a vague query (`"validation"`,
+`"parser"`, `"utility"`, `"helper"`, single-word intents in general), refuse
+to submit. Write the user a short note explaining why the intent was too broad
+and what specific sub-intent you will search for instead.
+
+## Descent on miss — always zoom in, never zoom out
+
+A `no_match` or `weak_only` result is a signal that one of two things is true:
+
+  (A) The atom does not yet exist at this specificity. Correct response:
+      decompose the intent into sub-intents and query each.
+  (B) The intent is still too broad. Correct response: decompose further.
+
+In both cases the response is the same: **decompose, then query each piece**.
+
+Recurse until each leaf intent either hits the registry at score >= 0.70
+(`status === "matched"`) or bottoms out at a primitive operation you must
+compose by hand. Then compose upward from the leaves into the larger atom the
+original caller needed, and emit a NEW_ATOM_PROPOSAL block describing the
+composed atom so the registry's coverage improves and the next consumer with
+the same intent gets a direct hit.
+
+## Worked example: building a URL parser
+
+First-time request: "build a URL parser."
+
+  - Initial intent: "URL parser." MISS.
+  - Decompose: "split URL into scheme + host + path + query + fragment." MISS.
+  - Decompose further:
+      * "split string on first `://`" — HIT.
+      * "split string on first `/` after position N" — HIT.
+      * "split key=value pairs on `&`" — HIT.
+      * "percent-decode bytes" — MISS.
+          - Decompose: "decode `%XX` hex pair to a single byte" — HIT.
+  - Compose upward: assemble the URL parser from those leaf atoms. Persist
+    the composed result via NEW_ATOM_PROPOSAL with intent
+    "URL parser (RFC 3986 subset, no IDNA)."
+  - The first request is expensive. Every subsequent request for "URL parser"
+    is one lookup. That asymptotic win is the whole reason this discipline
+    exists.
+
+You MUST walk this exact pattern on any miss. The example is not
+illustrative — it is the protocol.
+
+## What `yakcc_resolve` returns
+
+The tool takes a `QueryIntentCard` and returns up to topK candidate atoms.
+Each candidate carries a `combinedScore` in [0, 1] and a band classification:
 
   - score >= 0.85 (strong):     reference the atom by BlockMerkleRoot.
-  - 0.70 - 0.85   (confident):  present to user with "this looks like a fit."
-  - 0.50 - 0.70   (weak):       show alternatives; let user decide.
-  - score <  0.50 (poor):       result.status will be "no_match". Do NOT
-                                silently write the code. Instead, either:
-                                  (a) widen the query (relax a constraint
-                                      based on near_misses[*].failedAtLayer)
-                                      and re-issue, or
-                                  (b) emit a NEW_ATOM_PROPOSAL block
-                                      describing the gap so the registry
-                                      coverage improves.
+  - 0.70 - 0.85   (confident):  reference the atom; note it in your reply.
+  - 0.50 - 0.70   (weak):       this is a `weak_only` status — apply the
+                                descent rule above. Do NOT use the weak
+                                candidate as a substitute for a tight match.
+  - score <  0.50 (poor):       `status === "no_match"`. Apply the descent
+                                rule above. Do NOT silently write the code.
 
-Auto-accept rule: if combinedScore > 0.85 AND the gap to the second-best
-candidate is > 0.15, insert the BlockMerkleRoot reference into the project
-manifest without prompting the user.
+`auto-accept`: when `combinedScore > 0.85` AND the gap to the second-best
+candidate is > 0.15, You MUST insert the BlockMerkleRoot reference into the
+project manifest without prompting the user.
 
-Reserve hand-written code for project-specific business logic that does
-not generalize — the "glue" per the project's content-addressing model.
-Generic operations belong in the registry.
+## Building the intent card
 
-If `yakcc_resolve` is unreachable (registry offline, transport error),
-fall back to writing the code directly and emit a REGISTRY_UNREACHABLE
-note in your output so the user can audit later.
+  - `behavior`: a one-line natural-language description. Specific verbs
+                ("split string on first `://`"), not generic ones ("handle
+                URLs").
+  - `guarantees`: an array of specific properties the code must satisfy.
+                "rejects non-integer values" disambiguates from "rejects
+                non-numeric values."
+  - `signature`: input/output types as { name?, type } pairs.
+  - `errorConditions`, `propertyTests`, `nonFunctional`: optional dimensions
+                that narrow the search. Use them.
+  - `weights`: optional per-dimension floats; omit for equal weighting.
+
+## When the tool is unreachable
+
+If `yakcc_resolve` is unreachable (registry offline, transport error), you may
+fall back to writing the code directly, but you MUST emit a
+REGISTRY_UNREACHABLE note in your output so the user can audit later. The
+fallback path is for outages only — it is not an escape hatch from the
+discipline above.

--- a/packages/hooks-base/src/system-prompt.ts
+++ b/packages/hooks-base/src/system-prompt.ts
@@ -1,0 +1,48 @@
+/**
+ * system-prompt.ts — Authority surface for the yakcc discovery system prompt.
+ *
+ * @decision DEC-HOOK-PROMPT-DESCENT-001
+ * @title Descent-and-compose discovery system prompt path constant and loader
+ * @status accepted
+ * @rationale
+ *   WI-578 (#578, load-bearing) rewrote docs/system-prompts/yakcc-discovery.md from
+ *   a polite-suggestion tone to an imperative descent-and-compose discipline. This
+ *   module exports the canonical path constant and a loadDiscoveryPrompt() reader so
+ *   tests can import and inspect the live prompt file without duplicating the path.
+ *
+ *   IMPORTANT: This module does NOT export the prompt text itself — the prompt lives
+ *   exclusively in docs/system-prompts/yakcc-discovery.md. This module only provides
+ *   access to it. Duplicating the text here would violate the single-source-of-truth
+ *   invariant (DEC-V3-DISCOVERY-D4-001).
+ *
+ *   Cross-references:
+ *     DEC-V3-DISCOVERY-D4-001  — D4 ADR governing the prompt file
+ *     docs/adr/discovery-llm-interaction.md §Q8 — WI-578 revision record
+ *     docs/system-prompts/yakcc-discovery.md — the canonical prompt text
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Workspace-root-relative path to the canonical yakcc discovery system prompt.
+ * This value is the single source of truth for the path; IDE adapter packages
+ * (hooks-claude-code, hooks-cursor) duplicate it as a local constant — that
+ * duplication is a known marker, not a content-drift risk (they point at the
+ * same file). See plan §4 for the trade-off.
+ */
+export const DISCOVERY_PROMPT_PATH = "docs/system-prompts/yakcc-discovery.md";
+
+/**
+ * Load the discovery system prompt from the canonical location.
+ *
+ * @param workspaceRoot - Absolute path to the workspace root. Defaults to
+ *   process.cwd(). Tests should supply a deterministic absolute path.
+ * @returns The prompt text as a UTF-8 string.
+ * @throws If the file cannot be read (missing, permission error, etc.).
+ */
+export function loadDiscoveryPrompt(workspaceRoot?: string): string {
+  const root = workspaceRoot ?? process.cwd();
+  const fullPath = join(root, DISCOVERY_PROMPT_PATH);
+  return readFileSync(fullPath, "utf-8");
+}

--- a/packages/hooks-base/test/system-prompt-integration.test.ts
+++ b/packages/hooks-base/test/system-prompt-integration.test.ts
@@ -1,0 +1,509 @@
+/**
+ * system-prompt-integration.test.ts — Integration tests for WI-578 prompt rewrite.
+ *
+ * Tests:
+ *   1. Corpus validation: each pair in the test corpus has a loose intent that
+ *      meets the "loose" definition and a tight intent that meets the "tight"
+ *      definition. Proves the corpus is internally consistent.
+ *   2. Negative test: the new prompt file contains the refusal text that would
+ *      cause an LLM to reject loose queries (deterministic text assertion; no
+ *      live LLM call per plan §5 U2 and risk mitigation R3).
+ *   3. Telemetry descent-depth assertion (Design A heuristic, plan §6):
+ *      Scaffolded with a controlled in-memory fixture. The real threshold
+ *      (≥ 50% of misses show follow-on resolve within 30s in the same session)
+ *      is guarded by a "telemetry-thin" skip if fewer than 20 events exist.
+ *
+ * @decision DEC-HOOK-PROMPT-DESCENT-001
+ * @title Integration test: corpus validation + negative test + telemetry scaffold
+ * @status accepted
+ * @rationale
+ *   The compound-interaction production sequence for WI-578 is:
+ *     LLM receives the system prompt at session start
+ *     → LLM calls yakcc_resolve with an intent
+ *     → on miss, the new prompt induces decompose-and-recurse (not widen)
+ *     → follow-on resolve call appears in the same session within short window
+ *   This test exercises the text-level proof (corpus + negative) and the
+ *   heuristic telemetry assertion (Design A) that verifies the descent pattern
+ *   in real usage traces. The live LLM call cannot be made deterministic;
+ *   the telemetry fixture stands in for it per plan risk R3.
+ */
+
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+import { loadDiscoveryPrompt } from "../src/system-prompt.js";
+
+// ---------------------------------------------------------------------------
+// Workspace root resolution
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_ROOT = resolve(import.meta.dirname ?? __dirname, "../../..");
+const CORPUS_PATH = join(
+  WORKSPACE_ROOT,
+  "tmp/wi-578-investigation/test-corpus.json",
+);
+
+// ---------------------------------------------------------------------------
+// Types matching test-corpus.json schema
+// ---------------------------------------------------------------------------
+
+interface CorpusPair {
+  id: number;
+  loose: string;
+  tight: string;
+  looseReason: string;
+  tightReason: string;
+}
+
+interface Corpus {
+  pairs: CorpusPair[];
+  looseDefinition: {
+    description: string;
+    requiredAbsence: string[];
+  };
+  tightDefinition: {
+    description: string;
+    requiredPresence: string[];
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Heuristic loose/tight classifiers matching corpus definitions
+// ---------------------------------------------------------------------------
+
+/**
+ * A "loose" intent is one that:
+ *  - is a single word, OR
+ *  - is a two-word generic noun phrase ending in a generic noun like
+ *    "helper", "handler", "util", "manager", or
+ *  - lacks any RFC/algorithm/standard reference AND lacks specific output constraints
+ *
+ * This is a heuristic — it matches the corpus definition, not a formal grammar.
+ */
+function isLooseIntent(intent: string): boolean {
+  const trimmed = intent.trim();
+  const words = trimmed.split(/\s+/);
+
+  // Single-word: always loose
+  if (words.length === 1) return true;
+
+  // Two-word phrase with a generic trailing noun
+  const genericNouns = [
+    "helper",
+    "handler",
+    "util",
+    "utility",
+    "manager",
+    "processor",
+    "input",
+  ];
+  if (words.length === 2) {
+    const lastWord = words[words.length - 1]!.toLowerCase();
+    if (genericNouns.includes(lastWord)) return true;
+  }
+
+  // No specific verb (from the list of "specific verbs" the tight definition requires)
+  const specificVerbs = [
+    "validate",
+    "parse",
+    "format",
+    "convert",
+    "strip",
+    "decode",
+    "encode",
+    "compute",
+    "split",
+    "retry",
+    "throttle",
+  ];
+  const hasSpecificVerb = specificVerbs.some((v) =>
+    trimmed.toLowerCase().startsWith(v),
+  );
+  if (!hasSpecificVerb) return true;
+
+  return false;
+}
+
+/**
+ * A "tight" intent is one that:
+ *  - contains a specific action verb or named algorithm
+ *  - and contains at least one of: named standard/RFC, explicit constraint, output format
+ */
+function isTightIntent(intent: string): boolean {
+  const lower = intent.toLowerCase();
+
+  // Must contain a specific verb or named algorithm
+  const specificVerbsOrAlgorithms = [
+    "validate",
+    "parse",
+    "format",
+    "convert",
+    "strip",
+    "decode",
+    "encode",
+    "compute",
+    "split",
+    "retry",
+    "throttle",
+    "blake3",
+    "deep structural",
+  ];
+  const hasSpecific = specificVerbsOrAlgorithms.some((v) => lower.includes(v));
+  if (!hasSpecific) return false;
+
+  // Must also contain at least one specificity marker
+  const specificityMarkers = [
+    "rfc",
+    "iso",
+    "blake3",
+    "utf-8",
+    "hex",
+    "ms",
+    "ms,",
+    "decimal",
+    "ascii",
+    "html",
+    "&amp;",
+    "exponential",
+    "per n ms",
+    "fixed",
+    "thousands",
+    "thousands separator",
+    "url slug",
+    "no display name",
+    "no nan",
+    "no functions",
+  ];
+  const hasSpecificityMarker = specificityMarkers.some((m) =>
+    lower.includes(m),
+  );
+
+  return hasSpecificityMarker;
+}
+
+// ---------------------------------------------------------------------------
+// Load corpus once
+// ---------------------------------------------------------------------------
+
+let corpus: Corpus;
+try {
+  corpus = JSON.parse(readFileSync(CORPUS_PATH, "utf-8")) as Corpus;
+} catch {
+  corpus = { pairs: [], looseDefinition: { description: "", requiredAbsence: [] }, tightDefinition: { description: "", requiredPresence: [] } };
+}
+
+// ---------------------------------------------------------------------------
+// Test Suite 1: Corpus validation
+// ---------------------------------------------------------------------------
+
+describe("WI-578 test corpus: paired intent validation", () => {
+  it("corpus file exists and has 10 pairs", () => {
+    expect(corpus.pairs.length).toBe(10);
+  });
+
+  for (const pair of corpus.pairs) {
+    it(`pair ${pair.id}: loose intent "${pair.loose}" classifies as loose`, () => {
+      expect(isLooseIntent(pair.loose)).toBe(true);
+    });
+
+    it(`pair ${pair.id}: tight intent classifies as tight (not loose)`, () => {
+      // A tight intent should NOT be loose by the single-word / generic noun check
+      const words = pair.tight.trim().split(/\s+/);
+      // Tight intents are always multi-word
+      expect(words.length).toBeGreaterThan(2);
+    });
+
+    it(`pair ${pair.id}: tight intent contains a specific verb or algorithm`, () => {
+      expect(isTightIntent(pair.tight)).toBe(true);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Test Suite 2: Negative test — prompt induces refusal of loose intents
+// (deterministic text assertion; no live LLM call per plan R3)
+// ---------------------------------------------------------------------------
+
+describe("negative test: prompt induces refusal of loose intents", () => {
+  const prompt = loadDiscoveryPrompt(WORKSPACE_ROOT);
+
+  it("prompt names single-word intents as refuse-triggers", () => {
+    expect(prompt).toMatch(/single-word intents in general/);
+  });
+
+  it('prompt explicitly instructs to "refuse to submit" vague queries', () => {
+    expect(prompt).toMatch(/refuse\s+to submit/);
+  });
+
+  it('prompt names "validation" as a vague query example', () => {
+    expect(prompt).toMatch(/"validation"/);
+  });
+
+  it('prompt names "parser" as a vague query example', () => {
+    expect(prompt).toMatch(/"parser"/);
+  });
+
+  it('prompt names "utility" as a vague query example', () => {
+    expect(prompt).toMatch(/"utility"/);
+  });
+
+  it('prompt names "helper" as a vague query example', () => {
+    expect(prompt).toMatch(/"helper"/);
+  });
+
+  it("prompt instructs to write a note explaining why intent was too broad", () => {
+    // The prompt says: "Write the user a short note explaining why the intent was
+    // too broad and what specific sub-intent you will search for instead."
+    expect(prompt).toMatch(/short note explaining why the intent was too broad/);
+  });
+
+  it("prompt provides the URL-parser walkthrough as a concrete descent example", () => {
+    // Verify the walkthrough contains the decompose sequence
+    expect(prompt).toContain('split string on first `://`');
+    expect(prompt).toMatch(/decode `%XX` hex pair/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test Suite 3: Telemetry descent-depth assertion (Design A, plan §6)
+// ---------------------------------------------------------------------------
+
+/**
+ * Design A: post-hoc inference of descent depth from a controlled telemetry fixture.
+ *
+ * In production, this would read ~/.yakcc/telemetry/<session-id>.jsonl.
+ * In this test, we use a controlled in-memory fixture that simulates what the
+ * real telemetry would look like after the WI-578 prompt rewrite takes effect.
+ *
+ * The fixture represents a session where:
+ *   1. LLM calls resolve("URL parser") → no_match (loose, miss)
+ *   2. LLM decomposes and calls resolve("split string on first ://") → matched (descent)
+ *   3. LLM calls resolve("clamp number between bounds") → matched (tight, not a descent)
+ *   4. LLM calls resolve("hash") → no_match (loose, miss)
+ *   5. LLM decomposes and calls resolve("BLAKE3-256 hex digest of UTF-8 string") → matched (descent)
+ *
+ * In this fixture: 2 misses (events 1 and 4), both followed by a descent call within 30s.
+ * Expected: 100% descent-on-miss rate ≥ 50% threshold.
+ */
+
+interface TelemetryEvent {
+  sessionId: string;
+  t: number; // Unix timestamp ms
+  intentHash: string;
+  outcome: "matched" | "synthesis-required" | "no-match" | "weak-only";
+  topScore: number;
+  intentText?: string; // Optional: retained in fixture for descent inference
+}
+
+function isDescendedIntent(
+  parentText: string | undefined,
+  childText: string | undefined,
+): boolean {
+  if (!parentText || !childText) return false;
+  // A child intent is a descent if the parent intent text contains it OR
+  // the child is more specific (longer, with specific verbs) than the parent.
+  const parentWords = parentText.toLowerCase().split(/\s+/);
+  const childWords = childText.toLowerCase().split(/\s+/);
+  // More specific = child has more words (contains more specifics)
+  return childWords.length > parentWords.length;
+}
+
+function computeDescentRate(events: TelemetryEvent[]): {
+  totalMisses: number;
+  missesWithDescent: number;
+  rate: number;
+  skipped: boolean;
+  skipReason?: string;
+} {
+  // Skip if fewer than 20 events (telemetry-thin guard per plan §6)
+  if (events.length < 20) {
+    return {
+      totalMisses: 0,
+      missesWithDescent: 0,
+      rate: 0,
+      skipped: true,
+      skipReason: `telemetry-thin: only ${events.length} events (need >= 20)`,
+    };
+  }
+
+  // Sort by session + timestamp
+  const sorted = [...events].sort((a, b) => {
+    if (a.sessionId !== b.sessionId)
+      return a.sessionId.localeCompare(b.sessionId);
+    return a.t - b.t;
+  });
+
+  let totalMisses = 0;
+  let missesWithDescent = 0;
+  const WINDOW_MS = 30_000;
+
+  for (let i = 0; i < sorted.length; i++) {
+    const event = sorted[i]!;
+    const isMiss =
+      event.outcome === "no-match" ||
+      event.outcome === "synthesis-required" ||
+      event.outcome === "weak-only" ||
+      event.topScore < 0.7;
+
+    if (!isMiss) continue;
+    totalMisses++;
+
+    // Look for a follow-on event within 30s in the same session
+    const followOn = sorted.find(
+      (e, j) =>
+        j > i &&
+        e.sessionId === event.sessionId &&
+        e.t - event.t <= WINDOW_MS &&
+        e.intentHash !== event.intentHash,
+    );
+
+    if (followOn) {
+      // Optionally validate descent (intent text is more specific)
+      const isDescended = isDescendedIntent(
+        event.intentText,
+        followOn.intentText,
+      );
+      if (isDescended || followOn.intentText === undefined) {
+        // Accept if we can confirm descent OR if intent text is absent (can't refute)
+        missesWithDescent++;
+      }
+    }
+  }
+
+  const rate = totalMisses === 0 ? 0 : missesWithDescent / totalMisses;
+  return { totalMisses, missesWithDescent, rate, skipped: false };
+}
+
+describe("telemetry descent-depth assertion (Design A, plan §6)", () => {
+  it.todo(
+    "real-telemetry threshold: ≥50% of misses show follow-on resolve within 30s (requires #569 real telemetry surface)",
+    // TODO: When #569 lands and real session telemetry is accessible, replace
+    // this todo with a live assertion that reads ~/.yakcc/telemetry/*.jsonl
+    // and applies computeDescentRate(). Threshold 50% is documented as a
+    // placeholder per plan §6; real-world tuning follows #569.
+  );
+
+  it("Design A computeDescentRate skips when fewer than 20 events (telemetry-thin guard)", () => {
+    const thinEvents: TelemetryEvent[] = Array.from({ length: 5 }, (_, i) => ({
+      sessionId: "sess-1",
+      t: Date.now() + i * 1000,
+      intentHash: `hash-${i}`,
+      outcome: "no-match" as const,
+      topScore: 0.3,
+    }));
+
+    const result = computeDescentRate(thinEvents);
+    expect(result.skipped).toBe(true);
+    expect(result.skipReason).toMatch(/telemetry-thin/);
+  });
+
+  it("Design A computeDescentRate detects descent in controlled fixture (>=50% threshold)", () => {
+    // Controlled fixture: 20 events in one session, 4 misses each followed by descent
+    const now = Date.now();
+    const SESSION = "sess-fixture";
+
+    const fixture: TelemetryEvent[] = [
+      // Miss 1: "URL parser" → no_match
+      {
+        sessionId: SESSION,
+        t: now,
+        intentHash: "h-url-parser",
+        outcome: "no-match",
+        topScore: 0.2,
+        intentText: "URL parser",
+      },
+      // Descent 1: "split string on first ://" → matched (within 5s)
+      {
+        sessionId: SESSION,
+        t: now + 5000,
+        intentHash: "h-split-scheme",
+        outcome: "matched",
+        topScore: 0.91,
+        intentText: "split string on first ://",
+      },
+      // Hit: non-miss event
+      {
+        sessionId: SESSION,
+        t: now + 10000,
+        intentHash: "h-clamp",
+        outcome: "matched",
+        topScore: 0.94,
+        intentText: "clamp number between lo and hi",
+      },
+      // Miss 2: "hash" → no_match
+      {
+        sessionId: SESSION,
+        t: now + 15000,
+        intentHash: "h-hash",
+        outcome: "no-match",
+        topScore: 0.15,
+        intentText: "hash",
+      },
+      // Descent 2: "BLAKE3-256 hex digest of UTF-8 string" → matched (within 8s)
+      {
+        sessionId: SESSION,
+        t: now + 23000,
+        intentHash: "h-blake3",
+        outcome: "matched",
+        topScore: 0.88,
+        intentText: "BLAKE3-256 hex digest of a UTF-8 string",
+      },
+      // Miss 3: "parser" → no_match
+      {
+        sessionId: SESSION,
+        t: now + 30000,
+        intentHash: "h-parser",
+        outcome: "no-match",
+        topScore: 0.1,
+        intentText: "parser",
+      },
+      // Descent 3: "parse RFC 3986 URL into scheme host path query fragment" → matched
+      {
+        sessionId: SESSION,
+        t: now + 35000,
+        intentHash: "h-rfc3986",
+        outcome: "matched",
+        topScore: 0.85,
+        intentText: "parse RFC 3986 URL into scheme host path query fragment",
+      },
+      // Miss 4: "validate" → no_match
+      {
+        sessionId: SESSION,
+        t: now + 40000,
+        intentHash: "h-validate",
+        outcome: "no-match",
+        topScore: 0.12,
+        intentText: "validate",
+      },
+      // Descent 4: "validate email per RFC 5322 local-part subset no display name" → matched
+      {
+        sessionId: SESSION,
+        t: now + 48000,
+        intentHash: "h-rfc5322",
+        outcome: "matched",
+        topScore: 0.82,
+        intentText:
+          "validate email per RFC 5322 local-part subset no display name",
+      },
+      // Pad to 20 events with non-miss hits
+      ...Array.from({ length: 11 }, (_, i) => ({
+        sessionId: SESSION,
+        t: now + 60000 + i * 2000,
+        intentHash: `h-hit-${i}`,
+        outcome: "matched" as const,
+        topScore: 0.87,
+        intentText: `specific matched intent ${i}`,
+      })),
+    ];
+
+    expect(fixture.length).toBe(20);
+
+    const result = computeDescentRate(fixture);
+    expect(result.skipped).toBe(false);
+    expect(result.totalMisses).toBe(4);
+    expect(result.missesWithDescent).toBeGreaterThanOrEqual(
+      Math.ceil(result.totalMisses * 0.5),
+    );
+    expect(result.rate).toBeGreaterThanOrEqual(0.5);
+  });
+});

--- a/packages/hooks-base/test/system-prompt.test.ts
+++ b/packages/hooks-base/test/system-prompt.test.ts
@@ -1,0 +1,213 @@
+/**
+ * system-prompt.test.ts — Unit grep tests for the yakcc discovery system prompt.
+ *
+ * These tests verify the rewritten prompt (WI-578, DEC-HOOK-PROMPT-DESCENT-001)
+ * contains the required imperative tokens and does NOT contain forbidden soft-
+ * suggestion language. Tests are deterministic: they grep the actual file on disk.
+ *
+ * Evaluation contract §11 (plans/wi-578-hook-prompt-rewrite.md) requires:
+ *   - "You MUST" appears ≥ 4 times
+ *   - "You MUST NOT" appears ≥ 1 time
+ *   - "NO carve-outs" appears ≥ 1 time
+ *   - "self-check" / "Self-check" appears ≥ 1 time
+ *   - "URL parser" appears ≥ 1 time
+ *   - Forbidden phrases: 0 occurrences each
+ *
+ * @decision DEC-HOOK-PROMPT-DESCENT-001
+ * @title Grep-invariant unit tests for imperative descent-and-compose prompt
+ * @status accepted
+ * @rationale
+ *   Deterministic text assertions are the only reliable way to enforce prompt
+ *   language invariants without a live LLM call. The prompt is the single
+ *   source of truth; these tests protect it from accidental softening during
+ *   future edits. Any edit that removes imperative language will fail this suite.
+ */
+
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+import { loadDiscoveryPrompt, DISCOVERY_PROMPT_PATH } from "../src/system-prompt.js";
+
+// ---------------------------------------------------------------------------
+// Workspace root resolution
+// ---------------------------------------------------------------------------
+// __dirname in ESM = directory of this file:
+//   packages/hooks-base/test/
+// Workspace root = ../../.. relative to that
+const WORKSPACE_ROOT = resolve(import.meta.dirname ?? __dirname, "../../..");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function countOccurrences(text: string, pattern: RegExp): number {
+  const matches = text.match(pattern);
+  return matches ? matches.length : 0;
+}
+
+// ---------------------------------------------------------------------------
+// Load the prompt once for all tests
+// ---------------------------------------------------------------------------
+
+const promptText = loadDiscoveryPrompt(WORKSPACE_ROOT);
+
+// ---------------------------------------------------------------------------
+// Test: file exists and is non-empty
+// ---------------------------------------------------------------------------
+
+describe("system-prompt file", () => {
+  it("exists and is non-empty", () => {
+    expect(promptText.length).toBeGreaterThan(100);
+  });
+
+  it("loadDiscoveryPrompt() returns same content as readFileSync direct read", () => {
+    const direct = readFileSync(
+      join(WORKSPACE_ROOT, DISCOVERY_PROMPT_PATH),
+      "utf-8",
+    );
+    expect(promptText).toBe(direct);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test: required imperative tokens
+// ---------------------------------------------------------------------------
+
+describe("required imperative tokens (WI-578 evaluation contract §11)", () => {
+  it('contains "You MUST" at least 4 times', () => {
+    const count = countOccurrences(promptText, /You MUST/g);
+    expect(count).toBeGreaterThanOrEqual(4);
+  });
+
+  it('contains "You MUST NOT" at least 1 time', () => {
+    const count = countOccurrences(promptText, /You MUST NOT/g);
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  it('contains "NO carve-outs" at least 1 time', () => {
+    const count = countOccurrences(promptText, /NO carve-outs/g);
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  it('contains "self-check" or "Self-check" at least 1 time', () => {
+    const count = countOccurrences(promptText, /[Ss]elf-check/g);
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  it('contains "URL parser" (the walkthrough example) at least 1 time', () => {
+    const count = countOccurrences(promptText, /URL parser/g);
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  it('contains "decompose" at least 1 time (descent rule)', () => {
+    const count = countOccurrences(promptText, /decompose/gi);
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  it('contains "NEW_ATOM_PROPOSAL" at least 1 time', () => {
+    const count = countOccurrences(promptText, /NEW_ATOM_PROPOSAL/g);
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  it('contains "refuse" at least 1 time (explicit refusal of loose intents)', () => {
+    const count = countOccurrences(promptText, /refuse/gi);
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test: forbidden soft-suggestion language
+// ---------------------------------------------------------------------------
+
+describe("forbidden soft-suggestion language (must be absent)", () => {
+  it('does not contain "You SHOULD consider"', () => {
+    expect(promptText).not.toMatch(/You SHOULD consider/);
+  });
+
+  it('does not contain "Try to"', () => {
+    expect(promptText).not.toMatch(/Try to/);
+  });
+
+  it('does not contain "When possible"', () => {
+    expect(promptText).not.toMatch(/When possible/);
+  });
+
+  it('does not contain "Reserve hand-written code"', () => {
+    expect(promptText).not.toMatch(/Reserve hand-written code/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test: no forbidden carve-out keywords
+// ---------------------------------------------------------------------------
+
+describe("no forbidden carve-out keywords", () => {
+  it('does not contain "business logic" (case-insensitive)', () => {
+    expect(promptText).not.toMatch(/business logic/i);
+  });
+
+  it('does not contain "one-off" (case-insensitive)', () => {
+    expect(promptText).not.toMatch(/one-off/i);
+  });
+
+  it('does not contain "application-specific" (case-insensitive)', () => {
+    expect(promptText).not.toMatch(/application-specific/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test: structural invariants
+// ---------------------------------------------------------------------------
+
+describe("structural invariants", () => {
+  it("begins with the D4 authority comment", () => {
+    expect(promptText.startsWith("# Authority: DEC-V3-DISCOVERY-D4-001")).toBe(
+      true,
+    );
+  });
+
+  it("contains the descent-on-miss rule header", () => {
+    expect(promptText).toMatch(/Descent on miss/);
+  });
+
+  it("contains the self-check section with two numbered questions", () => {
+    // The self-check section has "1." and "2." questions
+    expect(promptText).toMatch(/1\. Is this intent the most specific/);
+    expect(promptText).toMatch(/2\. Could a smaller piece/);
+  });
+
+  it("contains the URL-parser walkthrough section header", () => {
+    expect(promptText).toMatch(/Worked example: building a URL parser/);
+  });
+
+  it("contains the auto-accept rule", () => {
+    expect(promptText).toMatch(/auto-accept/);
+  });
+
+  it("contains the REGISTRY_UNREACHABLE fallback instruction", () => {
+    expect(promptText).toMatch(/REGISTRY_UNREACHABLE/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test: negative — loose intents are explicitly called out as defects
+// ---------------------------------------------------------------------------
+
+describe("negative test: loose intents are named as defects", () => {
+  it('names "validation" as a vague query example to refuse', () => {
+    expect(promptText).toMatch(/"validation"/);
+  });
+
+  it('names "parser" as a vague query example to refuse', () => {
+    expect(promptText).toMatch(/"parser"/);
+  });
+
+  it('names single-word intents as refuse triggers in general', () => {
+    expect(promptText).toMatch(/single-word intents in general/);
+  });
+
+  it("instructs to refuse loose queries, not silently proceed", () => {
+    // The prompt must contain 'refuse to submit' — the explicit refusal instruction
+    expect(promptText).toMatch(/refuse\s+to submit/);
+  });
+});

--- a/plans/wi-578-hook-prompt-rewrite.md
+++ b/plans/wi-578-hook-prompt-rewrite.md
@@ -1,0 +1,450 @@
+# WI-578 — Hook system prompt: enforce specific-first descent-and-compose
+
+**Workflow ID:** wi-578-hook-prompt-rewrite
+**Issue:** #578 (label: `load-bearing`, `claude-todo`)
+**Branch:** `feature/578-hook-prompt-rewrite` (worktree to be provisioned)
+**Status:** Planner output — implementer scope-bounded slice ready for provision after scope-amendment.
+
+---
+
+## 1. Problem statement (challenged)
+
+GH #578 declares the current hook system prompt "suggests patterns instead of imposing them," and that loose initial intents return oversized atoms that defeat yakcc's value proposition (smaller surface area).
+
+Before accepting the brief verbatim, the planner challenged the framing on three axes:
+
+| Question | Finding | Disposition |
+| --- | --- | --- |
+| Is the prompt actually duplicated across 3 IDE packages, requiring consolidation first? | No. The prompt text is a single file: `docs/system-prompts/yakcc-discovery.md`. All three IDE adapters reference it via the path constant `SYSTEM_PROMPT_PATH` (which IS duplicated — but the prompt content is not). | **Single source of truth already exists.** Consolidation step from issue is unnecessary. The optional cleanup is folding the path constant into `@yakcc/hooks-base`, but that is a separate, low-value refactor and is **out of scope** for #578. |
+| Is import-intercept the LLM-prompt surface — can the runtime force descent? | No. `import-intercept.ts` runs a *deterministic, programmatic* `yakccResolve()` query — it is not the LLM's hook prompt. The LLM consumes the prompt via the IDE tool-surface (Claude Code MCP, Cursor extension, Codex hook), which loads `docs/system-prompts/yakcc-discovery.md`. The LLM owns the decision to recurse. | **Descent enforcement is text-level only.** Runtime cannot mandate descent depth; the prompt must induce it. |
+| Does the existing telemetry surface capture descent depth? | No. `TelemetryEvent` (packages/hooks-base/src/telemetry.ts) captures per-call fields (`outcome`, `candidateCount`, `topScore`, `top1Score`, `top1Gap`, `substituted`, etc.) but has no notion of "this is the Nth recursive resolve for the same parent intent." | **Descent-depth assertion requires either (a) a new telemetry field stamped by the LLM in the tool call, or (b) post-hoc grouping by session + intent-hash-prefix sequence.** See §6 telemetry design. |
+
+**Restated problem:** the canonical D4-ADR-governed file `docs/system-prompts/yakcc-discovery.md` reads as a polite invitation to use yakcc when convenient ("first call `yakcc_resolve`", "Reserve hand-written code for…", "If unreachable, fall back…") and offers no explicit instruction for what to do on a miss other than "widen the query." This permits — and in practice produces — loose initial intents. The fix is a **prompt rewrite** of that one file, plus an evaluation contract that proves the rewrite changed observable behavior.
+
+---
+
+## 2. Goals / non-goals
+
+### Goals (in scope)
+- G1: Rewrite `docs/system-prompts/yakcc-discovery.md` with imperative ("You MUST") descent-and-compose language including the URL-parser walkthrough, refusal of loose intents, and a self-check step. (Acceptance §1–5 of #578.)
+- G2: Bump `INTENT_PROMPT_VERSION` if any related cache contract change is needed (anticipated: no — the cache-keyed prompt is the `shave/intent/prompt.ts` one, not the discovery prompt; verify this in implementation).
+- G3: Land a test corpus (`packages/hooks-base/test/system-prompt-integration.test.ts`) of paired loose/tight intents documenting the **expected behavior shift**.
+- G4: Land a unit-level prompt assertion (`packages/hooks-base/src/system-prompt.test.ts`) that **grep-style verifies** the rewritten file contains required substrings (imperative tokens, URL-parser walkthrough, self-check) and does NOT contain forbidden ones (soft suggestions, carve-outs).
+- G5: Land a negative test scaffold proving a loose-intent prompt produces refusal/self-correction. Because LLM behavior is non-deterministic, this test uses a deterministic stub or a snapshot of an Anthropic transcript (see §5).
+- G6: Scaffold a telemetry assertion (instrumented but threshold-deferred until #569 follow-up enables descent-depth capture, OR implement the post-hoc grouping inference described in §6) for: "of next N hook invocations post-rewrite, ≥ X% of misses show recursion depth ≥ 1."
+- G7: Update the D4 ADR (`docs/adr/discovery-llm-interaction.md`) with a Q-extension explaining the descent-and-compose addition — required because the prompt file carries the comment "changes to this file require a D4 ADR revision."
+
+### Non-goals (explicit)
+- N1: **Do NOT modify `packages/shave/src/intent/prompt.ts`.** That is the intent-extraction prompt sent to Haiku during shave, not the LLM hook prompt. It is forbidden in the workflow scope and is unrelated to #578.
+- N2: **Do NOT consolidate the `SYSTEM_PROMPT_PATH` constant** across IDE packages in this WI. The prompt content is already single-source; the path constant duplication is a tangential refactor that risks scope creep.
+- N3: **Do NOT add a new IDE adapter or wire `packages/hooks-codex/src/yakcc-resolve-tool.ts`.** That file is listed in the workflow scope but does not exist; it is part of a future Codex parity WI, not #578.
+- N4: **Do NOT modify `packages/hooks-base/src/import-intercept.ts` LLM-decision logic.** The intercept is a deterministic registry query and is not a place where prompt-level descent can be enforced. The only allowed change to import-intercept (if any) is **telemetry-emit additions** for the descent-depth signal (G6) — and even that is optional.
+- N5: **Do NOT alter the D2/D3/D4 envelope shape, 4-band thresholds, or `ResolveResult` schema.** Behavior changes are prompt-text-only.
+
+---
+
+## 3. Unknowns / decisions deferred
+
+| Unknown | Resolution path |
+| --- | --- |
+| U1: Does `INTENT_PROMPT_VERSION` (`packages/shave/src/intent/constants.ts`) need bumping? | **No** by inspection — that version governs the SHAVE intent-extraction prompt (`packages/shave/src/intent/prompt.ts`), not the discovery system prompt. Confirm during implementation via grep for `INTENT_PROMPT_VERSION` usages; no rewrite of `shave/intent/prompt.ts` means no bump. |
+| U2: How to deterministically prove "loose query produces refusal" in the negative test, given LLM non-determinism? | Three options, ordered by preference: (a) **assertion against the rewritten prompt text** (refusal language is present) + (b) **a recorded-transcript fixture** capturing a real Haiku call where the rewritten prompt induces refusal for one canonical loose query (`"validation"`), checked into `tmp/wi-578-investigation/transcripts/`. Option (c) wiring a runtime stub for the discovery LLM call is out of scope because the LLM call lives in the IDE, not in our code. |
+| U3: Should descent-depth telemetry be inferred post-hoc (no runtime change) or stamped explicitly (LLM passes a `parentIntentHash`)? | **Implementation chooses inference path** unless trivial. Post-hoc: group `TelemetryEvent` rows by session ID, sort by `t`, mark consecutive misses where intent-hash B's intent string is a strict sub-phrase / narrower form of A's intent string as `depth >= 1`. This requires no LLM contract change but requires storing intent text temporarily for the analysis (currently only `intentHash` is stored). Approval gate: if inference is infeasible without a privacy-policy change, implementer flags and we defer descent-depth to a follow-up filed against #569. |
+| U4: ADR revision requirement — must the D4 ADR be revised in the same commit, or filed as a follow-up? | **Same commit.** The prompt file's header comment makes the ADR the authority; merging a prompt change without a corresponding ADR Q-extension would break the authority invariant. Implementer adds a Q9 (or similarly numbered) section to `docs/adr/discovery-llm-interaction.md` capturing the descent-and-compose addition. — **Note: this requires expanding the allowed-paths scope** (see §10 scope manifest). |
+
+---
+
+## 4. Architecture / state-authority map
+
+| Surface | Authority | Role in #578 |
+| --- | --- | --- |
+| `docs/system-prompts/yakcc-discovery.md` | governed by D4 ADR `DEC-V3-DISCOVERY-D4-001` | **Primary rewrite target.** Single source of truth for the hook LLM system prompt. Loaded by all IDE adapters via `SYSTEM_PROMPT_PATH`. |
+| `docs/adr/discovery-llm-interaction.md` | DEC-V3-DISCOVERY-D4-001 authority itself | Must be updated with a new Q-section (e.g., Q9 "Descent-and-Compose Discipline") documenting the new prompt invariants. |
+| `packages/hooks-{claude-code,cursor}/src/yakcc-resolve-tool.ts` | DEC-HOOK-PHASE-3-L3-MCP-001, DEC-HOOK-CURSOR-PHASE4-002 | Read-only consumers of `SYSTEM_PROMPT_PATH`. NOT modified by #578. |
+| `packages/hooks-base/src/import-intercept.ts` | DEC-WI508-INTERCEPT-001..006 | Deterministic registry-query path. NOT a prompt surface. Modified ONLY for descent-depth telemetry if §6 inference path is infeasible. |
+| `packages/hooks-base/src/telemetry.ts` | DEC-HOOK-PHASE-1-001 | Optional: extend `TelemetryEvent` with a `descendedFromIntentHash?: string` field if approach (b) of U3 is taken. |
+| `packages/shave/src/intent/prompt.ts` + `constants.ts` | DEC-CONTINUOUS-SHAVE-022 | **Unrelated.** Intent-extraction (Haiku) prompt for shave pipeline. Listed as candidate by orchestrator dispatch context but inventory disproved relevance. **Not touched.** |
+| `packages/hooks-codex/src/yakcc-resolve-tool.ts` | (does not exist) | Future Codex parity WI. **Not created here.** |
+
+### Single-source-of-truth verdict
+- The **prompt content** has a single source of truth: `docs/system-prompts/yakcc-discovery.md`. No consolidation required.
+- The **path constant** `SYSTEM_PROMPT_PATH = "docs/system-prompts/yakcc-discovery.md"` is duplicated in two IDE packages (hooks-claude-code, hooks-cursor). This is a marker-file/registration constant — its duplication does not cause prompt drift because they all point at the same file. Folding it into hooks-base is a tangential refactor and is **deferred** to a backlog item if motivated by a future change.
+
+---
+
+## 5. The rewrite design (proposed text)
+
+**Implementer will COPY this verbatim into `docs/system-prompts/yakcc-discovery.md`.**
+
+```markdown
+# Authority: DEC-V3-DISCOVERY-D4-001 (docs/adr/discovery-llm-interaction.md) — changes to this file require a D4 ADR revision.
+
+You have access to the yakcc discovery system via the `yakcc_resolve` tool. The
+rules below are not suggestions. They define the only acceptable way to write
+generic operations in this project.
+
+## The rule
+
+You MUST start every search with the most specific intent you can articulate
+for the immediate need. A loose initial intent is a defect — it produces
+oversized atoms that carry unused capabilities into the project. Unused code is
+attack surface, complexity debt, and reasoning load.
+
+You MUST NOT widen an intent to make a search hit. Widening is the failure
+mode this prompt exists to prevent. If you catch yourself reaching for a
+broader phrasing because "the narrow one missed," stop and apply the descent
+rule below.
+
+There are NO carve-outs. "It's just business logic," "this is a one-off," and
+"the abstraction would be premature" are not valid reasons to skip discovery.
+
+## Self-check before every `yakcc_resolve` call
+
+Before you submit a query, answer these two questions silently:
+
+  1. Is this intent the most specific I can articulate for what the immediate
+     caller needs? If no — narrow it now and re-check.
+  2. Could a smaller piece of this intent already exist as its own atom? If
+     yes — search for that smaller piece first.
+
+If either answer leaves you submitting a vague query (`"validation"`,
+`"parser"`, `"utility"`, `"helper"`, single-word intents in general), refuse
+to submit. Write the user a short note explaining why the intent was too broad
+and what specific sub-intent you will search for instead.
+
+## Descent on miss — always zoom in, never zoom out
+
+A `no_match` or `weak_only` result is a signal that one of two things is true:
+
+  (A) The atom does not yet exist at this specificity. Correct response:
+      decompose the intent into sub-intents and query each.
+  (B) The intent is still too broad. Correct response: decompose further.
+
+In both cases the response is the same: **decompose, then query each piece**.
+
+Recurse until each leaf intent either hits the registry at score >= 0.70
+(`status === "matched"`) or bottoms out at a primitive operation you must
+compose by hand. Then compose upward from the leaves into the larger atom the
+original caller needed, and emit a NEW_ATOM_PROPOSAL block describing the
+composed atom so the registry's coverage improves and the next consumer with
+the same intent gets a direct hit.
+
+## Worked example: building a URL parser
+
+First-time request: "build a URL parser."
+
+  - Initial intent: "URL parser." MISS.
+  - Decompose: "split URL into scheme + host + path + query + fragment." MISS.
+  - Decompose further:
+      * "split string on first `://`" — HIT.
+      * "split string on first `/` after position N" — HIT.
+      * "split key=value pairs on `&`" — HIT.
+      * "percent-decode bytes" — MISS.
+          - Decompose: "decode `%XX` hex pair to a single byte" — HIT.
+  - Compose upward: assemble the URL parser from those leaf atoms. Persist
+    the composed result via NEW_ATOM_PROPOSAL with intent
+    "URL parser (RFC 3986 subset, no IDNA)."
+  - The first request is expensive. Every subsequent request for "URL parser"
+    is one lookup. That asymptotic win is the whole reason this discipline
+    exists.
+
+You MUST walk this exact pattern on any miss. The example is not
+illustrative — it is the protocol.
+
+## What `yakcc_resolve` returns
+
+The tool takes a `QueryIntentCard` and returns up to topK candidate atoms.
+Each candidate carries a `combinedScore` in [0, 1] and a band classification:
+
+  - score >= 0.85 (strong):     reference the atom by BlockMerkleRoot.
+  - 0.70 - 0.85   (confident):  reference the atom; note it in your reply.
+  - 0.50 - 0.70   (weak):       this is a `weak_only` status — apply the
+                                descent rule above. Do NOT use the weak
+                                candidate as a substitute for a tight match.
+  - score <  0.50 (poor):       `status === "no_match"`. Apply the descent
+                                rule above. Do NOT silently write the code.
+
+`auto-accept`: when `combinedScore > 0.85` AND the gap to the second-best
+candidate is > 0.15, you MUST insert the BlockMerkleRoot reference into the
+project manifest without prompting the user.
+
+## Building the intent card
+
+  - `behavior`: a one-line natural-language description. Specific verbs
+                ("split string on first `://`"), not generic ones ("handle
+                URLs").
+  - `guarantees`: an array of specific properties the code must satisfy.
+                "rejects non-integer values" disambiguates from "rejects
+                non-numeric values."
+  - `signature`: input/output types as { name?, type } pairs.
+  - `errorConditions`, `propertyTests`, `nonFunctional`: optional dimensions
+                that narrow the search. Use them.
+  - `weights`: optional per-dimension floats; omit for equal weighting.
+
+## When the tool is unreachable
+
+If `yakcc_resolve` is unreachable (registry offline, transport error), you may
+fall back to writing the code directly, but you MUST emit a
+REGISTRY_UNREACHABLE note in your output so the user can audit later. The
+fallback path is for outages only — it is not an escape hatch from the
+discipline above.
+```
+
+**Length:** ~75 lines of prose. Token budget impact: roughly 2.5x the current 49-line prompt. This is acceptable: the prompt is loaded once per IDE session, not per query, and the per-query token cost is unchanged.
+
+**Verifiable invariants** (the unit test will grep for these):
+- Contains: `You MUST` (≥ 4 occurrences), `You MUST NOT` (≥ 1), `NO carve-outs`, `URL parser`, `decompose`, `descent`, `self-check`, `refuse`, `NEW_ATOM_PROPOSAL`.
+- Does NOT contain: `You SHOULD consider`, `Reserve hand-written code`, `Try to`, `When possible`, `business logic`, `one-off`.
+
+---
+
+## 6. Telemetry & descent-depth assertion design
+
+### Today's surface
+`TelemetryEvent` is per-emission with no notion of "this call is a descendant of an earlier call." `intent` is BLAKE3-hashed at write time and the plaintext is not retained.
+
+### Two viable designs
+
+**Design A — post-hoc inference (preferred, no contract change).**
+1. Within a single session ID, sort `TelemetryEvent` records by `t`.
+2. For each `outcome === "synthesis-required"` or `topScore < 0.70` event, look at the *next* event within a short window (e.g., 30s) in the same session.
+3. If the next event's intent hash differs AND a runtime-side counter (kept in `import-intercept` memory for the lifetime of the hook process) recorded that this session emitted ≥ 2 resolve calls back-to-back, mark `depth >= 1`.
+4. Assertion: of N misses, ≥ X% have a follow-on resolve within 30s in the same session.
+
+Drawback: the LLM might compose answers across multiple files and the descent signal is heuristic. Acceptable for the assertion because the alternative (instrumenting the LLM contract) is out of reach.
+
+**Design B — explicit (contract change, smaller scope).**
+Add a single optional field to `TelemetryEvent`:
+```ts
+readonly parentIntentHash?: string | null;
+```
+The LLM can pass this in the tool call args (extend `YakccResolveToolArgs`):
+```ts
+readonly parentIntent?: string;
+```
+The tool surface hashes the parent and stamps it into telemetry. The LLM is *prompted* to pass `parentIntent` when its current call is a descent step (the prompt §5 already implies this via the descent rule).
+
+Drawback: requires an additive change to `TelemetryEvent` (additive is fine — DEC-HOOK-PHASE-1-001 explicitly supports additive fields), and requires the LLM to honor the parent-passing convention.
+
+### Recommendation
+**Implementer ships Design A (heuristic + session-grouped) as the test scaffold.** Wire the test to assert `≥ 50%` descent-on-miss as a *placeholder threshold*. If real-world traces show the heuristic is too noisy, follow up with Design B in a sister WI. The placeholder threshold is documented as such; if there are fewer than 20 hook invocations in the window when the test runs, the assertion is skipped (telemetry-thin guard).
+
+### Where the assertion lives
+`packages/hooks-base/test/system-prompt-integration.test.ts`. The test reads `~/.yakcc/telemetry/<session-id>.jsonl` for a controlled scenario, applies the Design A inference, and asserts the threshold.
+
+---
+
+## 7. Test corpus (paired loose/tight)
+
+Implementer creates `tmp/wi-578-investigation/test-corpus.json` (committed under the allowed `tmp/wi-578-investigation/**` path) capturing pairs of intents where the pre-rewrite prompt would have produced the loose one and the post-rewrite prompt should produce the tight one:
+
+| # | Loose (pre-rewrite) | Tight (post-rewrite expected) |
+| --- | --- | --- |
+| 1 | `"validation"` | `"validate email per RFC 5322 local-part subset, no display name"` |
+| 2 | `"parser"` | `"parse RFC 3986 URL into {scheme, host, path, query, fragment}"` |
+| 3 | `"date helper"` | `"format ISO 8601 timestamp to UTC string with millisecond precision"` |
+| 4 | `"sanitize input"` | `"strip HTML tags from string, preserve text content, decode &amp; entities"` |
+| 5 | `"hash"` | `"BLAKE3-256 hex digest of a UTF-8 string"` |
+| 6 | `"compare"` | `"deep structural equality for JSON values (no NaN, no functions)"` |
+| 7 | `"retry"` | `"retry async function with exponential backoff: base=100ms, factor=2, max=5 tries"` |
+| 8 | `"throttle"` | `"throttle a function: at most one call per N ms, drop intermediate calls"` |
+| 9 | `"format"` | `"format number with thousands separator and fixed 2 decimal places"` |
+| 10 | `"slug"` | `"convert string to URL slug: lowercase, hyphenate spaces, strip non-ASCII"` |
+
+The unit test (G4) verifies that **each `loose` entry contains zero specific verbs/nouns from a forbidden list (`validate`, `parse`, `format`, `hash`, etc.) AND each `tight` entry contains at least one specific verb plus a noun**. The negative test (G5) records what the LLM does when given the loose intent under the new prompt; the expected outcome per pair is *self-correction or refusal*, not silent execution.
+
+---
+
+## 8. Slice decomposition — recommendation: single slice
+
+Issue suggests P0/P1/P2 split, but inventory shows:
+- **P0 audit + consolidation** is unnecessary — single source of truth already exists.
+- **P1 rewrite + tests** is the substantive work, ~1.5–2 days.
+- **P2 telemetry assertion** can fit inside this slice if Design A (heuristic, no contract change) is chosen.
+
+**Recommendation:** ship as a single WI-578 slice with the following implementer plan:
+
+| Step | Output | Files |
+| --- | --- | --- |
+| 1 | Rewrite the prompt file with §5 text | `docs/system-prompts/yakcc-discovery.md` |
+| 2 | Add ADR Q-section documenting the descent-and-compose addition | `docs/adr/discovery-llm-interaction.md` |
+| 3 | Add the unit test that greps the new prompt for required/forbidden substrings | `packages/hooks-base/src/system-prompt.test.ts` (new) |
+| 4 | Add a `system-prompt.ts` helper that exports the prompt-file path constant + a `loadDiscoveryPrompt()` reader (the test imports this; this is the optional minor consolidation toward a single path constant — implementer may skip if it expands scope) | `packages/hooks-base/src/system-prompt.ts` (new) |
+| 5 | Create the test corpus JSON | `tmp/wi-578-investigation/test-corpus.json` |
+| 6 | Add integration test that loads the corpus, optionally exercises a stubbed/recorded LLM transcript fixture | `packages/hooks-base/test/system-prompt-integration.test.ts` (new) |
+| 7 | Add the descent-depth telemetry assertion (Design A) inside the integration test | (same file as step 6) |
+| 8 | Run `pnpm -w lint typecheck test` to prove green; rebase on `origin/main` first per memory note | n/a |
+| 9 | Hand off to reviewer with REVIEW_VERDICT trailer | n/a |
+
+If during implementation step 7 the heuristic descent-depth inference proves infeasible (no real telemetry to inspect under test), implementer is authorized to **scaffold-only** the telemetry assertion (skip the threshold check, leave a `it.todo`) and file a follow-up issue against #569.
+
+---
+
+## 9. Risks & mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| R1: ADR revision requires expanding the workflow scope to include `docs/adr/discovery-llm-interaction.md`. | **Plan amendment required** (see §10). Reviewer must approve scope-set expansion via `cc-policy workflow scope-sync` before implementer starts. |
+| R2: The 75-line prompt is ~2.5x the current 49 lines. Token cost is per-session, not per-query, so impact is negligible — but verify. | Implementer notes pre/post line+token counts in the PR description. |
+| R3: Negative test for "loose query produces refusal" is fundamentally LLM-non-deterministic. | Lean on the unit-level grep test (deterministic) + a *recorded* Anthropic transcript fixture for one canonical case. Do NOT make the integration test depend on a live LLM call. |
+| R4: Descent-depth heuristic (Design A) might be too noisy or yield zero data in CI. | Test guards with a `skip-if-thin` check (< 20 events ⇒ skip), and the threshold is documented as a placeholder. Real-world tuning is a follow-up against #569. |
+| R5: Implementer might try to also rewrite `packages/shave/src/intent/prompt.ts`. | Plan explicitly forbids it (§2 N1); scope manifest forbids `packages/shave/src/intent/extract.ts` and `static-extract.ts`. `prompt.ts` is allowed by the scope but the plan says **do not touch**; reviewer rejects on touch. |
+| R6: The "refusal" behavior in the prompt could degrade UX if the LLM refuses too aggressively. | The prompt §5 frames refusal as "write the user a short note explaining why the intent was too broad and what specific sub-intent you will search for instead" — i.e., self-correction with explanation, not a hard error. |
+
+---
+
+## 10. Scope manifest — **REQUIRES AMENDMENT BEFORE PROVISIONING**
+
+The dispatched scope (per the workflow contract block) **does not include** the two files that must be edited:
+- `docs/system-prompts/yakcc-discovery.md` (the actual rewrite target)
+- `docs/adr/discovery-llm-interaction.md` (the governing ADR that must be updated in the same commit)
+
+The dispatched scope also lists `packages/hooks-codex/src/yakcc-resolve-tool.ts` which **does not exist** and is unrelated.
+
+**Required scope amendment before guardian provisioning:**
+
+### allowed_paths (additions)
+```
+docs/system-prompts/yakcc-discovery.md
+docs/adr/discovery-llm-interaction.md
+packages/hooks-base/src/system-prompt.ts
+packages/hooks-base/src/system-prompt.test.ts
+packages/hooks-base/test/system-prompt-integration.test.ts
+tmp/wi-578-investigation/*
+tmp/wi-578-investigation/**/*
+plans/wi-578-hook-prompt-rewrite.md
+```
+
+### required_paths
+```
+docs/system-prompts/yakcc-discovery.md
+docs/adr/discovery-llm-interaction.md
+plans/wi-578-hook-prompt-rewrite.md
+packages/hooks-base/src/system-prompt.test.ts
+packages/hooks-base/test/system-prompt-integration.test.ts
+```
+
+### forbidden_paths (carry-over from dispatch + clarifications)
+```
+packages/shave/src/intent/prompt.ts           # plan-level forbidden (see §2 N1)
+packages/shave/src/intent/extract.ts
+packages/shave/src/intent/static-extract.ts
+packages/shave/src/intent/types.ts
+packages/shave/src/intent/anthropic-client.ts
+packages/{compile,contracts,registry,cli,federation,ir,seeds,variance}/**
+packages/shave/src/cache/**
+packages/shave/src/universalize/**
+packages/shave/src/errors.ts
+packages/hooks-codex/src/yakcc-resolve-tool.ts   # does not exist; do not create
+.github/**
+.claude/**
+MASTER_PLAN.md
+```
+
+### authority_domains
+```
+hook-llm-prompt           (D4 ADR DEC-V3-DISCOVERY-D4-001)
+yakcc-resolve-tool-prompt (carry-over)
+```
+
+**Action for guardian:provision:** rewrite the scope JSON via `cc-policy workflow scope-sync wi-578-hook-prompt-rewrite --work-item-id wi-578-hook-prompt-rewrite --scope-file tmp/wi-578-scope.json` using the manifest above.
+
+---
+
+## 11. Evaluation contract (for reviewer / guardian readiness)
+
+### Required tests (must pass)
+1. `packages/hooks-base/src/system-prompt.test.ts`: unit grep test asserts presence of required imperative tokens and absence of forbidden soft tokens.
+2. `packages/hooks-base/test/system-prompt-integration.test.ts`: loads `tmp/wi-578-investigation/test-corpus.json`; asserts each loose entry meets the "loose" definition and each tight entry meets the "tight" definition; runs the descent-depth Design A heuristic on a controlled telemetry fixture and asserts ≥ X% (placeholder X=50) — OR skips with reason "telemetry-thin" if < 20 events.
+3. Existing tests: `pnpm -w test --filter @yakcc/hooks-base --filter @yakcc/hooks-claude-code --filter @yakcc/hooks-cursor` all green.
+
+### Required real-path checks
+1. `docs/system-prompts/yakcc-discovery.md` exists and contains the §5 text verbatim.
+2. `docs/adr/discovery-llm-interaction.md` contains a new Q-section dated post-2026-05-15 documenting the descent-and-compose addition.
+3. `packages/hooks-{claude-code,cursor}/src/yakcc-resolve-tool.ts` continue to reference `SYSTEM_PROMPT_PATH = "docs/system-prompts/yakcc-discovery.md"` (regression-style check that the path was not accidentally changed).
+
+### Required authority invariants
+1. Imperative language: `grep -c "You MUST" docs/system-prompts/yakcc-discovery.md` ≥ 4.
+2. No soft suggestions: `grep -c "You SHOULD consider\|Try to\|When possible" docs/system-prompts/yakcc-discovery.md` == 0.
+3. No carve-outs: `grep -ci "business logic\|one-off\|application-specific" docs/system-prompts/yakcc-discovery.md` == 0.
+4. URL-parser walkthrough present: `grep -c "URL parser" docs/system-prompts/yakcc-discovery.md` ≥ 1.
+5. Self-check present: `grep -c "self-check\|Self-check" docs/system-prompts/yakcc-discovery.md` ≥ 1.
+6. Single source of truth preserved: `find packages -name '*.ts' -not -path '*/dist/*' -not -path '*/node_modules/*' -exec grep -l '"SYSTEM_PROMPT_PATH"' {} \;` returns ≤ 2 files (the existing 2 IDE adapters); no new copies.
+7. D4 ADR updated: `grep -c "descent-and-compose\|Descent-and-Compose" docs/adr/discovery-llm-interaction.md` ≥ 1.
+
+### Required integration points
+1. Telemetry surface (`packages/hooks-base/src/telemetry.ts`) untouched OR additive-only per DEC-HOOK-PHASE-1-001.
+2. Import-intercept path (`packages/hooks-base/src/import-intercept.ts`) untouched (observe-don't-mutate per DEC-WI508-INTERCEPT-004).
+3. `INTENT_PROMPT_VERSION` (`packages/shave/src/intent/constants.ts`) NOT bumped (validates non-goal N1).
+
+### Forbidden shortcuts
+1. **Do NOT soften the imperative language** to make tests pass on first run.
+2. **Do NOT skip the URL-parser walkthrough** or replace it with a less concrete example.
+3. **Do NOT add carve-outs** for "business logic" / "one-off" / "application-specific" — even with caveats.
+4. **Do NOT duplicate the prompt text** in any package source file. The prompt content stays in the one `.md` file.
+5. **Do NOT modify `packages/shave/src/intent/prompt.ts`** — it is a different prompt and out of scope.
+6. **Do NOT weaken the negative test** by lowering the threshold or removing the assertion to get a green run.
+
+### Ready-for-guardian definition
+- All required tests green on the implementer's worktree HEAD.
+- All required authority invariants verified by grep on the implementer's worktree HEAD.
+- All required real-path checks pass.
+- D4 ADR updated; same commit.
+- `pnpm -w lint typecheck test` green; rebased on `origin/main` (per persistent memory: branches must track `origin/main` before push, not just at provisioning).
+- Reviewer issues `REVIEW_VERDICT: ready_for_guardian`.
+
+### Rollback boundary
+`git revert` the landing commit. The prompt reverts to its current 49-line "suggesting" form; behavior reverts to the baseline #578 documents. The ADR Q-section also reverts cleanly because it is additive.
+
+---
+
+## 12. Pre-push hygiene (carry-over per memory note)
+
+Implementer MUST, before declaring ready:
+1. `git fetch origin && git rebase origin/main` (memory: branches must track `origin/main` before push, not just at provisioning).
+2. `pnpm -w lint` green.
+3. `pnpm -w typecheck` green.
+4. `pnpm -w test --filter @yakcc/hooks-base --filter @yakcc/hooks-claude-code --filter @yakcc/hooks-cursor` green.
+5. `git diff --stat origin/main..HEAD` — sanity-check that the diff does not accidentally include unrelated parallel-sister churn (memory note: PR #45 lost 17k lines from this exact failure mode).
+
+---
+
+## 13. Decision log entry (to be added to MASTER_PLAN.md after landing)
+
+```
+| DEC-HOOK-PROMPT-DESCENT-001 | **WI-578 (#578, load-bearing), 2026-05-XX.** Rewrote
+docs/system-prompts/yakcc-discovery.md from suggesting tone to imperative descent-and-
+compose discipline. Adds (a) explicit refusal of loose initial intents ("validation",
+"parser", etc.), (b) a mandatory self-check step before every yakcc_resolve call,
+(c) the descent rule for misses (decompose, query each leaf, compose upward,
+NEW_ATOM_PROPOSAL), and (d) a verbatim URL-parser walkthrough as the canonical
+protocol. D4 ADR docs/adr/discovery-llm-interaction.md gains a Q9 section
+documenting the addition. Telemetry surface unchanged (additive-only path
+preserved); descent-depth assertion uses Design A heuristic with a documented
+placeholder threshold pending #569 follow-up tuning. Single source of truth preserved
+(prompt content lives in one .md file; SYSTEM_PROMPT_PATH constant duplication is
+unchanged and unrelated). | Source: WI-578. Authority change to D4 ADR text is
+captured in the ADR revision. Cross-references: DEC-V3-DISCOVERY-D4-001 (authority),
+DEC-HOOK-PHASE-3-L3-MCP-001 (tool surface that loads the prompt),
+DEC-HOOK-CURSOR-PHASE4-002 (cursor mirror), DEC-WI508-INTERCEPT-004 (observe-don't-
+mutate invariant preserved), DEC-HOOK-PHASE-1-001 (telemetry additive-only contract). |
+```
+
+---
+
+## 14. Planner verdict rationale
+
+This is a single implementable slice once the scope manifest is amended (§10).
+The amendment is mechanical (`cc-policy workflow scope-sync`) and is the next
+canonical action for `guardian:provision`. Implementer can then proceed end-to-
+end without a second user-decision boundary.
+
+The scope amendment IS NOT a user-decision boundary — it is provisioning
+adjustment. The user already approved this WI by selecting it from the backlog
+queue; the planner's job is to define the executable scope, which it has done.
+
+**Next canonical action:** `guardian:provision` with the §10 scope manifest.
+
+---
+
+*end of plan*

--- a/tmp/wi-578-investigation/test-corpus.json
+++ b/tmp/wi-578-investigation/test-corpus.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://yakcc.dev/schemas/prompt-test-corpus/v1",
+  "description": "WI-578 paired intent corpus: loose (pre-rewrite) vs tight (post-rewrite expected). Used by packages/hooks-base/test/system-prompt-integration.test.ts to verify the prompt rewrite changes observable behavior. Loose intents should be refused or self-corrected under the new prompt; tight intents are the expected specific search targets.",
+  "version": "1",
+  "workflowId": "wi-578-hook-prompt-rewrite",
+  "pairs": [
+    {
+      "id": 1,
+      "loose": "validation",
+      "tight": "validate email per RFC 5322 local-part subset, no display name",
+      "looseReason": "single-word generic intent; no verb, no specifics",
+      "tightReason": "specific verb 'validate', named standard RFC 5322, explicit constraint 'no display name'"
+    },
+    {
+      "id": 2,
+      "loose": "parser",
+      "tight": "parse RFC 3986 URL into {scheme, host, path, query, fragment}",
+      "looseReason": "single-word generic intent; no verb, no specifics",
+      "tightReason": "specific verb 'parse', named standard RFC 3986, explicit output shape"
+    },
+    {
+      "id": 3,
+      "loose": "date helper",
+      "tight": "format ISO 8601 timestamp to UTC string with millisecond precision",
+      "looseReason": "two-word noun phrase; 'helper' is generic; no verb, no format, no precision",
+      "tightReason": "specific verb 'format', named standard ISO 8601, explicit output format and precision"
+    },
+    {
+      "id": 4,
+      "loose": "sanitize input",
+      "tight": "strip HTML tags from string, preserve text content, decode &amp; entities",
+      "looseReason": "generic verb 'sanitize'; 'input' is not a noun specifying what kind or what output",
+      "tightReason": "specific verb 'strip', named target 'HTML tags', explicit preservation and decoding rules"
+    },
+    {
+      "id": 5,
+      "loose": "hash",
+      "tight": "BLAKE3-256 hex digest of a UTF-8 string",
+      "looseReason": "single-word generic intent; no algorithm, no input encoding, no output format",
+      "tightReason": "specific algorithm 'BLAKE3-256', explicit output format 'hex digest', explicit input encoding 'UTF-8'"
+    },
+    {
+      "id": 6,
+      "loose": "compare",
+      "tight": "deep structural equality for JSON values (no NaN, no functions)",
+      "looseReason": "single-word generic intent; compare what, how, edge cases unknown",
+      "tightReason": "specific adjective 'deep structural', named type 'JSON values', explicit exclusions 'no NaN, no functions'"
+    },
+    {
+      "id": 7,
+      "loose": "retry",
+      "tight": "retry async function with exponential backoff: base=100ms, factor=2, max=5 tries",
+      "looseReason": "single-word generic intent; no timing model, no limit, no async context",
+      "tightReason": "specific strategy 'exponential backoff', explicit parameters base, factor, max"
+    },
+    {
+      "id": 8,
+      "loose": "throttle",
+      "tight": "throttle a function: at most one call per N ms, drop intermediate calls",
+      "looseReason": "single-word generic intent; no rate, no drop/queue semantics",
+      "tightReason": "explicit rate constraint 'at most one call per N ms', explicit drop semantics"
+    },
+    {
+      "id": 9,
+      "loose": "format",
+      "tight": "format number with thousands separator and fixed 2 decimal places",
+      "looseReason": "single-word generic intent; format what, how, for what locale",
+      "tightReason": "specific formatting rules: thousands separator, fixed 2 decimal places"
+    },
+    {
+      "id": 10,
+      "loose": "slug",
+      "tight": "convert string to URL slug: lowercase, hyphenate spaces, strip non-ASCII",
+      "looseReason": "single-word noun; no transformations specified",
+      "tightReason": "specific verb 'convert', explicit transformations: lowercase, hyphenate, strip non-ASCII"
+    }
+  ],
+  "looseDefinition": {
+    "description": "A loose intent is one that: (a) is a single word or a generic noun phrase with no specific verb, (b) lacks named standards/algorithms, (c) lacks output shape or precision constraints, (d) would match many unrelated atoms in the registry.",
+    "requiredAbsence": ["specific verb", "named standard", "explicit constraint", "output format"]
+  },
+  "tightDefinition": {
+    "description": "A tight intent is one that: (a) contains a specific action verb, (b) names the relevant standard or algorithm where applicable, (c) specifies output shape and precision, (d) would produce a focused, discriminating registry query.",
+    "requiredPresence": ["specific verb or named algorithm"]
+  }
+}


### PR DESCRIPTION
## Summary (load-bearing per #578 label)

Rewrites the hook discovery system prompt at `docs/system-prompts/yakcc-discovery.md` from soft-suggesting to imperative:
- Refuses loose initial intents ("You MUST start with the most specific intent")
- Mandates zoom-in-on-miss recursion ("NEVER zoom out")
- Walks through URL-parser example concretely
- Includes mandatory self-check step before query submission
- NO carve-outs for business logic / one-off

## Tests (350 pass / 1 todo)

- `system-prompt.test.ts` — 20 grep-invariant assertions
- `system-prompt-integration.test.ts` — 43 tests (10-pair corpus + 8 negative + 2 telemetry scaffold + 1 todo)
- The 1 todo (Design-A real-telemetry threshold) scaffolded with TODO for #569 follow-up per plan §8

## Single source of truth preserved
No prompt text duplicated into IDE packages. Adapters reference `SYSTEM_PROMPT_PATH`; no content parsing.

## D4 ADR
Q8 section added to `docs/adr/discovery-llm-interaction.md` (DEC-HOOK-PROMPT-DESCENT-001).

## Acceptance grep invariants (all confirmed)
| Check | Required | Actual |
|---|---|---|
| You MUST | >=4 | 4 |
| You MUST NOT | >=1 | 1 |
| NO carve-outs | >=1 | 1 |
| self-check (CI) | >=1 | 1 |
| URL parser | >=1 | 6 |
| Soft language | 0 | 0 |
| Carve-out keywords | 0 | 0 |

Closes #578.