### PR TITLE
fix(shave): decompose() handles arrow-returns-arrow HOF patterns (closes #576)

### DIFF
--- a/packages/shave/src/universalize/recursion.ts
+++ b/packages/shave/src/universalize/recursion.ts
@@ -111,6 +111,36 @@
  *   - Compatible with WI-V2-09 byte-identical bootstrap: deterministic node
  *     enumeration, same shape on every pass.
  *
+ * @decision DEC-SLICER-ARROW-RETURNS-ARROW-001
+ * title: Expression-body ArrowFunction whose body is itself a function-like
+ *        descends into the inner function rather than returning []
+ * status: decided
+ * rationale:
+ *   The `hyphenReplace` pattern in semver's range.js (and similar HOF patterns
+ *   in the wild) produces an ArrowFunction whose expression body is another
+ *   ArrowFunction: `incPr => ($0, ...) => { if ... }`. The outer arrow has
+ *   cfCount > maxCF because forEachDescendant bleeds through the inner
+ *   function boundary, so isAtom() returns false. But the old expression-body
+ *   path returned `[]` unconditionally, causing DidNotReachAtomError.
+ *   The fix: when an expression-body arrow/function-expression has a body that
+ *   is itself a function-like node, return [body] so the slicer can descend
+ *   into the inner function's body block and find atomic leaves there.
+ * alternatives:
+ *   A. Don't cross function boundaries in countControlFlowBoundaries — rejected
+ *      because other call sites depend on the inclusive count for correctness;
+ *      scoping the change to decomposableChildrenOf is lower risk.
+ *   B. Treat the outer arrow as an atom regardless of CF count — rejected
+ *      because it would prevent the inner function from being decomposed,
+ *      producing a coarser-than-necessary atom tree.
+ * consequences:
+ *   - semver range.js (and any other higher-order arrow patterns) decompose
+ *     correctly, enabling satisfies subgraph moduleCount ≥ 8.
+ *   - No existing passing tests are affected: the branch only fires when
+ *     isAtom() already returned false AND the body is a function-like, a case
+ *     that previously always threw DidNotReachAtomError.
+ *   - Compatible with WI-V2-09 byte-identical bootstrap: descent order is
+ *     deterministic (single child = the inner function-like).
+ *
  * @decision DEC-SLICER-CHILDREN-EXPR-LEVEL-001
  * title: ConditionalExpression / BinaryExpression / ReturnStatement decompose
  *        to natural sub-expressions
@@ -752,7 +782,17 @@ function decomposableChildrenOf(node: Node): readonly Node[] {
     if (body !== undefined && body.getKind() === SyntaxKind.Block) {
       return (body as Node & { getStatements(): Node[] }).getStatements();
     }
-    // Expression-body arrow function — not further decomposable.
+    // Expression-body: if the body is itself a function-like (arrow-returns-arrow
+    // pattern), descend into it so the inner function can be atomized.
+    // (DEC-SLICER-ARROW-RETURNS-ARROW-001)
+    if (
+      body !== undefined &&
+      (body.getKind() === SyntaxKind.ArrowFunction ||
+        body.getKind() === SyntaxKind.FunctionExpression)
+    ) {
+      return [body];
+    }
+    // Expression-body arrow function with non-function-like body — not further decomposable.
     return [];
   }
 

--- a/packages/shave/src/universalize/semver-headline-bindings.test.ts
+++ b/packages/shave/src/universalize/semver-headline-bindings.test.ts
@@ -41,6 +41,9 @@
  * rationale:
  *   semver classes/range.js <-> classes/comparator.js is a genuine circular import.
  *   Slice 1 cycle guard proven on synthetic circular-pkg/; this corroborates on real npm source.
+ *   After the DEC-SLICER-ARROW-RETURNS-ARROW-001 engine fix (issue #576), range.js decompose()
+ *   succeeds and the cycle guard proof is live: both range.js and comparator.js appear exactly
+ *   once in the module forest (moduleCount=18, stubCount=0).
  */
 
 import { join, normalize } from "node:path";
@@ -133,7 +136,7 @@ function withSemanticIntentCard(
 describe("semver satisfies -- per-entry shave (WI-510 Slice 3)", () => {
   it(
     "section A -- moduleCount in [14,22], stubCount=0, forestTotalLeafCount>0 for satisfies subgraph",
-    { timeout: 120_000 },
+    { timeout: 300_000 },
     async () => {
       const forest = await shavePackage(SEMVER_FIXTURE_ROOT, {
         registry: emptyRegistry,
@@ -147,6 +150,7 @@ describe("semver satisfies -- per-entry shave (WI-510 Slice 3)", () => {
         forestModules(forest).map((m) => normalize(m.filePath).split("semver-7.8.0")[1]),
       );
       // Cycle guard proof: range <-> comparator must not cause hang.
+      // DEC-WI510-S3-CYCLE-GUARD-REAL-WORLD-PROOF-001: proven live after engine fix #576.
       // Plan section 5.6 criterion 12: each must appear exactly once.
       const filePaths = forestModules(forest).map((m) => m.filePath);
       const rangeCount = filePaths.filter((p) => p.endsWith("range.js")).length;
@@ -157,21 +161,22 @@ describe("semver satisfies -- per-entry shave (WI-510 Slice 3)", () => {
         "comparator.js:",
         comparatorCount,
       );
-      // Engine limit: classes/range.js contains an ArrowFunction that decompose() cannot handle.
-      // range.js degrades to a stub. Cycle guard proof deferred to a follow-on engine-capable slice.
-      // DEC-WI510-S3-CYCLE-GUARD-REAL-WORLD-PROOF-001: updated to reflect actual engine output.
       expect(
         forest.moduleCount,
-        "satisfies moduleCount: only satisfies.js shaved (range.js stubs)",
-      ).toBe(1);
-      expect(forest.stubCount, "satisfies stubCount: range.js stubs due to engine limit").toBe(1);
-      expect(rangeCount, "range.js not in module forest (stubs to engine limit)").toBe(0);
-      expect(comparatorCount, "comparator.js not in module forest (unreachable via stub)").toBe(0);
+        "satisfies moduleCount should be in [14,22]",
+      ).toBeGreaterThanOrEqual(14);
+      expect(
+        forest.moduleCount,
+        "satisfies moduleCount should be in [14,22]",
+      ).toBeLessThanOrEqual(22);
+      expect(forest.stubCount, "satisfies stubCount must be 0 after engine fix #576").toBe(0);
+      expect(rangeCount, "range.js must appear exactly once (cycle guard proof)").toBe(1);
+      expect(comparatorCount, "comparator.js must appear exactly once (cycle guard proof)").toBe(1);
       expect(forestTotalLeafCount(forest)).toBeGreaterThan(0);
     },
   );
 
-  it("section B -- forest.nodes[0] is satisfies.js", { timeout: 120_000 }, async () => {
+  it("section B -- forest.nodes[0] is satisfies.js", { timeout: 300_000 }, async () => {
     const forest = await shavePackage(SEMVER_FIXTURE_ROOT, {
       registry: emptyRegistry,
       entryPath: join(SEMVER_FIXTURE_ROOT, "functions", "satisfies.js"),
@@ -184,7 +189,7 @@ describe("semver satisfies -- per-entry shave (WI-510 Slice 3)", () => {
 
   it(
     "section C -- subgraph has only transitively-reachable modules; no unrelated semver behaviors",
-    { timeout: 120_000 },
+    { timeout: 300_000 },
     async () => {
       const forest = await shavePackage(SEMVER_FIXTURE_ROOT, {
         registry: emptyRegistry,
@@ -193,10 +198,10 @@ describe("semver satisfies -- per-entry shave (WI-510 Slice 3)", () => {
       const filePaths = forestModules(forest).map((m) => m.filePath);
       for (const fp of filePaths) expect(fp).toContain("semver-7.8.0");
       expect(filePaths.some((p) => p.includes("satisfies.js"))).toBe(true);
-      // range.js stubs (engine limit) — NOT in module list
-      expect(filePaths.some((p) => p.endsWith("range.js"))).toBe(false);
-      expect(filePaths.some((p) => p.endsWith("comparator.js"))).toBe(false);
-      expect(filePaths.some((p) => p.endsWith("semver.js") && p.includes("classes"))).toBe(false);
+      // Engine fix #576: range.js and comparator.js now decompose successfully.
+      expect(filePaths.some((p) => p.endsWith("range.js"))).toBe(true);
+      expect(filePaths.some((p) => p.endsWith("comparator.js"))).toBe(true);
+      expect(filePaths.some((p) => p.endsWith("semver.js") && p.includes("classes"))).toBe(true);
       const unrelated = ["inc.js", "diff.js", "clean.js"];
       for (const u of unrelated) {
         expect(
@@ -204,13 +209,13 @@ describe("semver satisfies -- per-entry shave (WI-510 Slice 3)", () => {
           `${u} must NOT be in satisfies subgraph`,
         ).toBe(true);
       }
-      expect(forestStubs(forest).length).toBe(1); // range.js stubs
+      expect(forestStubs(forest).length).toBe(0);
     },
   );
 
   it(
     "section D -- two-pass byte-identical determinism for satisfies subgraph",
-    { timeout: 120_000 },
+    { timeout: 600_000 },
     async () => {
       const entryPath = join(SEMVER_FIXTURE_ROOT, "functions", "satisfies.js");
       const forest1 = await shavePackage(SEMVER_FIXTURE_ROOT, {
@@ -241,7 +246,7 @@ describe("semver satisfies -- per-entry shave (WI-510 Slice 3)", () => {
 
   it(
     "section E -- satisfies forest persisted via real collectForestSlicePlans -> maybePersistNovelGlueAtom path",
-    { timeout: 120_000 },
+    { timeout: 300_000 },
     async () => {
       const registry = await openRegistry(":memory:", {
         embeddings: createOfflineEmbeddingProvider(),
@@ -266,11 +271,9 @@ describe("semver satisfies -- per-entry shave (WI-510 Slice 3)", () => {
           }
         }
         console.log("[satisfies sE] persisted atoms:", persistedCount);
-        // satisfies.js alone (range.js stubs) produces 0 novel-glue atoms — assert pipeline ran.
-        expect(
-          plans.length,
-          "satisfies sE: collectForestSlicePlans must produce plans",
-        ).toBeGreaterThan(0);
+        expect(plans.length, "satisfies sE: collectForestSlicePlans must produce plans").toBeGreaterThan(0);
+        // Engine fix #576: range.js decomposes now, so satisfies produces novel-glue atoms.
+        expect(persistedCount, "satisfies sE: must persist at least one atom after engine fix #576").toBeGreaterThan(0);
       } finally {
         await registry.close();
       }
@@ -886,7 +889,7 @@ describe("semver headline bindings -- compound interaction (real production sequ
     { timeout: 300_000 },
     async () => {
       const bindings = [
-        { name: "satisfies", entry: "satisfies.js", minMod: 1, maxMod: 1 }, // range.js stubs (engine limit)
+        { name: "satisfies", entry: "satisfies.js", minMod: 14, maxMod: 22 }, // engine fix #576: range.js now decomposes
         { name: "coerce", entry: "coerce.js", minMod: 6, maxMod: 12 },
         { name: "compare", entry: "compare.js", minMod: 5, maxMod: 10 },
         { name: "parse", entry: "parse.js", minMod: 5, maxMod: 10 },
@@ -902,11 +905,7 @@ describe("semver headline bindings -- compound interaction (real production sequ
           });
           expect(forest.moduleCount).toBeGreaterThanOrEqual(b.minMod);
           expect(forest.moduleCount).toBeLessThanOrEqual(b.maxMod);
-          if (b.entry === "satisfies.js") {
-            expect(forest.stubCount, "satisfies stubCount: range.js stubs").toBe(1);
-          } else {
-            expect(forest.stubCount, `${b.name} stubCount must be 0`).toBe(0);
-          }
+          expect(forest.stubCount, `${b.name} stubCount must be 0`).toBe(0);
           const firstNode = forest.nodes[0];
           expect(firstNode?.kind).toBe("module");
           if (firstNode?.kind === "module") expect(firstNode.filePath).toContain(b.entry);
@@ -921,12 +920,10 @@ describe("semver headline bindings -- compound interaction (real production sequ
               }
             }
           }
-          if (b.entry !== "satisfies.js") {
-            expect(
-              persistedCount,
-              `${b.name} compound: must persist at least one atom`,
-            ).toBeGreaterThan(0);
-          }
+          expect(
+            persistedCount,
+            `${b.name} compound: must persist at least one atom`,
+          ).toBeGreaterThan(0);
           console.log(
             `[compound] ${b.name}: moduleCount=${forest.moduleCount} stubCount=${forest.stubCount} persisted=${persistedCount}`,
           );

--- a/packages/shave/src/universalize/semver-headline-bindings.test.ts
+++ b/packages/shave/src/universalize/semver-headline-bindings.test.ts
@@ -165,10 +165,9 @@ describe("semver satisfies -- per-entry shave (WI-510 Slice 3)", () => {
         forest.moduleCount,
         "satisfies moduleCount should be in [14,22]",
       ).toBeGreaterThanOrEqual(14);
-      expect(
-        forest.moduleCount,
-        "satisfies moduleCount should be in [14,22]",
-      ).toBeLessThanOrEqual(22);
+      expect(forest.moduleCount, "satisfies moduleCount should be in [14,22]").toBeLessThanOrEqual(
+        22,
+      );
       expect(forest.stubCount, "satisfies stubCount must be 0 after engine fix #576").toBe(0);
       expect(rangeCount, "range.js must appear exactly once (cycle guard proof)").toBe(1);
       expect(comparatorCount, "comparator.js must appear exactly once (cycle guard proof)").toBe(1);
@@ -271,9 +270,15 @@ describe("semver satisfies -- per-entry shave (WI-510 Slice 3)", () => {
           }
         }
         console.log("[satisfies sE] persisted atoms:", persistedCount);
-        expect(plans.length, "satisfies sE: collectForestSlicePlans must produce plans").toBeGreaterThan(0);
+        expect(
+          plans.length,
+          "satisfies sE: collectForestSlicePlans must produce plans",
+        ).toBeGreaterThan(0);
         // Engine fix #576: range.js decomposes now, so satisfies produces novel-glue atoms.
-        expect(persistedCount, "satisfies sE: must persist at least one atom after engine fix #576").toBeGreaterThan(0);
+        expect(
+          persistedCount,
+          "satisfies sE: must persist at least one atom after engine fix #576",
+        ).toBeGreaterThan(0);
       } finally {
         await registry.close();
       }


### PR DESCRIPTION
## Summary

- **Root cause**: `decomposableChildrenOf()` in `recursion.ts` returned `[]` unconditionally for any expression-body `ArrowFunction`, but `isAtom()` (via `forEachDescendant`) bleeds CF-count through inner function boundaries — so an outer arrow like `incPr => ($0, ...) => { if ... }` had `cfCount > maxCF`, `isAtom()=false`, `decomposableChildren=[]`, and threw `DidNotReachAtomError`.
- **Fix**: When the expression body of a function-like node is itself an `ArrowFunction` or `FunctionExpression`, return `[body]` so the slicer can descend into the inner function and find atomic leaves. (`DEC-SLICER-ARROW-RETURNS-ARROW-001`)
- **Result**: semver `satisfies` subgraph now produces `moduleCount=18, stubCount=0`, including `range.js` and `comparator.js` exactly once each (cycle-guard proof). All semver headline-binding assertions and timeouts updated accordingly.

## Test plan

- [x] `pnpm --filter @yakcc/shave typecheck` — clean
- [x] Diagnostic run: `moduleCount: 18, stubCount: 0` confirmed after fix
- [x] `semver-headline-bindings.test.ts` sections A–E updated: `moduleCount in [14,22]`, `stubCount=0`, cycle-guard assertions live, timeouts raised to 300 s / 600 s for two-pass
- [x] `bcryptjs` ENGINE GAP failure is pre-existing and unrelated to this change

https://claude.ai/code/session_01PRDidE2fj9QcD8gReHzWpr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRDidE2fj9QcD8gReHzWpr)_