### PR TITLE
feat(cli): WI-656 Slice 2 — yakcc uninstall command (refs #656)

### DIFF
--- a/packages/cli/src/commands/uninstall.test.ts
+++ b/packages/cli/src/commands/uninstall.test.ts
@@ -1,0 +1,632 @@
+/**
+ * uninstall.test.ts — integration tests for `yakcc uninstall`.
+ *
+ * Production sequence exercised:
+ *   uninstall(argv, logger, opts?)
+ *   → parseArgs → DEC-CLI-UNINSTALL-DETECTION-001 (tier selection)
+ *   → uninstallHookForIde(each) → update .yakccrc.json / purge
+ *   → summary log
+ *
+ * All tests use mkdtempSync + real fs I/O (no mocks). overrideHome injects a
+ * controlled home directory for cline/continue marker resolution and for
+ * detectInstalledIdes() IDE detection, without touching the real HOME.
+ *
+ * Mirror of init.test.ts structure per EC-S2 and Sacred Practice #5.
+ *
+ * @decision DEC-CLI-UNINSTALL-TEST-001
+ * title: Uninstall tests use temp directories + overrideHome injection; no mocks
+ * status: accepted (WI-656-S2)
+ * rationale:
+ *   Same rationale as DEC-CLI-INIT-TEST-001. Real fs I/O proves the production
+ *   code paths work. CollectingLogger captures output without spying. Temp dirs
+ *   guarantee isolation. overrideHome avoids writing to the real HOME directory.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CollectingLogger, runCli } from "../index.js";
+import { init } from "./init.js";
+import { uninstall } from "./uninstall.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "yakcc-uninstall-test-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Read and parse .yakccrc.json from a directory, or null if absent/invalid. */
+function readRc(dir: string): Record<string, unknown> | null {
+  const p = join(dir, ".yakccrc.json");
+  if (!existsSync(p)) return null;
+  return JSON.parse(readFileSync(p, "utf-8")) as Record<string, unknown>;
+}
+
+/** Read and parse .claude/settings.json, or null if absent/invalid. */
+function readClaudeSettings(dir: string): Record<string, unknown> | null {
+  const p = join(dir, ".claude", "settings.json");
+  if (!existsSync(p)) return null;
+  return JSON.parse(readFileSync(p, "utf-8")) as Record<string, unknown>;
+}
+
+/** Check whether .claude/settings.json has a yakcc PreToolUse entry. */
+function claudeCodeHookPresent(dir: string): boolean {
+  const settings = readClaudeSettings(dir);
+  if (settings === null) return false;
+  const hooks = settings.hooks as Record<string, unknown[]> | undefined;
+  if (hooks === undefined) return false;
+  const preToolUse = hooks.PreToolUse as Array<Record<string, unknown>> | undefined;
+  if (!Array.isArray(preToolUse)) return false;
+  // The yakcc hook lives inside a nested hooks array on the PreToolUse entry
+  return preToolUse.some((entry) => {
+    const inner = entry.hooks as Array<Record<string, unknown>> | undefined;
+    return Array.isArray(inner) && inner.some((h) => h._yakcc === "yakcc-hook-v1");
+  });
+}
+
+/** Write a minimal .yakccrc.json to seed a scenario without running init. */
+function seedRc(dir: string, installedHooks: string[]): void {
+  const rc = {
+    version: 1,
+    mode: "local",
+    registry: { path: ".yakcc/registry.sqlite" },
+    installedHooks,
+  };
+  writeFileSync(join(dir, ".yakccrc.json"), `${JSON.stringify(rc, null, 2)}\n`, "utf-8");
+}
+
+/** Create a fake HOME directory with a .claude/ config dir present. */
+function makeHomeWithClaudeCode(base: string): string {
+  const fakeHome = join(base, "fakehome");
+  mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+  return fakeHome;
+}
+
+/** Run init for claude-code + cursor in tmpDir with a fake home. */
+async function initBothClaudeAndCursor(dir: string, fakeHome: string): Promise<void> {
+  mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+  mkdirSync(join(fakeHome, ".config", "Cursor"), { recursive: true });
+  const code = await init(
+    ["--target", dir, "--ide", "claude-code,cursor", "--no-seed"],
+    new CollectingLogger(),
+    {
+      overrideHome: fakeHome,
+    },
+  );
+  expect(code).toBe(0);
+}
+
+// ---------------------------------------------------------------------------
+// EC-S2-T1 — default uninstall, installedHooks-driven (happy path)
+// ---------------------------------------------------------------------------
+
+describe("uninstall — default, installedHooks-driven (EC-S2-T1)", () => {
+  it("removes claude-code and cursor hooks; .yakccrc.json stays with installedHooks:[]", async () => {
+    const fakeHome = join(tmpDir, "fakehome-t1");
+    await initBothClaudeAndCursor(tmpDir, fakeHome);
+
+    // Confirm hooks are installed
+    expect(claudeCodeHookPresent(tmpDir)).toBe(true);
+    const rcBefore = readRc(tmpDir);
+    expect((rcBefore?.installedHooks as string[]).includes("claude-code")).toBe(true);
+
+    const logger = new CollectingLogger();
+    const code = await uninstall(["--target", tmpDir], logger);
+
+    expect(code).toBe(0);
+    // Claude Code hook removed
+    expect(claudeCodeHookPresent(tmpDir)).toBe(false);
+    // .yakccrc.json still exists
+    expect(existsSync(join(tmpDir, ".yakccrc.json"))).toBe(true);
+    // installedHooks cleared to []
+    const rcAfter = readRc(tmpDir);
+    expect(rcAfter?.installedHooks).toEqual([]);
+    // .yakcc/ still exists (not purged)
+    expect(existsSync(join(tmpDir, ".yakcc"))).toBe(true);
+  });
+
+  it("preserves other .yakccrc.json keys (version, mode, registry) verbatim (EC-S2-I3)", async () => {
+    const fakeHome = join(tmpDir, "fakehome-i3");
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
+      overrideHome: fakeHome,
+    });
+
+    await uninstall(["--target", tmpDir], new CollectingLogger());
+
+    const rc = readRc(tmpDir);
+    expect(rc?.version).toBe(1);
+    expect(rc?.mode).toBe("local");
+    expect(rc?.registry).toEqual({ path: ".yakcc/registry.sqlite" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EC-S2-T2 — default uninstall, fallback to detectInstalledIdes()
+// ---------------------------------------------------------------------------
+
+describe("uninstall — fallback to detectInstalledIdes() (EC-S2-T2)", () => {
+  it("removes claude-code hook when no .yakccrc.json and overrideHome has .claude/", async () => {
+    const fakeHome = join(tmpDir, "fakehome-t2");
+    // Install claude-code hook manually (bypass init to skip writing .yakccrc.json)
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+    const { hooksClaudeCodeInstall } = await import("./hooks-install.js");
+    await hooksClaudeCodeInstall(["--target", tmpDir], new CollectingLogger());
+
+    // Confirm hook is present and no rc exists
+    expect(claudeCodeHookPresent(tmpDir)).toBe(true);
+    expect(existsSync(join(tmpDir, ".yakccrc.json"))).toBe(false);
+
+    const logger = new CollectingLogger();
+    const code = await uninstall(["--target", tmpDir], logger, { overrideHome: fakeHome });
+
+    expect(code).toBe(0);
+    // Claude Code hook removed via fallback detection path
+    expect(claudeCodeHookPresent(tmpDir)).toBe(false);
+  });
+
+  it("falls back when .yakccrc.json has empty installedHooks (still tries detection)", async () => {
+    const fakeHome = join(tmpDir, "fakehome-t2b");
+    // Seed rc with empty installedHooks
+    seedRc(tmpDir, []);
+    // Install a hook manually
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+    const { hooksClaudeCodeInstall } = await import("./hooks-install.js");
+    await hooksClaudeCodeInstall(["--target", tmpDir], new CollectingLogger());
+    expect(claudeCodeHookPresent(tmpDir)).toBe(true);
+
+    const code = await uninstall(["--target", tmpDir], new CollectingLogger(), {
+      overrideHome: fakeHome,
+    });
+
+    expect(code).toBe(0);
+    expect(claudeCodeHookPresent(tmpDir)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EC-S2-T3 — `--purge` removes data
+// ---------------------------------------------------------------------------
+
+describe("uninstall --purge — removes .yakcc/ and .yakccrc.json (EC-S2-T3)", () => {
+  it("purge removes .yakcc/ directory and .yakccrc.json", async () => {
+    const fakeHome = join(tmpDir, "fakehome-t3");
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
+      overrideHome: fakeHome,
+    });
+
+    expect(existsSync(join(tmpDir, ".yakcc"))).toBe(true);
+    expect(existsSync(join(tmpDir, ".yakccrc.json"))).toBe(true);
+
+    const logger = new CollectingLogger();
+    const code = await uninstall(["--target", tmpDir, "--purge"], logger, {
+      overrideHome: fakeHome,
+    });
+
+    expect(code).toBe(0);
+    expect(existsSync(join(tmpDir, ".yakcc"))).toBe(false);
+    expect(existsSync(join(tmpDir, ".yakccrc.json"))).toBe(false);
+  });
+
+  it("purge: hook files are also removed (uninstall loop runs before purge)", async () => {
+    const fakeHome = join(tmpDir, "fakehome-t3b");
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
+      overrideHome: fakeHome,
+    });
+
+    await uninstall(["--target", tmpDir, "--purge"], new CollectingLogger(), {
+      overrideHome: fakeHome,
+    });
+
+    expect(claudeCodeHookPresent(tmpDir)).toBe(false);
+  });
+
+  it("purge: summary contains 'purged' (DEC-CLI-UNINSTALL-PURGE-001 / EC-S2-T8)", async () => {
+    const fakeHome = join(tmpDir, "fakehome-t3c");
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
+      overrideHome: fakeHome,
+    });
+
+    const logger = new CollectingLogger();
+    await uninstall(["--target", tmpDir, "--purge"], logger, { overrideHome: fakeHome });
+
+    const allLog = logger.logLines.join("\n").toLowerCase();
+    expect(allLog).toContain("purged");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EC-S2-T4 — `--ide <single>` targets one IDE only
+// ---------------------------------------------------------------------------
+
+describe("uninstall --ide cursor — removes cursor only (EC-S2-T4)", () => {
+  it("cursor removed; claude-code hook UNCHANGED; installedHooks updated", async () => {
+    const fakeHome = join(tmpDir, "fakehome-t4");
+    await initBothClaudeAndCursor(tmpDir, fakeHome);
+
+    const rcBefore = readRc(tmpDir);
+    expect((rcBefore?.installedHooks as string[]).includes("claude-code")).toBe(true);
+    expect((rcBefore?.installedHooks as string[]).includes("cursor")).toBe(true);
+
+    const logger = new CollectingLogger();
+    const code = await uninstall(["--target", tmpDir, "--ide", "cursor"], logger);
+
+    expect(code).toBe(0);
+    // Claude Code hook preserved
+    expect(claudeCodeHookPresent(tmpDir)).toBe(true);
+    // installedHooks now has claude-code but not cursor
+    const rcAfter = readRc(tmpDir);
+    expect((rcAfter?.installedHooks as string[]).includes("claude-code")).toBe(true);
+    expect((rcAfter?.installedHooks as string[]).includes("cursor")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EC-S2-T5 — `--ide <comma-list>` targets multiple
+// ---------------------------------------------------------------------------
+
+describe("uninstall --ide claude-code,cline — removes both (EC-S2-T5)", () => {
+  it("claude-code and cline removed; cursor and continue PRESERVED", async () => {
+    const fakeHome = join(tmpDir, "fakehome-t5");
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+    mkdirSync(join(fakeHome, ".config", "Cursor"), { recursive: true });
+    mkdirSync(join(fakeHome, ".config", "cline"), { recursive: true });
+    mkdirSync(join(fakeHome, ".continue"), { recursive: true });
+
+    // Init all four IDEs
+    const initCode = await init(
+      ["--target", tmpDir, "--ide", "claude-code,cursor,cline,continue", "--no-seed"],
+      new CollectingLogger(),
+      { overrideHome: fakeHome },
+    );
+    expect(initCode).toBe(0);
+
+    const logger = new CollectingLogger();
+    const code = await uninstall(["--target", tmpDir, "--ide", "claude-code,cline"], logger, {
+      overrideHome: fakeHome,
+    });
+
+    expect(code).toBe(0);
+    // claude-code hook removed
+    expect(claudeCodeHookPresent(tmpDir)).toBe(false);
+    // cline marker removed
+    expect(existsSync(join(fakeHome, ".config", "cline", "yakcc-cline-hook.json"))).toBe(false);
+    // cursor settings still present
+    expect(existsSync(join(tmpDir, ".cursor", "settings.json"))).toBe(true);
+    // continue marker still present
+    expect(existsSync(join(fakeHome, ".continue", "yakcc-continue-hook.json"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EC-S2-T6 — `--ide` invalid name rejected
+// ---------------------------------------------------------------------------
+
+describe("uninstall --ide codex — rejected (EC-S2-T6 + EC-S2-F6)", () => {
+  it("exits 1 and logs all four known IDE names when given an unknown IDE", async () => {
+    const logger = new CollectingLogger();
+    const code = await uninstall(["--target", tmpDir, "--ide", "codex"], logger);
+
+    expect(code).toBe(1);
+    const errText = logger.errLines.join("\n");
+    expect(errText).toContain("unknown IDE name(s): codex");
+    expect(errText).toContain("claude-code");
+    expect(errText).toContain("cursor");
+    expect(errText).toContain("cline");
+    expect(errText).toContain("continue");
+  });
+
+  it("exits 1 for an empty string ide name", async () => {
+    const logger = new CollectingLogger();
+    const code = await uninstall(["--target", tmpDir, "--ide", "bogus-ide"], logger);
+    expect(code).toBe(1);
+  });
+
+  it("does not touch the filesystem before validation (fail-fast)", async () => {
+    await uninstall(["--target", tmpDir, "--ide", "codex"], new CollectingLogger());
+    // .yakcc/ must not be created — we fail before any fs mutation
+    expect(existsSync(join(tmpDir, ".yakcc"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EC-S2-T7 — idempotent re-run
+// ---------------------------------------------------------------------------
+
+describe("uninstall — idempotent re-run (EC-S2-T7)", () => {
+  it("calling uninstall twice on a non-init'd dir exits 0 both times", async () => {
+    const logger1 = new CollectingLogger();
+    const logger2 = new CollectingLogger();
+    const code1 = await uninstall(["--target", tmpDir], logger1, { overrideHome: tmpDir });
+    const code2 = await uninstall(["--target", tmpDir], logger2, { overrideHome: tmpDir });
+
+    expect(code1).toBe(0);
+    expect(code2).toBe(0);
+  });
+
+  it("second call has no error lines", async () => {
+    await uninstall(["--target", tmpDir], new CollectingLogger(), { overrideHome: tmpDir });
+    const logger2 = new CollectingLogger();
+    await uninstall(["--target", tmpDir], logger2, { overrideHome: tmpDir });
+
+    expect(logger2.errLines.length).toBe(0);
+  });
+
+  it("calling uninstall twice after an init exits 0 both times", async () => {
+    const fakeHome = join(tmpDir, "fakehome-t7");
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
+      overrideHome: fakeHome,
+    });
+
+    const code1 = await uninstall(["--target", tmpDir], new CollectingLogger(), {
+      overrideHome: fakeHome,
+    });
+    const code2 = await uninstall(["--target", tmpDir], new CollectingLogger(), {
+      overrideHome: fakeHome,
+    });
+
+    expect(code1).toBe(0);
+    expect(code2).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EC-S2-T8 — concise summary output (≤6 lines)
+// ---------------------------------------------------------------------------
+
+describe("uninstall — concise summary output (EC-S2-T8)", () => {
+  it("default uninstall: summary log is ≤6 non-empty lines", async () => {
+    const fakeHome = join(tmpDir, "fakehome-t8a");
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
+      overrideHome: fakeHome,
+    });
+
+    const logger = new CollectingLogger();
+    await uninstall(["--target", tmpDir], logger, { overrideHome: fakeHome });
+
+    const nonEmpty = logger.logLines.filter((l) => l.trim().length > 0);
+    expect(nonEmpty.length).toBeLessThanOrEqual(6);
+  });
+
+  it("purge uninstall: summary contains 'purged' AND IDE removal info", async () => {
+    const fakeHome = join(tmpDir, "fakehome-t8b");
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
+      overrideHome: fakeHome,
+    });
+
+    const logger = new CollectingLogger();
+    await uninstall(["--target", tmpDir, "--purge"], logger, { overrideHome: fakeHome });
+
+    const allLog = logger.logLines.join("\n").toLowerCase();
+    expect(allLog).toContain("purged");
+    // Summary should mention the IDE removal
+    expect(
+      logger.logLines.some((l) => l.includes("claude-code") || l.includes("Removed from")),
+    ).toBe(true);
+    // Total non-empty log lines ≤ 6
+    const nonEmpty = logger.logLines.filter((l) => l.trim().length > 0);
+    expect(nonEmpty.length).toBeLessThanOrEqual(6);
+  });
+
+  it("default uninstall: summary mentions 'Registry preserved'", async () => {
+    const fakeHome = join(tmpDir, "fakehome-t8c");
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
+      overrideHome: fakeHome,
+    });
+
+    const logger = new CollectingLogger();
+    await uninstall(["--target", tmpDir], logger, { overrideHome: fakeHome });
+
+    const allLog = logger.logLines.join("\n");
+    expect(allLog).toContain("Registry preserved");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EC-S2-T9 — runCli dispatch arm exists
+// ---------------------------------------------------------------------------
+
+describe("runCli dispatch — routes 'uninstall' to the uninstall handler (EC-S2-T9)", () => {
+  it("runCli(['uninstall', '--target', tmpDir]) exits 0", async () => {
+    const logger = new CollectingLogger();
+    const code = await runCli(["uninstall", "--target", tmpDir], logger, {});
+
+    expect(code).toBe(0);
+  });
+
+  it("runCli uninstall result matches direct uninstall() call", async () => {
+    const fakeHome = join(tmpDir, "fakehome-t9");
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
+      overrideHome: fakeHome,
+    });
+
+    const loggerViaRunCli = new CollectingLogger();
+    const codeViaRunCli = await runCli(["uninstall", "--target", tmpDir], loggerViaRunCli, {});
+
+    expect(codeViaRunCli).toBe(0);
+    // Hook should be removed
+    expect(claudeCodeHookPresent(tmpDir)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EC-S2-T10 — `--purge` without hooks succeeds (empty installedHooks edge case)
+// ---------------------------------------------------------------------------
+
+describe("uninstall --purge — empty installedHooks still removes data (EC-S2-T10)", () => {
+  it("purge with installedHooks:[] removes .yakcc/ and .yakccrc.json without error", async () => {
+    // Seed: .yakcc/ exists, .yakccrc.json exists with empty installedHooks
+    mkdirSync(join(tmpDir, ".yakcc"), { recursive: true });
+    seedRc(tmpDir, []);
+
+    const logger = new CollectingLogger();
+    const code = await uninstall(["--target", tmpDir, "--purge"], logger, {
+      overrideHome: tmpDir,
+    });
+
+    expect(code).toBe(0);
+    expect(existsSync(join(tmpDir, ".yakcc"))).toBe(false);
+    expect(existsSync(join(tmpDir, ".yakccrc.json"))).toBe(false);
+    // No errors logged
+    expect(logger.errLines.length).toBe(0);
+  });
+
+  it("purge with no .yakccrc.json at all still exits 0 (idempotent on missing files)", async () => {
+    mkdirSync(join(tmpDir, ".yakcc"), { recursive: true });
+    // No .yakccrc.json
+
+    const code = await uninstall(["--target", tmpDir, "--purge"], new CollectingLogger(), {
+      overrideHome: tmpDir,
+    });
+
+    expect(code).toBe(0);
+    expect(existsSync(join(tmpDir, ".yakcc"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EC-S2-R2 — help text for `yakcc --help` shows uninstall verb
+// ---------------------------------------------------------------------------
+
+describe("usage text — uninstall verb documented (EC-S2-R2)", () => {
+  it("yakcc --help output contains 'uninstall' verb and its flags", async () => {
+    const logger = new CollectingLogger();
+    await runCli(["--help"], logger);
+
+    const helpText = logger.logLines.join("\n");
+    expect(helpText).toContain("uninstall");
+    expect(helpText).toContain("--purge");
+    expect(helpText).toContain("--target");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EC-S2-I3 — .yakccrc.json schema invariant: version stays 1
+// ---------------------------------------------------------------------------
+
+describe("uninstall — .yakccrc.json schema invariants (EC-S2-I3)", () => {
+  it("version is still 1 after uninstall", async () => {
+    const fakeHome = join(tmpDir, "fakehome-i3");
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
+      overrideHome: fakeHome,
+    });
+
+    await uninstall(["--target", tmpDir], new CollectingLogger(), { overrideHome: fakeHome });
+
+    const rc = readRc(tmpDir);
+    expect(rc?.version).toBe(1);
+  });
+
+  it("installedHooks is [] (not absent) after default uninstall", async () => {
+    const fakeHome = join(tmpDir, "fakehome-i3b");
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
+      overrideHome: fakeHome,
+    });
+
+    await uninstall(["--target", tmpDir], new CollectingLogger(), { overrideHome: fakeHome });
+
+    const rc = readRc(tmpDir);
+    expect(Array.isArray(rc?.installedHooks)).toBe(true);
+    expect(rc?.installedHooks).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compound-interaction test (required by implementer dispatch contract)
+//
+// Exercises the real production sequence end-to-end crossing multiple components:
+//   init (writes hooks + rc) → uninstall (reads rc → removes hooks → clears rc)
+// Both functions are the real implementations operating on real temp-dir files.
+// ---------------------------------------------------------------------------
+
+describe("compound interaction: init → uninstall end-to-end", () => {
+  it("init then uninstall: all hooks removed, rc preserved with empty installedHooks, .yakcc/ preserved", async () => {
+    const fakeHome = join(tmpDir, "fakehome-compound");
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+    mkdirSync(join(fakeHome, ".config", "cline"), { recursive: true });
+
+    // Step 1: init with claude-code + cline
+    const initCode = await init(
+      ["--target", tmpDir, "--ide", "claude-code,cline", "--no-seed"],
+      new CollectingLogger(),
+      { overrideHome: fakeHome },
+    );
+    expect(initCode).toBe(0);
+
+    // Verify installed state
+    expect(claudeCodeHookPresent(tmpDir)).toBe(true);
+    expect(existsSync(join(fakeHome, ".config", "cline", "yakcc-cline-hook.json"))).toBe(true);
+    const rcAfterInit = readRc(tmpDir);
+    expect((rcAfterInit?.installedHooks as string[]).includes("claude-code")).toBe(true);
+    expect((rcAfterInit?.installedHooks as string[]).includes("cline")).toBe(true);
+
+    // Step 2: uninstall (default — no purge)
+    const uninstallLogger = new CollectingLogger();
+    const uninstallCode = await uninstall(["--target", tmpDir], uninstallLogger, {
+      overrideHome: fakeHome,
+    });
+    expect(uninstallCode).toBe(0);
+
+    // 3. Claude Code hook removed
+    expect(claudeCodeHookPresent(tmpDir)).toBe(false);
+    // 4. Cline marker removed
+    expect(existsSync(join(fakeHome, ".config", "cline", "yakcc-cline-hook.json"))).toBe(false);
+    // 5. .yakccrc.json preserved with installedHooks: []
+    expect(existsSync(join(tmpDir, ".yakccrc.json"))).toBe(true);
+    const rcAfterUninstall = readRc(tmpDir);
+    expect(rcAfterUninstall?.version).toBe(1);
+    expect(rcAfterUninstall?.installedHooks).toEqual([]);
+    // 6. .yakcc/ still exists (registry preserved)
+    expect(existsSync(join(tmpDir, ".yakcc"))).toBe(true);
+    expect(existsSync(join(tmpDir, ".yakcc", "registry.sqlite"))).toBe(true);
+    // 7. Summary contains "Removed from" and "Registry preserved"
+    const allLog = uninstallLogger.logLines.join("\n");
+    expect(allLog).toContain("Removed from");
+    expect(allLog).toContain("Registry preserved");
+  });
+
+  it("init → uninstall --purge: everything gone", async () => {
+    const fakeHome = join(tmpDir, "fakehome-compound-purge");
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+
+    const initCode = await init(
+      ["--target", tmpDir, "--ide", "claude-code", "--no-seed"],
+      new CollectingLogger(),
+      { overrideHome: fakeHome },
+    );
+    expect(initCode).toBe(0);
+
+    const logger = new CollectingLogger();
+    const code = await uninstall(["--target", tmpDir, "--purge"], logger, {
+      overrideHome: fakeHome,
+    });
+    expect(code).toBe(0);
+
+    // All yakcc artefacts gone
+    expect(claudeCodeHookPresent(tmpDir)).toBe(false);
+    expect(existsSync(join(tmpDir, ".yakcc"))).toBe(false);
+    expect(existsSync(join(tmpDir, ".yakccrc.json"))).toBe(false);
+
+    const allLog = logger.logLines.join("\n").toLowerCase();
+    expect(allLog).toContain("purged");
+  });
+});

--- a/packages/cli/src/commands/uninstall.ts
+++ b/packages/cli/src/commands/uninstall.ts
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: MIT
+//
+// uninstall.ts — handler for `yakcc uninstall [options]`
+//
+// The symmetric off-switch for `yakcc init`. Removes the yakcc hook from every
+// IDE that S1 init recorded in `.yakccrc.json`, or falls back to detectInstalledIdes().
+//
+// @decision DEC-CLI-UNINSTALL-COMMAND-001
+// title: `yakcc uninstall` top-level verb; default removes hooks but preserves data;
+//        `--purge` removes `.yakcc/` and `.yakccrc.json`; `--ide <list>` targets specific IDEs
+// status: accepted (WI-656-S2)
+// rationale:
+//   Operator directive 2026-05-17 (#656). Default-preserve-data is the safe behavior —
+//   `--purge` is the explicit opt-in for destructive removal. Symmetric with `yakcc init`.
+//   Non-interactive per parent plan NG6; the summary line is the visibility mechanism.
+//
+// @decision DEC-CLI-UNINSTALL-DETECTION-001
+// title: 3-tier detection — explicit `--ide` list → `.yakccrc.json installedHooks` → detectInstalledIdes() fallback
+// status: accepted (WI-656-S2)
+// rationale:
+//   Primary path uses the precise install-time inventory S1 init wrote. Fallback handles
+//   projects whose `.yakccrc.json` predates S1 or was never created via unified `init`.
+//   Avoids a new public API on `ide-detect.ts` (Sacred Practice #12 — no parallel authority).
+//   Per-IDE installers are idempotent on uninstall, so an over-broad fallback is safe.
+//
+// @decision DEC-CLI-UNINSTALL-PURGE-001
+// title: `--purge` is non-interactive; summary log line announces "purged" prominently
+// status: accepted (WI-656-S2)
+// rationale:
+//   Consistent with parent plan NG6 (no interactive prompts). Scriptability is preserved.
+//   Visibility is via the summary line, not a confirmation gate. Uses rmSync with
+//   { recursive: true, force: true } per C4 (cross-platform path safety).
+
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { parseArgs } from "node:util";
+import type { Logger } from "../index.js";
+import { type IdeName, KNOWN_IDE_NAMES, detectInstalledIdes } from "../lib/ide-detect.js";
+import { hooksClineInstall } from "./hooks-cline-install.js";
+import { hooksContinueInstall } from "./hooks-continue-install.js";
+import { hooksCursorInstall } from "./hooks-cursor-install.js";
+import { hooksClaudeCodeInstall } from "./hooks-install.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Subdirectory for all yakcc operational data — removed on `--purge`. */
+const YAKCC_DIR = ".yakcc";
+
+/** Config file at project root — read (for installedHooks) and mutated or deleted. */
+const RC_FILENAME = ".yakccrc.json";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Flexible rc schema — only the fields uninstall.ts needs are typed; the rest
+ * are preserved verbatim (EC-S2-I3: version stays 1, additive-only, no field removal).
+ */
+interface YakccRc {
+  version: number;
+  installedHooks?: string[];
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Options injection seam (mirrors init.ts InitOptions)
+// ---------------------------------------------------------------------------
+
+/**
+ * Internal options for `uninstall`. Tests inject these to avoid writing to
+ * the real HOME directory.
+ *
+ * @property overrideHome - Substitute for os.homedir() during IDE detection
+ *   and cline/continue directory resolution. Mirrors InitOptions.overrideHome.
+ */
+export interface UninstallOptions {
+  overrideHome?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Read `.yakccrc.json` from target directory, or return null if absent/corrupt.
+ * Parsing errors are silently swallowed and treated as "no rc" — the caller
+ * falls through to the detectInstalledIdes() tier.
+ */
+function readRc(targetDir: string): YakccRc | null {
+  const rcPath = join(targetDir, RC_FILENAME);
+  if (!existsSync(rcPath)) return null;
+  try {
+    return JSON.parse(readFileSync(rcPath, "utf-8")) as YakccRc;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a comma-separated `--ide` value into a list of IdeName.
+ * Returns `{ ok: IdeName[] }` on success, `{ err: string }` on invalid input.
+ *
+ * Mirrors init.ts's parseIdeList() — identical logic, same error shape (EC-S2-T6).
+ */
+function parseIdeList(raw: string): { ok: IdeName[] } | { err: string } {
+  const parts = raw.split(",").map((s) => s.trim().toLowerCase());
+  const invalid = parts.filter((p) => !(KNOWN_IDE_NAMES as readonly string[]).includes(p));
+  if (invalid.length > 0) {
+    return {
+      err:
+        `unknown IDE name(s): ${invalid.join(", ")}. ` +
+        `Known IDEs: ${KNOWN_IDE_NAMES.join(", ")}`,
+    };
+  }
+  return { ok: parts as IdeName[] };
+}
+
+// ---------------------------------------------------------------------------
+// Per-IDE uninstall dispatch
+//
+// Mirrors init.ts's installHookForIde() but flips --uninstall.
+// Uses the same static dispatch table (DEC-CLI-IDE-INSTALLER-DISPATCH-001).
+// No generic HookInstaller interface — per-IDE installers preserve their
+// surface-specific semantics (EC-S2-I2).
+// ---------------------------------------------------------------------------
+
+/**
+ * Dispatch to the per-IDE installer with --uninstall flag set.
+ *
+ * For claude-code and cursor: delegates to the settings.json-based uninstall.
+ * For cline and continue: delegates to the marker-file-based uninstall.
+ *
+ * Returns the exit code from the delegated installer (0 = success / already absent).
+ * The per-IDE installers are idempotent: absent marker → log message → exit 0.
+ */
+async function uninstallHookForIde(
+  ide: IdeName,
+  targetDir: string,
+  logger: Logger,
+  overrideHome?: string,
+): Promise<number> {
+  const home = overrideHome ?? homedir();
+
+  switch (ide) {
+    case "claude-code":
+      return hooksClaudeCodeInstall(["--target", targetDir, "--uninstall"], logger);
+    case "cursor":
+      return hooksCursorInstall(["--target", targetDir, "--uninstall"], logger);
+    case "cline":
+      return hooksClineInstall(["--uninstall"], logger, join(home, ".config", "cline"));
+    case "continue":
+      return hooksContinueInstall(["--uninstall"], logger, join(home, ".continue"));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handler for `yakcc uninstall [--target <dir>] [--purge] [--ide <list>]`.
+ *
+ * Steps performed (in order):
+ *  1. Parse and validate arguments (strict; fail fast before filesystem I/O).
+ *  2. Resolve targetDir (default ".").
+ *  3. Determine the IDE list to uninstall from (DEC-CLI-UNINSTALL-DETECTION-001):
+ *     a. If --ide <list>: use explicit list (validated; no rc or detection consulted).
+ *     b. Else if .yakccrc.json has non-empty installedHooks: use that array.
+ *     c. Else: call detectInstalledIdes(overrideHome) and use the result.
+ *  4. For each IDE: call uninstallHookForIde(); log failures as warnings (non-fatal).
+ *  5. If NOT --purge: update .yakccrc.json (if it exists):
+ *       --ide path: remove only the targeted IDEs from installedHooks.
+ *       default path: set installedHooks to [].
+ *       All other rc fields preserved verbatim (EC-S2-I3).
+ *  6. If --purge: rmSync(.yakcc/, recursive+force) and rmSync(.yakccrc.json, force).
+ *  7. Emit a concise summary line (≤6 lines total; "purged" word required when --purge).
+ *  8. Return 0 on success; 1 only on flag-parse or invalid --ide errors.
+ *
+ * Idempotency: per-IDE installers log "not installed — nothing to uninstall" and
+ * return 0 when the hook is already absent. Two consecutive uninstall calls both exit 0.
+ *
+ * @param argv   - Remaining argv after `uninstall` has been consumed by runCli.
+ * @param logger - Output sink; defaults to CONSOLE_LOGGER in production.
+ * @param opts   - Internal options (home override for tests).
+ * @returns Process exit code (0 = success, 1 = error).
+ */
+export async function uninstall(
+  argv: readonly string[],
+  logger: Logger,
+  opts?: UninstallOptions,
+): Promise<number> {
+  // -------------------------------------------------------------------------
+  // 1. Parse arguments
+  // -------------------------------------------------------------------------
+
+  let parsed: ReturnType<
+    typeof parseArgs<{
+      options: {
+        target: { type: "string"; short: "t" };
+        purge: { type: "boolean" };
+        ide: { type: "string" };
+      };
+    }>
+  >;
+
+  try {
+    parsed = parseArgs({
+      args: [...argv],
+      options: {
+        target: { type: "string", short: "t" },
+        purge: { type: "boolean" },
+        ide: { type: "string" },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+  } catch (err) {
+    logger.error(`error: ${(err as Error).message}`);
+    logger.error(
+      "Usage: yakcc uninstall [--target <dir>] [--purge] [--ide <claude-code|cursor|cline|continue,...>]",
+    );
+    return 1;
+  }
+
+  const targetDir = parsed.values.target ?? ".";
+  const doPurge = parsed.values.purge === true;
+  const ideRaw = parsed.values.ide;
+
+  // -------------------------------------------------------------------------
+  // 2. Validate --ide list (fail fast before touching the filesystem)
+  // -------------------------------------------------------------------------
+
+  let explicitIdes: IdeName[] | null = null;
+  if (ideRaw !== undefined) {
+    const parseResult = parseIdeList(ideRaw);
+    if ("err" in parseResult) {
+      logger.error(`error: ${parseResult.err}`);
+      return 1;
+    }
+    explicitIdes = parseResult.ok;
+  }
+
+  // -------------------------------------------------------------------------
+  // 3. Determine IDE list per DEC-CLI-UNINSTALL-DETECTION-001
+  //
+  // Tier 1: explicit --ide <list> (already validated above)
+  // Tier 2: .yakccrc.json installedHooks (non-empty array)
+  // Tier 3: detectInstalledIdes() fallback
+  // -------------------------------------------------------------------------
+
+  let idesToUninstall: IdeName[];
+
+  if (explicitIdes !== null) {
+    // Tier 1: caller gave us an explicit list — do not consult rc or detection
+    idesToUninstall = explicitIdes;
+  } else {
+    const rc = readRc(targetDir);
+    if (rc !== null && Array.isArray(rc.installedHooks) && rc.installedHooks.length > 0) {
+      // Tier 2: .yakccrc.json has a non-empty installedHooks inventory
+      // Filter to known IDE names (defensive against corrupted rc files)
+      idesToUninstall = rc.installedHooks.filter((name): name is IdeName =>
+        (KNOWN_IDE_NAMES as readonly string[]).includes(name),
+      );
+    } else {
+      // Tier 3: fallback to live detection (covers projects that used legacy
+      // per-IDE installers before `yakcc init` unified the surface)
+      const detected = detectInstalledIdes(opts?.overrideHome);
+      idesToUninstall = detected.map((d) => d.name);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // 4. Per-IDE uninstall loop
+  //
+  // Failures are non-fatal (logged as warnings). Mirrors init.ts's pattern of
+  // continuing after a per-IDE error so partial uninstall is still useful.
+  // -------------------------------------------------------------------------
+
+  const removedIdes: IdeName[] = [];
+
+  for (const ide of idesToUninstall) {
+    try {
+      const code = await uninstallHookForIde(ide, targetDir, logger, opts?.overrideHome);
+      if (code === 0) {
+        removedIdes.push(ide);
+      } else {
+        logger.error(`warning: uninstall from ${ide} returned exit ${code} — continuing`);
+      }
+    } catch (err) {
+      logger.error(`warning: uninstall from ${ide} failed: ${String(err)} — continuing`);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // 5. Update .yakccrc.json after a default (non-purge) uninstall
+  //
+  // If --ide was used: remove only the targeted IDEs from installedHooks.
+  // If no --ide (rc or detect path): set installedHooks to [].
+  // Skip if .yakccrc.json doesn't exist.
+  //
+  // EC-S2-I3: all fields except installedHooks are preserved verbatim.
+  // -------------------------------------------------------------------------
+
+  if (!doPurge) {
+    const rc = readRc(targetDir);
+    if (rc !== null) {
+      let updatedHooks: string[];
+      if (explicitIdes !== null) {
+        // --ide path: remove only the targeted IDEs from the inventory
+        updatedHooks = (rc.installedHooks ?? []).filter(
+          (h) => !explicitIdes?.includes(h as IdeName),
+        );
+      } else {
+        // Default path: clear the entire installedHooks array
+        updatedHooks = [];
+      }
+      const updated: YakccRc = { ...rc, installedHooks: updatedHooks };
+      try {
+        writeFileSync(
+          join(targetDir, RC_FILENAME),
+          `${JSON.stringify(updated, null, 2)}\n`,
+          "utf-8",
+        );
+      } catch (err) {
+        logger.error(`warning: cannot update ${RC_FILENAME}: ${String(err)}`);
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // 6. --purge: remove .yakcc/ and .yakccrc.json (DEC-CLI-UNINSTALL-PURGE-001)
+  //
+  // Runs AFTER the hook-removal loop. Uses rmSync with { force: true } so
+  // absent files/dirs are silently ignored (idempotent). Cross-platform paths
+  // via join() (C4).
+  // -------------------------------------------------------------------------
+
+  if (doPurge) {
+    try {
+      rmSync(join(targetDir, YAKCC_DIR), { recursive: true, force: true });
+    } catch (err) {
+      logger.error(`warning: cannot remove ${YAKCC_DIR}: ${String(err)}`);
+    }
+    try {
+      rmSync(join(targetDir, RC_FILENAME), { force: true });
+    } catch (err) {
+      logger.error(`warning: cannot remove ${RC_FILENAME}: ${String(err)}`);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // 7. Emit concise summary (G6: ≤6 lines total)
+  //
+  // The summary line MUST contain "purged" when --purge is active
+  // (DEC-CLI-UNINSTALL-PURGE-001 / EC-S2-T3 / EC-S2-T8).
+  // -------------------------------------------------------------------------
+
+  const absTargetDir = resolve(targetDir);
+
+  const removedLine =
+    removedIdes.length > 0
+      ? `Removed from: ${removedIdes.join(", ")}.`
+      : "No hooks removed (nothing was installed).";
+
+  if (doPurge) {
+    logger.log(`${removedLine} Purged .yakcc/ and ${RC_FILENAME} at ${absTargetDir}.`);
+  } else {
+    logger.log(`${removedLine} Registry preserved at ${join(absTargetDir, YAKCC_DIR)}.`);
+  }
+
+  return 0;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -49,6 +49,7 @@ import { registryRebuild } from "./commands/registry-rebuild.js";
 import { search } from "./commands/search.js";
 import { seed } from "./commands/seed.js";
 import { shave } from "./commands/shave.js";
+import { uninstall } from "./commands/uninstall.js";
 
 // Re-export ContractId for callers who import from @yakcc/cli.
 export type { ContractId } from "@yakcc/contracts";
@@ -132,6 +133,11 @@ COMMANDS
        [--ide <claude-code|cursor|     Explicit IDE list (skip auto-detect)
              cline|continue,...>]
        [--no-seed]                     Skip bootstrap corpus seed
+  uninstall [--target <dir>]          Remove yakcc IDE hooks (preserves data)
+            [--purge]                 Also remove .yakcc/ and .yakccrc.json
+            [--ide <claude-code|      Target specific IDEs only (default: all installed)
+                  cursor|cline|
+                  continue,...>]
   registry init [--path <p>]          Initialize a registry (default: .yakcc/registry.sqlite)
   registry rebuild [--path <p>]       Re-embed all blocks after an embedding model swap
   registry export --to <p>            Export registry as canonical SQLite (VACUUM INTO)
@@ -203,6 +209,14 @@ export async function runCli(
       // `yakcc init [--target <dir>] [--peer <url>]`
       const initArgv = subcommand !== undefined ? [subcommand, ...rest] : rest;
       return init(initArgv, logger);
+    }
+
+    case "uninstall": {
+      // `yakcc uninstall [--target <dir>] [--purge] [--ide <list>]`
+      // Symmetric off-switch for `yakcc init` (DEC-CLI-UNINSTALL-COMMAND-001).
+      // subcommand may be a flag like --target or --purge — reassemble into argv.
+      const uninstallArgv = subcommand !== undefined ? [subcommand, ...rest] : rest;
+      return uninstall(uninstallArgv, logger);
     }
 
     case "registry": {


### PR DESCRIPTION
## Summary

WI-656 Slice 2 of 3 — adds `yakcc uninstall` command per operator decision 2026-05-17. Composition layer over fully-shipped S1 primitives (ide-detect lib + per-IDE hooks installers from PR #681).

- **NEW** `packages/cli/src/commands/uninstall.ts` (376 LOC) — Default preserves `.yakcc/`; `--purge` removes `.yakcc/` + `.yakccrc.json`; `--ide <list>` targets specific IDEs; 3-tier IDE detection (`--ide` → `installedHooks` from `.yakccrc.json` → `detectInstalledIdes` fallback).
- **NEW** `packages/cli/src/commands/uninstall.test.ts` (632 LOC, 27 tests covering EC-S2-T1..T10 + dispatch + idempotency + bogus IDE rejection + purge message + 3-tier detection).
- **MODIFIED** `packages/cli/src/index.ts` (+14 LoC) — dispatch arm + usage update.

## DECs locked

- `DEC-CLI-UNINSTALL-COMMAND-001` — verb + default-preserves-data + `--purge` + `--ide`
- `DEC-CLI-UNINSTALL-DETECTION-001` — 3-tier IDE selection
- `DEC-CLI-UNINSTALL-PURGE-001` — `--purge` non-interactive; summary says "purged"

## Backward compat

All S1 files unchanged. `.yakccrc.json` schema unchanged (`version: 1`). No new npm dependencies.

## Test plan

- [x] 27/27 uninstall tests pass (`npx vitest run src/commands/uninstall.test.ts`)
- [x] Full CLI suite: 311 passed, 1 failed (pre-existing `cli.test.ts:202` corpus-ingestion timing — environment-level, not in this slice's scope; reviewer round 2 confirmed unchanged)
- [x] Reviewer round 2 verdict: `ready_for_guardian`, 0 blockers
- [x] Evaluation state: `ready_for_guardian` @ `393d278` (now squash-merged from `7bfec06`)

## Not in this slice (per plan)

- Docs / README / USING_YAKCC / MASTER_PLAN amendment → S3 (orchestrator-owned)

Refs #656 (parent — S2 of 3). Predecessor: PR #681 (S1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)