### PR TITLE
fix(hooks-base): add MIT SPDX header to system-prompt.ts (closes #587)

### DIFF
--- a/packages/hooks-base/src/system-prompt.ts
+++ b/packages/hooks-base/src/system-prompt.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /**
  * system-prompt.ts — Authority surface for the yakcc discovery system prompt.
  *


### PR DESCRIPTION
## Summary

- Adds `// SPDX-License-Identifier: MIT` as line 1 of `packages/hooks-base/src/system-prompt.ts`
- Trivial one-line fix matching the convention of all other files in `packages/hooks-base/src/`

## Why

`yakcc bootstrap` refuses to shave files without a recognizable license identifier. This file was added in #583 without the header, blocking the `two-pass bootstrap equivalence` CI check on every subsequent PR.

Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)