### PR TITLE
feat(hooks): #591 S3 — Layer 3 atom-size ratio enforcement (blocker/load-bearing/v0)

### DIFF
--- a/packages/hooks-base/src/atom-size-ratio.test.ts
+++ b/packages/hooks-base/src/atom-size-ratio.test.ts
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: MIT
+/**
+ * atom-size-ratio.test.ts — Unit tests for Layer 3 atom-size ratio enforcement.
+ *
+ * @decision DEC-HOOK-ENF-LAYER3-ATOM-SIZE-RATIO-001
+ * title: Layer 3 unit tests — parameterized over (atomComplexity, needComplexity) pairs
+ * status: decided (wi-591-s3-layer3)
+ * rationale:
+ *   Tests exercise the real production sequence:
+ *     1. computeAtomComplexity(atom) — spec-based proxy computation
+ *     2. computeNeedComplexity(callSite) — call-site proxy computation
+ *     3. enforceAtomSizeRatio(atom, callSite, config) — gate verdict
+ *   All thresholds injected via Layer3Config parameter (not env vars or files).
+ *   Covers: boundary conditions, minFloor bypass, config injection, edge cases.
+ *
+ * Production trigger: vitest default suite for @yakcc/hooks-base.
+ * Every PR touching packages/hooks-base/src/** will exercise it.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  computeAtomComplexity,
+  computeNeedComplexity,
+  enforceAtomSizeRatio,
+  isAtomSizeOk,
+  type AtomLike,
+  type CallSiteAnalysis,
+} from "./atom-size-ratio.js";
+import type { Layer3Config } from "./enforcement-config.js";
+import { resetConfigOverride, setConfigOverride, getDefaults } from "./enforcement-config.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Default Layer3Config matching getDefaults().layer3 */
+const DEFAULT_L3_CFG: Layer3Config = {
+  ratioThreshold: 10,
+  minFloor: 20,
+  disableGate: false,
+};
+
+/**
+ * Build a minimal AtomLike with direct complexity control.
+ *
+ * @param inputs    - spec.inputs count (part of transitiveNodes proxy)
+ * @param outputs   - spec.outputs count (part of transitiveNodes proxy + exportedSurface)
+ * @param guarantees - spec.guarantees count (part of transitiveNodes proxy)
+ * @param transitiveDeps - transitive dependency count
+ */
+function makeAtom(opts: {
+  inputs?: number;
+  outputs?: number;
+  guarantees?: number;
+  transitiveDeps?: number;
+}): AtomLike {
+  const inputs = opts.inputs ?? 0;
+  const outputs = opts.outputs ?? 0;
+  const guarantees = opts.guarantees ?? 0;
+  const transitiveDeps = opts.transitiveDeps ?? 0;
+
+  // exportedSurface = outputs.length (v1 proxy)
+  return {
+    spec: {
+      behavior: "stub",
+      inputs: Array.from({ length: inputs }, (_, i) => ({ name: `in${i}`, type: "string" })),
+      outputs: Array.from({ length: outputs }, (_, i) => ({ name: `out${i}`, type: "string" })),
+      guarantees: Array.from({ length: guarantees }, (_, i) => ({ description: `g${i}` })),
+      errorConditions: [],
+      nonFunctional: { purity: "pure", threadSafety: "safe" },
+      propertyTests: [],
+    } as unknown as import("@yakcc/contracts").SpecYak,
+    exportedSurface: outputs,
+    transitiveDeps,
+  };
+}
+
+function makeCallSite(bindingsUsed: number, statementCount: number): CallSiteAnalysis {
+  return { bindingsUsed, statementCount };
+}
+
+// ---------------------------------------------------------------------------
+// computeAtomComplexity
+// ---------------------------------------------------------------------------
+
+describe("computeAtomComplexity", () => {
+  it("returns 0 for a zero-spec atom with no deps", () => {
+    const atom = makeAtom({});
+    expect(computeAtomComplexity(atom)).toBe(0);
+  });
+
+  it("counts transitiveNodes = inputs + outputs + guarantees", () => {
+    // inputs=2, outputs=3, guarantees=1 → transitiveNodes=6, exportedSurface=3, deps=0
+    // atomComplexity = 6 + 5*3 + 2*0 = 6 + 15 = 21
+    const atom = makeAtom({ inputs: 2, outputs: 3, guarantees: 1 });
+    expect(computeAtomComplexity(atom)).toBe(21);
+  });
+
+  it("applies 5x weight to exportedSurface", () => {
+    // outputs=4 → transitiveNodes=4, exportedSurface=4
+    // atomComplexity = 4 + 5*4 = 24
+    const atom = makeAtom({ outputs: 4 });
+    expect(computeAtomComplexity(atom)).toBe(24);
+  });
+
+  it("applies 2x weight to transitiveDeps", () => {
+    // transitiveDeps=10 → atomComplexity = 0 + 0 + 2*10 = 20
+    const atom = makeAtom({ transitiveDeps: 10 });
+    expect(computeAtomComplexity(atom)).toBe(20);
+  });
+
+  it("combines all three terms correctly (lodash-shaped atom proxy)", () => {
+    // inputs=5, outputs=10, guarantees=5, deps=20
+    // transitiveNodes = 20, exportedSurface = 10
+    // atomComplexity = 20 + 5*10 + 2*20 = 20 + 50 + 40 = 110
+    const atom = makeAtom({ inputs: 5, outputs: 10, guarantees: 5, transitiveDeps: 20 });
+    expect(computeAtomComplexity(atom)).toBe(110);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeNeedComplexity
+// ---------------------------------------------------------------------------
+
+describe("computeNeedComplexity", () => {
+  it("returns 1 for zero-zero call site (floor prevents 0)", () => {
+    expect(computeNeedComplexity({ bindingsUsed: 0, statementCount: 0 })).toBe(1);
+  });
+
+  it("returns max(1, product) for normal inputs", () => {
+    expect(computeNeedComplexity({ bindingsUsed: 2, statementCount: 3 })).toBe(6);
+    expect(computeNeedComplexity({ bindingsUsed: 1, statementCount: 5 })).toBe(5);
+  });
+
+  it("applies floor when product is 0 (one factor is 0)", () => {
+    expect(computeNeedComplexity({ bindingsUsed: 0, statementCount: 10 })).toBe(1);
+    expect(computeNeedComplexity({ bindingsUsed: 5, statementCount: 0 })).toBe(1);
+  });
+
+  it("returns 1 for bindingsUsed=1, statementCount=1", () => {
+    expect(computeNeedComplexity({ bindingsUsed: 1, statementCount: 1 })).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enforceAtomSizeRatio — accept cases
+// ---------------------------------------------------------------------------
+
+describe("enforceAtomSizeRatio — accept (ok)", () => {
+  it("accepts when ratio is well below threshold", () => {
+    // atomComplexity=10, needComplexity=2 → ratio=5 < 10
+    const atom = makeAtom({ inputs: 2, outputs: 0, guarantees: 0, transitiveDeps: 4 });
+    // transitiveNodes=2, exportedSurface=0, deps=4 → 2 + 0 + 8 = 10
+    const callSite = makeCallSite(2, 1); // needComplexity = max(1, 2*1) = 2
+    const result = enforceAtomSizeRatio(atom, callSite, DEFAULT_L3_CFG);
+    expect(result.status).toBe("ok");
+    expect(result.layer).toBe(3);
+    if (result.status === "ok") {
+      expect(result.bypassed).toBe(false);
+      expect(result.ratio).toBe(5);
+    }
+  });
+
+  it("accepts when ratio is exactly at threshold (boundary: reject is STRICTLY greater)", () => {
+    // We need atomComplexity / needComplexity == 10 exactly
+    // Let atomComplexity = 20, needComplexity = 2 → ratio = 10 (NOT > 10, so accept)
+    // makeAtom: transitiveDeps=10 → atomComplexity = 0 + 0 + 20 = 20 ≥ minFloor=20, so bypass is false
+    const atom = makeAtom({ transitiveDeps: 10 }); // atomComplexity = 20
+    const callSite = makeCallSite(2, 1); // needComplexity = 2
+    const result = enforceAtomSizeRatio(atom, callSite, DEFAULT_L3_CFG);
+    // ratio = 20/2 = 10; 10 > 10 is false → accept
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.ratio).toBe(10);
+      expect(result.bypassed).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enforceAtomSizeRatio — reject cases
+// ---------------------------------------------------------------------------
+
+describe("enforceAtomSizeRatio — reject (atom-size-too-large)", () => {
+  it("rejects when ratio is 10.something > ratioThreshold=10", () => {
+    // atomComplexity=21, needComplexity=2 → ratio=10.5 > 10 → reject
+    // makeAtom: inputs=2, outputs=3, guarantees=1 → transitiveNodes=6, exportedSurface=3
+    // atomComplexity = 6 + 5*3 + 0 = 21 ≥ minFloor=20, no bypass
+    const atom = makeAtom({ inputs: 2, outputs: 3, guarantees: 1 });
+    const callSite = makeCallSite(2, 1); // needComplexity = 2
+    const result = enforceAtomSizeRatio(atom, callSite, DEFAULT_L3_CFG);
+    // ratio = 21/2 = 10.5 > 10 → reject
+    expect(result.status).toBe("atom-size-too-large");
+    expect(result.layer).toBe(3);
+    if (result.status === "atom-size-too-large") {
+      expect(result.atomComplexity).toBe(21);
+      expect(result.needComplexity).toBe(2);
+      expect(result.ratio).toBeCloseTo(10.5);
+      expect(result.ratioThreshold).toBe(10);
+      expect(result.suggestion).toContain("ATOM_OVERSIZED");
+      expect(result.suggestion).toContain("Decompose");
+    }
+  });
+
+  it("rejects a lodash-shaped atom (high complexity vs minimal need)", () => {
+    // lodash-shaped: inputs=5, outputs=10, guarantees=5, transitiveDeps=20
+    // atomComplexity = 110, needComplexity = max(1, 1*1) = 1 → ratio = 110 >> 10
+    const atom = makeAtom({ inputs: 5, outputs: 10, guarantees: 5, transitiveDeps: 20 });
+    const callSite = makeCallSite(1, 1);
+    const result = enforceAtomSizeRatio(atom, callSite, DEFAULT_L3_CFG);
+    expect(result.status).toBe("atom-size-too-large");
+    if (result.status === "atom-size-too-large") {
+      expect(result.ratio).toBe(110);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enforceAtomSizeRatio — minFloor bypass
+// ---------------------------------------------------------------------------
+
+describe("enforceAtomSizeRatio — minFloor bypass", () => {
+  it("bypasses ratio check when atomComplexity < minFloor (even if ratio would be huge)", () => {
+    // atomComplexity = 5 (< minFloor=20) → bypass always, even ratio=infinity
+    const atom = makeAtom({ inputs: 1, outputs: 1, guarantees: 0, transitiveDeps: 0 });
+    // transitiveNodes=2, exportedSurface=1 → atomComplexity = 2 + 5*1 + 0 = 7 < 20
+    const callSite = makeCallSite(1, 1); // needComplexity = 1
+    // If the gate ran: ratio = 7/1 = 7 < 10 → would accept anyway. Use ratio threshold=1 to force rejection.
+    const customCfg: Layer3Config = { ratioThreshold: 1, minFloor: 20, disableGate: false };
+    const result = enforceAtomSizeRatio(atom, callSite, customCfg);
+    // atomComplexity=7 < minFloor=20 → bypass, status=ok
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.bypassed).toBe(true);
+    }
+  });
+
+  it("does NOT bypass when atomComplexity equals minFloor", () => {
+    // atomComplexity = 20 (= minFloor=20) → NOT < minFloor, gate runs
+    // transitiveDeps=10 → atomComplexity = 0 + 0 + 20 = 20 (not < 20 → no bypass)
+    const atom = makeAtom({ transitiveDeps: 10 }); // atomComplexity = 20
+    const callSite = makeCallSite(1, 1); // needComplexity = 1
+    // ratio = 20/1 = 20 > ratioThreshold=10 → reject
+    const result = enforceAtomSizeRatio(atom, callSite, DEFAULT_L3_CFG);
+    expect(result.status).toBe("atom-size-too-large");
+    if (result.status === "atom-size-too-large") {
+      expect(result.ratio).toBe(20);
+    }
+  });
+
+  it("bypass occurs when atomComplexity is strictly below minFloor (boundary -1)", () => {
+    // atomComplexity = 19 (< minFloor=20) → bypass
+    // Need: transitiveNodes + 5*exportedSurface + 2*deps = 19
+    // inputs=4, outputs=3, guarantees=0, deps=0 → transitiveNodes=7, exportedSurface=3
+    // atomComplexity = 7 + 15 + 0 = 22 — too high. Try: inputs=1, outputs=0, deps=9
+    // transitiveNodes=1, exportedSurface=0, deps=9 → 1 + 0 + 18 = 19 < 20 → bypass
+    const atom = makeAtom({ inputs: 1, outputs: 0, guarantees: 0, transitiveDeps: 9 });
+    const callSite = makeCallSite(1, 1);
+    // With ratioThreshold=1 to force rejection if gate ran
+    const customCfg: Layer3Config = { ratioThreshold: 1, minFloor: 20, disableGate: false };
+    const result = enforceAtomSizeRatio(atom, callSite, customCfg);
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.bypassed).toBe(true);
+      expect(result.atomComplexity).toBe(19);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enforceAtomSizeRatio — custom config injection
+// ---------------------------------------------------------------------------
+
+describe("enforceAtomSizeRatio — config injection", () => {
+  it("respects custom ratioThreshold (lower → rejects earlier)", () => {
+    // atomComplexity=21, needComplexity=2 → ratio=10.5
+    // Default threshold=10: reject. Custom threshold=11: accept.
+    const atom = makeAtom({ inputs: 2, outputs: 3, guarantees: 1 }); // atomComplexity=21
+    const callSite = makeCallSite(2, 1); // needComplexity=2
+    const laxCfg: Layer3Config = { ratioThreshold: 11, minFloor: 20, disableGate: false };
+    expect(enforceAtomSizeRatio(atom, callSite, laxCfg).status).toBe("ok");
+    const strictCfg: Layer3Config = { ratioThreshold: 5, minFloor: 20, disableGate: false };
+    expect(enforceAtomSizeRatio(atom, callSite, strictCfg).status).toBe("atom-size-too-large");
+  });
+
+  it("respects custom minFloor (higher → more atoms bypass)", () => {
+    // atomComplexity=21 ≥ default minFloor=20 → gate runs, may reject.
+    // With minFloor=25: 21 < 25 → bypass → always accept.
+    const atom = makeAtom({ inputs: 2, outputs: 3, guarantees: 1 }); // atomComplexity=21
+    const callSite = makeCallSite(1, 1); // needComplexity=1 → ratio=21 > threshold=10 → would reject
+    const highFloorCfg: Layer3Config = { ratioThreshold: 10, minFloor: 25, disableGate: false };
+    const result = enforceAtomSizeRatio(atom, callSite, highFloorCfg);
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.bypassed).toBe(true);
+    }
+  });
+
+  it("uses global config when no config param is passed", () => {
+    // Set a config override via setConfigOverride and verify enforceAtomSizeRatio picks it up.
+    const defaults = getDefaults();
+    setConfigOverride({
+      ...defaults,
+      layer3: { ratioThreshold: 1000, minFloor: 0, disableGate: false },
+    });
+    // ratio=110 < 1000 → accept with global config
+    const atom = makeAtom({ inputs: 5, outputs: 10, guarantees: 5, transitiveDeps: 20 }); // atomComplexity=110
+    const callSite = makeCallSite(1, 1);
+    // No config param — will read from getEnforcementConfig().layer3 (our override)
+    const result = enforceAtomSizeRatio(atom, callSite);
+    expect(result.status).toBe("ok");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isAtomSizeOk convenience predicate
+// ---------------------------------------------------------------------------
+
+describe("isAtomSizeOk", () => {
+  it("returns true when enforceAtomSizeRatio returns ok", () => {
+    const atom = makeAtom({ transitiveDeps: 10 }); // atomComplexity=20, ratio=10 with needComplexity=2
+    const callSite = makeCallSite(2, 1);
+    expect(isAtomSizeOk(atom, callSite, DEFAULT_L3_CFG)).toBe(true);
+  });
+
+  it("returns false when enforceAtomSizeRatio returns atom-size-too-large", () => {
+    const atom = makeAtom({ inputs: 5, outputs: 10, guarantees: 5, transitiveDeps: 20 }); // atomComplexity=110
+    const callSite = makeCallSite(1, 1);
+    expect(isAtomSizeOk(atom, callSite, DEFAULT_L3_CFG)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe("enforceAtomSizeRatio — edge cases", () => {
+  it("zero-complexity atom with minFloor=0 and ratio > threshold → reject", () => {
+    // atomComplexity=0, needComplexity=1 → ratio=0 — never > any positive threshold
+    const atom = makeAtom({});
+    const callSite = makeCallSite(1, 1);
+    const zeroFloorCfg: Layer3Config = { ratioThreshold: 10, minFloor: 0, disableGate: false };
+    // ratio=0 < 10 → accept
+    const result = enforceAtomSizeRatio(atom, callSite, zeroFloorCfg);
+    expect(result.status).toBe("ok");
+  });
+
+  it("very large needComplexity reduces ratio to safe zone", () => {
+    // atomComplexity=110, needComplexity=50 → ratio=2.2 < 10 → accept
+    const atom = makeAtom({ inputs: 5, outputs: 10, guarantees: 5, transitiveDeps: 20 }); // 110
+    const callSite = makeCallSite(10, 5); // needComplexity = max(1, 50) = 50
+    const result = enforceAtomSizeRatio(atom, callSite, DEFAULT_L3_CFG);
+    expect(result.status).toBe("ok");
+  });
+
+  it("rejection carries ratioThreshold in envelope for telemetry", () => {
+    const atom = makeAtom({ inputs: 5, outputs: 10, guarantees: 5, transitiveDeps: 20 }); // 110
+    const callSite = makeCallSite(1, 1);
+    const result = enforceAtomSizeRatio(atom, callSite, DEFAULT_L3_CFG);
+    expect(result.status).toBe("atom-size-too-large");
+    if (result.status === "atom-size-too-large") {
+      expect(result.ratioThreshold).toBe(10);
+      expect(typeof result.suggestion).toBe("string");
+      expect(result.suggestion.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config reset between tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  resetConfigOverride();
+});
+
+afterEach(() => {
+  resetConfigOverride();
+});

--- a/packages/hooks-base/src/atom-size-ratio.ts
+++ b/packages/hooks-base/src/atom-size-ratio.ts
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: MIT
+//
+// @decision DEC-HOOK-ENF-LAYER3-ATOM-SIZE-RATIO-001
+// title: Layer 3 atom-size ratio enforcement — config-driven substitution-time gate
+// status: decided (wi-591-s3-layer3)
+// rationale:
+//   Layer 3 runs at substitution time — between the D2 auto-accept gate and
+//   renderSubstitution — to prevent substituting a "lodash-shaped" atom (high
+//   complexity, many exports, many transitive dependencies) when the immediate call
+//   site only needs a small fraction of what the atom provides.
+//
+//   The gate computes two complexity proxies:
+//     atomComplexity  = transitiveNodes + 5 * exportedSurface + 2 * transitiveDeps
+//     needComplexity  = max(1, bindingsUsed * statementCount)
+//   and rejects when atomComplexity / needComplexity > ratioThreshold.
+//
+//   In v1, transitiveNodes is approximated from the spec's
+//   inputs.length + outputs.length + guarantees.length because the shaved-IR node
+//   count is not yet exposed by @yakcc/registry. This proxy is documented explicitly
+//   so v2 can swap it for the real count without changing the gate interface.
+//
+//   Key design decisions:
+//   - ALL thresholds (ratioThreshold, minFloor) come exclusively from
+//     getEnforcementConfig().layer3 (DEC-HOOK-ENF-CONFIG-001). Nothing hardcoded.
+//   - Atoms with atomComplexity < minFloor skip the ratio check. This prevents
+//     false positives on micro-atoms (DEC-HOOK-ENF-LAYER3-MIN-FLOOR-001).
+//   - The gate is pure (no I/O, no async) — safe to call synchronously in the
+//     hot substitution path.
+//   - Escape hatch: YAKCC_HOOK_DISABLE_ATOM_SIZE_GATE=1 → layer3.disableGate=true.
+//     Checked by the caller in substitute.ts; this module does NOT check env vars.
+//
+//   Plug-in point: substitute.ts::executeSubstitution, between the auto-accept gate
+//   and the renderSubstitution call. This is the ONLY place Layer 3 runs
+//   (single plug point per Layer 3 spec).
+//
+//   Cross-reference:
+//     enforcement-config.ts — threshold authority (DEC-HOOK-ENF-CONFIG-001)
+//     enforcement-types.ts  — AtomSizeAcceptEnvelope, AtomSizeRejectEnvelope
+//     substitute.ts         — single plug point
+//     plans/wi-579-s3-layer3-atom-size-ratio.md
+
+import type { SpecYak } from "@yakcc/contracts";
+import type { AtomSizeRatioResult } from "./enforcement-types.js";
+import { getEnforcementConfig } from "./enforcement-config.js";
+
+// ---------------------------------------------------------------------------
+// AtomLike — minimal interface consumed by computeAtomComplexity
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal subset of a registry atom needed for Layer 3 complexity scoring.
+ *
+ * In the substitution pipeline, this is satisfied by the SpecYak + transitive
+ * dependency count fields from the winning candidate's block row.
+ */
+export interface AtomLike {
+  /** SpecYak contract — provides inputs, outputs, guarantees for the proxy count. */
+  readonly spec: SpecYak;
+  /**
+   * Number of named exports on this atom.
+   * In v1, this is derived from spec.outputs.length (the exported value count).
+   * In v2, use the registry's stored export-count when exposed.
+   */
+  readonly exportedSurface: number;
+  /**
+   * Transitive dependency count from the registry provenance row.
+   * Defaults to 0 when the registry has not stored provenance for this block.
+   */
+  readonly transitiveDeps: number;
+}
+
+// ---------------------------------------------------------------------------
+// CallSiteAnalysis — need-side complexity inputs
+// ---------------------------------------------------------------------------
+
+/**
+ * Call-site analysis inputs for needComplexity.
+ *
+ * In the substitution pipeline, these are derived from the originalCode snippet
+ * (ast-scan of the binding call). The caller (substitute.ts) extracts these
+ * before invoking enforceAtomSizeRatio.
+ */
+export interface CallSiteAnalysis {
+  /**
+   * Number of identifiers from the atom's export list referenced in the call-site code.
+   * Minimum 1 when the call site references the atom at all.
+   */
+  readonly bindingsUsed: number;
+  /**
+   * AST statement count under the calling function body containing the binding reference.
+   * Proxy for "how much code does the caller actually need from this atom?"
+   * Minimum 1 to avoid division by zero in ratio computation.
+   */
+  readonly statementCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Complexity proxy computations
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the atom-side complexity proxy from an AtomLike.
+ *
+ * Formula (v1 proxy, per plans/wi-579-hook-enforcement-architecture.md §5.4):
+ *   atomComplexity = transitiveNodes + 5 * exportedSurface + 2 * transitiveDeps
+ *
+ * where transitiveNodes = spec.inputs.length + spec.outputs.length + spec.guarantees.length
+ * (v1 approximation; v2 will use the real shaved-IR node count from @yakcc/registry).
+ *
+ * @decision DEC-HOOK-ENF-LAYER3-ATOM-SIZE-RATIO-001
+ * The 5× weight on exportedSurface reflects that each named export imposes a
+ * structural coupling cost on callers (they must understand, import, and test it).
+ * The 2× weight on transitiveDeps penalises deep dependency trees that bring
+ * indirect complexity. Both multipliers match the spec table in §5.4.
+ */
+export function computeAtomComplexity(atom: AtomLike): number {
+  const transitiveNodes =
+    (atom.spec.inputs?.length ?? 0) +
+    (atom.spec.outputs?.length ?? 0) +
+    (atom.spec.guarantees?.length ?? 0);
+
+  return transitiveNodes + 5 * atom.exportedSurface + 2 * atom.transitiveDeps;
+}
+
+/**
+ * Compute the need-side complexity proxy from a CallSiteAnalysis.
+ *
+ * Formula: needComplexity = max(1, bindingsUsed * statementCount)
+ *
+ * The max(1, …) floor ensures that a degenerate call site (0 bindings, 0
+ * statements — e.g. a placeholder) never produces a 0 denominator and inflates
+ * the ratio to infinity.
+ *
+ * @decision DEC-HOOK-ENF-LAYER3-ATOM-SIZE-RATIO-001
+ */
+export function computeNeedComplexity(callSite: CallSiteAnalysis): number {
+  return Math.max(1, callSite.bindingsUsed * callSite.statementCount);
+}
+
+// ---------------------------------------------------------------------------
+// Enforcement — public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate whether a candidate atom's complexity is proportionate to the
+ * immediate call-site need.
+ *
+ * Returns an AtomSizeRatioResult discriminated union:
+ *   - { layer: 3, status: "ok", atomComplexity, needComplexity, ratio }
+ *       — within configured bounds; proceed to renderSubstitution.
+ *   - { layer: 3, status: "atom-size-too-large", atomComplexity, needComplexity, ratio, … }
+ *       — atom is too complex for the immediate need; do NOT substitute.
+ *
+ * All thresholds are read from getEnforcementConfig().layer3 at call time
+ * (DEC-HOOK-ENF-CONFIG-001). Tests may use setConfigOverride() /
+ * resetConfigOverride() from enforcement-config.ts to inject controlled configs.
+ *
+ * Bypass conditions (status always "ok"):
+ *   (a) atomComplexity < minFloor — micro-atom, ratio check irrelevant.
+ *   (b) Escape hatch: caller sets layer3.disableGate=true before calling
+ *       (checked in substitute.ts; this function does NOT check env vars).
+ *
+ * @param atom     - AtomLike describing the candidate atom.
+ * @param callSite - CallSiteAnalysis from the original code snippet.
+ * @param config   - Optional Layer3Config override (used in tests; production
+ *                   callers omit this and rely on getEnforcementConfig()).
+ *
+ * @decision DEC-HOOK-ENF-LAYER3-ATOM-SIZE-RATIO-001
+ */
+export function enforceAtomSizeRatio(
+  atom: AtomLike,
+  callSite: CallSiteAnalysis,
+  config?: import("./enforcement-config.js").Layer3Config,
+): AtomSizeRatioResult {
+  const cfg = config ?? getEnforcementConfig().layer3;
+  const { ratioThreshold, minFloor } = cfg;
+
+  const atomComplexity = computeAtomComplexity(atom);
+  const needComplexity = computeNeedComplexity(callSite);
+  const ratio = atomComplexity / needComplexity;
+
+  // Bypass: atom is too small to trigger the ratio check.
+  if (atomComplexity < minFloor) {
+    return {
+      layer: 3,
+      status: "ok",
+      atomComplexity,
+      needComplexity,
+      ratio,
+      bypassed: true,
+    };
+  }
+
+  // Reject: ratio exceeds configured threshold.
+  if (ratio > ratioThreshold) {
+    return {
+      layer: 3,
+      status: "atom-size-too-large",
+      atomComplexity,
+      needComplexity,
+      ratio,
+      ratioThreshold,
+      suggestion:
+        `ATOM_OVERSIZED: candidate atom complexity ~${atomComplexity} vs immediate need ~${needComplexity} (ratio ${ratio.toFixed(1)}x).\n` +
+        `Refusing to substitute. Decompose the immediate need into sub-atoms and re-query each.`,
+    };
+  }
+
+  return {
+    layer: 3,
+    status: "ok",
+    atomComplexity,
+    needComplexity,
+    ratio,
+    bypassed: false,
+  };
+}
+
+/**
+ * Convenience predicate: returns true when the atom-size ratio check passes.
+ *
+ * Equivalent to `enforceAtomSizeRatio(atom, callSite, config).status === "ok"`.
+ */
+export function isAtomSizeOk(
+  atom: AtomLike,
+  callSite: CallSiteAnalysis,
+  config?: import("./enforcement-config.js").Layer3Config,
+): boolean {
+  return enforceAtomSizeRatio(atom, callSite, config).status === "ok";
+}

--- a/packages/hooks-base/src/enforcement-config.ts
+++ b/packages/hooks-base/src/enforcement-config.ts
@@ -2,7 +2,7 @@
 //
 // @decision DEC-HOOK-ENF-CONFIG-001
 // title: Central enforcement config module — sole authority for all layer thresholds
-// status: decided (wi-590-s2-layer2)
+// status: decided (wi-590-s2-layer2; extended wi-591-s3-layer3)
 // rationale:
 //   User directive (#590): "make the levels for rejection etc configurable via config.
 //   We want to be able to tune this to the right levels without having to rewrite code
@@ -22,6 +22,8 @@
 //     YAKCC_RESULT_CONFIDENT_THRESHOLD    → layer2.confidentThreshold (float)
 //     YAKCC_L1_MIN_WORDS                  → layer1.minWords (integer)
 //     YAKCC_L1_MAX_WORDS                  → layer1.maxWords (integer)
+//     YAKCC_ATOM_OVERSIZED_RATIO          → layer3.ratioThreshold (float; matches #579 issue body naming)
+//     YAKCC_HOOK_DISABLE_ATOM_SIZE_GATE   → layer3.disableGate = true
 //
 //   Config file: optional .yakcc/enforcement.json relative to the repo root,
 //   or the path pointed to by YAKCC_ENFORCEMENT_CONFIG_PATH.
@@ -30,9 +32,10 @@
 //   Memoization: the loaded config is cached after the first call.
 //   Tests can reset via setConfigOverride() / resetConfigOverride().
 //
-//   S3-S6 append their layer3/layer4/layer5/layer6 keys here following the same pattern.
+//   S4-S6 append their layer4/layer5/layer6 keys here following the same pattern.
 //
-//   Cross-reference: docs/enforcement-config.md, plans/wi-579-s2-layer2-result-set-size.md
+//   Cross-reference: docs/enforcement-config.md, plans/wi-579-s2-layer2-result-set-size.md,
+//   plans/wi-579-s3-layer3-atom-size-ratio.md
 
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -77,6 +80,47 @@ export interface Layer1Config {
 }
 
 /**
+ * Configuration for Layer 3 (atom-size ratio enforcement at substitution time).
+ *
+ * @decision DEC-HOOK-ENF-LAYER3-RATIO-THRESHOLD-001
+ * title: ratioThreshold default 10 matches #579 issue body "10x" spec
+ * status: decided (wi-591-s3-layer3)
+ * rationale:
+ *   The parent issue body explicitly calls out "10x" as the target ratio above which
+ *   an atom is considered oversized for an immediate need. Setting the default to 10
+ *   reproduces the spec intent without any file config present.
+ *
+ * @decision DEC-HOOK-ENF-LAYER3-MIN-FLOOR-001
+ * title: minFloor default 20 — small atoms skip ratio check entirely
+ * status: decided (wi-591-s3-layer3)
+ * rationale:
+ *   An atom with fewer than 20 complexity points is so small that any ratio check
+ *   would produce false positives (a pure 3-line function has atomComplexity ≈ 3;
+ *   ratio vs needComplexity=1 is always 3 — clearly not "oversized"). The floor
+ *   prevents spurious rejections on micro-atoms while keeping the gate meaningful
+ *   for substantial library-scale atoms (lodash-shaped, joi-shaped, etc.).
+ */
+export interface Layer3Config {
+  /**
+   * Maximum allowed ratio of atomComplexity / needComplexity before the gate fires.
+   * Default: 10 (DEC-HOOK-ENF-LAYER3-RATIO-THRESHOLD-001).
+   * Env: YAKCC_ATOM_OVERSIZED_RATIO
+   */
+  readonly ratioThreshold: number;
+  /**
+   * Atoms with atomComplexity strictly below this floor skip the ratio check entirely.
+   * Default: 20 (DEC-HOOK-ENF-LAYER3-MIN-FLOOR-001).
+   */
+  readonly minFloor: number;
+  /**
+   * When true, the Layer 3 atom-size ratio gate is disabled entirely.
+   * Equivalent to YAKCC_HOOK_DISABLE_ATOM_SIZE_GATE=1.
+   * Default: false.
+   */
+  readonly disableGate: boolean;
+}
+
+/**
  * Configuration for Layer 2 (result-set size enforcement).
  */
 export interface Layer2Config {
@@ -102,7 +146,7 @@ export interface Layer2Config {
 /**
  * Central enforcement configuration shape.
  *
- * S3-S6 implementers: append layer3/layer4/layer5/layer6 keys here following
+ * S4-S6 implementers: append layer4/layer5/layer6 keys here following
  * the same pattern. Do NOT add thresholds to layer modules directly.
  *
  * @decision DEC-HOOK-ENF-CONFIG-001
@@ -110,6 +154,7 @@ export interface Layer2Config {
 export interface EnforcementConfig {
   readonly layer1: Layer1Config;
   readonly layer2: Layer2Config;
+  readonly layer3: Layer3Config;
 }
 
 // ---------------------------------------------------------------------------
@@ -269,6 +314,11 @@ export function getDefaults(): EnforcementConfig {
       maxOverall: 10,
       confidentThreshold: 0.7,
     },
+    layer3: {
+      ratioThreshold: 10,
+      minFloor: 20,
+      disableGate: false,
+    },
   };
 }
 
@@ -295,6 +345,11 @@ interface PartialEnforcementConfigFile {
     maxConfident: number;
     maxOverall: number;
     confidentThreshold: number;
+  }>;
+  layer3?: Partial<{
+    ratioThreshold: number;
+    minFloor: number;
+    disableGate: boolean;
   }>;
 }
 
@@ -379,6 +434,26 @@ function validateConfigFile(raw: unknown, filePath: string): PartialEnforcementC
     }
   }
 
+  // Validate layer3 block
+  if ("layer3" in obj && obj.layer3 !== undefined) {
+    const l3 = obj.layer3;
+    if (typeof l3 !== "object" || l3 === null || Array.isArray(l3)) {
+      throw new TypeError(`enforcement-config: "${filePath}" layer3 must be an object`);
+    }
+    const l3obj = l3 as Record<string, unknown>;
+    for (const key of ["ratioThreshold", "minFloor"] as const) {
+      if (key in l3obj && typeof l3obj[key] !== "number") {
+        throw new TypeError(`enforcement-config: "${filePath}" layer3.${key} must be a number`);
+      }
+      if (key in l3obj && (l3obj[key] as number) <= 0) {
+        throw new TypeError(`enforcement-config: "${filePath}" layer3.${key} must be positive`);
+      }
+    }
+    if ("disableGate" in l3obj && typeof l3obj.disableGate !== "boolean") {
+      throw new TypeError(`enforcement-config: "${filePath}" layer3.disableGate must be a boolean`);
+    }
+  }
+
   return raw as PartialEnforcementConfigFile;
 }
 
@@ -411,6 +486,10 @@ function loadFromFile(filePath: string, defaults: EnforcementConfig): Enforcemen
       ...defaults.layer2,
       ...partial.layer2,
     },
+    layer3: {
+      ...defaults.layer3,
+      ...partial.layer3,
+    },
   };
 }
 
@@ -435,8 +514,10 @@ function loadFromFile(filePath: string, defaults: EnforcementConfig): Enforcemen
 function applyEnvOverrides(config: EnforcementConfig, env: NodeJS.ProcessEnv): EnforcementConfig {
   let layer1 = { ...config.layer1 };
   let layer2 = { ...config.layer2 };
+  let layer3 = { ...config.layer3 };
   let l1Changed = false;
   let l2Changed = false;
+  let l3Changed = false;
 
   // layer1 overrides
   if (env.YAKCC_HOOK_DISABLE_INTENT_GATE === "1") {
@@ -481,11 +562,25 @@ function applyEnvOverrides(config: EnforcementConfig, env: NodeJS.ProcessEnv): E
     }
   }
 
-  if (!l1Changed && !l2Changed) return config;
+  // layer3 overrides
+  if (env.YAKCC_ATOM_OVERSIZED_RATIO !== undefined) {
+    const v = Number.parseFloat(env.YAKCC_ATOM_OVERSIZED_RATIO);
+    if (!Number.isNaN(v) && v > 0) {
+      layer3 = { ...layer3, ratioThreshold: v };
+      l3Changed = true;
+    }
+  }
+  if (env.YAKCC_HOOK_DISABLE_ATOM_SIZE_GATE === "1") {
+    layer3 = { ...layer3, disableGate: true };
+    l3Changed = true;
+  }
+
+  if (!l1Changed && !l2Changed && !l3Changed) return config;
 
   return {
     layer1: l1Changed ? layer1 : config.layer1,
     layer2: l2Changed ? layer2 : config.layer2,
+    layer3: l3Changed ? layer3 : config.layer3,
   };
 }
 

--- a/packages/hooks-base/src/enforcement-types.ts
+++ b/packages/hooks-base/src/enforcement-types.ts
@@ -139,13 +139,65 @@ export interface ResultSetRejectEnvelope {
 export type ResultSetSizeResult = ResultSetAcceptEnvelope | ResultSetRejectEnvelope;
 
 // ---------------------------------------------------------------------------
-// Layers 3–5 placeholders — additive per Sacred Practice 12
+// Layer 3 — atom-size ratio enforcement (wi-591-s3-layer3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Layer 3 ACCEPT envelope: the atom-to-need ratio is within configured bounds,
+ * OR the atom's complexity is below the minFloor and was bypassed.
+ *
+ * @decision DEC-HOOK-ENF-LAYER3-ATOM-SIZE-RATIO-001
+ */
+export interface AtomSizeAcceptEnvelope {
+  readonly layer: 3;
+  readonly status: "ok";
+  /** Computed atomComplexity proxy value. */
+  readonly atomComplexity: number;
+  /** Computed needComplexity proxy value. */
+  readonly needComplexity: number;
+  /** Actual ratio (atomComplexity / needComplexity). */
+  readonly ratio: number;
+  /**
+   * True when the atom's complexity was below minFloor and the ratio check
+   * was bypassed entirely. False when the check ran and passed.
+   */
+  readonly bypassed: boolean;
+}
+
+/**
+ * Layer 3 REJECT envelope: the atom's complexity far exceeds the immediate
+ * call-site need.
+ *
+ * When this envelope is returned, substitute.ts MUST NOT call renderSubstitution.
+ * The suggestion text is surfaced to the LLM as a forcing-function message.
+ *
+ * @decision DEC-HOOK-ENF-LAYER3-ATOM-SIZE-RATIO-001
+ */
+export interface AtomSizeRejectEnvelope {
+  readonly layer: 3;
+  readonly status: "atom-size-too-large";
+  /** Computed atomComplexity proxy value at time of rejection. */
+  readonly atomComplexity: number;
+  /** Computed needComplexity proxy value at time of rejection. */
+  readonly needComplexity: number;
+  /** Actual ratio (atomComplexity / needComplexity). */
+  readonly ratio: number;
+  /** Configured threshold that was exceeded. */
+  readonly ratioThreshold: number;
+  /** Forcing-function text surfaced to the LLM. */
+  readonly suggestion: string;
+}
+
+/** Discriminated union result of enforceAtomSizeRatio(). */
+export type AtomSizeRatioResult = AtomSizeAcceptEnvelope | AtomSizeRejectEnvelope;
+
+// ---------------------------------------------------------------------------
+// Layers 4–5 placeholders — additive per Sacred Practice 12
 //
-// S3..S5 implementers append their envelope types here. No existing shape
+// S4..S5 implementers append their envelope types here. No existing shape
 // changes. This comment block documents the extension point so future
 // implementers know where to add.
 //
-// S3 will export: AtomSizeEnvelope (ok | atom_oversized)
 // S4 will export: DescentTrackingEnvelope (ok | descent_bypass_warning)
 // S5 will export: DriftEnvelope (ok | drift_alert)
 // ---------------------------------------------------------------------------

--- a/packages/hooks-base/src/substitute.ts
+++ b/packages/hooks-base/src/substitute.ts
@@ -49,6 +49,8 @@
 
 import type { SpecYak } from "@yakcc/contracts";
 import type { CandidateMatch } from "@yakcc/registry";
+import { enforceAtomSizeRatio, computeAtomComplexity, computeNeedComplexity } from "./atom-size-ratio.js";
+import { getEnforcementConfig } from "./enforcement-config.js";
 
 // ---------------------------------------------------------------------------
 // Score constants — D2 auto-accept thresholds
@@ -356,7 +358,13 @@ export type SubstitutionResult =
   | {
       readonly substituted: false;
       /** Reason for not substituting — aids telemetry and debugging. */
-      readonly reason: "no-candidates" | "score-below-threshold" | "gap-too-small" | "binding-extract-failed" | "disabled";
+      readonly reason:
+        | "no-candidates"
+        | "score-below-threshold"
+        | "gap-too-small"
+        | "binding-extract-failed"
+        | "disabled"
+        | "atom-size-too-large"; // Layer 3 reject (DEC-HOOK-ENF-LAYER3-ATOM-SIZE-RATIO-001)
     }
   | {
       readonly substituted: true;
@@ -411,7 +419,48 @@ export async function executeSubstitution(
     return { substituted: false, reason: "gap-too-small" };
   }
 
-  // Step 2: Extract the binding shape from the original code.
+  // Step 2: Layer 3 atom-size ratio gate (DEC-HOOK-ENF-LAYER3-ATOM-SIZE-RATIO-001).
+  // Runs BETWEEN the D2 auto-accept gate AND renderSubstitution — the single plug
+  // point per Layer 3 spec. Only runs when disableGate is false.
+  const l3cfg = getEnforcementConfig().layer3;
+  if (!l3cfg.disableGate) {
+    const best = candidates[0];
+    if (best !== undefined) {
+      // Build AtomLike from the winning candidate's spec block.
+      // specCanonicalBytes → SpecYak is attempted; on failure, use zero-complexity
+      // proxy so the gate is conservative (does not reject on spec parse errors).
+      let specForL3: SpecYak | undefined;
+      try {
+        const { validateSpecYak } = await import("@yakcc/contracts");
+        const specJson = new TextDecoder().decode(best.block.specCanonicalBytes);
+        specForL3 = validateSpecYak(JSON.parse(specJson));
+      } catch {
+        specForL3 = undefined;
+      }
+
+      const atomLike = {
+        spec: specForL3 ?? { inputs: [], outputs: [], guarantees: [] } as unknown as SpecYak,
+        // exportedSurface: number of named exports — v1 proxy: outputs.length.
+        exportedSurface: specForL3?.outputs?.length ?? 0,
+        // transitiveDeps: not yet exposed by @yakcc/registry; default 0 in v1.
+        transitiveDeps: 0,
+      };
+
+      // Need-side analysis: derive from originalCode (simple token scan; full
+      // ts-morph scan is deferred to v2 when the call-site AST is available).
+      // v1 proxy: bindingsUsed = 1 (the caller uses the atom), statementCount =
+      // number of semicolons + block-statements in originalCode (rough proxy).
+      const statementCount = Math.max(1, (originalCode.match(/;/g) ?? []).length);
+      const callSite = { bindingsUsed: 1, statementCount };
+
+      const l3Result = enforceAtomSizeRatio(atomLike, callSite, l3cfg);
+      if (l3Result.status === "atom-size-too-large") {
+        return { substituted: false, reason: "atom-size-too-large" };
+      }
+    }
+  }
+
+  // Step 3: Extract the binding shape from the original code.
   // Lazy-import to avoid circular references; @yakcc/ir is a peer package.
   const { extractBindingShape } = await import("@yakcc/ir");
   const binding = extractBindingShape(originalCode);
@@ -419,7 +468,7 @@ export async function executeSubstitution(
     return { substituted: false, reason: "binding-extract-failed" };
   }
 
-  // Step 3: Attempt to recover SpecYak from the winning candidate's specCanonicalBytes.
+  // Step 4: Attempt to recover SpecYak from the winning candidate's specCanonicalBytes.
   // specCanonicalBytes is a UTF-8-encoded canonical JSON blob (see canonicalize.ts).
   // If parsing/validation fails we fall through to the two-line Phase 2 rendering
   // (no contract comment) rather than failing the substitution entirely.
@@ -436,7 +485,7 @@ export async function executeSubstitution(
     }
   }
 
-  // Step 4: Render the substitution (with contract comment if spec was recovered).
+  // Step 5: Render the substitution (with contract comment if spec was recovered).
   const substitutedCode = renderSubstitution(decision.atomHash, originalCode, binding, spec);
 
   return {

--- a/packages/hooks-base/src/telemetry.ts
+++ b/packages/hooks-base/src/telemetry.ts
@@ -92,7 +92,16 @@ export type TelemetryEvent = {
     //   Emitted via outcomeOverride="result-set-too-large" at the Layer 2 gate in
     //   executeRegistryQueryWithSubstitution (index.ts). outcomeFromResponse() unchanged.
     //   Cross-reference: plans/wi-579-s2-layer2-result-set-size.md
-    | "result-set-too-large"; // S2 additive (DEC-HOOK-ENF-LAYER2-TELEMETRY-001)
+    | "result-set-too-large" // S2 additive (DEC-HOOK-ENF-LAYER2-TELEMETRY-001)
+    // @decision DEC-HOOK-ENF-LAYER3-TELEMETRY-001
+    // title: "atom-size-too-large" additive outcome for Layer 3 atom-size ratio gate (wi-591 S3)
+    // status: decided (wi-591-s3-layer3)
+    // rationale:
+    //   Additive expansion following the Layer 2 pattern (DEC-HOOK-ENF-LAYER2-TELEMETRY-001).
+    //   Emitted via outcomeOverride="atom-size-too-large" at the Layer 3 gate in
+    //   executeSubstitution (substitute.ts). outcomeFromResponse() unchanged.
+    //   Cross-reference: plans/wi-579-s3-layer3-atom-size-ratio.md
+    | "atom-size-too-large"; // S3 additive (DEC-HOOK-ENF-LAYER3-TELEMETRY-001)
   // ---------------------------------------------------------------------------
   // Phase 2 additions â€” additive fields (backwards-compatible per #217 spec).
   // Old telemetry consumers see these as optional (undefined in Phase 1 events).
@@ -230,8 +239,8 @@ export function hashIntent(intentText: string): string {
  */
 export function outcomeFromResponse(
   response: HookResponse,
-  outcomeOverride?: "atomized" | "intent-too-broad" | "result-set-too-large",
-): "registry-hit" | "synthesis-required" | "passthrough" | "atomized" | "intent-too-broad" | "result-set-too-large" {
+  outcomeOverride?: "atomized" | "intent-too-broad" | "result-set-too-large" | "atom-size-too-large",
+): "registry-hit" | "synthesis-required" | "passthrough" | "atomized" | "intent-too-broad" | "result-set-too-large" | "atom-size-too-large" {
   // Note: shave-on-miss outcome values are emitted directly via appendTelemetryEvent
   // from shave-on-miss.ts, not via this function. This function handles only the
   // four standard outcomes plus the override values.
@@ -315,7 +324,7 @@ export function captureTelemetry(opts: {
    * by the Layer 1 gate to set "intent-too-broad" (DEC-HOOK-ENF-LAYER1-TELEMETRY-001),
    * and by the Layer 2 gate to set "result-set-too-large" (DEC-HOOK-ENF-LAYER2-TELEMETRY-001).
    */
-  outcomeOverride?: "atomized" | "intent-too-broad" | "result-set-too-large";
+  outcomeOverride?: "atomized" | "intent-too-broad" | "result-set-too-large" | "atom-size-too-large";
   /** BMR prefixes of atoms created. Non-empty only for outcome === "atomized". */
   atomsCreated?: readonly string[];
   sessionId?: string;

--- a/packages/hooks-base/test/atom-size-ratio-integration.test.ts
+++ b/packages/hooks-base/test/atom-size-ratio-integration.test.ts
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: MIT
+// @mock-exempt: Registry is an external service boundary (@yakcc/registry wraps sqlite-vec).
+// Using plain in-memory stub objects (no vi.fn()) following the makeRegistryStub()
+// pattern from result-set-size-integration.test.ts.
+/**
+ * atom-size-ratio-integration.test.ts — Layer 3 integration tests.
+ *
+ * @decision DEC-HOOK-ENF-LAYER3-ATOM-SIZE-RATIO-001
+ * title: Layer 3 integration — atom-size ratio gate through substitute.ts pipeline
+ * status: decided (wi-591-s3-layer3)
+ * rationale:
+ *   Unit tests in atom-size-ratio.test.ts verify enforceAtomSizeRatio() in isolation.
+ *   These integration tests verify Layer 3 is correctly wired inside
+ *   executeSubstitution() — the substitution pipeline entry point in substitute.ts.
+ *
+ *   Production sequence exercised:
+ *     1. executeSubstitution(candidates, originalCode)
+ *     2. D2 auto-accept gate runs (candidates must pass — we use a high-score candidate)
+ *     3. Layer 3 gate runs: enforceAtomSizeRatio(atomLike, callSite, l3cfg)
+ *     4a. Oversized atom (high complexity) → substituted=false, reason="atom-size-too-large"
+ *     4b. Small atom (below minFloor) → bypass → substituted proceeds (binding-extract-failed
+ *         is expected here since no real AST is provided, but the Layer 3 gate did NOT block)
+ *
+ *   Compound-interaction requirement satisfied: exercises D2 auto-accept gate →
+ *   Layer 3 atom-size ratio gate → substitute result in one production sequence.
+ *
+ *   Registry stubs produce controlled specCanonicalBytes so Layer 3 can parse
+ *   a real SpecYak from the winning candidate's block. When spec bytes are empty,
+ *   the implementation uses zero-complexity defaults (bypass path).
+ *
+ *   Single plug point: Layer 3 runs ONLY in executeSubstitution (substitute.ts),
+ *   between the D2 gate and renderSubstitution.
+ *
+ * Production trigger: pnpm --filter @yakcc/hooks-base test
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CandidateMatch } from "@yakcc/registry";
+import {
+  resetConfigOverride,
+  setConfigOverride,
+  getDefaults,
+} from "../src/enforcement-config.js";
+import { executeSubstitution } from "../src/substitute.js";
+
+// ---------------------------------------------------------------------------
+// CandidateMatch stub helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a valid SpecYak JSON blob with controlled complexity proxy inputs.
+ *
+ * The SpecYak blob is what Layer 3 decodes from specCanonicalBytes via validateSpecYak().
+ * The real SpecYak required fields are: name, inputs, outputs, preconditions,
+ * postconditions, invariants, effects, level.
+ *
+ * Controlling inputs/outputs counts drives atomComplexity:
+ *   atomComplexity = (inputs.length + outputs.length + guarantees.length)
+ *                    + 5 * exportedSurface   (= 5 * outputs.length in v1)
+ *                    + 2 * transitiveDeps    (= 0 in v1, not in spec)
+ * substitute.ts reads exportedSurface = specForL3.outputs.length.
+ */
+function makeSpecBytes(opts: {
+  inputs?: number;
+  outputs?: number;
+}): Uint8Array {
+  const spec = {
+    name: "integration-stub",
+    level: "L0",
+    inputs: Array.from({ length: opts.inputs ?? 0 }, (_, i) => ({
+      name: `in${i}`,
+      type: "string",
+      description: `input parameter ${i}`,
+    })),
+    outputs: Array.from({ length: opts.outputs ?? 0 }, (_, i) => ({
+      name: `out${i}`,
+      type: "string",
+      description: `output parameter ${i}`,
+    })),
+    preconditions: [],
+    postconditions: [],
+    invariants: [],
+    effects: [],
+  };
+  return new TextEncoder().encode(JSON.stringify(spec));
+}
+
+/**
+ * Build a CandidateMatch stub that passes D2 auto-accept:
+ *   cosineDistance=0.10 → combinedScore = 1 - 0.01/4 = 0.9975 >> 0.85 threshold.
+ *   Single candidate so gap = top1Score - 0 = 0.9975 >> 0.15 gap threshold.
+ *
+ * The block.specCanonicalBytes is set via opts so Layer 3 can parse the SpecYak
+ * via validateSpecYak. The spec JSON must pass validateSpecYak validation; use
+ * makeSpecBytes() to produce valid bytes.
+ *
+ * atomComplexity formula (v1 proxy, substitute.ts):
+ *   transitiveNodes = spec.inputs.length + spec.outputs.length (+ guarantees=0, not in new schema)
+ *   exportedSurface = spec.outputs.length
+ *   transitiveDeps  = 0 (not exposed by registry in v1)
+ *   atomComplexity  = transitiveNodes + 5 * exportedSurface + 2 * transitiveDeps
+ *                   = (inputs + outputs) + 5 * outputs
+ *                   = inputs + 6 * outputs
+ */
+function makeAutoAcceptCandidate(opts: {
+  inputs?: number;
+  outputs?: number;
+  specBytes?: Uint8Array;
+}): CandidateMatch {
+  const specBytes =
+    opts.specBytes ??
+    makeSpecBytes({
+      ...(opts.inputs !== undefined ? { inputs: opts.inputs } : {}),
+      ...(opts.outputs !== undefined ? { outputs: opts.outputs } : {}),
+    });
+  return {
+    cosineDistance: 0.10,
+    block: {
+      blockMerkleRoot: "a".repeat(64),
+      specCanonicalBytes: specBytes,
+    },
+  } as unknown as CandidateMatch;
+}
+
+// ---------------------------------------------------------------------------
+// Setup/teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  resetConfigOverride();
+  // Ensure YAKCC_HOOK_DISABLE_SUBSTITUTE is NOT set so the substitute path runs.
+  delete process.env.YAKCC_HOOK_DISABLE_SUBSTITUTE;
+  delete process.env.YAKCC_HOOK_DISABLE_ATOM_SIZE_GATE;
+});
+
+afterEach(() => {
+  resetConfigOverride();
+  delete process.env.YAKCC_HOOK_DISABLE_SUBSTITUTE;
+  delete process.env.YAKCC_HOOK_DISABLE_ATOM_SIZE_GATE;
+});
+
+// ---------------------------------------------------------------------------
+// Integration: Layer 3 rejects oversized atom
+//
+// Compound-interaction test: D2 auto-accept gate → Layer 3 gate → result.
+// ---------------------------------------------------------------------------
+
+describe("Layer 3 integration — oversized atom rejected by executeSubstitution", () => {
+  it("returns substituted=false, reason=atom-size-too-large when atom is lodash-shaped", async () => {
+    // substitute.ts formula: atomComplexity = inputs + 6 * outputs (no guarantees in real SpecYak)
+    // inputs=2, outputs=20 → atomComplexity = 2 + 6*20 = 122
+    // minFloor=20, ratioThreshold=2 → ratio=122/1=122 >> 2 → reject
+    setConfigOverride({
+      ...getDefaults(),
+      layer3: { ratioThreshold: 2, minFloor: 20, disableGate: false },
+    });
+
+    const candidate = makeAutoAcceptCandidate({ inputs: 2, outputs: 20 });
+    const originalCode = "const result = fn();"; // 1 semicolon → statementCount=1, needComplexity=1
+
+    const result = await executeSubstitution([candidate], originalCode);
+
+    expect(result.substituted).toBe(false);
+    if (!result.substituted) {
+      expect(result.reason).toBe("atom-size-too-large");
+    }
+  });
+
+  it("returns atom-size-too-large with default config when atomComplexity >> 10x need", async () => {
+    // Default ratioThreshold=10, minFloor=20.
+    // inputs=0, outputs=30 → atomComplexity = 0 + 6*30 = 180 >= minFloor=20
+    // 1 semicolon in originalCode → statementCount=1, bindingsUsed=1 → needComplexity=1
+    // ratio=180/1=180 >> 10 → reject
+    const candidate = makeAutoAcceptCandidate({ inputs: 0, outputs: 30 });
+    const originalCode = "const x = fn();";
+
+    const result = await executeSubstitution([candidate], originalCode);
+
+    expect(result.substituted).toBe(false);
+    if (!result.substituted) {
+      expect(result.reason).toBe("atom-size-too-large");
+    }
+  });
+
+  it("does NOT substitute when atom spec bytes parse to large complexity", async () => {
+    // inputs=5, outputs=20 → atomComplexity = 5 + 6*20 = 125 >= minFloor=20
+    // 1 semicolon → needComplexity=1; ratio=125 >> ratioThreshold=10 → reject
+    const specBytes = makeSpecBytes({ inputs: 5, outputs: 20 });
+    const candidate = makeAutoAcceptCandidate({ specBytes });
+    const originalCode = "const r = transform();";
+
+    const result = await executeSubstitution([candidate], originalCode);
+
+    expect(result.substituted, "Layer 3 must block substitution of oversized atom").toBe(false);
+    if (!result.substituted) {
+      expect(result.reason).toBe("atom-size-too-large");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: Layer 3 does NOT block micro-atom (below minFloor)
+// ---------------------------------------------------------------------------
+
+describe("Layer 3 integration — micro-atom bypasses ratio check", () => {
+  it("does not return atom-size-too-large when spec is empty (zero complexity = bypass)", async () => {
+    // Empty spec → atomComplexity = 0 < minFloor=20 → bypass → gate passes.
+    // Layer 3 result: ok (bypassed). Pipeline continues to binding extraction.
+    // Since no real AST parsing context is available, result is binding-extract-failed —
+    // but the key assertion is that Layer 3 did NOT block (reason != atom-size-too-large).
+    const candidate = makeAutoAcceptCandidate({ specBytes: new Uint8Array(0) });
+    const originalCode = "const x = compute();";
+
+    const result = await executeSubstitution([candidate], originalCode);
+
+    // Layer 3 bypassed (empty spec → atomComplexity=0 < minFloor=20).
+    // Subsequent stages may fail (binding-extract), but NOT atom-size-too-large.
+    if (!result.substituted) {
+      expect(result.reason, "Layer 3 must not block empty-spec (zero complexity) atom").not.toBe(
+        "atom-size-too-large",
+      );
+    }
+  });
+
+  it("does not block atom with small spec (atomComplexity < minFloor=20)", async () => {
+    // inputs=1, outputs=2 → atomComplexity = 1 + 6*2 = 13 < minFloor=20 → bypass
+    // Even with a very strict threshold=1, bypass protects micro-atoms.
+    setConfigOverride({
+      ...getDefaults(),
+      layer3: { ratioThreshold: 1, minFloor: 20, disableGate: false },
+    });
+
+    const candidate = makeAutoAcceptCandidate({ inputs: 1, outputs: 2 });
+    const originalCode = "const x = compute();";
+
+    const result = await executeSubstitution([candidate], originalCode);
+
+    if (!result.substituted) {
+      expect(result.reason, "Layer 3 must bypass micro-atom (atomComplexity < minFloor)").not.toBe(
+        "atom-size-too-large",
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: YAKCC_HOOK_DISABLE_ATOM_SIZE_GATE=1 escape hatch
+// (checked via disableGate config; layer3.disableGate=true bypasses Layer 3)
+// ---------------------------------------------------------------------------
+
+describe("Layer 3 integration — disableGate escape hatch", () => {
+  it("does not block oversized atom when layer3.disableGate=true", async () => {
+    // inputs=0, outputs=30 → atomComplexity=180. Without disableGate → reject.
+    // With disableGate=true: skip Layer 3 → result is NOT atom-size-too-large.
+    setConfigOverride({
+      ...getDefaults(),
+      layer3: { ratioThreshold: 10, minFloor: 20, disableGate: true },
+    });
+
+    const candidate = makeAutoAcceptCandidate({ inputs: 0, outputs: 30 });
+    const originalCode = "const x = fn();";
+
+    const result = await executeSubstitution([candidate], originalCode);
+
+    if (!result.substituted) {
+      expect(result.reason, "Layer 3 must be skipped when disableGate=true").not.toBe(
+        "atom-size-too-large",
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: config-driven threshold (no hardcoded values)
+//
+// @decision DEC-HOOK-ENF-LAYER3-ATOM-SIZE-RATIO-001
+// Verifies thresholds come from enforcement-config, NOT hardcoded in substitute.ts.
+// ---------------------------------------------------------------------------
+
+describe("Layer 3 integration — config-driven thresholds (no hardcoded values)", () => {
+  it("uses ratioThreshold from config: raised threshold allows previously-rejected atom", async () => {
+    // inputs=2, outputs=20 → atomComplexity = 2 + 6*20 = 122
+    // Default ratioThreshold=10: 122 >> 10 → reject.
+    // With ratioThreshold=200: 122 < 200 → Layer 3 passes.
+    // Layer 3 passes → pipeline continues → binding-extract-failed (no real AST) or substituted.
+    setConfigOverride({
+      ...getDefaults(),
+      layer3: { ratioThreshold: 200, minFloor: 20, disableGate: false },
+    });
+
+    const candidate = makeAutoAcceptCandidate({ inputs: 2, outputs: 20 });
+    const originalCode = "const result = fn();";
+
+    const result = await executeSubstitution([candidate], originalCode);
+
+    // Layer 3 must NOT be the blocker. Result may be binding-extract-failed or substituted.
+    if (!result.substituted) {
+      expect(result.reason, "raised ratioThreshold=200 must not block this atom").not.toBe(
+        "atom-size-too-large",
+      );
+    }
+  });
+
+  it("uses ratioThreshold from config: lowered threshold rejects previously-accepted atom", async () => {
+    // inputs=1, outputs=2 → atomComplexity = 1 + 6*2 = 13
+    // Default config: 13 < minFloor=20 → bypass → passes.
+    // With minFloor=0, ratioThreshold=2: gate runs. ratio=13/1=13 > 2 → reject.
+    setConfigOverride({
+      ...getDefaults(),
+      layer3: { ratioThreshold: 2, minFloor: 0, disableGate: false },
+    });
+
+    const candidate = makeAutoAcceptCandidate({ inputs: 1, outputs: 2 });
+    const originalCode = "const r = fn();";
+
+    const result = await executeSubstitution([candidate], originalCode);
+
+    expect(result.substituted).toBe(false);
+    if (!result.substituted) {
+      expect(result.reason, "lowered ratioThreshold=2 + minFloor=0 must reject this atom").toBe(
+        "atom-size-too-large",
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: YAKCC_HOOK_DISABLE_SUBSTITUTE=1 escape hatch takes priority
+// ---------------------------------------------------------------------------
+
+describe("Layer 3 integration — YAKCC_HOOK_DISABLE_SUBSTITUTE escape hatch", () => {
+  it("returns disabled reason when YAKCC_HOOK_DISABLE_SUBSTITUTE=1, not atom-size-too-large", async () => {
+    process.env.YAKCC_HOOK_DISABLE_SUBSTITUTE = "1";
+
+    const candidate = makeAutoAcceptCandidate({ inputs: 0, outputs: 30 });
+    const originalCode = "const x = fn();";
+
+    const result = await executeSubstitution([candidate], originalCode);
+
+    expect(result.substituted).toBe(false);
+    if (!result.substituted) {
+      expect(result.reason).toBe("disabled");
+    }
+  });
+});

--- a/packages/hooks-base/test/enforcement-eval-corpus.json
+++ b/packages/hooks-base/test/enforcement-eval-corpus.json
@@ -98,5 +98,60 @@
     "expectedLayer": 2,
     "expectedOutcome": "accept",
     "notes": "YAKCC_RESULT_SET_MAX=5 env override raises maxConfident to 5; 4 confident < 5 → accept"
+  },
+  {
+    "id": "L3-001",
+    "input": "atom-size-ratio-check",
+    "expectedLayer": 3,
+    "expectedOutcome": "atom-oversized",
+    "atomComplexity": 110,
+    "needComplexity": 1,
+    "ratioThreshold": 10,
+    "minFloor": 20,
+    "notes": "lodash-shaped atom: inputs=5, outputs=10, guarantees=5, deps=20 → atomComplexity=110; needComplexity=1 → ratio=110 >> ratioThreshold=10; classic oversized exemplar from #579 issue body"
+  },
+  {
+    "id": "L3-002",
+    "input": "atom-size-ratio-check",
+    "expectedLayer": 3,
+    "expectedOutcome": "accept",
+    "atomComplexity": 7,
+    "needComplexity": 1,
+    "ratioThreshold": 10,
+    "minFloor": 20,
+    "notes": "micro-atom: inputs=1, outputs=1, guarantees=0, deps=0 → atomComplexity=7 < minFloor=20; ratio check bypassed entirely; always accept regardless of ratio"
+  },
+  {
+    "id": "L3-003",
+    "input": "atom-size-ratio-check",
+    "expectedLayer": 3,
+    "expectedOutcome": "accept",
+    "atomComplexity": 20,
+    "needComplexity": 2,
+    "ratioThreshold": 10,
+    "minFloor": 20,
+    "notes": "boundary at ratioThreshold: atomComplexity=20 (= minFloor, gate runs), needComplexity=2 → ratio=10.0; reject requires STRICTLY > threshold; 10 > 10 is false → accept"
+  },
+  {
+    "id": "L3-004",
+    "input": "atom-size-ratio-check",
+    "expectedLayer": 3,
+    "expectedOutcome": "atom-oversized",
+    "atomComplexity": 21,
+    "needComplexity": 2,
+    "ratioThreshold": 10,
+    "minFloor": 20,
+    "notes": "ratio boundary +1: atomComplexity=21 ≥ minFloor=20 (gate runs), needComplexity=2 → ratio=10.5 > ratioThreshold=10 → reject"
+  },
+  {
+    "id": "L3-005",
+    "input": "atom-size-ratio-check",
+    "expectedLayer": 3,
+    "expectedOutcome": "accept",
+    "atomComplexity": 110,
+    "needComplexity": 50,
+    "ratioThreshold": 10,
+    "minFloor": 20,
+    "notes": "large need-complexity reduces ratio to safe zone: atomComplexity=110, needComplexity=50 (bindingsUsed=10, statementCount=5) → ratio=2.2 < ratioThreshold=10 → accept even for lodash-shaped atom"
   }
 ]

--- a/packages/hooks-base/test/enforcement-eval-corpus.test.ts
+++ b/packages/hooks-base/test/enforcement-eval-corpus.test.ts
@@ -32,6 +32,9 @@ import { scoreIntentSpecificity } from "../src/intent-specificity.js";
 import type { CandidateMatch } from "@yakcc/registry";
 import { resetConfigOverride, setConfigOverride, getDefaults, loadEnforcementConfig } from "../src/enforcement-config.js";
 import { scoreResultSetSize } from "../src/result-set-size.js";
+import { enforceAtomSizeRatio } from "../src/atom-size-ratio.js";
+import type { AtomLike, CallSiteAnalysis } from "../src/atom-size-ratio.js";
+import type { Layer3Config } from "../src/enforcement-config.js";
 
 // ---------------------------------------------------------------------------
 // Corpus type
@@ -39,6 +42,7 @@ import { scoreResultSetSize } from "../src/result-set-size.js";
 
 interface CorpusRow {
   id: string;
+  /** For Layer 1 rows: the intent text. For Layer 2/3 rows: descriptive label (not interpreted). */
   input: string;
   expectedLayer: number;
   expectedOutcome: "intent-too-broad" | "accept" | "result-set-too-large" | "atom-oversized" | "descent-bypass-warning" | "drift-alert";
@@ -48,6 +52,11 @@ interface CorpusRow {
   confidentCount?: number;
   weakCount?: number;
   envOverrides?: Record<string, string>;
+  // Layer 3 fields — present only for L3-* rows
+  atomComplexity?: number;
+  needComplexity?: number;
+  ratioThreshold?: number;
+  minFloor?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -144,6 +153,90 @@ function buildCandidatesFromRow(row: CorpusRow): CandidateMatch[] {
 }
 
 // ---------------------------------------------------------------------------
+// Layer 3 helpers — build AtomLike + CallSiteAnalysis from corpus fields
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal AtomLike from a corpus row's atomComplexity proxy fields.
+ *
+ * The corpus stores the pre-computed complexity values (atomComplexity, needComplexity)
+ * rather than the raw spec fields. We reconstruct an AtomLike that reproduces
+ * the documented atomComplexity via the standard formula:
+ *   atomComplexity = transitiveNodes + 5 * exportedSurface + 2 * transitiveDeps
+ *
+ * Strategy: encode all complexity in transitiveDeps (cleanest single-field control):
+ *   transitiveDeps = atomComplexity / 2  when atomComplexity is even,
+ *   otherwise use inputs = atomComplexity (transitiveNodes only, exportedSurface=0, deps=0).
+ * Both roundtrip exactly.
+ */
+function makeAtomLikeFromRow(row: CorpusRow): AtomLike {
+  const atomComplexity = row.atomComplexity ?? 0;
+  // Encode via transitiveDeps when divisible by 2; otherwise via inputs only.
+  if (atomComplexity % 2 === 0) {
+    const deps = atomComplexity / 2;
+    return {
+      spec: {
+        inputs: [],
+        outputs: [],
+        guarantees: [],
+      } as unknown as import("@yakcc/contracts").SpecYak,
+      exportedSurface: 0,
+      transitiveDeps: deps,
+    };
+  }
+  // Odd: encode all in transitiveNodes (inputs only, no exports or deps).
+  return {
+    spec: {
+      inputs: Array.from({ length: atomComplexity }, (_, i) => ({ name: `in${i}`, type: "string" })),
+      outputs: [],
+      guarantees: [],
+    } as unknown as import("@yakcc/contracts").SpecYak,
+    exportedSurface: 0,
+    transitiveDeps: 0,
+  };
+}
+
+/**
+ * Build a CallSiteAnalysis that produces the row's documented needComplexity.
+ *
+ * needComplexity = max(1, bindingsUsed * statementCount).
+ * We use bindingsUsed=needComplexity, statementCount=1 for simplicity.
+ */
+function makeCallSiteFromRow(row: CorpusRow): CallSiteAnalysis {
+  const needComplexity = row.needComplexity ?? 1;
+  return { bindingsUsed: needComplexity, statementCount: 1 };
+}
+
+/**
+ * Assert a Layer 3 corpus row against enforceAtomSizeRatio().
+ *
+ * Builds AtomLike + CallSiteAnalysis from row fields and verifies the gate verdict.
+ *
+ * @decision DEC-HOOK-ENF-LAYER3-ATOM-SIZE-RATIO-001
+ */
+function assertLayer3Row(row: CorpusRow): void {
+  const cfg: Layer3Config = {
+    ratioThreshold: row.ratioThreshold ?? 10,
+    minFloor: row.minFloor ?? 20,
+    disableGate: false,
+  };
+  const atomLike = makeAtomLikeFromRow(row);
+  const callSite = makeCallSiteFromRow(row);
+
+  const result = enforceAtomSizeRatio(atomLike, callSite, cfg);
+
+  if (row.expectedOutcome === "atom-oversized") {
+    expect(result.status, `[${row.id}] expected atom-size-too-large for atomComplexity=${row.atomComplexity ?? 0} (${row.notes ?? ""})`).toBe("atom-size-too-large");
+    expect(result.layer, `[${row.id}] layer discriminant must be 3`).toBe(3);
+  } else if (row.expectedOutcome === "accept") {
+    expect(result.status, `[${row.id}] expected ok (accept) for atomComplexity=${row.atomComplexity ?? 0} (${row.notes ?? ""})`).toBe("ok");
+    expect(result.layer, `[${row.id}] layer discriminant must be 3`).toBe(3);
+  } else {
+    throw new Error(`[${row.id}] unexpected expectedOutcome="${row.expectedOutcome}" for a Layer 3 row`);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Layer 2 assertion helper
 // ---------------------------------------------------------------------------
 
@@ -214,6 +307,12 @@ describe("Layer 6 eval corpus — structural invariants", () => {
     expect(layer2Rows.length).toBe(5);
   });
 
+  it("S3 seeds exactly 5 Layer 3 rows", async () => {
+    const rows = await loadCorpus();
+    const layer3Rows = rows.filter((r) => r.expectedLayer === 3);
+    expect(layer3Rows.length).toBe(5);
+  });
+
   it("all S1 row ids follow L1-NNN format", async () => {
     const rows = await loadCorpus();
     const layer1Rows = rows.filter((r) => r.expectedLayer === 1);
@@ -227,6 +326,14 @@ describe("Layer 6 eval corpus — structural invariants", () => {
     const layer2Rows = rows.filter((r) => r.expectedLayer === 2);
     for (const row of layer2Rows) {
       expect(row.id, `id should match L2-NNN`).toMatch(/^L2-\d{3}$/);
+    }
+  });
+
+  it("all S3 row ids follow L3-NNN format", async () => {
+    const rows = await loadCorpus();
+    const layer3Rows = rows.filter((r) => r.expectedLayer === 3);
+    for (const row of layer3Rows) {
+      expect(row.id, `id should match L3-NNN`).toMatch(/^L3-\d{3}$/);
     }
   });
 });
@@ -368,5 +475,68 @@ describe("Layer 6 eval corpus — completeness gate", () => {
     const hasAccept = layer2Rows.some((r) => r.expectedOutcome === "accept");
     expect(hasReject, "corpus must contain at least one result-set-too-large row").toBe(true);
     expect(hasAccept, "corpus must contain at least one accept row for Layer 2").toBe(true);
+  });
+
+  it("corpus covers both reject and accept outcomes in Layer 3", async () => {
+    const rows = await loadCorpus();
+    const layer3Rows = rows.filter((r) => r.expectedLayer === 3);
+    const hasReject = layer3Rows.some((r) => r.expectedOutcome === "atom-oversized");
+    const hasAccept = layer3Rows.some((r) => r.expectedOutcome === "accept");
+    expect(hasReject, "corpus must contain at least one atom-oversized row").toBe(true);
+    expect(hasAccept, "corpus must contain at least one accept row for Layer 3").toBe(true);
+  });
+
+  it("corpus has grown to 17 rows (S1=7 + S2=5 + S3=5)", async () => {
+    const rows = await loadCorpus();
+    expect(rows.length).toBe(17);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Layer 3 eval gate — table-driven (S3 additive, wi-591-s3-layer3)
+// ---------------------------------------------------------------------------
+
+describe("Layer 6 eval corpus — Layer 3 rows", () => {
+  it("L3-001: lodash-shaped atom (atomComplexity=110, needComplexity=1) → atom-oversized", async () => {
+    const rows = await loadCorpus();
+    const row = rows.find((r) => r.id === "L3-001");
+    expect(row, "L3-001 must be in corpus").toBeDefined();
+    if (row) assertLayer3Row(row);
+  });
+
+  it("L3-002: micro-atom (atomComplexity=7 < minFloor=20) → accept (bypassed)", async () => {
+    const rows = await loadCorpus();
+    const row = rows.find((r) => r.id === "L3-002");
+    expect(row, "L3-002 must be in corpus").toBeDefined();
+    if (row) assertLayer3Row(row);
+  });
+
+  it("L3-003: boundary at ratioThreshold (ratio=10.0, not > 10) → accept", async () => {
+    const rows = await loadCorpus();
+    const row = rows.find((r) => r.id === "L3-003");
+    expect(row, "L3-003 must be in corpus").toBeDefined();
+    if (row) assertLayer3Row(row);
+  });
+
+  it("L3-004: boundary +1 (ratio=10.5 > ratioThreshold=10) → atom-oversized", async () => {
+    const rows = await loadCorpus();
+    const row = rows.find((r) => r.id === "L3-004");
+    expect(row, "L3-004 must be in corpus").toBeDefined();
+    if (row) assertLayer3Row(row);
+  });
+
+  it("L3-005: large needComplexity reduces ratio to safe zone (ratio=2.2 < 10) → accept", async () => {
+    const rows = await loadCorpus();
+    const row = rows.find((r) => r.id === "L3-005");
+    expect(row, "L3-005 must be in corpus").toBeDefined();
+    if (row) assertLayer3Row(row);
+  });
+
+  it("all Layer 3 rows pass (catch-all sweep for future corpus additions)", async () => {
+    const rows = await loadCorpus();
+    const layer3Rows = rows.filter((r) => r.expectedLayer === 3);
+    for (const row of layer3Rows) {
+      assertLayer3Row(row);
+    }
   });
 });

--- a/plans/wi-579-s3-layer3-atom-size-ratio.md
+++ b/plans/wi-579-s3-layer3-atom-size-ratio.md
@@ -1,0 +1,80 @@
+# WI-579-S3: Layer 3 — Atom-Size Ratio Enforcement
+
+**Issue:** #591 | **Slice:** S3 of 6 | **Status:** complete (wi-591-s3-layer3)
+
+## Problem
+
+An LLM-invoked substitution can replace a call site with a lodash-shaped atom —
+one that exports dozens of functions and carries hundreds of transitive dependencies —
+when the immediate need is a single, narrow operation. The caller pays the full
+complexity cost of the atom even though it uses ~1% of its surface.
+
+## Decision
+
+**Single plug point:** `substitute.ts::executeSubstitution`, between the D2 auto-accept
+gate and `renderSubstitution`. This is the ONLY place Layer 3 runs.
+
+**Complexity proxy (v1):**
+
+```
+atomComplexity = transitiveNodes + 5 * exportedSurface + 2 * transitiveDeps
+  where transitiveNodes = spec.inputs.length + spec.outputs.length + spec.guarantees.length
+        exportedSurface = spec.outputs.length (v1 proxy; v2 uses real export count)
+        transitiveDeps  = 0 (v1; not yet exposed by @yakcc/registry)
+
+needComplexity = max(1, bindingsUsed * statementCount)
+  where bindingsUsed  = 1 (v1: caller uses the atom)
+        statementCount = semicolon count in originalCode (rough proxy; v2 uses ts-morph AST)
+
+ratio = atomComplexity / needComplexity
+```
+
+**Gate logic:**
+
+- If `atomComplexity < minFloor` → bypass (micro-atom, no false positives).
+- If `ratio > ratioThreshold` → reject with status `atom-size-too-large`.
+- Otherwise → accept.
+
+## §5.4 Spec Compliance
+
+| Parameter | Default | Config key | Env var |
+|-----------|---------|-----------|---------|
+| `ratioThreshold` | 10 | `layer3.ratioThreshold` | `YAKCC_ATOM_OVERSIZED_RATIO` |
+| `minFloor` | 20 | `layer3.minFloor` | (none; file config only) |
+| `disableGate` | false | `layer3.disableGate` | `YAKCC_HOOK_DISABLE_ATOM_SIZE_GATE=1` |
+
+All thresholds are read from `getEnforcementConfig().layer3` at call time per
+DEC-HOOK-ENF-CONFIG-001. Nothing is hardcoded in `substitute.ts` or `atom-size-ratio.ts`.
+
+## Files Changed
+
+| File | Role |
+|------|------|
+| `src/atom-size-ratio.ts` | Layer 3 module — `AtomLike`, `CallSiteAnalysis`, `computeAtomComplexity`, `computeNeedComplexity`, `enforceAtomSizeRatio`, `isAtomSizeOk` |
+| `src/substitute.ts` | Single plug point — Layer 3 gate wired between D2 accept and `renderSubstitution` |
+| `src/enforcement-config.ts` | `Layer3Config` interface + `layer3` defaults (ratioThreshold=10, minFloor=20) + env var overrides |
+| `src/enforcement-types.ts` | `AtomSizeAcceptEnvelope`, `AtomSizeRejectEnvelope`, `AtomSizeRatioResult` (additive) |
+| `src/telemetry.ts` | `atom-size-too-large` outcome (additive) |
+| `src/atom-size-ratio.test.ts` | Unit tests — 30 cases across computeAtomComplexity, computeNeedComplexity, enforceAtomSizeRatio, isAtomSizeOk, edge cases |
+| `test/atom-size-ratio-integration.test.ts` | Integration tests — Layer 3 through executeSubstitution pipeline |
+| `test/enforcement-eval-corpus.json` | +5 L3-* rows (12 → 17 total) |
+| `test/enforcement-eval-corpus.test.ts` | Layer 3 named cases + structural invariants |
+
+## Authority Invariants
+
+- `enforcement-config.ts` is the SOLE source of truth for Layer 3 thresholds.
+- `substitute.ts` contains the ONLY plug point for Layer 3.
+- S1 (`intent-specificity.ts`) and S2 (`result-set-size.ts`) are untouched.
+- Telemetry is additive only (`atom-size-too-large` joins the outcome union).
+
+## Rollback
+
+`git revert` of this slice is independent of S1/S2. Layer 3 adds a new module
+(`atom-size-ratio.ts`) and a new gate call in `substitute.ts`. Reverting removes
+both without affecting existing enforcement layers.
+
+## Next Slice
+
+S4: Descent tracking (Layer 4) — detects when the LLM skips the descent-and-compose
+discipline by substituting at the wrong level. Implements `DescentTrackingEnvelope`
+(ok | descent_bypass_warning) defined in `enforcement-types.ts` §Layers 4–5 placeholder.


### PR DESCRIPTION
## Summary

Third slice (S3) of #579's 6-layer hook enforcement architecture. Layer 3 enforces atom-complexity-vs-need-complexity at substitution time, refusing substitutions where the candidate atom is significantly larger than the immediate need.

- **Plug point**: `substitute.ts::executeSubstitution` between D2 auto-accept gate and `renderSubstitution` (single plug point per spec)
- **Config-driven**: thresholds read from `enforcement-config.ts` layer3 keys (`ratioThreshold=10`, `minFloor=20`) — DEC-HOOK-ENF-LAYER3-RATIO-THRESHOLD-001 / DEC-HOOK-ENF-LAYER3-MIN-FLOOR-001
- **Escape hatches**: `YAKCC_ATOM_OVERSIZED_RATIO` (override threshold) + `YAKCC_HOOK_DISABLE_ATOM_SIZE_GATE` (full bypass)
- **Reject envelope**: kind `atom-size-too-large` with ratio + decompose request
- **Telemetry additive**: new outcome variant `atom-size-too-large` appended; no existing variants removed
- **Corpus extended**: +5 L3-* rows (12 → 17 total: 7 L1 + 5 L2 + 5 L3)
- **S1 + S2 untouched** (intent-specificity.ts and result-set-size.ts unmodified)

## Test plan

- [x] Layer 3 unit tests (`atom-size-ratio.test.ts`) — pass
- [x] Layer 3 integration tests through `substitute.ts` (`atom-size-ratio-integration.test.ts`) — pass
- [x] 5 new L3-* corpus rows pass via `enforcement-eval-corpus.test.ts`
- [x] All S1 (L1-001..L1-007) + S2 (L2-001..L2-005) corpus rows still pass — no regression
- [x] `pnpm --filter @yakcc/hooks-base test` — 418 pass / 0 fail / 1 pre-existing todo
- [x] Sister hooks-cursor (29/29) + hooks-claude-code (40/40) green
- [x] `pnpm -w lint` + `pnpm -w typecheck` clean
- [x] Reviewer verdict: `ready_for_guardian` (0 blockers / 0 major / 0 minor)
- [x] Scope: hooks-base/ + plans/ + tmp/ only

Closes #591. Refs #579 (closes when all 6 layers ship via S6).