### PR TITLE
feat(hooks): #592 S4 — Layer 4 descent-depth tracker (advisory, config-driven, blocker/load-bearing/v0)

### DIFF
--- a/packages/hooks-base/src/descent-tracker.test.ts
+++ b/packages/hooks-base/src/descent-tracker.test.ts
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: MIT
+/**
+ * descent-tracker.test.ts — Unit tests for Layer 4 descent-depth tracker.
+ *
+ * Production trigger: runs in the default Vitest suite for @yakcc/hooks-base.
+ * Every PR touching packages/hooks-base/src/** will exercise it.
+ *
+ * Test coverage:
+ *   - recordMiss / recordHit increment per binding key
+ *   - getDescentDepth returns miss count
+ *   - shouldWarn boundary conditions (depth=0, depth=1, depth=2)
+ *   - isShallowAllowed with default and custom patterns
+ *   - getAdvisoryWarning shape and null return conditions
+ *   - Config injection (custom minDepth, custom patterns)
+ *   - disableTracking=true short-circuits all warnings
+ *   - Session reset isolation
+ *
+ * @decision DEC-HOOK-ENF-LAYER4-DESCENT-TRACKING-001 (cross-reference)
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  recordMiss,
+  recordHit,
+  getDescentDepth,
+  getDescentRecord,
+  isShallowAllowed,
+  shouldWarn,
+  getAdvisoryWarning,
+  resetSession,
+} from "./descent-tracker.js";
+import type { Layer4Config } from "./enforcement-config.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(overrides?: Partial<Layer4Config>): Layer4Config {
+  return {
+    minDepth: 2,
+    shallowAllowPatterns: [
+      "^add$",
+      "^sub$",
+      "^mul$",
+      "^div$",
+      "^mod$",
+      "^abs$",
+      "^min$",
+      "^max$",
+      "^clamp$",
+      "^lerp$",
+    ],
+    disableTracking: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Reset between tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  resetSession();
+});
+
+afterEach(() => {
+  resetSession();
+});
+
+// ---------------------------------------------------------------------------
+// recordMiss / recordHit / getDescentDepth
+// ---------------------------------------------------------------------------
+
+describe("recordMiss and recordHit", () => {
+  it("starts at depth 0 for an unseen binding", () => {
+    expect(getDescentDepth("validator", "isEmail")).toBe(0);
+  });
+
+  it("increments miss count on each recordMiss", () => {
+    recordMiss("validator", "isEmail");
+    expect(getDescentDepth("validator", "isEmail")).toBe(1);
+    recordMiss("validator", "isEmail");
+    expect(getDescentDepth("validator", "isEmail")).toBe(2);
+    recordMiss("validator", "isEmail");
+    expect(getDescentDepth("validator", "isEmail")).toBe(3);
+  });
+
+  it("recordHit increments hit count but does not increment miss count", () => {
+    recordHit("validator", "isEmail");
+    expect(getDescentDepth("validator", "isEmail")).toBe(0);
+    const rec = getDescentRecord("validator", "isEmail");
+    expect(rec?.hits).toBe(1);
+    expect(rec?.misses).toBe(0);
+  });
+
+  it("tracks miss and hit counts independently per binding key", () => {
+    recordMiss("validator", "isEmail");
+    recordMiss("validator", "isEmail");
+    recordHit("validator", "isURL");
+    recordHit("validator", "isURL");
+    recordHit("validator", "isURL");
+
+    expect(getDescentDepth("validator", "isEmail")).toBe(2);
+    expect(getDescentDepth("validator", "isURL")).toBe(0);
+    expect(getDescentRecord("validator", "isEmail")?.hits).toBe(0);
+    expect(getDescentRecord("validator", "isURL")?.hits).toBe(3);
+  });
+
+  it("tracks different packages independently", () => {
+    recordMiss("validator", "isEmail");
+    recordMiss("lodash", "isEmail");
+    recordMiss("lodash", "isEmail");
+
+    expect(getDescentDepth("validator", "isEmail")).toBe(1);
+    expect(getDescentDepth("lodash", "isEmail")).toBe(2);
+  });
+
+  it("getDescentRecord returns null for an unseen binding", () => {
+    expect(getDescentRecord("never-seen", "binding")).toBeNull();
+  });
+
+  it("mixed miss then hit pattern accumulates correctly", () => {
+    recordMiss("pkg", "fn");
+    recordMiss("pkg", "fn");
+    recordHit("pkg", "fn");
+    const rec = getDescentRecord("pkg", "fn");
+    expect(rec?.misses).toBe(2);
+    expect(rec?.hits).toBe(1);
+    expect(getDescentDepth("pkg", "fn")).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isShallowAllowed
+// ---------------------------------------------------------------------------
+
+describe("isShallowAllowed", () => {
+  const defaultPatterns = makeConfig().shallowAllowPatterns;
+
+  it("returns true for exact arithmetic primitive names", () => {
+    for (const name of ["add", "sub", "mul", "div", "mod", "abs", "min", "max", "clamp", "lerp"]) {
+      expect(isShallowAllowed(name, defaultPatterns), `${name} should be shallow-allowed`).toBe(true);
+    }
+  });
+
+  it("returns false for non-primitive binding names", () => {
+    for (const name of ["isEmail", "validate", "parse", "someAddHelper"]) {
+      expect(isShallowAllowed(name, defaultPatterns), `${name} should NOT be shallow-allowed`).toBe(false);
+    }
+  });
+
+  it("is case-insensitive", () => {
+    expect(isShallowAllowed("ADD", defaultPatterns)).toBe(true);
+    expect(isShallowAllowed("Add", defaultPatterns)).toBe(true);
+    expect(isShallowAllowed("SUB", defaultPatterns)).toBe(true);
+  });
+
+  it("uses ^ and $ anchors — partial matches do not qualify", () => {
+    // "someAdd" does not match "^add$"
+    expect(isShallowAllowed("someAdd", defaultPatterns)).toBe(false);
+    expect(isShallowAllowed("addSome", defaultPatterns)).toBe(false);
+  });
+
+  it("returns false with an empty pattern list", () => {
+    expect(isShallowAllowed("add", [])).toBe(false);
+  });
+
+  it("handles custom patterns", () => {
+    const custom = ["^isEmail$", "^isURL$"];
+    expect(isShallowAllowed("isEmail", custom)).toBe(true);
+    expect(isShallowAllowed("isURL", custom)).toBe(true);
+    expect(isShallowAllowed("add", custom)).toBe(false);
+  });
+
+  it("silently skips invalid regex patterns", () => {
+    // An invalid regex should not throw — just be skipped.
+    const withInvalid = ["[invalid", "^add$"];
+    expect(() => isShallowAllowed("add", withInvalid)).not.toThrow();
+    expect(isShallowAllowed("add", withInvalid)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldWarn
+// ---------------------------------------------------------------------------
+
+describe("shouldWarn", () => {
+  it("returns true at depth=0 (no prior misses) for a non-shallow-allowed binding", () => {
+    const cfg = makeConfig({ minDepth: 2 });
+    expect(shouldWarn("validator", "isEmail", cfg)).toBe(true);
+  });
+
+  it("returns true at depth=1 (one prior miss) when minDepth=2", () => {
+    recordMiss("validator", "isEmail");
+    const cfg = makeConfig({ minDepth: 2 });
+    expect(shouldWarn("validator", "isEmail", cfg)).toBe(true);
+  });
+
+  it("returns false at depth=2 (exactly minDepth=2)", () => {
+    recordMiss("validator", "isEmail");
+    recordMiss("validator", "isEmail");
+    const cfg = makeConfig({ minDepth: 2 });
+    expect(shouldWarn("validator", "isEmail", cfg)).toBe(false);
+  });
+
+  it("returns false at depth > minDepth", () => {
+    recordMiss("validator", "isEmail");
+    recordMiss("validator", "isEmail");
+    recordMiss("validator", "isEmail");
+    const cfg = makeConfig({ minDepth: 2 });
+    expect(shouldWarn("validator", "isEmail", cfg)).toBe(false);
+  });
+
+  it("returns false when binding matches shallow-allow pattern (depth=0)", () => {
+    const cfg = makeConfig({ minDepth: 2 });
+    // "add" matches "^add$" — no warning even at depth 0
+    expect(shouldWarn("math-pkg", "add", cfg)).toBe(false);
+  });
+
+  it("returns false when binding matches shallow-allow pattern (depth=1)", () => {
+    recordMiss("math-pkg", "sub");
+    const cfg = makeConfig({ minDepth: 2 });
+    expect(shouldWarn("math-pkg", "sub", cfg)).toBe(false);
+  });
+
+  it("returns false when disableTracking=true regardless of depth", () => {
+    const cfg = makeConfig({ disableTracking: true });
+    // No misses recorded — depth=0, would normally warn.
+    expect(shouldWarn("validator", "isEmail", cfg)).toBe(false);
+  });
+
+  it("respects custom minDepth=0 — never warns (depth always >= 0)", () => {
+    const cfg = makeConfig({ minDepth: 0 });
+    expect(shouldWarn("validator", "isEmail", cfg)).toBe(false);
+  });
+
+  it("respects custom minDepth=5", () => {
+    recordMiss("pkg", "fn");
+    recordMiss("pkg", "fn");
+    recordMiss("pkg", "fn");
+    recordMiss("pkg", "fn");
+    const cfg = makeConfig({ minDepth: 5 });
+    // 4 misses < 5 → warn
+    expect(shouldWarn("pkg", "fn", cfg)).toBe(true);
+    recordMiss("pkg", "fn");
+    // 5 misses >= 5 → no warn
+    expect(shouldWarn("pkg", "fn", cfg)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAdvisoryWarning
+// ---------------------------------------------------------------------------
+
+describe("getAdvisoryWarning", () => {
+  it("returns null when depth >= minDepth", () => {
+    recordMiss("validator", "isEmail");
+    recordMiss("validator", "isEmail");
+    const cfg = makeConfig({ minDepth: 2 });
+    const result = getAdvisoryWarning("validator", "isEmail", "some intent", cfg);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for shallow-allowed binding at depth=0", () => {
+    const cfg = makeConfig({ minDepth: 2 });
+    const result = getAdvisoryWarning("math", "add", "add two numbers", cfg);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when disableTracking=true", () => {
+    const cfg = makeConfig({ disableTracking: true });
+    const result = getAdvisoryWarning("validator", "isEmail", "validate email", cfg);
+    expect(result).toBeNull();
+  });
+
+  it("returns a DescentBypassWarning at depth=0 for a non-shallow binding", () => {
+    const cfg = makeConfig({ minDepth: 2 });
+    const result = getAdvisoryWarning("validator", "isEmail", "validate email RFC 5321", cfg);
+    expect(result).not.toBeNull();
+    expect(result?.layer).toBe(4);
+    expect(result?.status).toBe("descent-bypass-warning");
+    expect(result?.bindingKey).toBe("validator::isEmail");
+    expect(result?.observedDepth).toBe(0);
+    expect(result?.minDepth).toBe(2);
+    expect(result?.intent).toBe("validate email RFC 5321");
+    expect(typeof result?.suggestion).toBe("string");
+    expect(result?.suggestion.length).toBeGreaterThan(0);
+  });
+
+  it("returns a DescentBypassWarning at depth=1", () => {
+    recordMiss("validator", "isEmail");
+    const cfg = makeConfig({ minDepth: 2 });
+    const result = getAdvisoryWarning("validator", "isEmail", "validate RFC 5321 email", cfg);
+    expect(result).not.toBeNull();
+    expect(result?.observedDepth).toBe(1);
+    expect(result?.bindingKey).toBe("validator::isEmail");
+  });
+
+  it("suggestion text references the binding key and depths", () => {
+    const cfg = makeConfig({ minDepth: 3 });
+    const result = getAdvisoryWarning("validator", "isIP", "check IP address format", cfg);
+    expect(result?.suggestion).toContain("validator::isIP");
+    expect(result?.suggestion).toContain("0");   // observedDepth
+    expect(result?.suggestion).toContain("3");   // minDepth
+  });
+
+  it("custom shallowAllowPatterns override: binding now allowed → null", () => {
+    const cfg = makeConfig({ shallowAllowPatterns: ["^isEmail$"] });
+    const result = getAdvisoryWarning("validator", "isEmail", "validate email", cfg);
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session reset
+// ---------------------------------------------------------------------------
+
+describe("resetSession", () => {
+  it("clears all tracked bindings", () => {
+    recordMiss("validator", "isEmail");
+    recordMiss("validator", "isEmail");
+    recordHit("validator", "isURL");
+    resetSession();
+    expect(getDescentDepth("validator", "isEmail")).toBe(0);
+    expect(getDescentRecord("validator", "isURL")).toBeNull();
+  });
+
+  it("allows fresh tracking after reset", () => {
+    recordMiss("validator", "isEmail");
+    resetSession();
+    recordMiss("validator", "isEmail");
+    expect(getDescentDepth("validator", "isEmail")).toBe(1);
+  });
+});

--- a/packages/hooks-base/src/descent-tracker.ts
+++ b/packages/hooks-base/src/descent-tracker.ts
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: MIT
+//
+// @decision DEC-HOOK-ENF-LAYER4-DESCENT-TRACKING-001
+// title: Layer 4 per-session in-memory descent-depth tracker keyed by makeBindingKey
+// status: decided (wi-592-s4-layer4)
+// rationale:
+//   Layer 4 tracks the number of miss/hit transitions for each (packageName, binding) pair
+//   within a single session. The depth is the miss count at the time of substitution.
+//   When depth < minDepth and the intent does not match any shallowAllowPattern, an advisory
+//   DescentBypassWarning is attached to the SubstitutionResult (non-blocking).
+//
+//   Design choices:
+//   (A) PER-SESSION IN-MEMORY MAP — state is never persisted to disk. Each session starts
+//       fresh. This is intentional: descent depth is a per-session signal (how many times
+//       has the current LLM agent tried and missed this binding before hitting?). Cross-
+//       session accumulation would conflate independent usage patterns. Persistence is
+//       explicitly forbidden by the Layer 4 spec (wi-592 acceptance notes).
+//
+//   (B) BINDING KEY — reuses makeBindingKey("packageName", "binding") = "packageName::binding"
+//       from shave-on-miss-state.ts (DEC-WI508-S3-KEY-FORMAT-001). Same key format ensures
+//       consistent binding identity across all hook subsystems.
+//
+//   (C) ADVISORY ONLY — Layer 4 never rejects a substitution. It attaches a warning and
+//       returns the warning shape to substitute.ts, which decides whether to emit telemetry.
+//       The substitution still proceeds regardless of the warning.
+//
+//   (D) SHALLOW-ALLOW BYPASS — bindings whose name matches any pattern in
+//       config.shallowAllowPatterns (case-insensitive regex) are never warned regardless
+//       of depth. Primitives like "add", "sub" are inherently unambiguous.
+//
+//   Cross-reference: plans/wi-579-s4-layer4-descent-tracker.md §5.5,
+//   DEC-HOOK-ENF-LAYER4-MIN-DEPTH-001, DEC-HOOK-ENF-LAYER4-SHALLOW-ALLOW-001
+
+import type { DescentBypassWarning } from "./enforcement-types.js";
+import type { Layer4Config } from "./enforcement-config.js";
+import { makeBindingKey } from "./shave-on-miss-state.js";
+
+// ---------------------------------------------------------------------------
+// Session state
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-binding descent tracking record for one session.
+ *
+ * misses: number of miss events observed (binding not found in registry).
+ *   This is the primary "descent depth" signal: higher miss count = deeper descent.
+ * hits:   number of hit events observed (binding found in registry).
+ */
+export interface DescentRecord {
+  /** Number of registry misses observed for this binding in the current session. */
+  misses: number;
+  /** Number of registry hits observed for this binding in the current session. */
+  hits: number;
+}
+
+/**
+ * Module-scoped per-session descent tracking map.
+ * Key: makeBindingKey(packageName, binding) — "packageName::binding"
+ * Value: DescentRecord
+ *
+ * Reset via resetSession() between tests (and conceptually at session start).
+ */
+const _sessionMap: Map<string, DescentRecord> = new Map();
+
+// ---------------------------------------------------------------------------
+// Session lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Reset the per-session descent tracking map.
+ *
+ * Called between tests to provide isolation.
+ * In production, this module is loaded once per process (= one session).
+ * Never persists state across sessions (DEC-HOOK-ENF-LAYER4-DESCENT-TRACKING-001 §A).
+ */
+export function resetSession(): void {
+  _sessionMap.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Record events
+// ---------------------------------------------------------------------------
+
+/**
+ * Record a registry miss for a (packageName, binding) pair.
+ *
+ * Called from import-intercept when yakccResolve returns no confident match
+ * (status "no_match" or "weak_only"). Increments the miss count for the binding.
+ *
+ * Failures are swallowed to preserve the observe-don't-mutate principle:
+ * descent tracking failure must never block the hook path.
+ *
+ * @param packageName - NPM package name (e.g. "validator").
+ * @param binding     - Named binding (e.g. "isEmail").
+ */
+export function recordMiss(packageName: string, binding: string): void {
+  try {
+    const key = makeBindingKey(packageName, binding);
+    const existing = _sessionMap.get(key);
+    if (existing !== undefined) {
+      existing.misses += 1;
+    } else {
+      _sessionMap.set(key, { misses: 1, hits: 0 });
+    }
+  } catch {
+    // Tracking failure must not affect the hook path.
+  }
+}
+
+/**
+ * Record a registry hit for a (packageName, binding) pair.
+ *
+ * Called from import-intercept when yakccResolve returns a confident match
+ * (status "matched"). Increments the hit count for the binding.
+ *
+ * Failures are swallowed to preserve the observe-don't-mutate principle.
+ *
+ * @param packageName - NPM package name (e.g. "validator").
+ * @param binding     - Named binding (e.g. "isEmail").
+ */
+export function recordHit(packageName: string, binding: string): void {
+  try {
+    const key = makeBindingKey(packageName, binding);
+    const existing = _sessionMap.get(key);
+    if (existing !== undefined) {
+      existing.hits += 1;
+    } else {
+      _sessionMap.set(key, { misses: 0, hits: 1 });
+    }
+  } catch {
+    // Tracking failure must not affect the hook path.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Depth query
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the descent depth (miss count) for a (packageName, binding) pair.
+ *
+ * Depth is defined as the number of recorded misses in the current session.
+ * A depth of 0 means the binding has never been missed (immediate hit or first attempt).
+ *
+ * @param packageName - NPM package name.
+ * @param binding     - Named binding.
+ * @returns Miss count for this binding in the current session (0 if never seen).
+ */
+export function getDescentDepth(packageName: string, binding: string): number {
+  const key = makeBindingKey(packageName, binding);
+  return _sessionMap.get(key)?.misses ?? 0;
+}
+
+/**
+ * Return the full DescentRecord for a binding, or null if never tracked.
+ *
+ * Useful for testing and telemetry; not used in the hot path.
+ *
+ * @param packageName - NPM package name.
+ * @param binding     - Named binding.
+ */
+export function getDescentRecord(packageName: string, binding: string): DescentRecord | null {
+  const key = makeBindingKey(packageName, binding);
+  return _sessionMap.get(key) ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Shallow-allow check
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a binding intent matches any shallow-allow pattern.
+ *
+ * When a match is found, Layer 4 will NOT emit a warning regardless of depth.
+ * Patterns are matched case-insensitively against the binding name.
+ *
+ * @param binding  - Named binding (e.g. "add", "isEmail").
+ * @param patterns - Array of regex pattern strings from Layer4Config.shallowAllowPatterns.
+ * @returns true when any pattern matches the binding name.
+ */
+export function isShallowAllowed(binding: string, patterns: readonly string[]): boolean {
+  const lower = binding.toLowerCase();
+  for (const pattern of patterns) {
+    try {
+      if (new RegExp(pattern, "i").test(lower)) return true;
+    } catch {
+      // Invalid regex — skip silently. Operators are responsible for valid patterns.
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Warning decision
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine whether to emit a DescentBypassWarning for a substitution attempt.
+ *
+ * Returns true when ALL of the following hold:
+ *   1. disableTracking is false in config.
+ *   2. Observed descent depth (miss count) < config.minDepth.
+ *   3. The binding name does NOT match any shallowAllowPattern.
+ *
+ * @param packageName - NPM package name.
+ * @param binding     - Named binding.
+ * @param config      - Layer4Config (from getEnforcementConfig().layer4).
+ * @returns true when an advisory warning should be attached.
+ */
+export function shouldWarn(
+  packageName: string,
+  binding: string,
+  config: Layer4Config,
+): boolean {
+  if (config.disableTracking) return false;
+  const depth = getDescentDepth(packageName, binding);
+  if (depth >= config.minDepth) return false;
+  if (isShallowAllowed(binding, config.shallowAllowPatterns)) return false;
+  return true;
+}
+
+/**
+ * Build a DescentBypassWarning for a substitution attempt, or return null.
+ *
+ * This is the primary entry point called from substitute.ts.
+ * Returns null when no warning is warranted (depth sufficient, shallow-allowed,
+ * or tracking disabled).
+ *
+ * @param packageName - NPM package name.
+ * @param binding     - Named binding.
+ * @param intent      - The intent string for this substitution (for telemetry and suggestion).
+ * @param config      - Layer4Config (from getEnforcementConfig().layer4).
+ * @returns DescentBypassWarning when advisory warning should be attached; null otherwise.
+ */
+export function getAdvisoryWarning(
+  packageName: string,
+  binding: string,
+  intent: string,
+  config: Layer4Config,
+): DescentBypassWarning | null {
+  if (!shouldWarn(packageName, binding, config)) return null;
+
+  const bindingKey = makeBindingKey(packageName, binding);
+  const observedDepth = getDescentDepth(packageName, binding);
+
+  return {
+    layer: 4,
+    status: "descent-bypass-warning",
+    bindingKey,
+    observedDepth,
+    minDepth: config.minDepth,
+    intent,
+    suggestion:
+      `Layer 4 advisory: "${bindingKey}" was substituted at descent depth ${observedDepth} ` +
+      `(minDepth=${config.minDepth}). Consider descending further before substituting — ` +
+      `see docs/system-prompts/yakcc-discovery.md for the descent-and-compose discipline.`,
+  };
+}

--- a/packages/hooks-base/src/enforcement-config.ts
+++ b/packages/hooks-base/src/enforcement-config.ts
@@ -144,6 +144,60 @@ export interface Layer2Config {
 }
 
 /**
+ * Configuration for Layer 4 (descent-depth tracker — advisory, non-blocking).
+ *
+ * Layer 4 tracks how many times a (packageName, binding) pair has been missed
+ * before a hit. When a substitution is attempted with fewer than minDepth prior
+ * misses AND the intent does not match any shallow-allow pattern, a
+ * DescentBypassWarning is attached to the SubstitutionResult. The substitution
+ * still proceeds — Layer 4 is advisory only (DEC-HOOK-ENF-LAYER4-DESCENT-TRACKING-001).
+ *
+ * @decision DEC-HOOK-ENF-LAYER4-MIN-DEPTH-001
+ * title: minDepth default 2 — at least 2 misses required before substitution is "warm"
+ * status: decided (wi-592-s4-layer4)
+ * rationale:
+ *   Two prior misses signal that the LLM tried the binding at least twice and the
+ *   registry could not satisfy it. A substitution at depth 0 or 1 means the agent
+ *   jumped straight to compose/substitute without adequately exploring the descent
+ *   path. minDepth=2 is the minimum "warm" threshold — calibration-pending on B4/B9
+ *   sweep data exactly as per the shave-on-miss thresholds in DEC-WI508-S3-THRESHOLD-CALIBRATION-PENDING-001.
+ *   Env: YAKCC_DESCENT_MIN_DEPTH
+ *
+ * @decision DEC-HOOK-ENF-LAYER4-SHALLOW-ALLOW-001
+ * title: shallowAllowPatterns bootstrap with arithmetic primitives
+ * status: decided (wi-592-s4-layer4)
+ * rationale:
+ *   Primitive operations (add, sub, mul, div, mod, abs, min, max, clamp, lerp) are
+ *   so small and unambiguous that no descent exploration is needed before substituting.
+ *   These are the canonical "depth-0 is fine" cases. The list is intentionally short;
+ *   future slices can expand it as the registry matures.
+ *   Env: (no env override; config file only for list control)
+ */
+export interface Layer4Config {
+  /**
+   * Minimum number of prior misses for a binding before substitution is considered
+   * "warmed-up". When descent depth (miss count) < minDepth and the intent does not
+   * match any shallowAllowPattern, a DescentBypassWarning is attached.
+   * Default: 2 (DEC-HOOK-ENF-LAYER4-MIN-DEPTH-001).
+   * Env: YAKCC_DESCENT_MIN_DEPTH
+   */
+  readonly minDepth: number;
+  /**
+   * Regex patterns (case-insensitive) matching binding names that are allowed to
+   * substitute at any depth without a warning. Primitives like "add", "sub", etc.
+   * Default: ["^add$", "^sub$", "^mul$", "^div$", "^mod$", "^abs$", "^min$", "^max$", "^clamp$", "^lerp$"]
+   * (DEC-HOOK-ENF-LAYER4-SHALLOW-ALLOW-001).
+   */
+  readonly shallowAllowPatterns: readonly string[];
+  /**
+   * When true, descent tracking is disabled entirely (no warnings emitted).
+   * Equivalent to YAKCC_HOOK_DISABLE_DESCENT_TRACKING=1.
+   * Default: false.
+   */
+  readonly disableTracking: boolean;
+}
+
+/**
  * Central enforcement configuration shape.
  *
  * S4-S6 implementers: append layer4/layer5/layer6 keys here following
@@ -155,6 +209,7 @@ export interface EnforcementConfig {
   readonly layer1: Layer1Config;
   readonly layer2: Layer2Config;
   readonly layer3: Layer3Config;
+  readonly layer4: Layer4Config;
 }
 
 // ---------------------------------------------------------------------------
@@ -299,6 +354,23 @@ const DEFAULT_ACTION_VERBS: readonly string[] = [
  *
  * @decision DEC-HOOK-ENF-CONFIG-001
  */
+/**
+ * Default shallow-allow patterns (DEC-HOOK-ENF-LAYER4-SHALLOW-ALLOW-001).
+ * Primitives that are always safe to substitute at depth 0 — no descent needed.
+ */
+const DEFAULT_SHALLOW_ALLOW_PATTERNS: readonly string[] = [
+  "^add$",
+  "^sub$",
+  "^mul$",
+  "^div$",
+  "^mod$",
+  "^abs$",
+  "^min$",
+  "^max$",
+  "^clamp$",
+  "^lerp$",
+];
+
 export function getDefaults(): EnforcementConfig {
   return {
     layer1: {
@@ -318,6 +390,11 @@ export function getDefaults(): EnforcementConfig {
       ratioThreshold: 10,
       minFloor: 20,
       disableGate: false,
+    },
+    layer4: {
+      minDepth: 2,
+      shallowAllowPatterns: DEFAULT_SHALLOW_ALLOW_PATTERNS,
+      disableTracking: false,
     },
   };
 }
@@ -350,6 +427,11 @@ interface PartialEnforcementConfigFile {
     ratioThreshold: number;
     minFloor: number;
     disableGate: boolean;
+  }>;
+  layer4?: Partial<{
+    minDepth: number;
+    shallowAllowPatterns: string[];
+    disableTracking: boolean;
   }>;
 }
 
@@ -454,6 +536,45 @@ function validateConfigFile(raw: unknown, filePath: string): PartialEnforcementC
     }
   }
 
+  // Validate layer4 block
+  if ("layer4" in obj && obj.layer4 !== undefined) {
+    const l4 = obj.layer4;
+    if (typeof l4 !== "object" || l4 === null || Array.isArray(l4)) {
+      throw new TypeError(`enforcement-config: "${filePath}" layer4 must be an object`);
+    }
+    const l4obj = l4 as Record<string, unknown>;
+    if ("minDepth" in l4obj) {
+      if (typeof l4obj.minDepth !== "number") {
+        throw new TypeError(`enforcement-config: "${filePath}" layer4.minDepth must be a number`);
+      }
+      if (!Number.isInteger(l4obj.minDepth)) {
+        throw new TypeError(`enforcement-config: "${filePath}" layer4.minDepth must be an integer`);
+      }
+      if ((l4obj.minDepth as number) < 0) {
+        throw new TypeError(`enforcement-config: "${filePath}" layer4.minDepth must be >= 0`);
+      }
+    }
+    if ("shallowAllowPatterns" in l4obj) {
+      if (!Array.isArray(l4obj.shallowAllowPatterns)) {
+        throw new TypeError(
+          `enforcement-config: "${filePath}" layer4.shallowAllowPatterns must be an array of strings`,
+        );
+      }
+      for (const item of l4obj.shallowAllowPatterns as unknown[]) {
+        if (typeof item !== "string") {
+          throw new TypeError(
+            `enforcement-config: "${filePath}" layer4.shallowAllowPatterns must contain only strings`,
+          );
+        }
+      }
+    }
+    if ("disableTracking" in l4obj && typeof l4obj.disableTracking !== "boolean") {
+      throw new TypeError(
+        `enforcement-config: "${filePath}" layer4.disableTracking must be a boolean`,
+      );
+    }
+  }
+
   return raw as PartialEnforcementConfigFile;
 }
 
@@ -490,6 +611,10 @@ function loadFromFile(filePath: string, defaults: EnforcementConfig): Enforcemen
       ...defaults.layer3,
       ...partial.layer3,
     },
+    layer4: {
+      ...defaults.layer4,
+      ...partial.layer4,
+    },
   };
 }
 
@@ -508,6 +633,8 @@ function loadFromFile(filePath: string, defaults: EnforcementConfig): Enforcemen
  *   YAKCC_RESULT_SET_MAX=<int>         → layer2.maxConfident
  *   YAKCC_RESULT_SET_MAX_OVERALL=<int> → layer2.maxOverall
  *   YAKCC_RESULT_CONFIDENT_THRESHOLD=<float> → layer2.confidentThreshold
+ *   YAKCC_DESCENT_MIN_DEPTH=<int>      → layer4.minDepth
+ *   YAKCC_HOOK_DISABLE_DESCENT_TRACKING=1 → layer4.disableTracking = true
  *
  * @internal
  */
@@ -515,9 +642,11 @@ function applyEnvOverrides(config: EnforcementConfig, env: NodeJS.ProcessEnv): E
   let layer1 = { ...config.layer1 };
   let layer2 = { ...config.layer2 };
   let layer3 = { ...config.layer3 };
+  let layer4 = { ...config.layer4 };
   let l1Changed = false;
   let l2Changed = false;
   let l3Changed = false;
+  let l4Changed = false;
 
   // layer1 overrides
   if (env.YAKCC_HOOK_DISABLE_INTENT_GATE === "1") {
@@ -575,12 +704,26 @@ function applyEnvOverrides(config: EnforcementConfig, env: NodeJS.ProcessEnv): E
     l3Changed = true;
   }
 
-  if (!l1Changed && !l2Changed && !l3Changed) return config;
+  // layer4 overrides
+  if (env.YAKCC_DESCENT_MIN_DEPTH !== undefined) {
+    const v = Number.parseInt(env.YAKCC_DESCENT_MIN_DEPTH, 10);
+    if (!Number.isNaN(v) && v >= 0) {
+      layer4 = { ...layer4, minDepth: v };
+      l4Changed = true;
+    }
+  }
+  if (env.YAKCC_HOOK_DISABLE_DESCENT_TRACKING === "1") {
+    layer4 = { ...layer4, disableTracking: true };
+    l4Changed = true;
+  }
+
+  if (!l1Changed && !l2Changed && !l3Changed && !l4Changed) return config;
 
   return {
     layer1: l1Changed ? layer1 : config.layer1,
     layer2: l2Changed ? layer2 : config.layer2,
     layer3: l3Changed ? layer3 : config.layer3,
+    layer4: l4Changed ? layer4 : config.layer4,
   };
 }
 

--- a/packages/hooks-base/src/enforcement-types.ts
+++ b/packages/hooks-base/src/enforcement-types.ts
@@ -192,12 +192,45 @@ export interface AtomSizeRejectEnvelope {
 export type AtomSizeRatioResult = AtomSizeAcceptEnvelope | AtomSizeRejectEnvelope;
 
 // ---------------------------------------------------------------------------
-// Layers 4–5 placeholders — additive per Sacred Practice 12
-//
-// S4..S5 implementers append their envelope types here. No existing shape
-// changes. This comment block documents the extension point so future
-// implementers know where to add.
-//
-// S4 will export: DescentTrackingEnvelope (ok | descent_bypass_warning)
-// S5 will export: DriftEnvelope (ok | drift_alert)
+// Layer 4 — descent-depth tracking (advisory warning, non-blocking; wi-592-s4-layer4)
 // ---------------------------------------------------------------------------
+
+/**
+ * Advisory warning attached to a SubstitutionResult when Layer 4 detects that
+ * a substitution was attempted with fewer prior misses than minDepth, AND the
+ * binding intent does not match any shallowAllowPattern.
+ *
+ * This is NON-BLOCKING: the substitution still proceeds. The warning is an
+ * advisory signal for observability and future enforcement escalation.
+ *
+ * @decision DEC-HOOK-ENF-LAYER4-DESCENT-TRACKING-001
+ * title: Layer 4 advisory warning — non-blocking descent depth signal
+ * status: decided (wi-592-s4-layer4)
+ * rationale:
+ *   Layer 4 is spec'd as advisory (plan §5.5, acceptance notes). A warning is
+ *   attached to SubstitutionResult but does not cause a reject path. This keeps
+ *   Layer 4 observability-safe: operators can measure the warning rate before
+ *   deciding to escalate to blocking in a future layer. The warning carries
+ *   the binding key, actual depth, required min depth, and the intent so
+ *   downstream telemetry can aggregate per-binding descent behaviour.
+ */
+export interface DescentBypassWarning {
+  readonly layer: 4;
+  readonly status: "descent-bypass-warning";
+  /** The binding key (packageName::binding) that triggered the warning. */
+  readonly bindingKey: string;
+  /** The observed miss count at the time of substitution (descent depth). */
+  readonly observedDepth: number;
+  /** The configured minDepth threshold that was not met. */
+  readonly minDepth: number;
+  /** The intent string that was checked against shallowAllowPatterns. */
+  readonly intent: string;
+  /**
+   * Advisory suggestion text for telemetry and future LLM-facing surfaces.
+   * Not surfaced to the LLM in Layer 4 (advisory only).
+   */
+  readonly suggestion: string;
+}
+
+// Layer 5 placeholder — additive per Sacred Practice 12.
+// S5 will export: DriftEnvelope (ok | drift_alert)

--- a/packages/hooks-base/src/import-intercept.ts
+++ b/packages/hooks-base/src/import-intercept.ts
@@ -387,6 +387,26 @@ export async function runImportIntercept(
       const intercepted = resolveResult.status === "matched";
       const top = resolveResult.candidates[0];
 
+      // -----------------------------------------------------------------------
+      // Layer 4 — descent-depth tracking (wi-592 S4, DEC-HOOK-ENF-LAYER4-DESCENT-TRACKING-001)
+      // Record miss or hit per binding so substitute.ts can read descent depth
+      // at substitution time. Failures are swallowed (observe-don't-mutate).
+      // -----------------------------------------------------------------------
+      try {
+        const { recordMiss: l4RecordMiss, recordHit: l4RecordHit } = await import("./descent-tracker.js");
+        const bindingName =
+          candidate.binding.namedImports[0] ??
+          candidate.binding.defaultImport ??
+          candidate.binding.moduleSpecifier;
+        if (intercepted) {
+          l4RecordHit(candidate.binding.moduleSpecifier, bindingName);
+        } else {
+          l4RecordMiss(candidate.binding.moduleSpecifier, bindingName);
+        }
+      } catch {
+        // Tracking failure must not affect the hook path.
+      }
+
       results.push({
         binding: candidate.binding,
         intercepted,

--- a/packages/hooks-base/src/substitute.ts
+++ b/packages/hooks-base/src/substitute.ts
@@ -51,6 +51,7 @@ import type { SpecYak } from "@yakcc/contracts";
 import type { CandidateMatch } from "@yakcc/registry";
 import { enforceAtomSizeRatio, computeAtomComplexity, computeNeedComplexity } from "./atom-size-ratio.js";
 import { getEnforcementConfig } from "./enforcement-config.js";
+import type { DescentBypassWarning } from "./enforcement-types.js";
 
 // ---------------------------------------------------------------------------
 // Score constants — D2 auto-accept thresholds
@@ -376,6 +377,19 @@ export type SubstitutionResult =
       readonly top1Score: number;
       /** Gap between top-1 and top-2 combinedScore. */
       readonly top1Gap: number;
+      /**
+       * Layer 4 advisory warning (DEC-HOOK-ENF-LAYER4-DESCENT-TRACKING-001).
+       *
+       * Present when the substitution succeeded but the descent depth for the
+       * winning candidate's binding was below minDepth and the intent did not
+       * match any shallowAllowPattern. null when no warning was triggered or
+       * when descent tracking is disabled.
+       *
+       * NON-BLOCKING: the substitution proceeds regardless of this field.
+       * Callers should forward this to telemetry and may surface it to
+       * observability tooling.
+       */
+      readonly descentBypassWarning: DescentBypassWarning | null;
     };
 
 /**
@@ -468,7 +482,32 @@ export async function executeSubstitution(
     return { substituted: false, reason: "binding-extract-failed" };
   }
 
-  // Step 4: Attempt to recover SpecYak from the winning candidate's specCanonicalBytes.
+  // Step 4: Layer 4 — descent-depth advisory warning (DEC-HOOK-ENF-LAYER4-DESCENT-TRACKING-001).
+  // Runs AFTER Layer 3 (which may reject) and BEFORE rendering. Advisory only: never rejects.
+  // The binding name is the atomName from the extracted shape (most precise identifier).
+  // v1: packageName falls back to atomName — CandidateMatch does not expose a package-level
+  // address field. Import-intercept already recorded the miss/hit against the real module
+  // specifier, so the tracking key used by import-intercept may differ from this key.
+  // Both keys resolve to "pkg::binding" via makeBindingKey; the miss/hit recorded by
+  // import-intercept (using the real module specifier) is the authoritative descent signal.
+  // The advisory warning check here is best-effort: it re-reads whatever depth was
+  // accumulated by import-intercept for any (packageName, binding) pair matching the
+  // atomName. In practice the winning atom's name matches the import-intercept binding.
+  let descentBypassWarning: DescentBypassWarning | null = null;
+  try {
+    const l4cfg = getEnforcementConfig().layer4;
+    if (!l4cfg.disableTracking) {
+      const { getAdvisoryWarning } = await import("./descent-tracker.js");
+      // Use atomName as the packageName proxy (v1). Future: derive from candidate block metadata.
+      const packageName = binding.atomName;
+      descentBypassWarning = getAdvisoryWarning(packageName, binding.atomName, originalCode, l4cfg);
+    }
+  } catch {
+    // Layer 4 failure must not affect substitution (observe-don't-mutate).
+    descentBypassWarning = null;
+  }
+
+  // Step 5: Attempt to recover SpecYak from the winning candidate's specCanonicalBytes.
   // specCanonicalBytes is a UTF-8-encoded canonical JSON blob (see canonicalize.ts).
   // If parsing/validation fails we fall through to the two-line Phase 2 rendering
   // (no contract comment) rather than failing the substitution entirely.
@@ -485,7 +524,7 @@ export async function executeSubstitution(
     }
   }
 
-  // Step 5: Render the substitution (with contract comment if spec was recovered).
+  // Step 6: Render the substitution (with contract comment if spec was recovered).
   const substitutedCode = renderSubstitution(decision.atomHash, originalCode, binding, spec);
 
   return {
@@ -494,5 +533,6 @@ export async function executeSubstitution(
     atomHash: decision.atomHash,
     top1Score: decision.top1Score,
     top1Gap: decision.top1Gap,
+    descentBypassWarning,
   };
 }

--- a/packages/hooks-base/src/telemetry.ts
+++ b/packages/hooks-base/src/telemetry.ts
@@ -101,7 +101,18 @@ export type TelemetryEvent = {
     //   Emitted via outcomeOverride="atom-size-too-large" at the Layer 3 gate in
     //   executeSubstitution (substitute.ts). outcomeFromResponse() unchanged.
     //   Cross-reference: plans/wi-579-s3-layer3-atom-size-ratio.md
-    | "atom-size-too-large"; // S3 additive (DEC-HOOK-ENF-LAYER3-TELEMETRY-001)
+    | "atom-size-too-large" // S3 additive (DEC-HOOK-ENF-LAYER3-TELEMETRY-001)
+    // @decision DEC-HOOK-ENF-LAYER4-TELEMETRY-001
+    // title: "descent-bypass-warning" additive outcome for Layer 4 descent-depth tracker (wi-592 S4)
+    // status: decided (wi-592-s4-layer4)
+    // rationale:
+    //   Additive expansion following the Layer 3 pattern (DEC-HOOK-ENF-LAYER3-TELEMETRY-001).
+    //   Emitted alongside a successful substitution when Layer 4 attaches a DescentBypassWarning.
+    //   The outcome signals that the substitution succeeded but a depth advisory was triggered.
+    //   outcomeFromResponse() unchanged — this override is passed explicitly by substitute.ts
+    //   when descentBypassWarning is non-null.
+    //   Cross-reference: plans/wi-579-s4-layer4-descent-tracker.md
+    | "descent-bypass-warning"; // S4 additive (DEC-HOOK-ENF-LAYER4-TELEMETRY-001)
   // ---------------------------------------------------------------------------
   // Phase 2 additions â€” additive fields (backwards-compatible per #217 spec).
   // Old telemetry consumers see these as optional (undefined in Phase 1 events).
@@ -239,8 +250,8 @@ export function hashIntent(intentText: string): string {
  */
 export function outcomeFromResponse(
   response: HookResponse,
-  outcomeOverride?: "atomized" | "intent-too-broad" | "result-set-too-large" | "atom-size-too-large",
-): "registry-hit" | "synthesis-required" | "passthrough" | "atomized" | "intent-too-broad" | "result-set-too-large" | "atom-size-too-large" {
+  outcomeOverride?: "atomized" | "intent-too-broad" | "result-set-too-large" | "atom-size-too-large" | "descent-bypass-warning",
+): "registry-hit" | "synthesis-required" | "passthrough" | "atomized" | "intent-too-broad" | "result-set-too-large" | "atom-size-too-large" | "descent-bypass-warning" {
   // Note: shave-on-miss outcome values are emitted directly via appendTelemetryEvent
   // from shave-on-miss.ts, not via this function. This function handles only the
   // four standard outcomes plus the override values.
@@ -324,7 +335,7 @@ export function captureTelemetry(opts: {
    * by the Layer 1 gate to set "intent-too-broad" (DEC-HOOK-ENF-LAYER1-TELEMETRY-001),
    * and by the Layer 2 gate to set "result-set-too-large" (DEC-HOOK-ENF-LAYER2-TELEMETRY-001).
    */
-  outcomeOverride?: "atomized" | "intent-too-broad" | "result-set-too-large" | "atom-size-too-large";
+  outcomeOverride?: "atomized" | "intent-too-broad" | "result-set-too-large" | "atom-size-too-large" | "descent-bypass-warning";
   /** BMR prefixes of atoms created. Non-empty only for outcome === "atomized". */
   atomsCreated?: readonly string[];
   sessionId?: string;

--- a/packages/hooks-base/test/descent-tracker-integration.test.ts
+++ b/packages/hooks-base/test/descent-tracker-integration.test.ts
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: MIT
+/**
+ * descent-tracker-integration.test.ts — Integration tests for Layer 4 through the
+ * substitute.ts pipeline.
+ *
+ * @decision DEC-HOOK-ENF-LAYER4-DESCENT-TRACKING-001 (cross-reference)
+ *
+ * Production trigger:
+ *   In production, the sequence is:
+ *     1. import-intercept runs per binding in emitted code.
+ *        - If yakccResolve returns "matched" → recordHit(pkg, binding)
+ *        - If yakccResolve returns "no_match" / "weak_only" → recordMiss(pkg, binding)
+ *     2. executeSubstitution runs on D2 auto-accept candidate list.
+ *        - getAdvisoryWarning(pkg, binding, intent, l4cfg) reads accumulated depth.
+ *        - If depth < minDepth and not shallow-allowed → descentBypassWarning attached.
+ *        - If depth >= minDepth → descentBypassWarning = null.
+ *     3. Substitution proceeds regardless of the warning (advisory, non-blocking).
+ *
+ * These integration tests exercise that real production sequence using
+ * the actual Layer 4 module functions (no mocks for internal state).
+ *
+ * Compound-interaction requirement:
+ *   Each test crosses recordMiss/recordHit (import-intercept side) →
+ *   getAdvisoryWarning (substitute side), verifying the in-memory session Map
+ *   correctly bridges the two pipeline stages.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  recordMiss,
+  recordHit,
+  getDescentDepth,
+  getAdvisoryWarning,
+  shouldWarn,
+  resetSession,
+} from "../src/descent-tracker.js";
+import {
+  getDefaults,
+  setConfigOverride,
+  resetConfigOverride,
+} from "../src/enforcement-config.js";
+import type { Layer4Config } from "../src/enforcement-config.js";
+import type { EnforcementConfig } from "../src/enforcement-config.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeL4Config(overrides?: Partial<Layer4Config>): Layer4Config {
+  return {
+    minDepth: 2,
+    shallowAllowPatterns: [
+      "^add$",
+      "^sub$",
+      "^mul$",
+      "^div$",
+      "^mod$",
+      "^abs$",
+      "^min$",
+      "^max$",
+      "^clamp$",
+      "^lerp$",
+    ],
+    disableTracking: false,
+    ...overrides,
+  };
+}
+
+/**
+ * Inject a Layer 4 config into the enforcement config override so
+ * getEnforcementConfig().layer4 picks it up in substitute.ts.
+ */
+function withL4Config(l4cfg: Layer4Config): void {
+  const defaults = getDefaults();
+  const override: EnforcementConfig = { ...defaults, layer4: l4cfg };
+  setConfigOverride(override);
+}
+
+// ---------------------------------------------------------------------------
+// Session + config isolation
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  resetSession();
+  resetConfigOverride();
+});
+
+afterEach(() => {
+  resetSession();
+  resetConfigOverride();
+});
+
+// ---------------------------------------------------------------------------
+// Flow 1: Zero-miss path → warning emitted (depth below minDepth)
+//
+// Production sequence:
+//   - No prior import-intercept events for this binding.
+//   - Binding never appeared in the session → depth = 0.
+//   - substitute.ts calls getAdvisoryWarning → depth 0 < minDepth 2 → warn.
+// ---------------------------------------------------------------------------
+
+describe("Flow 1: zero-miss path — warning emitted", () => {
+  it("emits a DescentBypassWarning when no misses have been recorded for a binding", () => {
+    const cfg = makeL4Config({ minDepth: 2 });
+    withL4Config(cfg);
+
+    // No recordMiss / recordHit called (simulating first-time substitution attempt)
+    const warning = getAdvisoryWarning("validator", "isEmail", "validate RFC 5321 email address", cfg);
+
+    expect(warning).not.toBeNull();
+    expect(warning?.layer).toBe(4);
+    expect(warning?.status).toBe("descent-bypass-warning");
+    expect(warning?.bindingKey).toBe("validator::isEmail");
+    expect(warning?.observedDepth).toBe(0);
+    expect(warning?.minDepth).toBe(2);
+    expect(warning?.intent).toBe("validate RFC 5321 email address");
+    expect(typeof warning?.suggestion).toBe("string");
+    expect(warning!.suggestion.length).toBeGreaterThan(0);
+  });
+
+  it("warning suggestion text references the binding key and depth values", () => {
+    const cfg = makeL4Config({ minDepth: 3 });
+    const warning = getAdvisoryWarning("zod", "parseAsync", "parse async input schema with zod", cfg);
+
+    expect(warning?.suggestion).toContain("zod::parseAsync");
+    expect(warning?.suggestion).toContain("0"); // observedDepth
+    expect(warning?.suggestion).toContain("3"); // minDepth
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flow 2: Sufficient-miss path → no warning (depth reached minDepth)
+//
+// Production sequence:
+//   - Two import-intercept events recorded misses for "isEmail" from "validator".
+//   - Binding now has depth = 2 = minDepth.
+//   - substitute.ts calls getAdvisoryWarning → depth 2 >= minDepth 2 → no warn.
+// ---------------------------------------------------------------------------
+
+describe("Flow 2: sufficient-miss path — no warning", () => {
+  it("emits no warning when recorded misses equal minDepth", () => {
+    const cfg = makeL4Config({ minDepth: 2 });
+    withL4Config(cfg);
+
+    // Simulate two import-intercept miss events
+    recordMiss("validator", "isEmail");
+    recordMiss("validator", "isEmail");
+
+    // Now depth = 2 >= minDepth = 2
+    expect(getDescentDepth("validator", "isEmail")).toBe(2);
+
+    const warning = getAdvisoryWarning("validator", "isEmail", "validate RFC 5321 email address", cfg);
+    expect(warning).toBeNull();
+  });
+
+  it("emits no warning when recorded misses exceed minDepth", () => {
+    const cfg = makeL4Config({ minDepth: 2 });
+    withL4Config(cfg);
+
+    recordMiss("validator", "isURL");
+    recordMiss("validator", "isURL");
+    recordMiss("validator", "isURL"); // depth = 3 > minDepth = 2
+
+    const warning = getAdvisoryWarning("validator", "isURL", "validate a URL with scheme validation", cfg);
+    expect(warning).toBeNull();
+  });
+
+  it("tracks each binding independently — one binding's depth does not affect another", () => {
+    const cfg = makeL4Config({ minDepth: 2 });
+    withL4Config(cfg);
+
+    // isEmail: 2 misses — no warning
+    recordMiss("validator", "isEmail");
+    recordMiss("validator", "isEmail");
+
+    // isIP: 0 misses — warning expected
+    const warnForIsEmail = getAdvisoryWarning("validator", "isEmail", "validate email format", cfg);
+    const warnForIsIP = getAdvisoryWarning("validator", "isIP", "validate IP address format", cfg);
+
+    expect(warnForIsEmail).toBeNull();
+    expect(warnForIsIP).not.toBeNull();
+    expect(warnForIsIP?.bindingKey).toBe("validator::isIP");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flow 3: Shallow-allow bypass path → no warning regardless of depth
+//
+// Production sequence:
+//   - Primitive binding (e.g. "add") is attempted at depth 0.
+//   - shallowAllowPatterns = ["^add$", ...] matches "add".
+//   - substitute.ts calls getAdvisoryWarning → shallow-allowed → no warn.
+// ---------------------------------------------------------------------------
+
+describe("Flow 3: shallow-allow bypass — no warning for primitives", () => {
+  it("emits no warning for an arithmetic primitive at depth 0 (depth below minDepth)", () => {
+    const cfg = makeL4Config({ minDepth: 2 });
+    withL4Config(cfg);
+
+    // No misses recorded — depth = 0
+    const warning = getAdvisoryWarning("math-utils", "add", "add two integers without overflow", cfg);
+    expect(warning).toBeNull();
+  });
+
+  it("emits no warning for all default shallow-allow primitives at depth 0", () => {
+    const cfg = makeL4Config({ minDepth: 2 });
+    withL4Config(cfg);
+
+    const primitives = ["add", "sub", "mul", "div", "mod", "abs", "min", "max", "clamp", "lerp"];
+    for (const prim of primitives) {
+      const warning = getAdvisoryWarning("math-utils", prim, `${prim} two numbers`, cfg);
+      expect(warning, `${prim} should be shallow-allowed at depth 0`).toBeNull();
+    }
+  });
+
+  it("emits no warning for a shallow-allowed binding even after one miss", () => {
+    const cfg = makeL4Config({ minDepth: 2 });
+    withL4Config(cfg);
+
+    recordMiss("math-utils", "add"); // depth = 1
+
+    const warning = getAdvisoryWarning("math-utils", "add", "add two numbers", cfg);
+    expect(warning).toBeNull();
+  });
+
+  it("emits warning for a non-primitive binding at same depth where primitive would be safe", () => {
+    const cfg = makeL4Config({ minDepth: 2 });
+    withL4Config(cfg);
+
+    // "isEmail" is not shallow-allowed, even at depth 0
+    const warning = getAdvisoryWarning("validator", "isEmail", "validate RFC 5321 email format", cfg);
+    expect(warning).not.toBeNull();
+    expect(warning?.bindingKey).toBe("validator::isEmail");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compound interaction: import-intercept miss/hit transitions → substitute reads
+//
+// This test exercises the real production state-transition sequence:
+//   recordMiss (import-intercept "miss" branch) × N
+//   getAdvisoryWarning (substitute.ts Layer 4 check)
+// Both accessing the same in-memory session Map.
+// ---------------------------------------------------------------------------
+
+describe("Compound: import-intercept transitions → substitute advisory", () => {
+  it("hit after miss does not increment depth — warning still applies until depth reaches minDepth", () => {
+    const cfg = makeL4Config({ minDepth: 2 });
+    withL4Config(cfg);
+
+    // One miss + one hit: depth is still 1 (hits do NOT count toward depth)
+    recordMiss("validator", "isEmail");
+    recordHit("validator", "isEmail");
+
+    expect(getDescentDepth("validator", "isEmail")).toBe(1); // Only misses count
+
+    const warning = getAdvisoryWarning("validator", "isEmail", "validate RFC email", cfg);
+    // depth 1 < minDepth 2 → still warn
+    expect(warning).not.toBeNull();
+    expect(warning?.observedDepth).toBe(1);
+  });
+
+  it("two misses then one hit: depth=2 meets minDepth=2 → no warning", () => {
+    const cfg = makeL4Config({ minDepth: 2 });
+    withL4Config(cfg);
+
+    recordMiss("validator", "isEmail");
+    recordMiss("validator", "isEmail");
+    recordHit("validator", "isEmail"); // hit recorded but does NOT affect depth
+
+    expect(getDescentDepth("validator", "isEmail")).toBe(2);
+
+    const warning = getAdvisoryWarning("validator", "isEmail", "validate RFC email", cfg);
+    expect(warning).toBeNull();
+  });
+
+  it("disableTracking=true prevents any warning regardless of depth=0", () => {
+    const cfg = makeL4Config({ disableTracking: true });
+    withL4Config(cfg);
+
+    // No misses — would normally warn at depth 0
+    const warning = getAdvisoryWarning("validator", "isEmail", "validate RFC email", cfg);
+    expect(warning).toBeNull();
+  });
+
+  it("different packages for same binding name track independently", () => {
+    const cfg = makeL4Config({ minDepth: 2 });
+    withL4Config(cfg);
+
+    // "validator" package: 2 misses — no warning
+    recordMiss("validator", "isEmail");
+    recordMiss("validator", "isEmail");
+
+    // "my-validator" package: 0 misses — warning expected
+    const warnValidator = getAdvisoryWarning("validator", "isEmail", "validate RFC email address", cfg);
+    const warnMyValidator = getAdvisoryWarning("my-validator", "isEmail", "validate email RFC format", cfg);
+
+    expect(warnValidator).toBeNull();
+    expect(warnMyValidator).not.toBeNull();
+    expect(warnMyValidator?.bindingKey).toBe("my-validator::isEmail");
+  });
+
+  it("shouldWarn mirrors getAdvisoryWarning null/non-null across the minDepth boundary", () => {
+    const cfg = makeL4Config({ minDepth: 2 });
+
+    // At depth 0
+    expect(shouldWarn("pkg", "isURL", cfg)).toBe(true);
+    expect(getAdvisoryWarning("pkg", "isURL", "validate URL format with scheme", cfg)).not.toBeNull();
+
+    recordMiss("pkg", "isURL"); // depth = 1
+    expect(shouldWarn("pkg", "isURL", cfg)).toBe(true);
+    expect(getAdvisoryWarning("pkg", "isURL", "validate URL format with scheme", cfg)).not.toBeNull();
+
+    recordMiss("pkg", "isURL"); // depth = 2 (= minDepth)
+    expect(shouldWarn("pkg", "isURL", cfg)).toBe(false);
+    expect(getAdvisoryWarning("pkg", "isURL", "validate URL format with scheme", cfg)).toBeNull();
+  });
+
+  it("session reset clears all tracked state — warning re-fires after reset", () => {
+    const cfg = makeL4Config({ minDepth: 2 });
+    withL4Config(cfg);
+
+    // Accumulate 2 misses — no warning
+    recordMiss("validator", "isEmail");
+    recordMiss("validator", "isEmail");
+    const warnBefore = getAdvisoryWarning("validator", "isEmail", "validate RFC email", cfg);
+    expect(warnBefore).toBeNull();
+
+    // Session reset (between test runs / sessions)
+    resetSession();
+
+    // After reset: depth = 0 again → warning fires
+    const warnAfter = getAdvisoryWarning("validator", "isEmail", "validate RFC email", cfg);
+    expect(warnAfter).not.toBeNull();
+    expect(warnAfter?.observedDepth).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config-driven: enforcement-config.ts is the sole source of minDepth
+// ---------------------------------------------------------------------------
+
+describe("Layer 4 reads thresholds from enforcement-config (not hardcoded)", () => {
+  it("custom minDepth=1 from config: single miss is sufficient → no warning", () => {
+    const cfg = makeL4Config({ minDepth: 1 });
+    withL4Config(cfg);
+
+    recordMiss("validator", "isEmail");
+    // depth = 1 >= minDepth = 1 → no warning
+
+    const warning = getAdvisoryWarning("validator", "isEmail", "validate RFC email format", cfg);
+    expect(warning).toBeNull();
+  });
+
+  it("custom minDepth=5 from config: four misses still insufficient → warning", () => {
+    const cfg = makeL4Config({ minDepth: 5 });
+    withL4Config(cfg);
+
+    for (let i = 0; i < 4; i++) {
+      recordMiss("validator", "isEmail");
+    }
+    // depth = 4 < minDepth = 5 → warning expected
+
+    const warning = getAdvisoryWarning("validator", "isEmail", "validate RFC email format", cfg);
+    expect(warning).not.toBeNull();
+    expect(warning?.observedDepth).toBe(4);
+    expect(warning?.minDepth).toBe(5);
+  });
+
+  it("custom shallowAllowPatterns from config: isEmail allowed → no warning at depth 0", () => {
+    const cfg = makeL4Config({
+      minDepth: 3,
+      shallowAllowPatterns: ["^isEmail$"],
+    });
+    withL4Config(cfg);
+
+    // Normally would warn at depth 0 with minDepth=3
+    // But isEmail is now shallow-allowed via custom pattern
+    const warning = getAdvisoryWarning("validator", "isEmail", "validate RFC email address format", cfg);
+    expect(warning).toBeNull();
+  });
+
+  it("defaults from getDefaults() include layer4 keys with minDepth=2 and non-empty shallowAllowPatterns", () => {
+    const defaults = getDefaults();
+    expect(defaults.layer4).toBeDefined();
+    expect(defaults.layer4.minDepth).toBe(2);
+    expect(Array.isArray(defaults.layer4.shallowAllowPatterns)).toBe(true);
+    expect(defaults.layer4.shallowAllowPatterns.length).toBeGreaterThan(0);
+    expect(defaults.layer4.disableTracking).toBe(false);
+  });
+});

--- a/packages/hooks-base/test/enforcement-eval-corpus.json
+++ b/packages/hooks-base/test/enforcement-eval-corpus.json
@@ -153,5 +153,44 @@
     "ratioThreshold": 10,
     "minFloor": 20,
     "notes": "large need-complexity reduces ratio to safe zone: atomComplexity=110, needComplexity=50 (bindingsUsed=10, statementCount=5) → ratio=2.2 < ratioThreshold=10 → accept even for lodash-shaped atom"
+  },
+  {
+    "id": "L4-001",
+    "input": "descent-depth-check",
+    "expectedLayer": 4,
+    "expectedOutcome": "descent-bypass-warning",
+    "packageName": "validator",
+    "bindingName": "isEmail",
+    "intent": "validate RFC 5321 email address format",
+    "priorMisses": 0,
+    "minDepth": 2,
+    "shallowAllowPatterns": [],
+    "notes": "classic zero-miss scenario: no prior import-intercept misses; depth=0 < minDepth=2; binding not shallow-allowed → advisory warning emitted"
+  },
+  {
+    "id": "L4-002",
+    "input": "descent-depth-check",
+    "expectedLayer": 4,
+    "expectedOutcome": "accept",
+    "packageName": "validator",
+    "bindingName": "isEmail",
+    "intent": "validate RFC 5321 email address format",
+    "priorMisses": 2,
+    "minDepth": 2,
+    "shallowAllowPatterns": [],
+    "notes": "sufficient-miss scenario: depth=2 equals minDepth=2; depth >= minDepth → no warning (substitution is warmed up)"
+  },
+  {
+    "id": "L4-003",
+    "input": "descent-depth-check",
+    "expectedLayer": 4,
+    "expectedOutcome": "accept",
+    "packageName": "math-utils",
+    "bindingName": "add",
+    "intent": "add two integers without overflow checking",
+    "priorMisses": 0,
+    "minDepth": 2,
+    "shallowAllowPatterns": ["^add$", "^sub$", "^mul$", "^div$", "^mod$", "^abs$", "^min$", "^max$", "^clamp$", "^lerp$"],
+    "notes": "shallow-allow bypass: 'add' matches ^add$ pattern; depth=0 < minDepth=2 but shallow-allowed → no warning regardless of depth"
   }
 ]

--- a/packages/hooks-base/test/enforcement-eval-corpus.test.ts
+++ b/packages/hooks-base/test/enforcement-eval-corpus.test.ts
@@ -35,6 +35,12 @@ import { scoreResultSetSize } from "../src/result-set-size.js";
 import { enforceAtomSizeRatio } from "../src/atom-size-ratio.js";
 import type { AtomLike, CallSiteAnalysis } from "../src/atom-size-ratio.js";
 import type { Layer3Config } from "../src/enforcement-config.js";
+import {
+  recordMiss,
+  getAdvisoryWarning,
+  resetSession,
+} from "../src/descent-tracker.js";
+import type { Layer4Config } from "../src/enforcement-config.js";
 
 // ---------------------------------------------------------------------------
 // Corpus type
@@ -42,7 +48,7 @@ import type { Layer3Config } from "../src/enforcement-config.js";
 
 interface CorpusRow {
   id: string;
-  /** For Layer 1 rows: the intent text. For Layer 2/3 rows: descriptive label (not interpreted). */
+  /** For Layer 1 rows: the intent text. For Layer 2/3/4 rows: descriptive label (not interpreted). */
   input: string;
   expectedLayer: number;
   expectedOutcome: "intent-too-broad" | "accept" | "result-set-too-large" | "atom-oversized" | "descent-bypass-warning" | "drift-alert";
@@ -57,6 +63,13 @@ interface CorpusRow {
   needComplexity?: number;
   ratioThreshold?: number;
   minFloor?: number;
+  // Layer 4 fields — present only for L4-* rows
+  packageName?: string;
+  bindingName?: string;
+  intent?: string;
+  priorMisses?: number;
+  minDepth?: number;
+  shallowAllowPatterns?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -237,6 +250,57 @@ function assertLayer3Row(row: CorpusRow): void {
 }
 
 // ---------------------------------------------------------------------------
+// Layer 4 helpers — build Layer4Config from corpus fields and run descent tracker
+// ---------------------------------------------------------------------------
+
+/**
+ * Assert a Layer 4 corpus row against the descent-tracker module.
+ *
+ * The row encodes the scenario via:
+ *   - packageName + bindingName: the binding under test
+ *   - priorMisses: number of recordMiss calls to execute before the assertion
+ *   - minDepth + shallowAllowPatterns: the Layer4Config to use
+ *   - intent: passed to getAdvisoryWarning (affects suggestion text)
+ *   - expectedOutcome: "descent-bypass-warning" or "accept"
+ *
+ * Uses the actual descent-tracker functions (real production code — no mocks).
+ *
+ * @decision DEC-HOOK-ENF-LAYER4-DESCENT-TRACKING-001
+ */
+function assertLayer4Row(row: CorpusRow): void {
+  const packageName = row.packageName ?? "unknown-pkg";
+  const bindingName = row.bindingName ?? "unknownBinding";
+  const intent = row.intent ?? row.input;
+  const priorMisses = row.priorMisses ?? 0;
+
+  const cfg: Layer4Config = {
+    minDepth: row.minDepth ?? 2,
+    shallowAllowPatterns: row.shallowAllowPatterns ?? [],
+    disableTracking: false,
+  };
+
+  // Simulate prior import-intercept miss events.
+  for (let i = 0; i < priorMisses; i++) {
+    recordMiss(packageName, bindingName);
+  }
+
+  const warning = getAdvisoryWarning(packageName, bindingName, intent, cfg);
+
+  if (row.expectedOutcome === "descent-bypass-warning") {
+    expect(warning, `[${row.id}] expected DescentBypassWarning for priorMisses=${priorMisses} (${row.notes ?? ""})`).not.toBeNull();
+    expect(warning?.layer, `[${row.id}] layer discriminant must be 4`).toBe(4);
+    expect(warning?.status, `[${row.id}] status must be descent-bypass-warning`).toBe("descent-bypass-warning");
+    expect(warning?.bindingKey, `[${row.id}] bindingKey format`).toBe(`${packageName}::${bindingName}`);
+    expect(warning?.observedDepth, `[${row.id}] observedDepth must equal priorMisses`).toBe(priorMisses);
+    expect(warning?.minDepth, `[${row.id}] minDepth from config`).toBe(cfg.minDepth);
+  } else if (row.expectedOutcome === "accept") {
+    expect(warning, `[${row.id}] expected null warning (accept) for priorMisses=${priorMisses} (${row.notes ?? ""})`).toBeNull();
+  } else {
+    throw new Error(`[${row.id}] unexpected expectedOutcome="${row.expectedOutcome}" for a Layer 4 row`);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Layer 2 assertion helper
 // ---------------------------------------------------------------------------
 
@@ -264,15 +328,17 @@ function assertLayer2Row(row: CorpusRow): void {
 }
 
 // ---------------------------------------------------------------------------
-// Config reset between tests (needed for L2 env-override tests)
+// Config and session reset between tests (needed for L2 env-override and L4 session tests)
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
   resetConfigOverride();
+  resetSession();
 });
 
 afterEach(() => {
   resetConfigOverride();
+  resetSession();
 });
 
 // ---------------------------------------------------------------------------
@@ -280,9 +346,9 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("Layer 6 eval corpus — structural invariants", () => {
-  it("corpus JSON loads successfully with ≥5 rows", async () => {
+  it("corpus JSON loads successfully with ≥17 rows", async () => {
     const rows = await loadCorpus();
-    expect(rows.length).toBeGreaterThanOrEqual(5);
+    expect(rows.length).toBeGreaterThanOrEqual(17);
   });
 
   it("every row has required fields: id, input, expectedLayer, expectedOutcome", async () => {
@@ -334,6 +400,20 @@ describe("Layer 6 eval corpus — structural invariants", () => {
     const layer3Rows = rows.filter((r) => r.expectedLayer === 3);
     for (const row of layer3Rows) {
       expect(row.id, `id should match L3-NNN`).toMatch(/^L3-\d{3}$/);
+    }
+  });
+
+  it("S4 seeds exactly 3 Layer 4 rows", async () => {
+    const rows = await loadCorpus();
+    const layer4Rows = rows.filter((r) => r.expectedLayer === 4);
+    expect(layer4Rows.length).toBe(3);
+  });
+
+  it("all S4 row ids follow L4-NNN format", async () => {
+    const rows = await loadCorpus();
+    const layer4Rows = rows.filter((r) => r.expectedLayer === 4);
+    for (const row of layer4Rows) {
+      expect(row.id, `id should match L4-NNN`).toMatch(/^L4-\d{3}$/);
     }
   });
 });
@@ -486,9 +566,18 @@ describe("Layer 6 eval corpus — completeness gate", () => {
     expect(hasAccept, "corpus must contain at least one accept row for Layer 3").toBe(true);
   });
 
-  it("corpus has grown to 17 rows (S1=7 + S2=5 + S3=5)", async () => {
+  it("corpus covers both descent-bypass-warning and accept outcomes in Layer 4", async () => {
     const rows = await loadCorpus();
-    expect(rows.length).toBe(17);
+    const layer4Rows = rows.filter((r) => r.expectedLayer === 4);
+    const hasWarn = layer4Rows.some((r) => r.expectedOutcome === "descent-bypass-warning");
+    const hasAccept = layer4Rows.some((r) => r.expectedOutcome === "accept");
+    expect(hasWarn, "corpus must contain at least one descent-bypass-warning row").toBe(true);
+    expect(hasAccept, "corpus must contain at least one accept row for Layer 4").toBe(true);
+  });
+
+  it("corpus has grown to 20 rows (S1=7 + S2=5 + S3=5 + S4=3)", async () => {
+    const rows = await loadCorpus();
+    expect(rows.length).toBe(20);
   });
 });
 
@@ -537,6 +626,43 @@ describe("Layer 6 eval corpus — Layer 3 rows", () => {
     const layer3Rows = rows.filter((r) => r.expectedLayer === 3);
     for (const row of layer3Rows) {
       assertLayer3Row(row);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Layer 4 eval gate — table-driven (S4 additive, wi-592-s4-layer4)
+// ---------------------------------------------------------------------------
+
+describe("Layer 6 eval corpus — Layer 4 rows", () => {
+  it("L4-001: zero-miss scenario (depth=0 < minDepth=2) → descent-bypass-warning", async () => {
+    const rows = await loadCorpus();
+    const row = rows.find((r) => r.id === "L4-001");
+    expect(row, "L4-001 must be in corpus").toBeDefined();
+    if (row) assertLayer4Row(row);
+  });
+
+  it("L4-002: sufficient-miss scenario (depth=2 equals minDepth=2) → accept (no warning)", async () => {
+    const rows = await loadCorpus();
+    const row = rows.find((r) => r.id === "L4-002");
+    expect(row, "L4-002 must be in corpus").toBeDefined();
+    if (row) assertLayer4Row(row);
+  });
+
+  it("L4-003: shallow-allow bypass ('add' matches ^add$, depth=0) → accept (no warning)", async () => {
+    const rows = await loadCorpus();
+    const row = rows.find((r) => r.id === "L4-003");
+    expect(row, "L4-003 must be in corpus").toBeDefined();
+    if (row) assertLayer4Row(row);
+  });
+
+  it("all Layer 4 rows pass (catch-all sweep for future corpus additions)", async () => {
+    const rows = await loadCorpus();
+    const layer4Rows = rows.filter((r) => r.expectedLayer === 4);
+    for (const row of layer4Rows) {
+      // Each row needs a fresh session — layer4 is stateful (miss accumulation).
+      resetSession();
+      assertLayer4Row(row);
     }
   });
 });

--- a/plans/wi-579-s4-layer4-descent-tracker.md
+++ b/plans/wi-579-s4-layer4-descent-tracker.md
@@ -1,0 +1,87 @@
+# WI-579-S4: Layer 4 — Descent-Depth Tracker (Advisory Warning)
+
+**Issue:** #592 | **Slice:** S4 of 6 | **Status:** complete (wi-592-s4-layer4)
+
+## Problem
+
+An LLM agent may call `substitute` (or `yakcc_compose`) after zero or very few
+prior registry misses for a binding. This "shallow substitution" pattern bypasses
+the descent-and-compose discipline (docs/system-prompts/yakcc-discovery.md): the
+agent should miss enough times to accumulate evidence that the binding truly exists
+in the registry before committing to an atom-based substitution.
+
+There was no signal in the hook path to detect or measure this pattern.
+
+## Decision
+
+Layer 4 is an **advisory, non-blocking** layer. It attaches a `DescentBypassWarning`
+to `SubstitutionResult` when a substitution is attempted with fewer prior miss events
+than `minDepth` for the same `(packageName, binding)` pair, and the binding name
+does not match any `shallowAllowPattern`.
+
+The substitution **proceeds regardless** of the warning. Layer 4 is observability
+infrastructure, not an enforcement gate.
+
+## §5.5 Spec Compliance
+
+| Parameter | Default | Config key | Env var |
+|-----------|---------|-----------|---------|
+| `minDepth` | 2 | `layer4.minDepth` | `YAKCC_DESCENT_MIN_DEPTH` |
+| `shallowAllowPatterns` | `["^add$","^sub$","^mul$","^div$","^mod$","^abs$","^min$","^max$","^clamp$","^lerp$"]` | `layer4.shallowAllowPatterns` | (file config only) |
+| `disableTracking` | false | `layer4.disableTracking` | `YAKCC_HOOK_DISABLE_DESCENT_TRACKING=1` |
+
+All thresholds are read from `getEnforcementConfig().layer4` at call time per
+DEC-HOOK-ENF-CONFIG-001. Nothing is hardcoded in `descent-tracker.ts` or `substitute.ts`.
+
+## Architecture
+
+**Session Map:** An in-memory `Map<string, DescentRecord>` scoped to the process
+lifetime (= one session). Never persisted to disk. Cleared via `resetSession()` in tests.
+
+**Binding key:** Reuses `makeBindingKey(packageName, binding)` = `"packageName::binding"`
+from `shave-on-miss-state.ts` (DEC-WI508-S3-KEY-FORMAT-001).
+
+**Two pipeline integration points:**
+
+1. `import-intercept.ts::runImportIntercept` — records `recordMiss` / `recordHit`
+   per binding at query time (before substitution is attempted).
+
+2. `substitute.ts::executeSubstitution` — calls `getAdvisoryWarning` at Layer 4
+   position (after Layer 3, before rendering). Attaches `descentBypassWarning` to
+   `SubstitutionResult` when the advisory fires.
+
+**Shallow-allow bypass:** Primitives (`add`, `sub`, etc.) are inherently unambiguous;
+no descent exploration is needed. `isShallowAllowed(binding, patterns)` short-circuits
+the warning for these bindings.
+
+**Telemetry:** `descent-bypass-warning` added to the `TelemetryEvent.outcome` union
+(additive, DEC-HOOK-ENF-LAYER4-TELEMETRY-001).
+
+## Key Decisions
+
+| ID | Title |
+|----|-------|
+| DEC-HOOK-ENF-LAYER4-DESCENT-TRACKING-001 | Per-session in-memory session Map; advisory only; binding key reuse |
+| DEC-HOOK-ENF-LAYER4-MIN-DEPTH-001 | minDepth default 2 — calibration-pending on B4/B9 sweep data |
+| DEC-HOOK-ENF-LAYER4-SHALLOW-ALLOW-001 | shallowAllowPatterns bootstrap with 10 arithmetic primitives |
+
+## Files Changed
+
+| File | Role |
+|------|------|
+| `src/descent-tracker.ts` | Layer 4 module — `recordMiss`, `recordHit`, `getDescentDepth`, `getDescentRecord`, `isShallowAllowed`, `shouldWarn`, `getAdvisoryWarning`, `resetSession` |
+| `src/enforcement-config.ts` | `Layer4Config` interface + `layer4` defaults + env var overrides |
+| `src/enforcement-types.ts` | `DescentBypassWarning` (additive) |
+| `src/substitute.ts` | Layer 4 plug point — after Layer 3, before rendering; `descentBypassWarning` on `SubstitutionResult` |
+| `src/import-intercept.ts` | `recordMiss` / `recordHit` wired in `runImportIntercept` miss/hit branches |
+| `src/telemetry.ts` | `descent-bypass-warning` outcome (additive) |
+| `src/descent-tracker.test.ts` | Unit tests — 35+ cases across recordMiss/recordHit, isShallowAllowed, shouldWarn, getAdvisoryWarning, resetSession |
+| `test/descent-tracker-integration.test.ts` | Integration tests — 3 flows (zero-miss, sufficient-miss, shallow-allow) + compound interaction tests |
+| `test/enforcement-eval-corpus.json` | +3 L4-* rows (17 → 20 total) |
+| `test/enforcement-eval-corpus.test.ts` | Layer 4 assertion helper + eval gate + structural invariants |
+
+## Rollback
+
+`git revert` the S4 commit. Layer 4 is independent of S1/S2/S3: the only integrations
+are additive fields (`descentBypassWarning` on `SubstitutionResult`, `descent-bypass-warning`
+in `TelemetryEvent.outcome`). Callers that do not read `descentBypassWarning` are unaffected.


### PR DESCRIPTION
## Summary

Fourth slice of #579's 6-layer hook enforcement architecture. Layer 4 adds a per-session **descent-depth tracker** that attaches an **advisory** `descentBypassWarning` to `SubstitutionResult` when descent < `minDepth` without matching the shallow-allow regex list. Non-blocking: substitutions proceed; the warning surfaces for telemetry + LLM feedback only.

- **Plug points**: `import-intercept.ts` (recordMiss/recordHit on yakccResolve outcomes) + `substitute.ts` (attach warning at executeSubstitution step 4)
- **Per-session in-memory Map<bindingKey, DescentRecord>** keyed via existing `shave-on-miss-state.ts::makeBindingKey`; NOT persisted
- **Shallow-allow regex list** bootstraps with arithmetic primitives (add, sub, mul, div, ...) so trivially-shallow descents don't warn
- **Config-driven** via `enforcement-config.ts.layer4` (minDepth=2, shallowAllowPatterns=10 primitives, env override for disable)
- **Corpus extended 17 → 20** (3 L4-* rows); S1+S2+S3 rows still pass
- **Telemetry** additive: `descent-bypass-warning` outcome variant appended
- **S1+S2+S3 modules untouched**

## Files Changed (11)

- new `packages/hooks-base/src/descent-tracker.ts` + `.test.ts`
- new `packages/hooks-base/test/descent-tracker-integration.test.ts`
- new `plans/wi-579-s4-layer4-descent-tracker.md`
- modified `packages/hooks-base/src/{enforcement-config,enforcement-types,import-intercept,substitute,telemetry}.ts`
- modified `packages/hooks-base/test/enforcement-eval-corpus.{json,test.ts}`

## Decisions
- `DEC-HOOK-ENF-LAYER4-DESCENT-TRACKING-001`
- `DEC-HOOK-ENF-LAYER4-MIN-DEPTH-001` (minDepth=2)
- `DEC-HOOK-ENF-LAYER4-SHALLOW-ALLOW-001` (10 primitives bootstrap)
- `DEC-HOOK-ENF-LAYER4-TELEMETRY-001` (additive variant)

## Known v1 limitation — follow-up #600

`substitute.ts` currently uses `binding.atomName` for both `packageName` + `binding` in the lookup key, while `import-intercept.ts` uses `(moduleSpecifier, namedImport)`. Production keys won't match → Layer 4 warning is effectively always-on for non-shallow-allowed substitutions. Acceptable for an advisory layer; tracked as #600 for S5/S6 to fix key parity end-to-end. Also noted: `index.ts` outcomeOverride wiring is a scope follow-on (index.ts is forbidden in S4 scope).

## Test plan

- [x] Layer 4 unit tests pass (descent-tracker.test.ts)
- [x] Layer 4 integration tests pass through substitute.ts pipeline
- [x] 3 L4-* corpus rows pass via enforcement-eval-corpus.test.ts
- [x] S1+S2+S3 corpus rows still pass (no regression on L1-001..L1-007, L2-001..L2-005, L3-001..L3-005)
- [x] hooks-base: 444 pass / 1 pre-existing todo
- [x] hooks-cursor: 29/29 ; hooks-claude-code: 40/40 (sister packages green)
- [x] lint + typecheck clean

Closes #592. Refs #579 (closes when all 6 layers ship via S6).