### PR TITLE
ci(closer-parity-as): drop cancel-in-progress so verified-marker cache can populate (closes #612)

### DIFF
--- a/.github/workflows/closer-parity-as.yml
+++ b/.github/workflows/closer-parity-as.yml
@@ -26,7 +26,21 @@ on:
 
 concurrency:
   group: closer-parity-as-${{ github.ref }}
-  cancel-in-progress: true
+  # @decision DEC-CI-CLOSER-PARITY-NO-CANCEL-001
+  # @title closer-parity-as does NOT cancel in-progress runs
+  # @status accepted
+  # @rationale Pre-WI-612: cancel-in-progress=true killed every push:main
+  # run in active-merge sessions before the verified-marker cache could
+  # populate. Observed 2026-05-16: 5 consecutive runs cancelled (HEADs
+  # 7eea48b / e49c885 / b5dff3a / 60e66e9 / 772b0c2), each preempted by
+  # the next merge within minutes. Off PR critical path (this workflow
+  # is push:main + workflow_dispatch only, per DEC-CI-CLOSER-PARITY-AS-WORKFLOW-001)
+  # so concurrent runs are acceptable in cost; the benefit is that any
+  # one run completing fills the content-keyed verified-marker cache
+  # (DEC-AS-COMPILE-CACHE-001) so subsequent runs short-circuit.
+  # Mirrors DEC-CI-TEST-ADVISORY-SEPARATE-WORKFLOW-001 (PR #582) / WI-596
+  # (PR #605) pattern for pr-ci-test-advisory.yml. Cross-ref #612.
+  cancel-in-progress: false
 
 jobs:
   parity:


### PR DESCRIPTION
## What

Closes #612. Flips \`concurrency.cancel-in-progress\` from \`true\` to \`false\` on \`.github/workflows/closer-parity-as.yml\`. 1-line semantic change + 12-line DEC annotation.

## Why

In active-merge sessions, every push:main was killing the in-flight \`closer-parity-as\` run before the content-keyed \`verified-marker\` cache (DEC-AS-COMPILE-CACHE-001) could populate. Observed 2026-05-16 (5 consecutive runs cancelled):

| HEAD | Status |
|---|---|
| 7eea48b | cancelled |
| e49c885 | cancelled |
| b5dff3a | cancelled |
| 60e66e9 | cancelled |
| 772b0c2 | cancelled at 42m24s (was actively running; preempted) |

The workflow is off PR critical path (\`push:main\` + \`workflow_dispatch\` only, per DEC-CI-CLOSER-PARITY-AS-WORKFLOW-001), so concurrent runs during merge bursts are an acceptable cost. The benefit is that any one run that completes fills the cache so subsequent runs short-circuit on the same content state.

## Pattern

Mirrors DEC-CI-TEST-ADVISORY-SEPARATE-WORKFLOW-001 (PR #582) / WI-596 (PR #605) for \`pr-ci-test-advisory.yml\`, which deliberately has no \`cancel-in-progress\` for exactly this reason.

## NOT this PR

- The 60-min cold-shave wall-clock problem is **#485** (separate WI). This PR is just \"don't kill the run\"; #485 is \"make the run fast enough.\" Both are needed for closer-parity-as to produce useful post-merge signal.

## Test plan

- [x] YAML parses cleanly (reviewer confirmed via gh workflow view)
- [x] Only \`.github/workflows/closer-parity-as.yml\` modified (reviewer confirmed)
- [ ] \`pr-ci.yml\` goes green on this PR (lint + typecheck + build + branch-hygiene + B6a — trivial since no source changed)
- [ ] Post-merge: observe a closer-parity-as run survive a subsequent push (instead of being cancelled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)