### PR TITLE
feat(hooks): #590 S2 — Layer 2 result-set size enforcement + central enforcement-config (blocker/load-bearing/v0)

### DIFF
--- a/docs/enforcement-config.md
+++ b/docs/enforcement-config.md
@@ -1,0 +1,138 @@
+# Enforcement Config
+
+Central configuration module for the yakcc hook enforcement stack. All tunable
+thresholds across all enforcement layers (L1–L6 and beyond) are owned exclusively
+by `packages/hooks-base/src/enforcement-config.ts` (DEC-HOOK-ENF-CONFIG-001).
+
+No layer module may hardcode a threshold. Layer modules call
+`getEnforcementConfig().layerN` at runtime.
+
+---
+
+## Loading precedence
+
+Highest wins:
+
+1. `setConfigOverride()` — test hook (in-process only)
+2. Env vars (see mapping below)
+3. Config file (`.yakcc/enforcement.json` or `YAKCC_ENFORCEMENT_CONFIG_PATH`)
+4. Compiled defaults (match prior hardcoded constants — no behavior change on fresh install)
+
+---
+
+## Env var mapping
+
+| Env var                              | Config key                  | Type    | Default |
+|--------------------------------------|-----------------------------|---------|---------|
+| `YAKCC_HOOK_DISABLE_INTENT_GATE`     | `layer1.disableGate`        | `"1"`   | `false` |
+| `YAKCC_L1_MIN_WORDS`                 | `layer1.minWords`           | integer | `4`     |
+| `YAKCC_L1_MAX_WORDS`                 | `layer1.maxWords`           | integer | `20`    |
+| `YAKCC_RESULT_SET_MAX`               | `layer2.maxConfident`       | integer | `3`     |
+| `YAKCC_RESULT_SET_MAX_OVERALL`       | `layer2.maxOverall`         | integer | `10`    |
+| `YAKCC_RESULT_CONFIDENT_THRESHOLD`   | `layer2.confidentThreshold` | float   | `0.70`  |
+| `YAKCC_HOOK_DISABLE_RESULT_SET_GATE` | (escape hatch — checked at call site in index.ts) | `"1"` | unset |
+| `YAKCC_ENFORCEMENT_CONFIG_PATH`      | (file path override)        | string  | unset   |
+
+Env vars always override the config file. Invalid values (non-numeric, out-of-range)
+are silently ignored and the file/default value is used.
+
+---
+
+## Config file format
+
+Place at `.yakcc/enforcement.json` in the repo root, or point to it with
+`YAKCC_ENFORCEMENT_CONFIG_PATH`.
+
+All fields are optional. Unspecified fields fall back to defaults.
+
+```json
+{
+  "layer1": {
+    "minWords": 4,
+    "maxWords": 20,
+    "stopWords": ["things", "stuff", "utility", "helper", "manager",
+                  "handler", "service", "system", "processor", "worker"],
+    "metaWords": ["various", "general", "common", "some", "any",
+                  "several", "misc", "generic"],
+    "actionVerbs": ["parse", "validate", "encode", "decode", "hash",
+                    "compare", "split", "join", "filter", "map"],
+    "disableGate": false
+  },
+  "layer2": {
+    "maxConfident": 3,
+    "maxOverall": 10,
+    "confidentThreshold": 0.70
+  }
+}
+```
+
+Validation: non-object values, wrong types, or `confidentThreshold` outside `[0, 1]`
+throw with a descriptive message at load time (not silently ignored).
+
+---
+
+## Layer 1 thresholds (intent-specificity gate)
+
+| Field         | Default   | Meaning                                             |
+|---------------|-----------|-----------------------------------------------------|
+| `minWords`    | `4`       | Minimum whitespace-tokenized word count             |
+| `maxWords`    | `20`      | Maximum whitespace-tokenized word count             |
+| `stopWords`   | 10 words  | Tokens that signal a generic noun (reject)          |
+| `metaWords`   | 8 words   | Tokens that signal vague framing (reject)           |
+| `actionVerbs` | ~90 verbs | Allowlist — intent must contain at least one        |
+| `disableGate` | `false`   | `true` bypasses Layer 1 entirely (breakglass only)  |
+
+Layer 1 rejects if: `wordCount < minWords`, `wordCount > maxWords`, any token is in
+`stopWords`, any token is in `metaWords`, or no token is in `actionVerbs` (and no
+`is`/`has`/`can` predicate prefix is present).
+
+---
+
+## Layer 2 thresholds (result-set size gate)
+
+| Field                | Default | Meaning                                                           |
+|----------------------|---------|-------------------------------------------------------------------|
+| `maxConfident`       | `3`     | Max candidates with `combinedScore >= confidentThreshold` allowed |
+| `maxOverall`         | `10`    | Max total candidates allowed (backstop for dense embedding spaces)|
+| `confidentThreshold` | `0.70`  | Score cutoff: matches `CONFIDENT_THRESHOLD` in `yakcc-resolve.ts`|
+
+Layer 2 rejects when `confidentCount > maxConfident` OR `totalCount > maxOverall`.
+
+Score formula: `combinedScore = 1 - cosineDistance² / 4` (identical to `yakcc-resolve.ts`).
+
+---
+
+## Tuning guide
+
+**Too many false rejections (Layer 2 fires on legitimate queries):**
+- Raise `maxConfident` (e.g. to `5`) and observe bench/B5-coherence impact.
+- Raise `maxOverall` if the registry embedding space is legitimately dense for a domain.
+
+**Too many ambiguous results slipping through:**
+- Lower `maxConfident` (e.g. to `2`).
+- Lower `confidentThreshold` to 0.65 to expand the "confident" band.
+
+**Layer 1 blocking valid intents:**
+- Extend `actionVerbs` in the config file — no code change needed.
+- Use `YAKCC_L1_MIN_WORDS=3` if your registry has 3-word precision intents.
+
+**Emergency bypass:**
+- `YAKCC_HOOK_DISABLE_INTENT_GATE=1` disables Layer 1.
+- `YAKCC_HOOK_DISABLE_RESULT_SET_GATE=1` disables Layer 2.
+- These are breakglass only. Do not leave set in production.
+
+---
+
+## S3-S6 extension protocol
+
+When implementing Layer 3 (atom-size enforcement) and beyond:
+
+1. Add `layer3: Layer3Config` to `EnforcementConfig` in `enforcement-config.ts`.
+2. Add defaults to `getDefaults()` (must preserve prior defaults exactly).
+3. Add env-var mapping to `applyEnvOverrides()`.
+4. Add schema validation to `validateConfigFile()`.
+5. Layer module imports `getEnforcementConfig().layer3` — no local constants.
+6. Update this doc with the new layer's env vars and config fields.
+
+Cross-reference: `packages/hooks-base/src/enforcement-config.ts` (DEC-HOOK-ENF-CONFIG-001),
+`plans/wi-579-s2-layer2-result-set-size.md`.

--- a/packages/hooks-base/src/__fixtures__/enforcement-config-sample.json
+++ b/packages/hooks-base/src/__fixtures__/enforcement-config-sample.json
@@ -1,0 +1,25 @@
+{
+  "_comment": "Sample .yakcc/enforcement.json — place at repo root or set YAKCC_ENFORCEMENT_CONFIG_PATH. All fields optional; unspecified fields fall back to defaults. See docs/enforcement-config.md.",
+  "layer1": {
+    "minWords": 4,
+    "maxWords": 20,
+    "stopWords": [
+      "things", "stuff", "utility", "helper", "manager",
+      "handler", "service", "system", "processor", "worker"
+    ],
+    "metaWords": [
+      "various", "general", "common", "some", "any", "several", "misc", "generic"
+    ],
+    "actionVerbs": [
+      "parse", "validate", "encode", "decode", "hash", "compare",
+      "split", "join", "filter", "map", "reduce", "sort", "find",
+      "match", "extract", "convert", "serialize", "deserialize"
+    ],
+    "disableGate": false
+  },
+  "layer2": {
+    "maxConfident": 3,
+    "maxOverall": 10,
+    "confidentThreshold": 0.70
+  }
+}

--- a/packages/hooks-base/src/enforcement-config.test.ts
+++ b/packages/hooks-base/src/enforcement-config.test.ts
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: MIT
+/**
+ * enforcement-config.test.ts — Unit tests for the central enforcement config module.
+ *
+ * Production trigger: loadEnforcementConfig() / getEnforcementConfig() are called
+ * synchronously at the entry point of every enforcement layer (L1, L2, …).
+ * These tests verify:
+ *   1. Default config matches prior hardcoded S1 values exactly (regression-gate).
+ *   2. Env-var overrides are applied with highest precedence.
+ *   3. File overrides are merged correctly (partial and full).
+ *   4. Invalid file/field content throws clearly.
+ *   5. setConfigOverride / resetConfigOverride work for test isolation.
+ *   6. Memoization: repeated calls return the same object (file is read once).
+ *
+ * @decision DEC-HOOK-ENF-CONFIG-001
+ */
+
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  getDefaults,
+  getEnforcementConfig,
+  loadEnforcementConfig,
+  resetConfigOverride,
+  setConfigOverride,
+} from "./enforcement-config.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTempConfigFile(content: unknown): string {
+  const dir = join(tmpdir(), "yakcc-enforcement-config-tests");
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  const filePath = join(dir, `enforcement-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+  writeFileSync(filePath, JSON.stringify(content), "utf-8");
+  return filePath;
+}
+
+function cleanTempFile(filePath: string): void {
+  try {
+    unlinkSync(filePath);
+  } catch {
+    // ignore cleanup errors
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  resetConfigOverride();
+});
+
+afterEach(() => {
+  resetConfigOverride();
+});
+
+// ---------------------------------------------------------------------------
+// 1. Default config — regression gate against prior S1 hardcoded values
+// ---------------------------------------------------------------------------
+
+describe("getDefaults() — S1 regression gate", () => {
+  it("layer1.minWords is 4 (matches prior MIN_WORDS constant)", () => {
+    expect(getDefaults().layer1.minWords).toBe(4);
+  });
+
+  it("layer1.maxWords is 20 (matches prior MAX_WORDS constant)", () => {
+    expect(getDefaults().layer1.maxWords).toBe(20);
+  });
+
+  it("layer1.disableGate is false", () => {
+    expect(getDefaults().layer1.disableGate).toBe(false);
+  });
+
+  it("layer1.stopWords contains the 10 canonical S1 words", () => {
+    const expected = [
+      "things", "stuff", "utility", "helper", "manager",
+      "handler", "service", "system", "processor", "worker",
+    ];
+    const sw = new Set(getDefaults().layer1.stopWords);
+    for (const w of expected) {
+      expect(sw.has(w), `stopWords missing: ${w}`).toBe(true);
+    }
+    expect(getDefaults().layer1.stopWords.length).toBe(10);
+  });
+
+  it("layer1.metaWords contains the 8 canonical S1 words", () => {
+    const expected = ["various", "general", "common", "some", "any", "several", "misc", "generic"];
+    const mw = new Set(getDefaults().layer1.metaWords);
+    for (const w of expected) {
+      expect(mw.has(w), `metaWords missing: ${w}`).toBe(true);
+    }
+    expect(getDefaults().layer1.metaWords.length).toBe(8);
+  });
+
+  it("layer1.actionVerbs contains parse, validate, hash", () => {
+    const av = new Set(getDefaults().layer1.actionVerbs);
+    expect(av.has("parse")).toBe(true);
+    expect(av.has("validate")).toBe(true);
+    expect(av.has("hash")).toBe(true);
+  });
+
+  it("layer2.maxConfident is 3", () => {
+    expect(getDefaults().layer2.maxConfident).toBe(3);
+  });
+
+  it("layer2.maxOverall is 10", () => {
+    expect(getDefaults().layer2.maxOverall).toBe(10);
+  });
+
+  it("layer2.confidentThreshold is 0.7", () => {
+    expect(getDefaults().layer2.confidentThreshold).toBeCloseTo(0.7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. loadEnforcementConfig with no file, no env — returns defaults
+// ---------------------------------------------------------------------------
+
+describe("loadEnforcementConfig() — no file, no env overrides", () => {
+  it("returns defaults when no file path and empty env", () => {
+    const cfg = loadEnforcementConfig({ filePath: "/nonexistent/enforcement.json", env: {} });
+    const defaults = getDefaults();
+    expect(cfg.layer1.minWords).toBe(defaults.layer1.minWords);
+    expect(cfg.layer1.maxWords).toBe(defaults.layer1.maxWords);
+    expect(cfg.layer2.maxConfident).toBe(defaults.layer2.maxConfident);
+    expect(cfg.layer2.maxOverall).toBe(defaults.layer2.maxOverall);
+    expect(cfg.layer2.confidentThreshold).toBeCloseTo(defaults.layer2.confidentThreshold);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Env-var overrides
+// ---------------------------------------------------------------------------
+
+describe("loadEnforcementConfig() — env-var overrides", () => {
+  it("YAKCC_HOOK_DISABLE_INTENT_GATE=1 sets layer1.disableGate=true", () => {
+    const cfg = loadEnforcementConfig({
+      filePath: "/nonexistent/enforcement.json",
+      env: { YAKCC_HOOK_DISABLE_INTENT_GATE: "1" },
+    });
+    expect(cfg.layer1.disableGate).toBe(true);
+  });
+
+  it("YAKCC_HOOK_DISABLE_INTENT_GATE absent → layer1.disableGate remains false", () => {
+    const cfg = loadEnforcementConfig({ filePath: "/nonexistent/enforcement.json", env: {} });
+    expect(cfg.layer1.disableGate).toBe(false);
+  });
+
+  it("YAKCC_L1_MIN_WORDS overrides layer1.minWords", () => {
+    const cfg = loadEnforcementConfig({
+      filePath: "/nonexistent/enforcement.json",
+      env: { YAKCC_L1_MIN_WORDS: "6" },
+    });
+    expect(cfg.layer1.minWords).toBe(6);
+  });
+
+  it("YAKCC_L1_MAX_WORDS overrides layer1.maxWords", () => {
+    const cfg = loadEnforcementConfig({
+      filePath: "/nonexistent/enforcement.json",
+      env: { YAKCC_L1_MAX_WORDS: "15" },
+    });
+    expect(cfg.layer1.maxWords).toBe(15);
+  });
+
+  it("YAKCC_RESULT_SET_MAX overrides layer2.maxConfident", () => {
+    const cfg = loadEnforcementConfig({
+      filePath: "/nonexistent/enforcement.json",
+      env: { YAKCC_RESULT_SET_MAX: "5" },
+    });
+    expect(cfg.layer2.maxConfident).toBe(5);
+  });
+
+  it("YAKCC_RESULT_SET_MAX_OVERALL overrides layer2.maxOverall", () => {
+    const cfg = loadEnforcementConfig({
+      filePath: "/nonexistent/enforcement.json",
+      env: { YAKCC_RESULT_SET_MAX_OVERALL: "20" },
+    });
+    expect(cfg.layer2.maxOverall).toBe(20);
+  });
+
+  it("YAKCC_RESULT_CONFIDENT_THRESHOLD overrides layer2.confidentThreshold", () => {
+    const cfg = loadEnforcementConfig({
+      filePath: "/nonexistent/enforcement.json",
+      env: { YAKCC_RESULT_CONFIDENT_THRESHOLD: "0.85" },
+    });
+    expect(cfg.layer2.confidentThreshold).toBeCloseTo(0.85);
+  });
+
+  it("non-numeric YAKCC_L1_MIN_WORDS is silently ignored (falls back to default)", () => {
+    const cfg = loadEnforcementConfig({
+      filePath: "/nonexistent/enforcement.json",
+      env: { YAKCC_L1_MIN_WORDS: "not-a-number" },
+    });
+    expect(cfg.layer1.minWords).toBe(getDefaults().layer1.minWords);
+  });
+
+  it("env var overrides take precedence over file values", () => {
+    const filePath = makeTempConfigFile({ layer2: { maxConfident: 7 } });
+    try {
+      // File says maxConfident=7, env says 2 — env wins
+      const cfg = loadEnforcementConfig({
+        filePath,
+        env: { YAKCC_RESULT_SET_MAX: "2" },
+      });
+      expect(cfg.layer2.maxConfident).toBe(2);
+    } finally {
+      cleanTempFile(filePath);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. File override — partial and full
+// ---------------------------------------------------------------------------
+
+describe("loadEnforcementConfig() — file overrides", () => {
+  it("partial layer2 file override merges with defaults", () => {
+    const filePath = makeTempConfigFile({ layer2: { maxConfident: 5 } });
+    try {
+      const cfg = loadEnforcementConfig({ filePath, env: {} });
+      expect(cfg.layer2.maxConfident).toBe(5);
+      // Unset keys fall back to defaults
+      expect(cfg.layer2.maxOverall).toBe(getDefaults().layer2.maxOverall);
+      expect(cfg.layer2.confidentThreshold).toBeCloseTo(getDefaults().layer2.confidentThreshold);
+      // layer1 is entirely default
+      expect(cfg.layer1.minWords).toBe(getDefaults().layer1.minWords);
+    } finally {
+      cleanTempFile(filePath);
+    }
+  });
+
+  it("full layer1 + layer2 file override applies all values", () => {
+    const filePath = makeTempConfigFile({
+      layer1: { minWords: 3, maxWords: 25, disableGate: true },
+      layer2: { maxConfident: 1, maxOverall: 5, confidentThreshold: 0.8 },
+    });
+    try {
+      const cfg = loadEnforcementConfig({ filePath, env: {} });
+      expect(cfg.layer1.minWords).toBe(3);
+      expect(cfg.layer1.maxWords).toBe(25);
+      expect(cfg.layer1.disableGate).toBe(true);
+      expect(cfg.layer2.maxConfident).toBe(1);
+      expect(cfg.layer2.maxOverall).toBe(5);
+      expect(cfg.layer2.confidentThreshold).toBeCloseTo(0.8);
+    } finally {
+      cleanTempFile(filePath);
+    }
+  });
+
+  it("layer1 stopWords/metaWords/actionVerbs can be overridden via file", () => {
+    const filePath = makeTempConfigFile({
+      layer1: { stopWords: ["foo", "bar"], metaWords: ["baz"], actionVerbs: ["qux"] },
+    });
+    try {
+      const cfg = loadEnforcementConfig({ filePath, env: {} });
+      expect(cfg.layer1.stopWords).toEqual(["foo", "bar"]);
+      expect(cfg.layer1.metaWords).toEqual(["baz"]);
+      expect(cfg.layer1.actionVerbs).toEqual(["qux"]);
+    } finally {
+      cleanTempFile(filePath);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Invalid config rejection
+// ---------------------------------------------------------------------------
+
+describe("loadEnforcementConfig() — invalid config rejection", () => {
+  it("throws on invalid JSON in config file", () => {
+    const dir = join(tmpdir(), "yakcc-enforcement-config-tests");
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    const filePath = join(dir, `invalid-${Date.now()}.json`);
+    writeFileSync(filePath, "{ this is not json }", "utf-8");
+    try {
+      expect(() => loadEnforcementConfig({ filePath, env: {} })).toThrow();
+    } finally {
+      cleanTempFile(filePath);
+    }
+  });
+
+  it("throws TypeError when config file root is not an object", () => {
+    const filePath = makeTempConfigFile([1, 2, 3]);
+    try {
+      expect(() => loadEnforcementConfig({ filePath, env: {} })).toThrow(TypeError);
+    } finally {
+      cleanTempFile(filePath);
+    }
+  });
+
+  it("throws TypeError when layer2.maxConfident is not an integer", () => {
+    const filePath = makeTempConfigFile({ layer2: { maxConfident: 2.5 } });
+    try {
+      expect(() => loadEnforcementConfig({ filePath, env: {} })).toThrow(TypeError);
+    } finally {
+      cleanTempFile(filePath);
+    }
+  });
+
+  it("throws TypeError when layer2.confidentThreshold is out of [0,1]", () => {
+    const filePath = makeTempConfigFile({ layer2: { confidentThreshold: 1.5 } });
+    try {
+      expect(() => loadEnforcementConfig({ filePath, env: {} })).toThrow(TypeError);
+    } finally {
+      cleanTempFile(filePath);
+    }
+  });
+
+  it("throws TypeError when layer1.stopWords contains a non-string", () => {
+    const filePath = makeTempConfigFile({ layer1: { stopWords: ["ok", 42] } });
+    try {
+      expect(() => loadEnforcementConfig({ filePath, env: {} })).toThrow(TypeError);
+    } finally {
+      cleanTempFile(filePath);
+    }
+  });
+
+  it("throws TypeError when layer1 is not an object", () => {
+    const filePath = makeTempConfigFile({ layer1: "not-an-object" });
+    try {
+      expect(() => loadEnforcementConfig({ filePath, env: {} })).toThrow(TypeError);
+    } finally {
+      cleanTempFile(filePath);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. setConfigOverride / resetConfigOverride
+// ---------------------------------------------------------------------------
+
+describe("setConfigOverride / resetConfigOverride", () => {
+  it("setConfigOverride makes getEnforcementConfig return the override", () => {
+    const override = {
+      ...getDefaults(),
+      layer2: { maxConfident: 99, maxOverall: 100, confidentThreshold: 0.5 },
+    };
+    setConfigOverride(override);
+    const cfg = getEnforcementConfig();
+    expect(cfg.layer2.maxConfident).toBe(99);
+    expect(cfg.layer2.maxOverall).toBe(100);
+  });
+
+  it("resetConfigOverride clears override and returns defaults", () => {
+    const override = {
+      ...getDefaults(),
+      layer2: { maxConfident: 99, maxOverall: 100, confidentThreshold: 0.5 },
+    };
+    setConfigOverride(override);
+    resetConfigOverride();
+    // After reset, should get normal defaults (with nonexistent file)
+    const cfg = loadEnforcementConfig({ filePath: "/nonexistent/enforcement.json", env: {} });
+    expect(cfg.layer2.maxConfident).toBe(getDefaults().layer2.maxConfident);
+  });
+
+  it("override takes precedence over file and env", () => {
+    const override = {
+      ...getDefaults(),
+      layer2: { maxConfident: 42, maxOverall: 100, confidentThreshold: 0.5 },
+    };
+    setConfigOverride(override);
+    const filePath = makeTempConfigFile({ layer2: { maxConfident: 7 } });
+    try {
+      const cfg = loadEnforcementConfig({ filePath, env: { YAKCC_RESULT_SET_MAX: "1" } });
+      expect(cfg.layer2.maxConfident).toBe(42);
+    } finally {
+      cleanTempFile(filePath);
+    }
+  });
+});

--- a/packages/hooks-base/src/enforcement-config.ts
+++ b/packages/hooks-base/src/enforcement-config.ts
@@ -1,0 +1,613 @@
+// SPDX-License-Identifier: MIT
+//
+// @decision DEC-HOOK-ENF-CONFIG-001
+// title: Central enforcement config module — sole authority for all layer thresholds
+// status: decided (wi-590-s2-layer2)
+// rationale:
+//   User directive (#590): "make the levels for rejection etc configurable via config.
+//   We want to be able to tune this to the right levels without having to rewrite code
+//   each time."
+//
+//   This module is the SOLE source of truth for every tunable threshold across all
+//   enforcement layers (L1–L6 and beyond). No layer module may hardcode a threshold.
+//   All layer modules import getter(s) from this file instead.
+//
+//   Loading precedence (highest wins): env var → config file → defaults.
+//
+//   Env var mapping:
+//     YAKCC_HOOK_DISABLE_INTENT_GATE="1"  → layer1.disableGate = true
+//     YAKCC_ENFORCEMENT_CONFIG_PATH       → absolute path to a JSON config file
+//     YAKCC_RESULT_SET_MAX                → layer2.maxConfident (integer)
+//     YAKCC_RESULT_SET_MAX_OVERALL        → layer2.maxOverall (integer)
+//     YAKCC_RESULT_CONFIDENT_THRESHOLD    → layer2.confidentThreshold (float)
+//     YAKCC_L1_MIN_WORDS                  → layer1.minWords (integer)
+//     YAKCC_L1_MAX_WORDS                  → layer1.maxWords (integer)
+//
+//   Config file: optional .yakcc/enforcement.json relative to the repo root,
+//   or the path pointed to by YAKCC_ENFORCEMENT_CONFIG_PATH.
+//   Invalid JSON or schema violations throw with a clear message.
+//
+//   Memoization: the loaded config is cached after the first call.
+//   Tests can reset via setConfigOverride() / resetConfigOverride().
+//
+//   S3-S6 append their layer3/layer4/layer5/layer6 keys here following the same pattern.
+//
+//   Cross-reference: docs/enforcement-config.md, plans/wi-579-s2-layer2-result-set-size.md
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Config shape
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration for Layer 1 (intent-specificity gate).
+ * Defaults match the prior hardcoded constants in intent-specificity.ts exactly
+ * so S1 behavior is preserved with zero semantic change when no config is present.
+ */
+export interface Layer1Config {
+  /** Minimum number of whitespace-tokenized words an intent must have. Default: 4. */
+  readonly minWords: number;
+  /** Maximum number of whitespace-tokenized words an intent may have. Default: 20. */
+  readonly maxWords: number;
+  /**
+   * Stop-words that signal a generic, non-specific intent.
+   * Default: the 10 canonical words from #579.
+   */
+  readonly stopWords: readonly string[];
+  /**
+   * Meta-words that signal vague, catch-all intent framing.
+   * Default: the 8 canonical words from #579.
+   */
+  readonly metaWords: readonly string[];
+  /**
+   * Curated set of action verbs. An intent must contain at least one token
+   * matching an entry here (case-insensitive after lowercasing) to pass the
+   * action-verb check.
+   * Default: the full verb list from intent-specificity.ts.
+   */
+  readonly actionVerbs: readonly string[];
+  /**
+   * When true, the Layer 1 intent-specificity gate is disabled entirely.
+   * Equivalent to setting YAKCC_HOOK_DISABLE_INTENT_GATE=1.
+   * Default: false.
+   */
+  readonly disableGate: boolean;
+}
+
+/**
+ * Configuration for Layer 2 (result-set size enforcement).
+ */
+export interface Layer2Config {
+  /**
+   * Maximum number of confident candidates (combinedScore >= confidentThreshold)
+   * allowed in a result set before the gate fires.
+   * Default: 3.
+   */
+  readonly maxConfident: number;
+  /**
+   * Maximum total candidates allowed regardless of score.
+   * Default: 10.
+   */
+  readonly maxOverall: number;
+  /**
+   * Score band cutoff: candidates with combinedScore >= this value are counted
+   * as "confident" for the maxConfident check.
+   * Default: 0.70 (matches CONFIDENT_THRESHOLD from yakcc-resolve.ts).
+   */
+  readonly confidentThreshold: number;
+}
+
+/**
+ * Central enforcement configuration shape.
+ *
+ * S3-S6 implementers: append layer3/layer4/layer5/layer6 keys here following
+ * the same pattern. Do NOT add thresholds to layer modules directly.
+ *
+ * @decision DEC-HOOK-ENF-CONFIG-001
+ */
+export interface EnforcementConfig {
+  readonly layer1: Layer1Config;
+  readonly layer2: Layer2Config;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+/**
+ * Default stop-words (matches the prior hardcoded set in intent-specificity.ts exactly).
+ * Preserving this list here ensures S1 defaults are reproduced correctly.
+ */
+const DEFAULT_STOP_WORDS: readonly string[] = [
+  "things",
+  "stuff",
+  "utility",
+  "helper",
+  "manager",
+  "handler",
+  "service",
+  "system",
+  "processor",
+  "worker",
+];
+
+/**
+ * Default meta-words (matches the prior hardcoded set in intent-specificity.ts exactly).
+ */
+const DEFAULT_META_WORDS: readonly string[] = [
+  "various",
+  "general",
+  "common",
+  "some",
+  "any",
+  "several",
+  "misc",
+  "generic",
+];
+
+/**
+ * Default action verbs (matches the prior hardcoded set in intent-specificity.ts exactly).
+ */
+const DEFAULT_ACTION_VERBS: readonly string[] = [
+  "parse",
+  "validate",
+  "encode",
+  "decode",
+  "hash",
+  "compare",
+  "split",
+  "join",
+  "filter",
+  "map",
+  "reduce",
+  "sort",
+  "find",
+  "match",
+  "extract",
+  "convert",
+  "serialize",
+  "deserialize",
+  "normalize",
+  "sanitize",
+  "format",
+  "render",
+  "build",
+  "emit",
+  "read",
+  "write",
+  "append",
+  "prepend",
+  "trim",
+  "pad",
+  "slice",
+  "chunk",
+  "flatten",
+  "merge",
+  "diff",
+  "patch",
+  "compress",
+  "decompress",
+  "encrypt",
+  "decrypt",
+  "sign",
+  "verify",
+  "generate",
+  "create",
+  "delete",
+  "update",
+  "insert",
+  "select",
+  "query",
+  "scan",
+  "index",
+  "tokenize",
+  "lex",
+  "compile",
+  "transpile",
+  "transform",
+  "project",
+  "fold",
+  "unfold",
+  "group",
+  "partition",
+  "zip",
+  "unzip",
+  "pack",
+  "unpack",
+  "escape",
+  "unescape",
+  "quote",
+  "unquote",
+  "wrap",
+  "unwrap",
+  "resolve",
+  "reject",
+  "retry",
+  "throttle",
+  "debounce",
+  "batch",
+  "stream",
+  "pipe",
+  "fork",
+  "collect",
+  "drain",
+  "flush",
+  "reset",
+  "clamp",
+  "lerp",
+  "round",
+  "truncate",
+  "abs",
+  "sum",
+  "count",
+  "measure",
+];
+
+/**
+ * Return the canonical default EnforcementConfig.
+ *
+ * Defaults reproduce the prior hardcoded constants from intent-specificity.ts
+ * exactly so there is zero semantic change when no config file or env vars are
+ * present.
+ *
+ * @decision DEC-HOOK-ENF-CONFIG-001
+ */
+export function getDefaults(): EnforcementConfig {
+  return {
+    layer1: {
+      minWords: 4,
+      maxWords: 20,
+      stopWords: DEFAULT_STOP_WORDS,
+      metaWords: DEFAULT_META_WORDS,
+      actionVerbs: DEFAULT_ACTION_VERBS,
+      disableGate: false,
+    },
+    layer2: {
+      maxConfident: 3,
+      maxOverall: 10,
+      confidentThreshold: 0.7,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// File-based config loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Partial config shape accepted in the JSON config file.
+ * Both layer1 and layer2 sub-objects are optional; unset fields fall back to
+ * the corresponding default value. This allows tuning a single threshold without
+ * having to specify the entire schema.
+ */
+interface PartialEnforcementConfigFile {
+  layer1?: Partial<{
+    minWords: number;
+    maxWords: number;
+    stopWords: string[];
+    metaWords: string[];
+    actionVerbs: string[];
+    disableGate: boolean;
+  }>;
+  layer2?: Partial<{
+    maxConfident: number;
+    maxOverall: number;
+    confidentThreshold: number;
+  }>;
+}
+
+/**
+ * Validate that a parsed config file object has acceptable types for all
+ * provided fields. Throws TypeError with a descriptive message on any violation.
+ *
+ * @internal
+ */
+function validateConfigFile(raw: unknown, filePath: string): PartialEnforcementConfigFile {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new TypeError(
+      `enforcement-config: "${filePath}" must be a JSON object, got ${Array.isArray(raw) ? "array" : typeof raw}`,
+    );
+  }
+  const obj = raw as Record<string, unknown>;
+
+  // Validate layer1 block
+  if ("layer1" in obj && obj.layer1 !== undefined) {
+    const l1 = obj.layer1;
+    if (typeof l1 !== "object" || l1 === null || Array.isArray(l1)) {
+      throw new TypeError(`enforcement-config: "${filePath}" layer1 must be an object`);
+    }
+    const l1obj = l1 as Record<string, unknown>;
+    for (const key of ["minWords", "maxWords"] as const) {
+      if (key in l1obj && typeof l1obj[key] !== "number") {
+        throw new TypeError(`enforcement-config: "${filePath}" layer1.${key} must be a number`);
+      }
+      if (key in l1obj && !Number.isInteger(l1obj[key])) {
+        throw new TypeError(`enforcement-config: "${filePath}" layer1.${key} must be an integer`);
+      }
+    }
+    for (const key of ["stopWords", "metaWords", "actionVerbs"] as const) {
+      if (key in l1obj) {
+        if (!Array.isArray(l1obj[key])) {
+          throw new TypeError(
+            `enforcement-config: "${filePath}" layer1.${key} must be an array of strings`,
+          );
+        }
+        for (const item of l1obj[key] as unknown[]) {
+          if (typeof item !== "string") {
+            throw new TypeError(
+              `enforcement-config: "${filePath}" layer1.${key} must contain only strings`,
+            );
+          }
+        }
+      }
+    }
+    if ("disableGate" in l1obj && typeof l1obj.disableGate !== "boolean") {
+      throw new TypeError(`enforcement-config: "${filePath}" layer1.disableGate must be a boolean`);
+    }
+  }
+
+  // Validate layer2 block
+  if ("layer2" in obj && obj.layer2 !== undefined) {
+    const l2 = obj.layer2;
+    if (typeof l2 !== "object" || l2 === null || Array.isArray(l2)) {
+      throw new TypeError(`enforcement-config: "${filePath}" layer2 must be an object`);
+    }
+    const l2obj = l2 as Record<string, unknown>;
+    for (const key of ["maxConfident", "maxOverall"] as const) {
+      if (key in l2obj) {
+        if (typeof l2obj[key] !== "number") {
+          throw new TypeError(`enforcement-config: "${filePath}" layer2.${key} must be a number`);
+        }
+        if (!Number.isInteger(l2obj[key])) {
+          throw new TypeError(`enforcement-config: "${filePath}" layer2.${key} must be an integer`);
+        }
+      }
+    }
+    if ("confidentThreshold" in l2obj) {
+      if (typeof l2obj.confidentThreshold !== "number") {
+        throw new TypeError(
+          `enforcement-config: "${filePath}" layer2.confidentThreshold must be a number`,
+        );
+      }
+      if ((l2obj.confidentThreshold as number) < 0 || (l2obj.confidentThreshold as number) > 1) {
+        throw new TypeError(
+          `enforcement-config: "${filePath}" layer2.confidentThreshold must be in [0, 1]`,
+        );
+      }
+    }
+  }
+
+  return raw as PartialEnforcementConfigFile;
+}
+
+/**
+ * Load config from a JSON file at the given path and merge into defaults.
+ * Throws on invalid JSON or schema violations.
+ *
+ * @internal
+ */
+function loadFromFile(filePath: string, defaults: EnforcementConfig): EnforcementConfig {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(filePath, "utf-8"));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      // File does not exist — use defaults silently.
+      return defaults;
+    }
+    throw new Error(`enforcement-config: failed to parse "${filePath}": ${(err as Error).message}`);
+  }
+
+  const partial = validateConfigFile(raw, filePath);
+
+  return {
+    layer1: {
+      ...defaults.layer1,
+      ...partial.layer1,
+    },
+    layer2: {
+      ...defaults.layer2,
+      ...partial.layer2,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Env-var overrides
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply env-var overrides on top of a merged config.
+ * Env vars have the highest precedence (above file, above defaults).
+ *
+ * Mapping:
+ *   YAKCC_HOOK_DISABLE_INTENT_GATE=1   → layer1.disableGate = true
+ *   YAKCC_L1_MIN_WORDS=<int>           → layer1.minWords
+ *   YAKCC_L1_MAX_WORDS=<int>           → layer1.maxWords
+ *   YAKCC_RESULT_SET_MAX=<int>         → layer2.maxConfident
+ *   YAKCC_RESULT_SET_MAX_OVERALL=<int> → layer2.maxOverall
+ *   YAKCC_RESULT_CONFIDENT_THRESHOLD=<float> → layer2.confidentThreshold
+ *
+ * @internal
+ */
+function applyEnvOverrides(config: EnforcementConfig, env: NodeJS.ProcessEnv): EnforcementConfig {
+  let layer1 = { ...config.layer1 };
+  let layer2 = { ...config.layer2 };
+  let l1Changed = false;
+  let l2Changed = false;
+
+  // layer1 overrides
+  if (env.YAKCC_HOOK_DISABLE_INTENT_GATE === "1") {
+    layer1 = { ...layer1, disableGate: true };
+    l1Changed = true;
+  }
+  if (env.YAKCC_L1_MIN_WORDS !== undefined) {
+    const v = Number.parseInt(env.YAKCC_L1_MIN_WORDS, 10);
+    if (!Number.isNaN(v)) {
+      layer1 = { ...layer1, minWords: v };
+      l1Changed = true;
+    }
+  }
+  if (env.YAKCC_L1_MAX_WORDS !== undefined) {
+    const v = Number.parseInt(env.YAKCC_L1_MAX_WORDS, 10);
+    if (!Number.isNaN(v)) {
+      layer1 = { ...layer1, maxWords: v };
+      l1Changed = true;
+    }
+  }
+
+  // layer2 overrides
+  if (env.YAKCC_RESULT_SET_MAX !== undefined) {
+    const v = Number.parseInt(env.YAKCC_RESULT_SET_MAX, 10);
+    if (!Number.isNaN(v)) {
+      layer2 = { ...layer2, maxConfident: v };
+      l2Changed = true;
+    }
+  }
+  if (env.YAKCC_RESULT_SET_MAX_OVERALL !== undefined) {
+    const v = Number.parseInt(env.YAKCC_RESULT_SET_MAX_OVERALL, 10);
+    if (!Number.isNaN(v)) {
+      layer2 = { ...layer2, maxOverall: v };
+      l2Changed = true;
+    }
+  }
+  if (env.YAKCC_RESULT_CONFIDENT_THRESHOLD !== undefined) {
+    const v = Number.parseFloat(env.YAKCC_RESULT_CONFIDENT_THRESHOLD);
+    if (!Number.isNaN(v) && v >= 0 && v <= 1) {
+      layer2 = { ...layer2, confidentThreshold: v };
+      l2Changed = true;
+    }
+  }
+
+  if (!l1Changed && !l2Changed) return config;
+
+  return {
+    layer1: l1Changed ? layer1 : config.layer1,
+    layer2: l2Changed ? layer2 : config.layer2,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Config file path resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the enforcement config file path.
+ *
+ * Priority:
+ * 1. YAKCC_ENFORCEMENT_CONFIG_PATH env var (absolute path)
+ * 2. .yakcc/enforcement.json relative to process.cwd()
+ *
+ * Returns null when neither exists. Does NOT throw for missing files.
+ *
+ * @internal
+ */
+function resolveConfigFilePath(env: NodeJS.ProcessEnv): string | null {
+  if (env.YAKCC_ENFORCEMENT_CONFIG_PATH !== undefined) {
+    return env.YAKCC_ENFORCEMENT_CONFIG_PATH;
+  }
+  const candidate = join(process.cwd(), ".yakcc", "enforcement.json");
+  if (existsSync(candidate)) {
+    return candidate;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Memoization + override mechanism for tests
+// ---------------------------------------------------------------------------
+
+/** Cached config after first successful load. Null = not yet loaded. */
+let _cachedConfig: EnforcementConfig | null = null;
+
+/** Explicit override (test hook). When set, overrides the cached config. */
+let _configOverride: EnforcementConfig | null = null;
+
+/**
+ * Override the enforcement config for the current process.
+ * Used by tests to inject controlled configs without env/file gymnastics.
+ *
+ * Call resetConfigOverride() in afterEach to restore normal loading.
+ *
+ * @example
+ * setConfigOverride({ ...getDefaults(), layer2: { maxConfident: 1, maxOverall: 3, confidentThreshold: 0.70 } });
+ */
+export function setConfigOverride(config: EnforcementConfig): void {
+  _configOverride = config;
+}
+
+/**
+ * Clear the config override set by setConfigOverride().
+ * Also clears the memo cache so the next loadEnforcementConfig() call re-reads.
+ */
+export function resetConfigOverride(): void {
+  _configOverride = null;
+  _cachedConfig = null;
+}
+
+// ---------------------------------------------------------------------------
+// Public loader
+// ---------------------------------------------------------------------------
+
+/**
+ * Load and return the active EnforcementConfig.
+ *
+ * Loading order (highest wins):
+ *   1. setConfigOverride() value (test hook)
+ *   2. Env var overrides (YAKCC_RESULT_SET_MAX, YAKCC_HOOK_DISABLE_INTENT_GATE, …)
+ *   3. Config file (.yakcc/enforcement.json or YAKCC_ENFORCEMENT_CONFIG_PATH)
+ *   4. Default values (getDefaults())
+ *
+ * The result is memoized after the first call. Call resetConfigOverride() to
+ * invalidate the memo (e.g., between tests).
+ *
+ * @param opts.filePath - Override the config file path (skips the env lookup).
+ * @param opts.env      - Override process.env (useful for testing env-var logic).
+ *
+ * @throws Error when the config file exists but contains invalid JSON.
+ * @throws TypeError when the config file contains incorrect field types.
+ *
+ * @decision DEC-HOOK-ENF-CONFIG-001
+ */
+export function loadEnforcementConfig(opts?: {
+  filePath?: string;
+  env?: NodeJS.ProcessEnv;
+}): EnforcementConfig {
+  if (_configOverride !== null) {
+    return _configOverride;
+  }
+
+  if (_cachedConfig !== null) {
+    // Re-apply env overrides even on cached config so test env manipulation
+    // is picked up without requiring a resetConfigOverride call.
+    // (The file-load result is cached; env overrides are re-evaluated each call.)
+    return applyEnvOverrides(_cachedConfig, opts?.env ?? process.env);
+  }
+
+  const env = opts?.env ?? process.env;
+  const defaults = getDefaults();
+
+  // Load from file if available.
+  const filePath = opts?.filePath ?? resolveConfigFilePath(env);
+  const fileConfig = filePath !== null ? loadFromFile(filePath, defaults) : defaults;
+
+  // Cache the file-merged config (before env overrides).
+  _cachedConfig = fileConfig;
+
+  // Apply env overrides on top (not cached).
+  return applyEnvOverrides(fileConfig, env);
+}
+
+/**
+ * Convenience getter: returns the active enforcement config.
+ *
+ * This is the function layer modules should import and call.
+ * Equivalent to loadEnforcementConfig() with no options.
+ *
+ * @decision DEC-HOOK-ENF-CONFIG-001
+ */
+export function getEnforcementConfig(): EnforcementConfig {
+  return loadEnforcementConfig();
+}

--- a/packages/hooks-base/src/enforcement-types.ts
+++ b/packages/hooks-base/src/enforcement-types.ts
@@ -71,13 +71,80 @@ export interface IntentAcceptEnvelope {
 export type IntentSpecificityResult = IntentAcceptEnvelope | IntentRejectEnvelope;
 
 // ---------------------------------------------------------------------------
-// Layers 2–5 placeholders — additive per Sacred Practice 12
+// Layer 2 — result-set size enforcement (wi-590-s2-layer2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Layer 2 ACCEPT envelope: result-set size is within configured bounds.
+ *
+ * @decision DEC-HOOK-ENF-LAYER2-RESULT-SET-SIZE-001
+ */
+export interface ResultSetAcceptEnvelope {
+  readonly layer: 2;
+  readonly status: "ok";
+  /**
+   * Number of candidates in the "confident" band (combinedScore >= confidentThreshold).
+   * Zero when no candidates meet the threshold.
+   */
+  readonly confidentCount: number;
+  /**
+   * Total number of candidates evaluated (all score bands).
+   */
+  readonly totalCount: number;
+}
+
+/**
+ * Reasons a Layer 2 result-set size check can produce a REJECT verdict.
+ *
+ * @decision DEC-HOOK-ENF-LAYER2-RESULT-SET-SIZE-001
+ */
+export type ResultSetRejectReason =
+  | "too_many_confident" // confidentCount > maxConfident
+  | "too_many_overall";  // totalCount > maxOverall
+
+/**
+ * Layer 2 REJECT envelope: the result set was too large.
+ *
+ * When this envelope is returned, callers MUST NOT use the candidates as a
+ * direct match — the result set is ambiguous. The intent should be decomposed
+ * or narrowed before resubmitting.
+ *
+ * @decision DEC-HOOK-ENF-LAYER2-RESULT-SET-SIZE-001
+ */
+export interface ResultSetRejectEnvelope {
+  readonly layer: 2;
+  readonly status: "result_set_too_large";
+  /** All reject reasons that applied (at least one when status = result_set_too_large). */
+  readonly reasons: readonly ResultSetRejectReason[];
+  /**
+   * Number of candidates in the confident band at time of rejection.
+   */
+  readonly confidentCount: number;
+  /**
+   * Total number of candidates at time of rejection.
+   */
+  readonly totalCount: number;
+  /**
+   * Thresholds that were violated (for telemetry / debugging).
+   */
+  readonly maxConfident: number;
+  readonly maxOverall: number;
+  /**
+   * Forcing-function suggestion surfaced to the LLM.
+   */
+  readonly suggestion: string;
+}
+
+/** Discriminated union result of scoreResultSetSize(). */
+export type ResultSetSizeResult = ResultSetAcceptEnvelope | ResultSetRejectEnvelope;
+
+// ---------------------------------------------------------------------------
+// Layers 3–5 placeholders — additive per Sacred Practice 12
 //
-// S2..S5 implementers append their envelope types here. No existing shape
+// S3..S5 implementers append their envelope types here. No existing shape
 // changes. This comment block documents the extension point so future
 // implementers know where to add.
 //
-// S2 will export: ResultSetEnvelope (ok | result_set_too_large)
 // S3 will export: AtomSizeEnvelope (ok | atom_oversized)
 // S4 will export: DescentTrackingEnvelope (ok | descent_bypass_warning)
 // S5 will export: DriftEnvelope (ok | drift_alert)

--- a/packages/hooks-base/src/index.ts
+++ b/packages/hooks-base/src/index.ts
@@ -548,6 +548,41 @@ export async function executeRegistryQueryWithSubstitution(
   const { response, candidateCount, topScore, candidates } =
     await _executeRegistryQueryInternalWithCandidates(registry, ctx, options, originalCode);
 
+  // ---------------------------------------------------------------------------
+  // Layer 2 — result-set size enforcement (wi-590-s2-layer2, DEC-HOOK-ENF-LAYER2-RESULT-SET-SIZE-001)
+  // Run AFTER registry query resolves and BEFORE candidates are returned to the consumer.
+  // A large "confident" band means the intent is too broad for the registry to discriminate
+  // reliably. Escape hatch: YAKCC_HOOK_DISABLE_RESULT_SET_GATE=1 bypasses this check.
+  // ---------------------------------------------------------------------------
+  if (process.env.YAKCC_HOOK_DISABLE_RESULT_SET_GATE !== "1") {
+    const { scoreResultSetSize } = await import("./result-set-size.js");
+    const sizeCheck = scoreResultSetSize(candidates);
+    if (sizeCheck.status === "result_set_too_large") {
+      // Telemetry side-effect only — must not affect the passthrough return.
+      try {
+        const { captureTelemetry } = await import("./telemetry.js");
+        captureTelemetry({
+          intent: ctx.intent,
+          toolName,
+          response: { kind: "passthrough" },
+          candidateCount,
+          topScore,
+          latencyMs: Date.now() - start,
+          outcomeOverride: "result-set-too-large",
+          ...(options.sessionId !== undefined ? { sessionId: options.sessionId } : {}),
+          ...(options.telemetryDir !== undefined ? { telemetryDir: options.telemetryDir } : {}),
+        });
+      } catch {
+        // Telemetry failure must never affect the hook outcome (observe-don't-mutate).
+      }
+      return {
+        kind: "passthrough",
+        substituted: false,
+        resultSetRejectEnvelope: sizeCheck,
+      };
+    }
+  }
+
   // Attempt substitution if not disabled.
   let substitutionResult: import("./substitute.js").SubstitutionResult | null = null;
   let substitutionLatencyMs: number | null = null;
@@ -719,6 +754,13 @@ export type HookResponseWithSubstitution = HookResponse & (
        * Callers may surface intentRejectEnvelope.suggestion to the LLM as a forcing-function.
        */
       readonly intentRejectEnvelope?: import("./enforcement-types.js").IntentRejectEnvelope;
+      /**
+       * Layer 2 result-set size reject envelope (wi-590-s2-layer2, DEC-HOOK-ENF-LAYER2-RESULT-SET-SIZE-001).
+       * Present when Layer 2 rejected the result set as too large/ambiguous.
+       * When set, the registry WAS queried but returned too many confident candidates.
+       * Callers may surface resultSetRejectEnvelope.suggestion to the LLM as a forcing-function.
+       */
+      readonly resultSetRejectEnvelope?: import("./enforcement-types.js").ResultSetRejectEnvelope;
     }
   | { readonly substituted: true; readonly substitutedCode: string; readonly atomHash: string }
 );
@@ -827,4 +869,48 @@ export {
   MIN_WORDS,
   MAX_WORDS,
 } from "./intent-specificity.js";
+
+// ---------------------------------------------------------------------------
+// wi-590-s2-layer2 -- Layer 2 result-set size gate (public surface)
+// ---------------------------------------------------------------------------
+
+/**
+ * @decision DEC-HOOK-ENF-LAYER2-RESULT-SET-SIZE-001
+ * Layer 2 enforcement module and shared envelope types exported from hooks-base
+ * so IDE adapters can surface resultSetRejectEnvelope.suggestion to the LLM.
+ * No enforcement logic lives in IDE adapters — they consume only these types.
+ */
+export type {
+  ResultSetAcceptEnvelope,
+  ResultSetRejectEnvelope,
+  ResultSetRejectReason,
+  ResultSetSizeResult,
+} from "./enforcement-types.js";
+export {
+  scoreResultSetSize,
+  isResultSetSizeOk,
+} from "./result-set-size.js";
+
+// ---------------------------------------------------------------------------
+// wi-590-s2-layer2 -- central enforcement config (public surface)
+// ---------------------------------------------------------------------------
+
+/**
+ * @decision DEC-HOOK-ENF-CONFIG-001
+ * Central enforcement config module exported from hooks-base.
+ * S3-S6 implementers: use getEnforcementConfig() for all threshold reads.
+ * IDE adapters: no direct config access needed — enforcement runs inside hooks-base.
+ */
+export type {
+  EnforcementConfig,
+  Layer1Config,
+  Layer2Config,
+} from "./enforcement-config.js";
+export {
+  getDefaults,
+  getEnforcementConfig,
+  loadEnforcementConfig,
+  setConfigOverride,
+  resetConfigOverride,
+} from "./enforcement-config.js";
 

--- a/packages/hooks-base/src/intent-specificity.ts
+++ b/packages/hooks-base/src/intent-specificity.ts
@@ -16,200 +16,100 @@
 //   Default behavior is ENFORCE. The env var is for breakglass and test isolation only.
 //   @decision DEC-HOOK-ENF-LAYER1-ESCAPE-HATCH-001
 //
-//   Cross-reference: plans/wi-579-hook-enforcement-architecture.md §5.2
+//   S2 retrofit (wi-590-s2-layer2, DEC-HOOK-ENF-CONFIG-001):
+//   All threshold constants were hardcoded here in S1. They are now DERIVED FROM
+//   the central enforcement-config.ts module at call time. The exported constants
+//   (MIN_WORDS, MAX_WORDS, STOP_WORDS, META_WORDS, ACTION_VERBS) are PRESERVED as
+//   snapshots of the default values for backward compatibility with existing callers
+//   and tests. Layer-module logic reads from the config via getEnforcementConfig()
+//   at call time; the exported constant snapshots serve as documentation and as the
+//   values used by callers that import them directly (which is fine — they match defaults).
+//
+//   Cross-reference: plans/wi-579-hook-enforcement-architecture.md §5.2,
+//                    docs/enforcement-config.md, enforcement-config.ts
 
 import type { IntentSpecificityResult } from "./enforcement-types.js";
+import { getDefaults, getEnforcementConfig } from "./enforcement-config.js";
+import type { EnforcementConfig } from "./enforcement-config.js";
 
 export type { IntentSpecificityResult } from "./enforcement-types.js";
 export type { IntentAcceptEnvelope, IntentRejectEnvelope, IntentRejectReason } from "./enforcement-types.js";
 
 // ---------------------------------------------------------------------------
-// Threshold constants — sole authority per plan §10 invariants
+// Exported constant snapshots — default values for backward compatibility.
+//
+// @decision DEC-HOOK-ENF-LAYER1-CONSTANTS-RETROFIT-001
+// title: Exported constants are snapshots of enforcement-config defaults (S2 retrofit)
+// status: decided (wi-590-s2-layer2)
+// rationale:
+//   S1 hardcoded thresholds directly in this file. S2 (wi-590-s2-layer2) introduces a
+//   central enforcement-config.ts module (DEC-HOOK-ENF-CONFIG-001) as the SOLE source
+//   of truth. The S1-exported constants (MIN_WORDS, MAX_WORDS, STOP_WORDS, META_WORDS,
+//   ACTION_VERBS) are retained as snapshots of the config defaults to preserve the public
+//   API for existing callers (index.ts exports, intent-specificity.test.ts imports).
+//
+//   IMPORTANT: the exported constants reflect DEFAULT values only. When a config file or
+//   env var overrides a threshold, scoreIntentSpecificity() uses the overridden values —
+//   but the exported constants retain the default snapshot. This is acceptable because:
+//   (a) Existing callers that import these constants use them for documentation/assertion
+//       purposes, not for gating decisions.
+//   (b) All production gating goes through scoreIntentSpecificity(), which reads from the
+//       live config at call time via getEnforcementConfig().
+//
+//   S3-S6: follow this same pattern — export default snapshots for API compat while all
+//   production logic reads from getEnforcementConfig().
 // ---------------------------------------------------------------------------
+
+const _defaults = getDefaults().layer1;
 
 /**
  * Minimum number of whitespace-tokenized words an intent must have.
- * Intents shorter than this are categorically underspecified.
+ * Snapshot of the enforcement-config default (4). Production gating reads from config.
  *
- * @decision DEC-HOOK-ENF-LAYER1-MIN-WORDS-001
- * Value 4 matches the lower bound in the #579 issue body.
+ * @decision DEC-HOOK-ENF-LAYER1-CONSTANTS-RETROFIT-001
  */
-export const MIN_WORDS = 4;
+export const MIN_WORDS: number = _defaults.minWords;
 
 /**
  * Maximum number of whitespace-tokenized words an intent may have.
- * Intents longer than this are likely copy-paste artifacts or doc blobs.
+ * Snapshot of the enforcement-config default (20). Production gating reads from config.
  *
- * @decision DEC-HOOK-ENF-LAYER1-MAX-WORDS-001
- * Value 20 matches the upper bound in the #579 issue body.
+ * @decision DEC-HOOK-ENF-LAYER1-CONSTANTS-RETROFIT-001
  */
-export const MAX_WORDS = 20;
-
-// ---------------------------------------------------------------------------
-// Stop-word list
-// ---------------------------------------------------------------------------
+export const MAX_WORDS: number = _defaults.maxWords;
 
 /**
- * Stop-words that signal a generic, non-specific intent.
- * Any intent whose token list contains one of these strings (exact token match,
- * lowercased) is rejected with reason "stop_word_present".
+ * Stop-words snapshot — the default set from enforcement-config.ts.
+ * Production gating reads from the live config at call time.
  *
  * @decision DEC-HOOK-ENF-LAYER1-STOP-WORDS-001
+ * @decision DEC-HOOK-ENF-LAYER1-CONSTANTS-RETROFIT-001
  * The base 8 from #579 body + `processor` and `worker` for additional breadth.
  * Do NOT add entries here without a companion corpus row in enforcement-eval-corpus.json.
  */
-export const STOP_WORDS: ReadonlySet<string> = new Set([
-  "things",
-  "stuff",
-  "utility",
-  "helper",
-  "manager",
-  "handler",
-  "service",
-  "system",
-  "processor",
-  "worker",
-]);
-
-// ---------------------------------------------------------------------------
-// Meta-word list
-// ---------------------------------------------------------------------------
+export const STOP_WORDS: ReadonlySet<string> = new Set(_defaults.stopWords);
 
 /**
- * Meta-words that signal vague, catch-all intent framing.
- * Any intent whose token list contains one of these strings (exact token match,
- * lowercased) is rejected with reason "meta_word_present".
+ * Meta-words snapshot — the default set from enforcement-config.ts.
+ * Production gating reads from the live config at call time.
  *
  * @decision DEC-HOOK-ENF-LAYER1-META-WORDS-001
+ * @decision DEC-HOOK-ENF-LAYER1-CONSTANTS-RETROFIT-001
  * The base 4 from #579 body + `any`, `several`, `misc`, `generic` for breadth.
  */
-export const META_WORDS: ReadonlySet<string> = new Set([
-  "various",
-  "general",
-  "common",
-  "some",
-  "any",
-  "several",
-  "misc",
-  "generic",
-]);
-
-// ---------------------------------------------------------------------------
-// Action-verb allowlist
-// ---------------------------------------------------------------------------
+export const META_WORDS: ReadonlySet<string> = new Set(_defaults.metaWords);
 
 /**
- * Curated set of action verbs. An intent must contain at least one token
- * that exactly matches (lowercased) an entry here to pass the action-verb check.
+ * Action-verb allowlist snapshot — the default set from enforcement-config.ts.
+ * Production gating reads from the live config at call time.
  *
  * @decision DEC-HOOK-ENF-LAYER1-ACTION-VERBS-001
+ * @decision DEC-HOOK-ENF-LAYER1-CONSTANTS-RETROFIT-001
  * Positive signal complements the negative stop/meta-word heuristics.
  * Verbs are all lowercase; comparison is done after lowercasing the token.
  * The list covers the most common atom operations in the yakcc registry corpus.
- * "isemail", "isuuid", etc. are not in this list because they are nouns used
- * as function names — they pass through the word-count and stop/meta checks
- * without needing an action verb (the intent "isEmail RFC 5321 subset" has
- * the implicit verb "validate" encoded in the "is-" prefix — it passes because
- * it has ≥4 words and no stop/meta words, not because of this check).
- *
- * If an intent consistently fails the action-verb check incorrectly, add the
- * verb here and add a companion corpus row.
  */
-export const ACTION_VERBS: ReadonlySet<string> = new Set([
-  "parse",
-  "validate",
-  "encode",
-  "decode",
-  "hash",
-  "compare",
-  "split",
-  "join",
-  "filter",
-  "map",
-  "reduce",
-  "sort",
-  "find",
-  "match",
-  "extract",
-  "convert",
-  "serialize",
-  "deserialize",
-  "normalize",
-  "sanitize",
-  "format",
-  "render",
-  "build",
-  "emit",
-  "read",
-  "write",
-  "append",
-  "prepend",
-  "trim",
-  "pad",
-  "slice",
-  "chunk",
-  "flatten",
-  "merge",
-  "diff",
-  "patch",
-  "compress",
-  "decompress",
-  "encrypt",
-  "decrypt",
-  "sign",
-  "verify",
-  "generate",
-  "create",
-  "delete",
-  "update",
-  "insert",
-  "select",
-  "query",
-  "scan",
-  "index",
-  "tokenize",
-  "lex",
-  "compile",
-  "transpile",
-  "transform",
-  "project",
-  "fold",
-  "unfold",
-  "group",
-  "partition",
-  "zip",
-  "unzip",
-  "pack",
-  "unpack",
-  "escape",
-  "unescape",
-  "quote",
-  "unquote",
-  "wrap",
-  "unwrap",
-  "resolve",
-  "reject",
-  "retry",
-  "throttle",
-  "debounce",
-  "batch",
-  "stream",
-  "pipe",
-  "fork",
-  "join",
-  "collect",
-  "drain",
-  "flush",
-  "reset",
-  "clamp",
-  "lerp",
-  "round",
-  "truncate",
-  "abs",
-  "sum",
-  "count",
-  "measure",
-]);
+export const ACTION_VERBS: ReadonlySet<string> = new Set(_defaults.actionVerbs);
 
 // ---------------------------------------------------------------------------
 // I/O hint detection helpers (advisory — raises score only)
@@ -240,7 +140,7 @@ function hasIoHint(intent: string): boolean {
 
 /**
  * Tokenize an intent string into lowercase words by splitting on whitespace.
- * Punctuation attached to words is stripped before matching (e.g. "string," → "string").
+ * Punctuation attached to words is stripped before matching (e.g. "string," -> "string").
  */
 function tokenize(intent: string): readonly string[] {
   return intent
@@ -260,22 +160,26 @@ function tokenize(intent: string): readonly string[] {
  * Score = clamp01(
  *   0.5
  *   + 0.1  if has_io_hint
- *   + 0.1  if wordCount ∈ [6, 14]
+ *   + 0.1  if wordCount in [6, 14]
  *   + min(0.3, 0.05 * count_of_specific_tokens)
  * )
  *
- * where specific_tokens = tokens that are in ACTION_VERBS or have length > 6.
+ * where specific_tokens = tokens that are in actionVerbs or have length > 6.
  * This rewards richer, more descriptive intents without blocking on word length.
  *
  * The score is telemetry-only; Layer 5 aggregates it in a rolling window.
  */
-function computeScore(intent: string, tokens: readonly string[]): number {
+function computeScore(
+  intent: string,
+  tokens: readonly string[],
+  actionVerbs: ReadonlySet<string>,
+): number {
   const wordCount = tokens.length;
   const ioBonus = hasIoHint(intent) ? 0.1 : 0;
   const lengthBonus = wordCount >= 6 && wordCount <= 14 ? 0.1 : 0;
 
   const specificTokenCount = tokens.filter(
-    (t) => ACTION_VERBS.has(t) || t.length > 6,
+    (t) => actionVerbs.has(t) || t.length > 6,
   ).length;
   const specificityBonus = Math.min(0.3, 0.05 * specificTokenCount);
 
@@ -291,7 +195,7 @@ const SUGGESTION_TEXT =
   "INTENT_TOO_BROAD: intent failed specificity gate.\n" +
   "Refusing to query the registry. Per docs/system-prompts/yakcc-discovery.md,\n" +
   "decompose this into specific sub-intents and resubmit each.\n" +
-  'Example: "validation" → "isEmail (RFC 5321 subset)", "isUUID v4",\n' +
+  'Example: "validation" -> "isEmail (RFC 5321 subset)", "isUUID v4",\n' +
   '"validateCreditCard (Luhn)".';
 
 // ---------------------------------------------------------------------------
@@ -306,16 +210,33 @@ const SUGGESTION_TEXT =
  *   - { layer: 1, status: "intent_too_broad", reasons, suggestion } — reject; do NOT query.
  *
  * This function is pure (no I/O, no async). It is safe to call synchronously
- * in the hot hook path. All threshold constants are declared in this file and
- * imported nowhere else — this file is the single authority.
+ * in the hot hook path.
+ *
+ * S2 retrofit: all thresholds are now read from the central enforcement-config.ts
+ * module via getEnforcementConfig() (DEC-HOOK-ENF-CONFIG-001). Pass a custom config
+ * in tests via setConfigOverride() / resetConfigOverride() (no param needed here).
  *
  * Escape hatch: YAKCC_HOOK_DISABLE_INTENT_GATE=1 bypasses this layer at the
  * call site in index.ts and import-intercept.ts; this function itself does NOT
  * check the env var (callers own the bypass check).
  *
  * @decision DEC-HOOK-ENF-LAYER1-INTENT-SPECIFICITY-001
+ * @decision DEC-HOOK-ENF-LAYER1-CONSTANTS-RETROFIT-001
  */
-export function scoreIntentSpecificity(intent: string): IntentSpecificityResult {
+export function scoreIntentSpecificity(
+  intent: string,
+  _config?: EnforcementConfig,
+): IntentSpecificityResult {
+  // Read the live config — honors setConfigOverride() in tests and env/file overrides
+  // in production. The optional _config param is accepted but ignored in favor of
+  // getEnforcementConfig() to ensure the shared memoization and override mechanism works.
+  const cfg = getEnforcementConfig().layer1;
+  const minWords = cfg.minWords;
+  const maxWords = cfg.maxWords;
+  const stopWords = new Set(cfg.stopWords);
+  const metaWords = new Set(cfg.metaWords);
+  const actionVerbs = new Set(cfg.actionVerbs);
+
   const tokens = tokenize(intent);
   const wordCount = tokens.length;
   const reasons: Array<import("./enforcement-types.js").IntentRejectReason> = [];
@@ -333,11 +254,11 @@ export function scoreIntentSpecificity(intent: string): IntentSpecificityResult 
   }
 
   // --- Length checks ---
-  if (wordCount === 0 || wordCount < MIN_WORDS) {
+  if (wordCount === 0 || wordCount < minWords) {
     // @decision DEC-HOOK-ENF-LAYER1-MIN-WORDS-001
     reasons.push("too_short");
   }
-  if (wordCount > MAX_WORDS) {
+  if (wordCount > maxWords) {
     // @decision DEC-HOOK-ENF-LAYER1-MAX-WORDS-001
     reasons.push("too_long");
   }
@@ -345,7 +266,7 @@ export function scoreIntentSpecificity(intent: string): IntentSpecificityResult 
   // --- Stop-word check ---
   // @decision DEC-HOOK-ENF-LAYER1-STOP-WORDS-001
   for (const token of tokens) {
-    if (STOP_WORDS.has(token)) {
+    if (stopWords.has(token)) {
       reasons.push("stop_word_present");
       break;
     }
@@ -354,7 +275,7 @@ export function scoreIntentSpecificity(intent: string): IntentSpecificityResult 
   // --- Meta-word check ---
   // @decision DEC-HOOK-ENF-LAYER1-META-WORDS-001
   for (const token of tokens) {
-    if (META_WORDS.has(token)) {
+    if (metaWords.has(token)) {
       reasons.push("meta_word_present");
       break;
     }
@@ -365,10 +286,10 @@ export function scoreIntentSpecificity(intent: string): IntentSpecificityResult 
   // reason set for telemetry — but it can only produce a reject if nothing
   // else already did AND the word-count bracket is valid.
   // @decision DEC-HOOK-ENF-LAYER1-ACTION-VERBS-001
-  const hasActionVerb = tokens.some((t) => ACTION_VERBS.has(t));
+  const hasActionVerb = tokens.some((t) => actionVerbs.has(t));
 
   // Boolean-predicate prefix signal: tokens starting with "is", "has", or "can"
-  // encode an implicit action verb ("isEmail" ≈ "validates email").
+  // encode an implicit action verb ("isEmail" ~= "validates email").
   // Per plan §5.2: "isEmail RFC 5321 subset" accepts because the 'is-' prefix
   // encodes the validation intent — it does not require a standalone action verb.
   // This check is separate from ACTION_VERBS so the list stays pure verb forms.
@@ -379,12 +300,12 @@ export function scoreIntentSpecificity(intent: string): IntentSpecificityResult 
   //   TypeScript boolean predicates (isEmail, isUUID, hasProperty, canRetry) encode
   //   the action verb as a morphological prefix. Requiring a standalone action verb
   //   for these intents would reject all "isX/hasX" registry queries, which contradicts
-  //   the plan §5.2 exemplar ("isEmail RFC 5321 subset" → accept).
+  //   the plan §5.2 exemplar ("isEmail RFC 5321 subset" -> accept).
   //   Cross-reference: plans/wi-579-hook-enforcement-architecture.md §5.2
   const hasBooleanPrefixVerb = tokens.some(
-    (t) => t.startsWith("is") && t.length > 2 ||
-           t.startsWith("has") && t.length > 3 ||
-           t.startsWith("can") && t.length > 3,
+    (t) => (t.startsWith("is") && t.length > 2) ||
+           (t.startsWith("has") && t.length > 3) ||
+           (t.startsWith("can") && t.length > 3),
   );
 
   // If no stop/meta/length reason yet, check for missing action verb.
@@ -406,7 +327,7 @@ export function scoreIntentSpecificity(intent: string): IntentSpecificityResult 
   return {
     layer: 1,
     status: "ok",
-    score: computeScore(intent, tokens),
+    score: computeScore(intent, tokens, actionVerbs),
   };
 }
 

--- a/packages/hooks-base/src/result-set-size.test.ts
+++ b/packages/hooks-base/src/result-set-size.test.ts
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: MIT
+/**
+ * result-set-size.test.ts — Unit tests for Layer 2 result-set size enforcement.
+ *
+ * Production trigger: scoreResultSetSize() is called synchronously inside
+ * executeRegistryQueryWithSubstitution() (index.ts) AFTER the registry query
+ * resolves and BEFORE candidates are returned to the consumer.
+ *
+ * These tests verify:
+ *   1. Default config — accept when confidentCount <= 3 AND totalCount <= 10.
+ *   2. Reject when confidentCount > maxConfident (too_many_confident).
+ *   3. Reject when totalCount > maxOverall (too_many_overall).
+ *   4. Accept/reject boundaries are exact (=limit → accept, limit+1 → reject).
+ *   5. Config overrides drive threshold changes (no hardcoded constants in module).
+ *   6. isResultSetSizeOk() convenience predicate mirrors status.
+ *   7. Reject envelope carries correct counts and thresholds for telemetry.
+ *
+ * @decision DEC-HOOK-ENF-LAYER2-RESULT-SET-SIZE-001
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CandidateMatch } from "@yakcc/registry";
+import { getDefaults, resetConfigOverride, setConfigOverride } from "./enforcement-config.js";
+import { isResultSetSizeOk, scoreResultSetSize } from "./result-set-size.js";
+
+// ---------------------------------------------------------------------------
+// Helpers — build minimal CandidateMatch objects
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal CandidateMatch-shaped stub with the given cosine distance.
+ *
+ * combinedScore = 1 - d^2/4.
+ * CONFIDENT_THRESHOLD = 0.70 → cosineDistance <= sqrt((1-0.70)*4) = sqrt(1.2) ~= 1.095.
+ *
+ * Quick reference:
+ *   d=0.0   → score=1.00  (confident)
+ *   d=0.5   → score=0.9375 (confident)
+ *   d=1.0   → score=0.75   (confident)
+ *   d=1.095 → score=0.70   (confident, at threshold)
+ *   d=1.1   → score=0.6975 (NOT confident)
+ *   d=1.5   → score=0.4375 (NOT confident)
+ *   d=2.0   → score=0.00   (maximally distant)
+ */
+function makeCandidate(cosineDistance: number): CandidateMatch {
+  return {
+    cosineDistance,
+    block: {
+      specCanonicalBytes: new Uint8Array(0),
+      spec: {
+        behavior: "stub",
+        inputs: [],
+        outputs: [],
+        guarantees: [],
+        errorConditions: [],
+        nonFunctional: { purity: "pure", threadSafety: "safe" },
+        propertyTests: [],
+      },
+    },
+  } as unknown as CandidateMatch;
+}
+
+/** Build N confident candidates (score >= 0.70, d=0.5). */
+function makeConfidentCandidates(n: number): CandidateMatch[] {
+  return Array.from({ length: n }, () => makeCandidate(0.5));
+}
+
+/** Build N weak candidates (score < 0.70, d=1.2). */
+function makeWeakCandidates(n: number): CandidateMatch[] {
+  return Array.from({ length: n }, () => makeCandidate(1.2));
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown — reset config between tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  resetConfigOverride();
+});
+
+afterEach(() => {
+  resetConfigOverride();
+});
+
+// ---------------------------------------------------------------------------
+// 1. Default config — accept paths
+// ---------------------------------------------------------------------------
+
+describe("scoreResultSetSize() — accept paths (default config)", () => {
+  it("accepts empty candidate list", () => {
+    const result = scoreResultSetSize([]);
+    expect(result.status).toBe("ok");
+    expect(result.layer).toBe(2);
+    if (result.status === "ok") {
+      expect(result.confidentCount).toBe(0);
+      expect(result.totalCount).toBe(0);
+    }
+  });
+
+  it("accepts exactly maxConfident=3 confident candidates", () => {
+    const candidates = makeConfidentCandidates(3);
+    const result = scoreResultSetSize(candidates);
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.confidentCount).toBe(3);
+      expect(result.totalCount).toBe(3);
+    }
+  });
+
+  it("accepts mix of confident + weak within limits", () => {
+    // 2 confident + 5 weak = 7 total, 2 confident — all within defaults
+    const candidates = [...makeConfidentCandidates(2), ...makeWeakCandidates(5)];
+    const result = scoreResultSetSize(candidates);
+    expect(result.status).toBe("ok");
+  });
+
+  it("accepts exactly maxOverall=10 total candidates (0 confident)", () => {
+    const candidates = makeWeakCandidates(10);
+    const result = scoreResultSetSize(candidates);
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.confidentCount).toBe(0);
+      expect(result.totalCount).toBe(10);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. too_many_confident rejections
+// ---------------------------------------------------------------------------
+
+describe("scoreResultSetSize() — too_many_confident rejections", () => {
+  it("rejects when confidentCount = maxConfident + 1 (4 confident, default max=3)", () => {
+    const candidates = makeConfidentCandidates(4);
+    const result = scoreResultSetSize(candidates);
+    expect(result.status).toBe("result_set_too_large");
+    expect(result.layer).toBe(2);
+    if (result.status === "result_set_too_large") {
+      expect(result.reasons).toContain("too_many_confident");
+      expect(result.confidentCount).toBe(4);
+      expect(result.totalCount).toBe(4);
+      expect(result.maxConfident).toBe(3);
+      expect(typeof result.suggestion).toBe("string");
+      expect(result.suggestion.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("rejects 10 confident candidates — only too_many_confident reason (total=10 at limit)", () => {
+    const candidates = makeConfidentCandidates(10);
+    const result = scoreResultSetSize(candidates);
+    expect(result.status).toBe("result_set_too_large");
+    if (result.status === "result_set_too_large") {
+      expect(result.reasons).toContain("too_many_confident");
+      // total=10 equals maxOverall=10, so too_many_overall NOT triggered
+      expect(result.reasons).not.toContain("too_many_overall");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. too_many_overall rejections
+// ---------------------------------------------------------------------------
+
+describe("scoreResultSetSize() — too_many_overall rejections", () => {
+  it("rejects when totalCount = maxOverall + 1 (11 weak, default max=10)", () => {
+    const candidates = makeWeakCandidates(11);
+    const result = scoreResultSetSize(candidates);
+    expect(result.status).toBe("result_set_too_large");
+    if (result.status === "result_set_too_large") {
+      expect(result.reasons).toContain("too_many_overall");
+      expect(result.reasons).not.toContain("too_many_confident");
+      expect(result.totalCount).toBe(11);
+      expect(result.maxOverall).toBe(10);
+    }
+  });
+
+  it("rejects with both reasons when both limits exceeded", () => {
+    // 5 confident + 8 weak = 13 total; 5 > maxConfident=3 AND 13 > maxOverall=10
+    const candidates = [...makeConfidentCandidates(5), ...makeWeakCandidates(8)];
+    const result = scoreResultSetSize(candidates);
+    expect(result.status).toBe("result_set_too_large");
+    if (result.status === "result_set_too_large") {
+      expect(result.reasons).toContain("too_many_confident");
+      expect(result.reasons).toContain("too_many_overall");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Exact boundary: limit → accept; limit+1 → reject
+// ---------------------------------------------------------------------------
+
+describe("scoreResultSetSize() — boundary precision", () => {
+  it("confident boundary: exactly maxConfident accepts, maxConfident+1 rejects", () => {
+    const atLimit = makeConfidentCandidates(3); // default maxConfident=3
+    expect(scoreResultSetSize(atLimit).status).toBe("ok");
+
+    const overLimit = makeConfidentCandidates(4);
+    expect(scoreResultSetSize(overLimit).status).toBe("result_set_too_large");
+  });
+
+  it("overall boundary: exactly maxOverall accepts, maxOverall+1 rejects", () => {
+    const atLimit = makeWeakCandidates(10); // default maxOverall=10
+    expect(scoreResultSetSize(atLimit).status).toBe("ok");
+
+    const overLimit = makeWeakCandidates(11);
+    expect(scoreResultSetSize(overLimit).status).toBe("result_set_too_large");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Config overrides drive threshold changes
+// ---------------------------------------------------------------------------
+
+describe("scoreResultSetSize() — config overrides (no hardcoded constants)", () => {
+  it("tighter config: maxConfident=1 rejects 2 confident", () => {
+    setConfigOverride({
+      ...getDefaults(),
+      layer2: { maxConfident: 1, maxOverall: 10, confidentThreshold: 0.7 },
+    });
+    const candidates = makeConfidentCandidates(2);
+    const result = scoreResultSetSize(candidates);
+    expect(result.status).toBe("result_set_too_large");
+    if (result.status === "result_set_too_large") {
+      expect(result.reasons).toContain("too_many_confident");
+      expect(result.maxConfident).toBe(1);
+    }
+  });
+
+  it("looser config: maxConfident=10 accepts 9 confident", () => {
+    setConfigOverride({
+      ...getDefaults(),
+      layer2: { maxConfident: 10, maxOverall: 50, confidentThreshold: 0.7 },
+    });
+    const candidates = makeConfidentCandidates(9);
+    expect(scoreResultSetSize(candidates).status).toBe("ok");
+  });
+
+  it("confidentThreshold override changes which candidates are 'confident'", () => {
+    // Raise threshold to 0.95 — d=0.5 gives score=0.9375 < 0.95, NOT confident
+    setConfigOverride({
+      ...getDefaults(),
+      layer2: { maxConfident: 1, maxOverall: 10, confidentThreshold: 0.95 },
+    });
+    // 3 candidates with d=0.5 (score=0.9375) — not confident at threshold=0.95
+    const candidates = makeConfidentCandidates(3); // d=0.5, score=0.9375
+    // 0.9375 < 0.95, so confidentCount=0, which is <= maxConfident=1 → accept
+    const result = scoreResultSetSize(candidates);
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.confidentCount).toBe(0);
+    }
+  });
+
+  it("env-var YAKCC_RESULT_SET_MAX override applies (maxConfident=1)", () => {
+    // Simulate what loadEnforcementConfig({ env: { YAKCC_RESULT_SET_MAX: "1" } }) produces.
+    // Using setConfigOverride avoids async dynamic import in a sync test body.
+    setConfigOverride({
+      ...getDefaults(),
+      layer2: { maxConfident: 1, maxOverall: 10, confidentThreshold: 0.7 },
+    });
+    const result = scoreResultSetSize(makeConfidentCandidates(2));
+    expect(result.status).toBe("result_set_too_large");
+    if (result.status === "result_set_too_large") {
+      expect(result.maxConfident).toBe(1);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. isResultSetSizeOk() convenience predicate
+// ---------------------------------------------------------------------------
+
+describe("isResultSetSizeOk()", () => {
+  it("returns true for accepted candidate list", () => {
+    expect(isResultSetSizeOk(makeConfidentCandidates(2))).toBe(true);
+  });
+
+  it("returns false for rejected candidate list", () => {
+    expect(isResultSetSizeOk(makeConfidentCandidates(4))).toBe(false);
+  });
+
+  it("returns true for empty list", () => {
+    expect(isResultSetSizeOk([])).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Reject envelope shape verification (telemetry coverage)
+// ---------------------------------------------------------------------------
+
+describe("scoreResultSetSize() — reject envelope completeness", () => {
+  it("reject envelope has all required fields for telemetry", () => {
+    const candidates = makeConfidentCandidates(5);
+    const result = scoreResultSetSize(candidates);
+    expect(result.status).toBe("result_set_too_large");
+    if (result.status === "result_set_too_large") {
+      expect(result.layer).toBe(2);
+      expect(Array.isArray(result.reasons)).toBe(true);
+      expect(result.reasons.length).toBeGreaterThan(0);
+      expect(typeof result.confidentCount).toBe("number");
+      expect(typeof result.totalCount).toBe("number");
+      expect(typeof result.maxConfident).toBe("number");
+      expect(typeof result.maxOverall).toBe("number");
+      expect(typeof result.suggestion).toBe("string");
+    }
+  });
+
+  it("accept envelope has layer=2 and numeric counts", () => {
+    const result = scoreResultSetSize(makeConfidentCandidates(2));
+    expect(result.layer).toBe(2);
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(typeof result.confidentCount).toBe("number");
+      expect(typeof result.totalCount).toBe("number");
+    }
+  });
+});

--- a/packages/hooks-base/src/result-set-size.ts
+++ b/packages/hooks-base/src/result-set-size.ts
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+//
+// @decision DEC-HOOK-ENF-LAYER2-RESULT-SET-SIZE-001
+// title: Layer 2 result-set size enforcement — config-driven ambiguity gate
+// status: decided (wi-590-s2-layer2)
+// rationale:
+//   Layer 2 runs AFTER the registry query returns candidates and BEFORE results are
+//   returned to the caller. It prevents ambiguous, overloaded result sets from
+//   propagating to the consumer — a large "confident" band means the intent is too
+//   broad for the registry to discriminate reliably.
+//
+//   Two checks are applied:
+//     (a) confidentCount > maxConfident: too many candidates in the confident band
+//         (combinedScore >= confidentThreshold). This signals that multiple registry
+//         atoms match the intent with high confidence — decompose further.
+//     (b) totalCount > maxOverall: even in the weak band, a very large result set
+//         means the intent is not discriminating. This is a backstop for unusual
+//         embedding distributions.
+//
+//   Configuration is ENTIRELY driven by getEnforcementConfig().layer2 (DEC-HOOK-ENF-CONFIG-001).
+//   No threshold is hardcoded here. Defaults (maxConfident=3, maxOverall=10,
+//   confidentThreshold=0.70) match the CONFIDENT_THRESHOLD already used in
+//   yakcc-resolve.ts, so no behavior change occurs when no config file is present.
+//
+//   The function is pure (no I/O, no async). It is safe to call synchronously in the
+//   hot hook path after registry.findCandidatesByQuery() resolves.
+//
+//   Escape hatch: not defined for Layer 2 (use a config override with high thresholds
+//   instead, or disable the gate entirely via YAKCC_HOOK_DISABLE_RESULT_SET_GATE=1).
+//
+//   Cross-reference:
+//     enforcement-config.ts — threshold authority (DEC-HOOK-ENF-CONFIG-001)
+//     enforcement-types.ts  — ResultSetSizeResult, ResultSetAcceptEnvelope, ResultSetRejectEnvelope
+//     index.ts              — wire point (executeRegistryQueryWithSubstitution)
+//     docs/enforcement-config.md — tuning guide
+//     plans/wi-579-s2-layer2-result-set-size.md
+
+import type { CandidateMatch } from "@yakcc/registry";
+import type { ResultSetSizeResult } from "./enforcement-types.js";
+import { getEnforcementConfig } from "./enforcement-config.js";
+
+// ---------------------------------------------------------------------------
+// Suggestion text surfaced to the LLM on reject
+// ---------------------------------------------------------------------------
+
+const SUGGESTION_TEXT =
+  "RESULT_SET_TOO_LARGE: intent matched too many registry candidates.\n" +
+  "Refusing to return an ambiguous result set. Per docs/system-prompts/yakcc-discovery.md,\n" +
+  "decompose this into more specific sub-intents and resubmit each separately.\n" +
+  'Example: "encode string" -> "encodeURIComponent (percent-encoding)", "btoa (base64 ASCII)",\n' +
+  '"TextEncoder UTF-8 encode to Uint8Array".';
+
+// ---------------------------------------------------------------------------
+// Score helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the combined score for a candidate using the same formula as yakcc-resolve.ts.
+ *
+ * combinedScore = 1 - cosineDistance^2 / 4
+ *
+ * The formula converts a cosine distance in [0, 2] to a score in [0, 1] where
+ * 1.0 = perfect match and 0.0 = maximally distant. This matches CONFIDENT_THRESHOLD
+ * (0.70) usage in yakcc-resolve.ts.
+ *
+ * @decision DEC-HOOK-ENF-LAYER2-SCORE-FORMULA-001
+ * title: Combined-score formula matches yakcc-resolve.ts (1 - d^2/4)
+ * status: decided (wi-590-s2-layer2)
+ * rationale:
+ *   Reusing the same formula ensures that the Layer 2 "confident band" aligns exactly
+ *   with what yakcc-resolve.ts classifies as "matched" (score >= CONFIDENT_THRESHOLD=0.70).
+ *   A separate formula would create inconsistency between Layer 2 and the resolve layer.
+ */
+function candidateToCombinedScore(candidate: CandidateMatch): number {
+  const d = candidate.cosineDistance;
+  return 1 - (d * d) / 4;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Score and gate a candidate list through Layer 2 result-set size rules.
+ *
+ * Returns a ResultSetSizeResult discriminated union:
+ *   - { layer: 2, status: "ok", confidentCount, totalCount }
+ *       — result set is within bounds; proceed.
+ *   - { layer: 2, status: "result_set_too_large", reasons, ..., suggestion }
+ *       — result set is ambiguous; do NOT return to consumer.
+ *
+ * This function is pure (no I/O, no async). It is safe to call synchronously
+ * in the hot hook path after the registry query resolves.
+ *
+ * All thresholds are read from getEnforcementConfig().layer2 at call time
+ * (DEC-HOOK-ENF-CONFIG-001). Tests may use setConfigOverride() / resetConfigOverride()
+ * from enforcement-config.ts to inject controlled configs.
+ *
+ * Escape hatch: YAKCC_HOOK_DISABLE_RESULT_SET_GATE=1 bypasses this layer at the
+ * call site in index.ts; this function itself does NOT check the env var.
+ *
+ * @param candidates - The full candidate list from registry.findCandidatesByQuery().
+ *
+ * @decision DEC-HOOK-ENF-LAYER2-RESULT-SET-SIZE-001
+ */
+export function scoreResultSetSize(candidates: readonly CandidateMatch[]): ResultSetSizeResult {
+  const cfg = getEnforcementConfig().layer2;
+  const { maxConfident, maxOverall, confidentThreshold } = cfg;
+
+  const totalCount = candidates.length;
+  const confidentCount = candidates.filter(
+    (c) => candidateToCombinedScore(c) >= confidentThreshold,
+  ).length;
+
+  const reasons: Array<import("./enforcement-types.js").ResultSetRejectReason> = [];
+
+  if (confidentCount > maxConfident) {
+    reasons.push("too_many_confident");
+  }
+  if (totalCount > maxOverall) {
+    reasons.push("too_many_overall");
+  }
+
+  if (reasons.length > 0) {
+    return {
+      layer: 2,
+      status: "result_set_too_large",
+      reasons: reasons as readonly import("./enforcement-types.js").ResultSetRejectReason[],
+      confidentCount,
+      totalCount,
+      maxConfident,
+      maxOverall,
+      suggestion: SUGGESTION_TEXT,
+    };
+  }
+
+  return {
+    layer: 2,
+    status: "ok",
+    confidentCount,
+    totalCount,
+  };
+}
+
+/**
+ * Convenience predicate: returns true when the result set passes the size gate.
+ *
+ * Equivalent to `scoreResultSetSize(candidates).status === "ok"`.
+ */
+export function isResultSetSizeOk(candidates: readonly CandidateMatch[]): boolean {
+  return scoreResultSetSize(candidates).status === "ok";
+}

--- a/packages/hooks-base/src/telemetry.ts
+++ b/packages/hooks-base/src/telemetry.ts
@@ -82,8 +82,17 @@ export type TelemetryEvent = {
     //   Additive expansion following the #569/#574 shave-on-miss pattern (Sacred Practice 12).
     //   Emitted via outcomeOverride="intent-too-broad" at the Layer 1 gate in
     //   executeRegistryQueryWithSubstitution (index.ts). outcomeFromResponse() unchanged.
-    //   Cross-reference: plans/wi-579-hook-enforcement-architecture.md ��7.6
-    | "intent-too-broad"; // S1 additive (DEC-HOOK-ENF-LAYER1-TELEMETRY-001)
+    //   Cross-reference: plans/wi-579-hook-enforcement-architecture.md ��7.6
+    | "intent-too-broad" // S1 additive (DEC-HOOK-ENF-LAYER1-TELEMETRY-001)
+    // @decision DEC-HOOK-ENF-LAYER2-TELEMETRY-001
+    // title: "result-set-too-large" additive outcome for Layer 2 result-set size gate (wi-590 S2)
+    // status: decided (wi-590-s2-layer2)
+    // rationale:
+    //   Additive expansion following the Layer 1 pattern (DEC-HOOK-ENF-LAYER1-TELEMETRY-001).
+    //   Emitted via outcomeOverride="result-set-too-large" at the Layer 2 gate in
+    //   executeRegistryQueryWithSubstitution (index.ts). outcomeFromResponse() unchanged.
+    //   Cross-reference: plans/wi-579-s2-layer2-result-set-size.md
+    | "result-set-too-large"; // S2 additive (DEC-HOOK-ENF-LAYER2-TELEMETRY-001)
   // ---------------------------------------------------------------------------
   // Phase 2 additions â€” additive fields (backwards-compatible per #217 spec).
   // Old telemetry consumers see these as optional (undefined in Phase 1 events).
@@ -221,11 +230,11 @@ export function hashIntent(intentText: string): string {
  */
 export function outcomeFromResponse(
   response: HookResponse,
-  outcomeOverride?: "atomized" | "intent-too-broad",
-): "registry-hit" | "synthesis-required" | "passthrough" | "atomized" | "intent-too-broad" {
+  outcomeOverride?: "atomized" | "intent-too-broad" | "result-set-too-large",
+): "registry-hit" | "synthesis-required" | "passthrough" | "atomized" | "intent-too-broad" | "result-set-too-large" {
   // Note: shave-on-miss outcome values are emitted directly via appendTelemetryEvent
   // from shave-on-miss.ts, not via this function. This function handles only the
-  // four standard outcomes plus the atomized override.
+  // four standard outcomes plus the override values.
   if (outcomeOverride !== undefined) return outcomeOverride;
   return response.kind;
 }
@@ -302,10 +311,11 @@ export function captureTelemetry(opts: {
   // Phase 3 / D-HOOK-7 additions â€” additive, all optional.
   /** Explicit outcome override â€” used by the atomize path to set "atomized". */
   /**
-   * Explicit outcome override. Used by the atomize path to set "atomized" and by
-   * the Layer 1 gate to set "intent-too-broad" (DEC-HOOK-ENF-LAYER1-TELEMETRY-001).
+   * Explicit outcome override. Used by the atomize path to set "atomized",
+   * by the Layer 1 gate to set "intent-too-broad" (DEC-HOOK-ENF-LAYER1-TELEMETRY-001),
+   * and by the Layer 2 gate to set "result-set-too-large" (DEC-HOOK-ENF-LAYER2-TELEMETRY-001).
    */
-  outcomeOverride?: "atomized" | "intent-too-broad";
+  outcomeOverride?: "atomized" | "intent-too-broad" | "result-set-too-large";
   /** BMR prefixes of atoms created. Non-empty only for outcome === "atomized". */
   atomsCreated?: readonly string[];
   sessionId?: string;

--- a/packages/hooks-base/test/enforcement-eval-corpus.json
+++ b/packages/hooks-base/test/enforcement-eval-corpus.json
@@ -47,5 +47,56 @@
     "expectedLayer": 1,
     "expectedOutcome": "accept",
     "notes": "action verb (convert) + I/O specifics (to single byte) — high-quality specific intent"
+  },
+  {
+    "id": "L2-001",
+    "input": "result-set-too-large",
+    "candidateCount": 12,
+    "confidentCount": 12,
+    "weakCount": 0,
+    "expectedLayer": 2,
+    "expectedOutcome": "result-set-too-large",
+    "notes": "12 confident candidates (d=0.5, score=0.9375 >= threshold=0.70) — far exceeds maxConfident=3; both too_many_confident and too_many_overall triggered"
+  },
+  {
+    "id": "L2-002",
+    "input": "result-set-too-large",
+    "candidateCount": 4,
+    "confidentCount": 4,
+    "weakCount": 0,
+    "expectedLayer": 2,
+    "expectedOutcome": "result-set-too-large",
+    "notes": "4 confident candidates — maxConfident=3, so 4 > 3 triggers too_many_confident (boundary +1 scenario)"
+  },
+  {
+    "id": "L2-003",
+    "input": "accept",
+    "candidateCount": 3,
+    "confidentCount": 3,
+    "weakCount": 0,
+    "expectedLayer": 2,
+    "expectedOutcome": "accept",
+    "notes": "exactly 3 confident candidates — at the boundary (maxConfident=3), not over it; accept"
+  },
+  {
+    "id": "L2-004",
+    "input": "accept",
+    "candidateCount": 5,
+    "confidentCount": 0,
+    "weakCount": 5,
+    "expectedLayer": 2,
+    "expectedOutcome": "accept",
+    "notes": "0 confident + 5 weak candidates — confidentCount=0 within maxConfident=3, totalCount=5 within maxOverall=10; surface (weak band informational)"
+  },
+  {
+    "id": "L2-005",
+    "input": "accept",
+    "candidateCount": 4,
+    "confidentCount": 4,
+    "weakCount": 0,
+    "envOverrides": { "YAKCC_RESULT_SET_MAX": "5" },
+    "expectedLayer": 2,
+    "expectedOutcome": "accept",
+    "notes": "YAKCC_RESULT_SET_MAX=5 env override raises maxConfident to 5; 4 confident < 5 → accept"
   }
 ]

--- a/packages/hooks-base/test/enforcement-eval-corpus.test.ts
+++ b/packages/hooks-base/test/enforcement-eval-corpus.test.ts
@@ -25,11 +25,13 @@
  * Every PR touching packages/hooks-base/src/** will exercise it.
  */
 
-import { createReadStream } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { scoreIntentSpecificity } from "../src/intent-specificity.js";
+import type { CandidateMatch } from "@yakcc/registry";
+import { resetConfigOverride, setConfigOverride, getDefaults, loadEnforcementConfig } from "../src/enforcement-config.js";
+import { scoreResultSetSize } from "../src/result-set-size.js";
 
 // ---------------------------------------------------------------------------
 // Corpus type
@@ -41,6 +43,11 @@ interface CorpusRow {
   expectedLayer: number;
   expectedOutcome: "intent-too-broad" | "accept" | "result-set-too-large" | "atom-oversized" | "descent-bypass-warning" | "drift-alert";
   notes?: string;
+  // Layer 2 fields — present only for L2-* rows
+  candidateCount?: number;
+  confidentCount?: number;
+  weakCount?: number;
+  envOverrides?: Record<string, string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -80,6 +87,102 @@ function assertLayer1Row(row: CorpusRow): void {
 }
 
 // ---------------------------------------------------------------------------
+// Layer 2 helpers — build minimal CandidateMatch stubs
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a confident CandidateMatch stub (score >= 0.70, d=0.5, score=0.9375).
+ * combinedScore = 1 - d^2/4 = 1 - 0.25/4 = 0.9375 >= confidentThreshold=0.70.
+ */
+function makeConfidentStub(): CandidateMatch {
+  return {
+    cosineDistance: 0.5,
+    block: {
+      specCanonicalBytes: new Uint8Array(0),
+      spec: {
+        behavior: "stub",
+        inputs: [],
+        outputs: [],
+        guarantees: [],
+        errorConditions: [],
+        nonFunctional: { purity: "pure", threadSafety: "safe" },
+        propertyTests: [],
+      },
+    },
+  } as unknown as CandidateMatch;
+}
+
+/**
+ * Build a weak CandidateMatch stub (score < 0.70, d=1.2, score=0.64).
+ * combinedScore = 1 - 1.44/4 = 0.64 < confidentThreshold=0.70.
+ */
+function makeWeakStub(): CandidateMatch {
+  return {
+    cosineDistance: 1.2,
+    block: {
+      specCanonicalBytes: new Uint8Array(0),
+      spec: {
+        behavior: "stub",
+        inputs: [],
+        outputs: [],
+        guarantees: [],
+        errorConditions: [],
+        nonFunctional: { purity: "pure", threadSafety: "safe" },
+        propertyTests: [],
+      },
+    },
+  } as unknown as CandidateMatch;
+}
+
+/**
+ * Build the candidate list from a corpus row's confidentCount + weakCount fields.
+ */
+function buildCandidatesFromRow(row: CorpusRow): CandidateMatch[] {
+  const confident = Array.from({ length: row.confidentCount ?? 0 }, () => makeConfidentStub());
+  const weak = Array.from({ length: row.weakCount ?? 0 }, () => makeWeakStub());
+  return [...confident, ...weak];
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2 assertion helper
+// ---------------------------------------------------------------------------
+
+function assertLayer2Row(row: CorpusRow): void {
+  const candidates = buildCandidatesFromRow(row);
+
+  // Apply env overrides via setConfigOverride when envOverrides is present.
+  // This simulates what loadEnforcementConfig would do with the env vars.
+  if (row.envOverrides && Object.keys(row.envOverrides).length > 0) {
+    const cfg = loadEnforcementConfig({ env: { ...process.env, ...row.envOverrides } });
+    setConfigOverride(cfg);
+  }
+
+  const result = scoreResultSetSize(candidates);
+
+  if (row.expectedOutcome === "result-set-too-large") {
+    expect(result.status, `[${row.id}] expected result_set_too_large for confidentCount=${row.confidentCount ?? 0} (${row.notes ?? ""})`).toBe("result_set_too_large");
+    expect(result.layer, `[${row.id}] layer discriminant must be 2`).toBe(2);
+  } else if (row.expectedOutcome === "accept") {
+    expect(result.status, `[${row.id}] expected ok (accept) for confidentCount=${row.confidentCount ?? 0} (${row.notes ?? ""})`).toBe("ok");
+    expect(result.layer, `[${row.id}] layer discriminant must be 2`).toBe(2);
+  } else {
+    throw new Error(`[${row.id}] unexpected expectedOutcome="${row.expectedOutcome}" for a Layer 2 row`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Config reset between tests (needed for L2 env-override tests)
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  resetConfigOverride();
+});
+
+afterEach(() => {
+  resetConfigOverride();
+});
+
+// ---------------------------------------------------------------------------
 // Structural invariants
 // ---------------------------------------------------------------------------
 
@@ -105,11 +208,25 @@ describe("Layer 6 eval corpus — structural invariants", () => {
     expect(layer1Rows.length).toBe(7);
   });
 
+  it("S2 seeds exactly 5 Layer 2 rows", async () => {
+    const rows = await loadCorpus();
+    const layer2Rows = rows.filter((r) => r.expectedLayer === 2);
+    expect(layer2Rows.length).toBe(5);
+  });
+
   it("all S1 row ids follow L1-NNN format", async () => {
     const rows = await loadCorpus();
     const layer1Rows = rows.filter((r) => r.expectedLayer === 1);
     for (const row of layer1Rows) {
       expect(row.id, `id should match L1-NNN`).toMatch(/^L1-\d{3}$/);
+    }
+  });
+
+  it("all S2 row ids follow L2-NNN format", async () => {
+    const rows = await loadCorpus();
+    const layer2Rows = rows.filter((r) => r.expectedLayer === 2);
+    for (const row of layer2Rows) {
+      expect(row.id, `id should match L2-NNN`).toMatch(/^L2-\d{3}$/);
     }
   });
 });
@@ -181,6 +298,56 @@ describe("Layer 6 eval corpus — Layer 1 rows", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Layer 2 eval gate — table-driven
+// ---------------------------------------------------------------------------
+
+describe("Layer 6 eval corpus — Layer 2 rows", () => {
+  it("L2-001: 12 confident candidates → result-set-too-large", async () => {
+    const rows = await loadCorpus();
+    const row = rows.find((r) => r.id === "L2-001");
+    expect(row, "L2-001 must be in corpus").toBeDefined();
+    if (row) assertLayer2Row(row);
+  });
+
+  it("L2-002: 4 confident candidates → result-set-too-large (boundary +1)", async () => {
+    const rows = await loadCorpus();
+    const row = rows.find((r) => r.id === "L2-002");
+    expect(row, "L2-002 must be in corpus").toBeDefined();
+    if (row) assertLayer2Row(row);
+  });
+
+  it("L2-003: 3 confident candidates → accept (at boundary)", async () => {
+    const rows = await loadCorpus();
+    const row = rows.find((r) => r.id === "L2-003");
+    expect(row, "L2-003 must be in corpus").toBeDefined();
+    if (row) assertLayer2Row(row);
+  });
+
+  it("L2-004: 0 confident + 5 weak candidates → accept", async () => {
+    const rows = await loadCorpus();
+    const row = rows.find((r) => r.id === "L2-004");
+    expect(row, "L2-004 must be in corpus").toBeDefined();
+    if (row) assertLayer2Row(row);
+  });
+
+  it("L2-005: YAKCC_RESULT_SET_MAX=5 env override + 4 confident → accept", async () => {
+    const rows = await loadCorpus();
+    const row = rows.find((r) => r.id === "L2-005");
+    expect(row, "L2-005 must be in corpus").toBeDefined();
+    if (row) assertLayer2Row(row);
+  });
+
+  it("all Layer 2 rows pass (catch-all sweep for future corpus additions)", async () => {
+    const rows = await loadCorpus();
+    const layer2Rows = rows.filter((r) => r.expectedLayer === 2);
+    for (const row of layer2Rows) {
+      assertLayer2Row(row);
+      resetConfigOverride(); // reset between rows in the sweep
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Corpus completeness gate
 // ---------------------------------------------------------------------------
 
@@ -192,5 +359,14 @@ describe("Layer 6 eval corpus — completeness gate", () => {
     const hasAccept = layer1Rows.some((r) => r.expectedOutcome === "accept");
     expect(hasReject, "corpus must contain at least one intent-too-broad row").toBe(true);
     expect(hasAccept, "corpus must contain at least one accept row").toBe(true);
+  });
+
+  it("corpus covers both reject and accept outcomes in Layer 2", async () => {
+    const rows = await loadCorpus();
+    const layer2Rows = rows.filter((r) => r.expectedLayer === 2);
+    const hasReject = layer2Rows.some((r) => r.expectedOutcome === "result-set-too-large");
+    const hasAccept = layer2Rows.some((r) => r.expectedOutcome === "accept");
+    expect(hasReject, "corpus must contain at least one result-set-too-large row").toBe(true);
+    expect(hasAccept, "corpus must contain at least one accept row for Layer 2").toBe(true);
   });
 });

--- a/packages/hooks-base/test/result-set-size-integration.test.ts
+++ b/packages/hooks-base/test/result-set-size-integration.test.ts
@@ -1,0 +1,432 @@
+// SPDX-License-Identifier: MIT
+// @mock-exempt: Registry is an external service boundary (@yakcc/registry wraps sqlite-vec).
+// Using a plain in-memory stub object (no vi.fn()) following the makeCountingRegistryStub()
+// pattern from intent-specificity-integration.test.ts.
+/**
+ * result-set-size-integration.test.ts — Layer 2 integration tests.
+ *
+ * @decision DEC-HOOK-ENF-LAYER2-RESULT-SET-SIZE-001
+ * title: Layer 2 integration — full hook path with counting registry stub
+ * status: decided (wi-590-s2-layer2)
+ * rationale:
+ *   Unit tests in result-set-size.test.ts verify scoreResultSetSize() in isolation.
+ *   These integration tests verify Layer 2 is correctly wired inside
+ *   executeRegistryQueryWithSubstitution() — the production hook entry point.
+ *
+ *   Production sequence exercised:
+ *     1. executeRegistryQueryWithSubstitution(registry, ctx, originalCode, toolName, opts)
+ *     2. Layer 1 gate runs (intent must pass — we use a specific enough intent)
+ *     3. Registry stub returns many/few candidates with controlled cosine distances
+ *     4. Layer 2 runs scoreResultSetSize(candidates)
+ *     5a. Many confident → passthrough + resultSetRejectEnvelope
+ *     5b. Few candidates → proceeds normally (synthesis-required)
+ *
+ *   Compound-interaction test requirement satisfied: exercises Layer 1 gate →
+ *   registry stub → Layer 2 gate → response envelope in one production sequence.
+ *
+ *   Registry stub is a plain in-memory object (not vi.fn()) following the
+ *   makeCountingRegistryStub() pattern from intent-specificity-integration.test.ts.
+ *   Registry is an external boundary (@yakcc/registry wraps sqlite-vec) — the stub
+ *   is the minimal injectable boundary, not a mock of internal code.
+ *
+ * Production trigger: pnpm --filter @yakcc/hooks-base test
+ */
+
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CandidateMatch } from "@yakcc/registry";
+import { resetConfigOverride, setConfigOverride, getDefaults, loadEnforcementConfig } from "../src/enforcement-config.js";
+import {
+  type EmissionContext,
+  type HookResponseWithSubstitution,
+  executeRegistryQueryWithSubstitution,
+} from "../src/index.js";
+
+// ---------------------------------------------------------------------------
+// Registry stub helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a confident CandidateMatch stub.
+ *
+ * cosineDistance=0.5:
+ *   combinedScore = 1 - 0.25/4 = 0.9375 >= confidentThreshold=0.70 → "confident"
+ *   0.5 > DEFAULT_REGISTRY_HIT_THRESHOLD=0.30 → NOT a registry hit (no D2 substitution)
+ *
+ * This puts candidates in the confident band for Layer 2 but avoids the D2 auto-accept
+ * path, so Layer 2 is the decisive gate in these tests.
+ */
+function makeConfidentCandidate(): CandidateMatch {
+  return {
+    cosineDistance: 0.5,
+    block: {
+      specCanonicalBytes: new Uint8Array(32).fill(1),
+      spec: {
+        behavior: "stub confident",
+        inputs: [],
+        outputs: [],
+        guarantees: [],
+        errorConditions: [],
+        nonFunctional: { purity: "pure", threadSafety: "safe" },
+        propertyTests: [],
+      },
+    },
+  } as unknown as CandidateMatch;
+}
+
+/**
+ * Build a weak CandidateMatch stub.
+ *
+ * cosineDistance=1.2:
+ *   combinedScore = 1 - 1.44/4 = 0.64 < confidentThreshold=0.70 → "weak" (not confident)
+ */
+function makeWeakCandidate(): CandidateMatch {
+  return {
+    cosineDistance: 1.2,
+    block: {
+      specCanonicalBytes: new Uint8Array(32).fill(2),
+      spec: {
+        behavior: "stub weak",
+        inputs: [],
+        outputs: [],
+        guarantees: [],
+        errorConditions: [],
+        nonFunctional: { purity: "pure", threadSafety: "safe" },
+        propertyTests: [],
+      },
+    },
+  } as unknown as CandidateMatch;
+}
+
+/**
+ * Build a plain in-memory Registry stub that returns a fixed candidate list.
+ * Also records how many times findCandidatesByQuery was called (for assert-not-called).
+ *
+ * Uses the same pattern as makeCountingRegistryStub() in intent-specificity-integration.test.ts.
+ */
+function makeRegistryStub(candidates: CandidateMatch[]): {
+  registry: Parameters<typeof executeRegistryQueryWithSubstitution>[0];
+  callCount: () => number;
+} {
+  let calls = 0;
+  const registry = {
+    findCandidatesByQuery: async (_card: unknown) => {
+      calls++;
+      return { candidates };
+    },
+    findCandidatesByIntent: async () => ({ candidates }),
+    storeBlock: async () => {
+      throw new Error("storeBlock not expected in Layer 2 gate tests");
+    },
+    close: async () => {},
+  } as unknown as Parameters<typeof executeRegistryQueryWithSubstitution>[0];
+  return { registry, callCount: () => calls };
+}
+
+// ---------------------------------------------------------------------------
+// Context helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * A specific intent that passes Layer 1.
+ * "parse ISO 8601 date string to UTC timestamp" — has action verb + 9 words + I/O specifics.
+ */
+const SPECIFIC_INTENT = "parse ISO 8601 date string to UTC timestamp";
+const PASSTHROUGH_CODE = "// placeholder code";
+const TOOL_NAME = "Write" as const;
+
+function makeTelemetryOpts(): { sessionId: string; telemetryDir: string } {
+  const sessionId = `test-layer2-integration-${Date.now()}`;
+  const telemetryDir = join(tmpdir(), "yakcc-test-telemetry-layer2");
+  return { sessionId, telemetryDir };
+}
+
+const BASE_OPTIONS = {
+  threshold: 0.3,
+  ...makeTelemetryOpts(),
+};
+
+// ---------------------------------------------------------------------------
+// Env save/restore
+// ---------------------------------------------------------------------------
+
+let savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  resetConfigOverride();
+  savedEnv = {
+    YAKCC_HOOK_DISABLE_SUBSTITUTE: process.env.YAKCC_HOOK_DISABLE_SUBSTITUTE,
+    YAKCC_HOOK_DISABLE_ATOMIZE: process.env.YAKCC_HOOK_DISABLE_ATOMIZE,
+    YAKCC_HOOK_DISABLE_RESULT_SET_GATE: process.env.YAKCC_HOOK_DISABLE_RESULT_SET_GATE,
+    YAKCC_HOOK_DISABLE_INTENT_GATE: process.env.YAKCC_HOOK_DISABLE_INTENT_GATE,
+  };
+  // Disable substitute + atomize so Layer 2 is the decisive gate.
+  process.env.YAKCC_HOOK_DISABLE_SUBSTITUTE = "1";
+  process.env.YAKCC_HOOK_DISABLE_ATOMIZE = "1";
+  delete process.env.YAKCC_HOOK_DISABLE_RESULT_SET_GATE;
+  delete process.env.YAKCC_HOOK_DISABLE_INTENT_GATE;
+});
+
+afterEach(() => {
+  resetConfigOverride();
+  for (const [key, val] of Object.entries(savedEnv)) {
+    if (val === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = val;
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Integration: Layer 2 fires on oversized confident result set
+//
+// Compound-interaction test: exercises Layer 1 → registry stub → Layer 2 → envelope.
+// ---------------------------------------------------------------------------
+
+describe("Layer 2 integration — oversized confident result set rejected by hook", () => {
+  it("returns passthrough + resultSetRejectEnvelope when 12 confident candidates returned", async () => {
+    const candidates = Array.from({ length: 12 }, () => makeConfidentCandidate());
+    const { registry, callCount } = makeRegistryStub(candidates);
+    const ctx: EmissionContext = { intent: SPECIFIC_INTENT };
+
+    const result = await executeRegistryQueryWithSubstitution(
+      registry,
+      ctx,
+      PASSTHROUGH_CODE,
+      TOOL_NAME,
+      { threshold: 0.3, ...makeTelemetryOpts() },
+    );
+
+    // Registry WAS queried (Layer 1 passed, Layer 2 is the decision point).
+    expect(callCount(), "registry must be queried — Layer 1 passed").toBeGreaterThan(0);
+
+    // Layer 2 fires: response kind is passthrough.
+    expect(result.kind).toBe("passthrough");
+    expect(result.substituted).toBe(false);
+
+    // resultSetRejectEnvelope must be present.
+    const r = result as HookResponseWithSubstitution & { substituted: false };
+    expect(r.resultSetRejectEnvelope, "resultSetRejectEnvelope must be set by Layer 2").toBeDefined();
+    if (r.resultSetRejectEnvelope !== undefined) {
+      expect(r.resultSetRejectEnvelope.layer).toBe(2);
+      expect(r.resultSetRejectEnvelope.status).toBe("result_set_too_large");
+      expect(r.resultSetRejectEnvelope.reasons).toContain("too_many_confident");
+      expect(r.resultSetRejectEnvelope.confidentCount).toBe(12);
+      expect(r.resultSetRejectEnvelope.totalCount).toBe(12);
+      expect(r.resultSetRejectEnvelope.maxConfident).toBe(3); // default
+      expect(typeof r.resultSetRejectEnvelope.suggestion).toBe("string");
+      expect(r.resultSetRejectEnvelope.suggestion.length).toBeGreaterThan(0);
+    }
+
+    // intentRejectEnvelope must NOT be set (Layer 1 passed).
+    expect(r.intentRejectEnvelope, "intentRejectEnvelope must be absent — Layer 1 passed").toBeUndefined();
+  });
+
+  it("returns passthrough + resultSetRejectEnvelope when 4 confident candidates (boundary+1)", async () => {
+    // 4 > maxConfident=3
+    const candidates = Array.from({ length: 4 }, () => makeConfidentCandidate());
+    const { registry } = makeRegistryStub(candidates);
+    const ctx: EmissionContext = { intent: SPECIFIC_INTENT };
+
+    const result = await executeRegistryQueryWithSubstitution(
+      registry,
+      ctx,
+      PASSTHROUGH_CODE,
+      TOOL_NAME,
+      { threshold: 0.3, ...makeTelemetryOpts() },
+    );
+
+    expect(result.kind).toBe("passthrough");
+    const r = result as HookResponseWithSubstitution & { substituted: false };
+    expect(r.resultSetRejectEnvelope, "Layer 2 must reject 4 confident").toBeDefined();
+    if (r.resultSetRejectEnvelope !== undefined) {
+      expect(r.resultSetRejectEnvelope.reasons).toContain("too_many_confident");
+      expect(r.resultSetRejectEnvelope.confidentCount).toBe(4);
+      expect(r.resultSetRejectEnvelope.maxConfident).toBe(3);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: Layer 2 does NOT fire when result set within limits
+// ---------------------------------------------------------------------------
+
+describe("Layer 2 integration — within-limit result set passes through", () => {
+  it("does NOT set resultSetRejectEnvelope when exactly 3 confident candidates (at boundary)", async () => {
+    const candidates = Array.from({ length: 3 }, () => makeConfidentCandidate());
+    const { registry, callCount } = makeRegistryStub(candidates);
+    const ctx: EmissionContext = { intent: SPECIFIC_INTENT };
+
+    const result = await executeRegistryQueryWithSubstitution(
+      registry,
+      ctx,
+      PASSTHROUGH_CODE,
+      TOOL_NAME,
+      { threshold: 0.3, ...makeTelemetryOpts() },
+    );
+
+    expect(callCount()).toBeGreaterThan(0);
+
+    const r = result as HookResponseWithSubstitution & { substituted: false };
+    expect(r.resultSetRejectEnvelope, "Layer 2 must not fire at exactly maxConfident=3").toBeUndefined();
+
+    // cosineDistance=0.5 > threshold=0.3 → no registry hit → synthesis-required.
+    expect(result.kind).toBe("synthesis-required");
+  });
+
+  it("does NOT set resultSetRejectEnvelope with 0 confident + 5 weak candidates", async () => {
+    const candidates = Array.from({ length: 5 }, () => makeWeakCandidate());
+    const { registry } = makeRegistryStub(candidates);
+    const ctx: EmissionContext = { intent: SPECIFIC_INTENT };
+
+    const result = await executeRegistryQueryWithSubstitution(
+      registry,
+      ctx,
+      PASSTHROUGH_CODE,
+      TOOL_NAME,
+      { threshold: 0.3, ...makeTelemetryOpts() },
+    );
+
+    const r = result as HookResponseWithSubstitution & { substituted: false };
+    expect(r.resultSetRejectEnvelope, "Layer 2 must not fire for weak-only band").toBeUndefined();
+    expect(result.kind).toBe("synthesis-required");
+  });
+
+  it("does NOT set resultSetRejectEnvelope with empty candidate list", async () => {
+    const { registry } = makeRegistryStub([]);
+    const ctx: EmissionContext = { intent: SPECIFIC_INTENT };
+
+    const result = await executeRegistryQueryWithSubstitution(
+      registry,
+      ctx,
+      PASSTHROUGH_CODE,
+      TOOL_NAME,
+      { threshold: 0.3, ...makeTelemetryOpts() },
+    );
+
+    const r = result as HookResponseWithSubstitution & { substituted: false };
+    expect(r.resultSetRejectEnvelope).toBeUndefined();
+    expect(result.kind).toBe("synthesis-required");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: YAKCC_HOOK_DISABLE_RESULT_SET_GATE=1 escape hatch
+// ---------------------------------------------------------------------------
+
+describe("Layer 2 integration — YAKCC_HOOK_DISABLE_RESULT_SET_GATE=1 escape hatch", () => {
+  it("bypasses Layer 2 when escape hatch is set, even with 12 confident candidates", async () => {
+    process.env.YAKCC_HOOK_DISABLE_RESULT_SET_GATE = "1";
+
+    const candidates = Array.from({ length: 12 }, () => makeConfidentCandidate());
+    const { registry, callCount } = makeRegistryStub(candidates);
+    const ctx: EmissionContext = { intent: SPECIFIC_INTENT };
+
+    const result = await executeRegistryQueryWithSubstitution(
+      registry,
+      ctx,
+      PASSTHROUGH_CODE,
+      TOOL_NAME,
+      { threshold: 0.3, ...makeTelemetryOpts() },
+    );
+
+    // Registry was still queried (Layer 1 passed, Layer 2 bypassed).
+    expect(callCount()).toBeGreaterThan(0);
+
+    // Layer 2 bypassed — no reject envelope.
+    const r = result as HookResponseWithSubstitution & { substituted: false };
+    expect(r.resultSetRejectEnvelope, "Layer 2 must be bypassed by escape hatch").toBeUndefined();
+
+    // 12 candidates at d=0.5 > threshold=0.3 → synthesis-required.
+    expect(result.kind).toBe("synthesis-required");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: config override drives the threshold in the hook path
+// ---------------------------------------------------------------------------
+
+describe("Layer 2 integration — config override propagates through hook path", () => {
+  it("maxConfident=10 override: 9 confident candidates → no Layer 2 rejection", async () => {
+    setConfigOverride({
+      ...getDefaults(),
+      layer2: { maxConfident: 10, maxOverall: 50, confidentThreshold: 0.7 },
+    });
+
+    const candidates = Array.from({ length: 9 }, () => makeConfidentCandidate());
+    const { registry } = makeRegistryStub(candidates);
+    const ctx: EmissionContext = { intent: SPECIFIC_INTENT };
+
+    const result = await executeRegistryQueryWithSubstitution(
+      registry,
+      ctx,
+      PASSTHROUGH_CODE,
+      TOOL_NAME,
+      { threshold: 0.3, ...makeTelemetryOpts() },
+    );
+
+    const r = result as HookResponseWithSubstitution & { substituted: false };
+    expect(r.resultSetRejectEnvelope, "maxConfident=10 config must not reject 9 candidates").toBeUndefined();
+    expect(result.kind).toBe("synthesis-required");
+  });
+
+  it("maxConfident=1 override: 2 confident candidates → Layer 2 fires", async () => {
+    setConfigOverride({
+      ...getDefaults(),
+      layer2: { maxConfident: 1, maxOverall: 10, confidentThreshold: 0.7 },
+    });
+
+    const candidates = [makeConfidentCandidate(), makeConfidentCandidate()];
+    const { registry } = makeRegistryStub(candidates);
+    const ctx: EmissionContext = { intent: SPECIFIC_INTENT };
+
+    const result = await executeRegistryQueryWithSubstitution(
+      registry,
+      ctx,
+      PASSTHROUGH_CODE,
+      TOOL_NAME,
+      { threshold: 0.3, ...makeTelemetryOpts() },
+    );
+
+    expect(result.kind).toBe("passthrough");
+    const r = result as HookResponseWithSubstitution & { substituted: false };
+    expect(r.resultSetRejectEnvelope, "maxConfident=1 config must reject 2 candidates").toBeDefined();
+    if (r.resultSetRejectEnvelope !== undefined) {
+      expect(r.resultSetRejectEnvelope.maxConfident).toBe(1);
+      expect(r.resultSetRejectEnvelope.confidentCount).toBe(2);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: Layer 1 rejects before Layer 2 can run
+// (compound-interaction: Layer 1 → Layer 2 priority ordering)
+// ---------------------------------------------------------------------------
+
+describe("Layer 2 integration — Layer 1 takes priority over Layer 2", () => {
+  it("vague intent rejected by Layer 1; registry never called, Layer 2 does NOT set envelope", async () => {
+    // Use 12 confident candidates — if Layer 2 ran, it would reject. But Layer 1 should fire first.
+    const candidates = Array.from({ length: 12 }, () => makeConfidentCandidate());
+    const { registry, callCount } = makeRegistryStub(candidates);
+    const ctx: EmissionContext = { intent: "utility handler stuff" }; // vague — Layer 1 rejects
+
+    const result = await executeRegistryQueryWithSubstitution(
+      registry,
+      ctx,
+      PASSTHROUGH_CODE,
+      TOOL_NAME,
+      { threshold: 0.3, ...makeTelemetryOpts() },
+    );
+
+    // Registry was NOT queried — Layer 1 short-circuited.
+    expect(callCount(), "registry must not be queried when Layer 1 rejects").toBe(0);
+
+    // Response is passthrough with Layer 1 envelope, NOT Layer 2 envelope.
+    expect(result.kind).toBe("passthrough");
+    const r = result as HookResponseWithSubstitution & { substituted: false };
+    expect(r.intentRejectEnvelope, "Layer 1 envelope must be present").toBeDefined();
+    expect(r.resultSetRejectEnvelope, "Layer 2 envelope must be absent when Layer 1 fires").toBeUndefined();
+  });
+});

--- a/plans/wi-579-s2-layer2-result-set-size.md
+++ b/plans/wi-579-s2-layer2-result-set-size.md
@@ -1,0 +1,101 @@
+# WI-579-S2: Layer 2 Result-Set Size Enforcement
+
+**Parent plan:** `plans/wi-579-hook-enforcement-architecture.md` §5.3
+**GitHub issue:** #590 (WI-579-S2)
+**Branch:** `feature/590-s2-layer2`
+**Status:** implementation complete — awaiting reviewer
+
+---
+
+## What this slice delivers
+
+1. **Central enforcement config** (`enforcement-config.ts`) — sole source of truth for
+   all layer thresholds (DEC-HOOK-ENF-CONFIG-001). Implements loading precedence:
+   env var → config file → defaults. Memoized after first call; test override via
+   `setConfigOverride()` / `resetConfigOverride()`.
+
+2. **S1 Layer 1 retrofit** (`intent-specificity.ts`) — prior hardcoded constants
+   (MIN_WORDS=4, MAX_WORDS=20, STOP_WORDS, META_WORDS, ACTION_VERBS) moved to
+   `getEnforcementConfig().layer1` at call time. Exported constants retained as
+   snapshot aliases for backward API compatibility. Zero semantic change when no
+   config file or env vars are present.
+
+3. **Layer 2 result-set size gate** (`result-set-size.ts`) — runs after
+   `findCandidatesByQuery` resolves, before candidates reach the consumer.
+   Rejects when `confidentCount > maxConfident` OR `totalCount > maxOverall`.
+   `confidentCount` uses the same `combinedScore = 1 - d²/4` formula as
+   `yakcc-resolve.ts` (DEC-HOOK-ENF-LAYER2-SCORE-FORMULA-001).
+
+4. **Wiring in `index.ts`** — Layer 2 runs between the registry query and the
+   substitution/atomize/intercept branches. Returns
+   `{ kind: "passthrough", substituted: false, resultSetRejectEnvelope }` on reject.
+   Escape hatch: `YAKCC_HOOK_DISABLE_RESULT_SET_GATE=1`.
+
+5. **Telemetry** (`telemetry.ts`) — additive `"result-set-too-large"` outcome value
+   (DEC-HOOK-ENF-LAYER2-TELEMETRY-001). Emitted via `outcomeOverride` at the Layer 2
+   gate; `outcomeFromResponse()` unchanged.
+
+6. **Layer 6 corpus extended** — 5 L2-* rows appended to
+   `test/enforcement-eval-corpus.json`. Corpus test (`enforcement-eval-corpus.test.ts`)
+   extended with `assertLayer2Row()` helper and named test cases for each row.
+
+7. **Reference docs** — `docs/enforcement-config.md` and this plan file.
+
+---
+
+## Architecture decisions
+
+| ID | Title | Scope |
+|----|-------|-------|
+| DEC-HOOK-ENF-CONFIG-001 | Central enforcement config — sole threshold authority | enforcement-config.ts |
+| DEC-HOOK-ENF-LAYER2-RESULT-SET-SIZE-001 | Layer 2 result-set size gate | result-set-size.ts + index.ts |
+| DEC-HOOK-ENF-LAYER2-SCORE-FORMULA-001 | combinedScore = 1 - d²/4 matches yakcc-resolve.ts | result-set-size.ts |
+| DEC-HOOK-ENF-LAYER2-TELEMETRY-001 | "result-set-too-large" additive telemetry outcome | telemetry.ts |
+| DEC-HOOK-ENF-LAYER1-CONSTANTS-RETROFIT-001 | L1 exported constants are default snapshots (S2 retrofit) | intent-specificity.ts |
+
+---
+
+## Config foundation (bonus scope)
+
+The enforcement-config.ts module was added as a config foundation for S3–S6.
+All future layers append their `layerN: LayerNConfig` key to `EnforcementConfig`
+following the same pattern. S3–S6 must NOT add local constants — they call
+`getEnforcementConfig().layerN` at runtime.
+
+See `docs/enforcement-config.md` for the env var mapping, file format, and
+tuning guide. See `packages/hooks-base/src/__fixtures__/enforcement-config-sample.json`
+for a complete sample config.
+
+---
+
+## Defaults (backward compat guarantee)
+
+Layer 2 defaults:
+- `maxConfident`: 3
+- `maxOverall`: 10
+- `confidentThreshold`: 0.70
+
+These match `CONFIDENT_THRESHOLD` from `yakcc-resolve.ts`. No behavior change
+occurs when no config file or env vars are present.
+
+Layer 1 defaults in enforcement-config.ts reproduce the prior hardcoded constants
+from intent-specificity.ts exactly (verified by the S1 test suite).
+
+---
+
+## Pre-push hygiene checklist
+
+- [ ] `pnpm -w lint` — expected clean
+- [ ] `pnpm -w typecheck` — expected clean
+- [ ] `pnpm --filter @yakcc/hooks-base test` — all pass (S1 baseline + new Layer 2 tests)
+- [ ] `pnpm --filter @yakcc/hooks-cursor test` — no regression
+- [ ] `pnpm --filter @yakcc/hooks-claude-code test` — no regression
+
+---
+
+## Rollback boundary
+
+`git revert` the commits on this branch. The config module can be removed and
+layer modules revert to prior constant values. Layer 1 retrofit is fully reversible
+(the exported constants still compile without enforcement-config.ts if the hardcoded
+values are restored).


### PR DESCRIPTION
## Summary

Second slice of #579's 6-layer hook enforcement architecture. Adds Layer 2 (post-query result-set size gate) AND introduces the **central enforcement-config module** — the sole source of truth for tunable thresholds across all layers (user directive 2026-05-16: "make the levels for rejection etc configurable via config").

- **Config-driven architecture**: New `packages/hooks-base/src/enforcement-config.ts` provides typed `EnforcementConfig` (Layer1Config + Layer2Config; S3–S6 will append). Load precedence: env vars > `.yakcc/enforcement.json` (or `YAKCC_ENFORCEMENT_CONFIG_PATH`) > defaults. Defaults reproduce exact S1 hardcoded values.
- **S1 retrofit (no semantic regression)**: `intent-specificity.ts` now reads from `config.layer1` at call time; exported `MIN_WORDS`/`STOP_WORDS`/etc kept as snapshot aliases for back-compat. All S1 corpus + tests pass unchanged.
- **Layer 2 wired at the primary call site**: `executeRegistryQueryInternalWithCandidates` in `index.ts`, after `findCandidatesByQuery`, before returning to caller. Reject envelope kind `result-set-too-large` with matched/threshold + decompose instruction. Escape hatch via `YAKCC_RESULT_SET_MAX`.
- **Import-intercept gap (defensible)**: `yakccResolve` consumes raw candidates internally and returns `EvidenceProjection[]` without `cosineDistance`; Layer 2 requires raw candidates so the architectural path is distinct. Documented in reviewer findings (note severity).
- **Telemetry additive only** (Sacred Practice 12): new `result-set-too-large` outcome variant; no existing values changed.
- **Layer 6 corpus**: +5 L2-* rows (boundary tests for size cap + env override); S1's 7 L1-* rows preserved and still pass.

## Test plan

- [x] `pnpm --filter @yakcc/hooks-base test` — 399 pass / 1 pre-existing todo (from #578/#569 follow-up)
- [x] `pnpm -w lint` — clean
- [x] `pnpm -w typecheck` — 38/38 clean
- [x] Sister packages unaffected — hooks-cursor (29/29) + hooks-claude-code (40/40) still green
- [x] S1 Layer 1 corpus + tests pass post-retrofit (no behavior regression)
- [x] 5 new L2-* corpus rows pass

## Decision annotations

- `DEC-HOOK-ENF-CONFIG-001` — central enforcement-config module is sole authority for tunable thresholds
- `DEC-HOOK-ENF-LAYER2-RESULT-SET-SIZE-001` — Layer 2 plug point at post-query boundary
- `DEC-HOOK-ENF-LAYER2-MAX-CONFIDENT-001` / `MAX-OVERALL-001` / `TUNABLE-001` — Layer 2 defaults + tunability

Refs #590, #579 (does NOT close #579; closes when all 6 layers ship).