### PR TITLE
ci: post-merge advisory gate — move long-lived tests off PR critical path (closes #596, closes #595)

### DIFF
--- a/.github/workflows/pr-ci-test-advisory.yml
+++ b/.github/workflows/pr-ci-test-advisory.yml
@@ -1,44 +1,58 @@
+# @decision DEC-CI-POSTMERGE-ADVISORY-GATE-001
+# Title: Rewire pr-ci-test-advisory from pull_request to push:main (closes #596, #595)
+# Status: accepted
+# Rationale: Long-running tests (20 min) must NOT be in the merge critical path.
+# The prior pull_request trigger caused every PR push to queue a 20-min job that
+# was non-gating but consumed runner minutes and produced misleading PR UI noise.
+# Moving the trigger to push:branches:[main] makes the run post-merge and
+# non-blocking by construction. On failure the workflow auto-files a GitHub Issue
+# with log tail via file-ci-regression.sh (D3+D4 dedup mechanism) so regressions
+# surface retrospectively without blocking developer flow. workflow_dispatch is
+# retained for on-demand ad-hoc validation. DEC-CI-FAST-PATH-PHASE-1-005
+# established this precedent for bootstrap.yml/test.yml/wave-3-parity.yml; WI-596
+# applies the same pattern here.
+#
 # @decision DEC-CI-TEST-ADVISORY-SEPARATE-WORKFLOW-001
 # Title: test-advisory split from pr-ci.yml to escape cancel-in-progress
-# Status: accepted
+# Status: superseded by DEC-CI-POSTMERGE-ADVISORY-GATE-001 (trigger now push:main)
 # Rationale: pr-ci.yml uses cancel-in-progress=true so new commits / origin/main
 # updates kill in-flight runs. The 20-min advisory test job was being killed
 # repeatedly (PRs #562/#566/#570/#571 all hit this; PR #570 merged with wrong
 # assertions because vitest never completed). Splitting the advisory test into
-# its own workflow with no cancel-in-progress lets it run to completion without
-# blocking the fast pr-ci.yml gates.
-# Per DEC-CI-MERGE-GATE-ENFORCE-001 this remains advisory (continue-on-error
-# at job level; not added to branch protection required checks).
+# its own workflow with no cancel-in-progress let it run to completion without
+# blocking the fast pr-ci.yml gates. WI-596 completes the move by dropping the
+# pull_request trigger entirely.
 
 name: pr-ci-test-advisory
 
 on:
-  pull_request:
+  push:
     branches: [main]
+  workflow_dispatch:    # manual ad-hoc trigger for on-demand validation
 
-# DELIBERATELY NO cancel-in-progress. The whole point of this split is that
-# advisory tests should complete even when fast checks are re-fired on new
-# commits. Latest run wins per GitHub's natural queueing.
-# (Alternative considered: cancel-in-progress=true on a distinct group keyed
-# on github.run_id — but that defeats the purpose. Plain queue is correct.)
+# No cancel-in-progress: post-merge push:main runs are independent and should
+# complete. Each push to main is a distinct commit; all advisory runs should
+# finish and file issues if they fail.
+
+permissions:
+  issues: write
+  contents: read
 
 jobs:
   # ---------------------------------------------------------------------------
-  # test-advisory — affected packages, NON-GATING
-  # DEC-CI-MERGE-GATE-ENFORCE-001: tests do NOT gate merges per operator policy
-  # ("tests that take this fucking long sure as fuck shouldn't be critical path
-  # for merges", 2026-05-11). `continue-on-error: true` at the JOB level surfaces
-  # failures in the PR UI for fast feedback but does NOT block the merge button.
-  # Slice C's branch protection MUST NOT include this job in required contexts.
-  # Moved here from pr-ci.yml by DEC-CI-TEST-ADVISORY-SEPARATE-WORKFLOW-001 to
-  # escape pr-ci.yml's cancel-in-progress, which was killing the 20-min job
-  # whenever a new commit pushed.
+  # test-advisory — affected packages, NON-GATING, post-merge advisory
+  # DEC-CI-POSTMERGE-ADVISORY-GATE-001: fires AFTER merge (push:main trigger),
+  # not during PR review. Failure does NOT block merges; instead, auto-files a
+  # GitHub Issue with log tail and merge-PR reference for retrospective triage.
+  # DEC-CI-MERGE-GATE-ENFORCE-001: this job is NOT in branch-protection required
+  # contexts. Branch protection continues to require only:
+  #   lint (full workspace), typecheck (full workspace), build (full workspace),
+  #   branch hygiene check, B6a air-gap benchmark (zero outbound).
   # ---------------------------------------------------------------------------
   test-advisory:
     name: test (affected packages, advisory)
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -56,11 +70,25 @@ jobs:
       - name: Build full workspace (required before tests can resolve workspace deps)
         run: pnpm -r build
 
-      - name: Test affected packages (non-gating)
+      - name: Test affected packages (post-merge advisory)
         # Affected filter retained for cycle-time speed (DEC-CI-FAST-PATH-PHASE-1-001).
-        # Failure surfaces in PR UI but does NOT block merge (see continue-on-error
-        # at the job level above).
+        # tee captures stdout+stderr to tmp/test-advisory.log for the on-failure
+        # regression-issue step (D4: log excerpt from tee, NOT from gh api run logs
+        # which are unavailable until the run completes).
+        # set -o pipefail: non-zero exit from pnpm propagates through tee.
+        # continue-on-error is dropped: on push:main, failure should exit non-zero
+        # so the on-failure step below fires correctly.
+        id: test
         run: |
+          mkdir -p tmp
           FILTER=$(bash scripts/affected-packages.sh)
           echo "Affected filter: $FILTER"
-          eval "pnpm $FILTER test"
+          set -o pipefail
+          eval "pnpm $FILTER test" 2>&1 | tee tmp/test-advisory.log
+
+      - name: Auto-file regression issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash .github/workflows/scripts/file-ci-regression.sh

--- a/.github/workflows/scripts/file-ci-regression.sh
+++ b/.github/workflows/scripts/file-ci-regression.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# file-ci-regression.sh — auto-file or comment on a ci-regression GitHub Issue
+#
+# @decision DEC-CI-POSTMERGE-ADVISORY-GATE-001
+# Title: Auto-file regression issues with dedup-by-open-issue-title (D3+D4)
+# Status: accepted
+# Rationale: When pr-ci-test-advisory.yml fires on push:main and the test step
+# fails, this script is invoked by the on-failure step. It:
+#   1. Builds an issue body with header (run URL, SHA, author, timestamp),
+#      best-effort merge-PR# extraction, step name, log tail from
+#      tmp/test-advisory.log, optional revert hint, and DEC-ID footer.
+#   2. Creates the ci-regression label idempotently (--force).
+#   3. Deduplicates by searching for an open issue with the same step-name prefix.
+#      If found: appends a comment. If not: files a new issue.
+# This avoids spam on flaky regressions (D3) and keeps the issue body consistent
+# with D4's content specification.
+#
+# Required env vars (supplied by GitHub Actions):
+#   GITHUB_SHA           — full commit SHA that triggered the workflow run
+#   GITHUB_REPOSITORY    — owner/repo (e.g. cneckar/yakcc)
+#   GITHUB_SERVER_URL    — https://github.com
+#   GITHUB_RUN_ID        — numeric run ID
+#   GH_TOKEN             — GitHub token with issues:write (from secrets.GITHUB_TOKEN)
+#
+# Optional env vars (available on push:main events):
+#   GITHUB_ACTOR         — the actor who triggered the run (may differ from commit author)
+#
+# The log file tmp/test-advisory.log is produced by the test step's tee command.
+# If it does not exist (e.g. failure before the tee step), a fallback message
+# is used.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# 1. Build header fields
+# ---------------------------------------------------------------------------
+STEP_NAME="test (affected packages, advisory)"
+SHA_FULL="${GITHUB_SHA}"
+SHA_SHORT="${GITHUB_SHA:0:7}"
+RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+# Commit message first line (for merge-PR extraction and header display)
+COMMIT_MSG=$(git log -1 --format="%s" "${SHA_FULL}" 2>/dev/null || echo "")
+
+# Commit author name + email from git (more reliable than event payload on
+# push:main events where GITHUB_EVENT_PATH contents vary by workflow context)
+COMMIT_AUTHOR=$(git log -1 --format="%an <%ae>" "${SHA_FULL}" 2>/dev/null || echo "unknown")
+
+# Commit timestamp (ISO 8601)
+COMMIT_TIMESTAMP=$(git log -1 --format="%cI" "${SHA_FULL}" 2>/dev/null || echo "unknown")
+
+# ---------------------------------------------------------------------------
+# 2. Best-effort merge-PR# extraction from squash-merge commit message
+#    Pattern: matches (#NNN) at end of line — the squash-merge convention
+#    used on this repo (verified against recent merged PRs).
+# ---------------------------------------------------------------------------
+MERGE_PR_NUM=""
+if echo "${COMMIT_MSG}" | grep -qE '\(#[0-9]+\)'; then
+    MERGE_PR_NUM=$(echo "${COMMIT_MSG}" | grep -oE '#[0-9]+' | tail -1 | tr -d '#')
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Log tail — from tmp/test-advisory.log (D4: NOT gh api run logs)
+# ---------------------------------------------------------------------------
+LOG_TAIL=""
+if [ -f "tmp/test-advisory.log" ]; then
+    LOG_TAIL=$(tail -100 tmp/test-advisory.log)
+else
+    LOG_TAIL="(log file tmp/test-advisory.log not found — failure may have occurred before the test step)"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Build issue body (D4 content spec)
+# ---------------------------------------------------------------------------
+build_body() {
+    local context_sha="${1:-${SHA_SHORT}}"
+
+    cat <<EOF
+## CI Regression on main
+
+**Workflow run:** ${RUN_URL}
+**Commit:** \`${SHA_FULL}\`
+**Short SHA:** \`${context_sha}\`
+**Commit message:** ${COMMIT_MSG}
+**Author:** ${COMMIT_AUTHOR}
+**Timestamp:** ${COMMIT_TIMESTAMP}
+EOF
+
+    if [ -n "${MERGE_PR_NUM}" ]; then
+        echo "**Merge PR:** #${MERGE_PR_NUM}"
+    fi
+
+    cat <<EOF
+
+**Failing step:** \`${STEP_NAME}\`
+
+<details>
+<summary>Log tail (last 100 lines)</summary>
+
+\`\`\`
+${LOG_TAIL}
+\`\`\`
+
+</details>
+EOF
+
+    if [ -n "${MERGE_PR_NUM}" ]; then
+        echo ""
+        echo "**Suggested follow-up:** If this is a clean regression, \`gh pr revert ${MERGE_PR_NUM}\` may be appropriate. Otherwise investigate and close this issue when resolved."
+    fi
+
+    cat <<EOF
+
+---
+*auto-filed by \`.github/workflows/pr-ci-test-advisory.yml\` (DEC-CI-POSTMERGE-ADVISORY-GATE-001)*
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# 5. Create ci-regression label idempotently (--force succeeds if it exists)
+# ---------------------------------------------------------------------------
+gh label create ci-regression \
+    --color C5DEF5 \
+    --description "Auto-filed CI regression on main" \
+    --force
+
+# ---------------------------------------------------------------------------
+# 6. Dedup check: search for an open issue with the same step-name prefix (D3)
+#    Key: workflow step name, not individual test-case — failure is at step level.
+# ---------------------------------------------------------------------------
+DEDUP_SEARCH="CI regression on main: ${STEP_NAME}"
+
+EXISTING_ISSUE=$(gh issue list \
+    --state open \
+    --label ci-regression \
+    --search "${DEDUP_SEARCH}" \
+    --json number \
+    --jq '.[0].number' \
+    2>/dev/null || echo "")
+
+# ---------------------------------------------------------------------------
+# 7. File new issue or append comment to existing open issue
+# ---------------------------------------------------------------------------
+ISSUE_TITLE="CI regression on main: ${STEP_NAME} failed at commit ${SHA_SHORT}"
+BODY=$(build_body "${SHA_SHORT}")
+
+if [ -n "${EXISTING_ISSUE}" ] && [ "${EXISTING_ISSUE}" != "null" ]; then
+    echo "Open ci-regression issue #${EXISTING_ISSUE} already exists — appending comment."
+    gh issue comment "${EXISTING_ISSUE}" --body "${BODY}"
+    echo "Commented on issue #${EXISTING_ISSUE}: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/issues/${EXISTING_ISSUE}"
+else
+    echo "No open ci-regression issue found — filing new issue."
+    gh issue create \
+        --title "${ISSUE_TITLE}" \
+        --body "${BODY}" \
+        --label "ci-regression,claude-todo"
+    echo "Filed new ci-regression issue."
+fi


### PR DESCRIPTION
## What this PR does

Closes #596 (architectural fix) and #595 (timeout symptom).

WI-596 Slice 1 — moves the long-running `test (affected packages, advisory)` job off PR critical path. The workflow now runs once per merge on `main` (`push: branches: [main]`) instead of on every PR. On failure, the workflow auto-files a `ci-regression` issue with the failing step, log tail, suggested revert hint, and DEC-ID footer (deduplicating against open issues so flakes don't spam).

## Why

Per `DEC-CI-MERGE-GATE-ENFORCE-001` ("tests that take this fucking long sure as fuck shouldn't be critical path for merges", 2026-05-11). PR #582 split the advisory test into its own workflow (escaping cancel-in-progress), but the test itself still hits the GitHub-Actions 20-min job timeout consistently — most recently on PR #589 (#579 Slice 1) where the job was cancelled at exactly 20m15s with `continue-on-error: true` providing no useful signal. The right fix is to take the long-running test off the PR critical path entirely.

## What changes

| File | Change |
|---|---|
| `.github/workflows/pr-ci-test-advisory.yml` | trigger `pull_request` → `push:[main]` + `workflow_dispatch`; `permissions: {issues: write, contents: read}`; removed `continue-on-error: true`; test step `tee`s to `tmp/test-advisory.log`; new `if: failure()` step calls the auto-file script |
| `.github/workflows/scripts/file-ci-regression.sh` | new (~158 lines, `set -euo pipefail`, shellcheck-clean). On failure: idempotent `ci-regression` label create, dedup by open-issue search, files new or comments on existing |

## What does NOT change

- `pr-ci.yml` — byte-identical (fast-path PR gate untouched)
- `scripts/affected-packages.sh` — byte-identical
- Branch protection on `main` — 5-context required list unchanged (`lint`, `typecheck`, `build`, `branch hygiene`, `B6a`); advisory test was already NOT required

## DEC

`DEC-CI-POSTMERGE-ADVISORY-GATE-001` — new. Supersedes `DEC-CI-TEST-ADVISORY-SEPARATE-WORKFLOW-001`.

## Test plan

- [ ] `pr-ci.yml` goes green on this PR (lint + typecheck + build + branch-hygiene + B6a)
- [ ] `pr-ci-test-advisory` does NOT appear in this PR's checks (positive proof of rewire)
- [ ] After merge, observe `pr-ci-test-advisory` runs on `push:main`
- [ ] If post-merge advisory passes: no issue filed (expected silent-success)
- [ ] If post-merge advisory fails on a future merge: a `ci-regression` issue is auto-filed (or comment-appended on existing open one)

## Sibling

- Closes #596 (architectural fix)
- Closes #595 (timeout symptom — resolved by removing the run from PR-time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)