### PR TITLE
docs: WI-656 Slice 3 (FINAL) — align CLI UX docs (closes #656)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The name is a yak-shave joke that is also a thesis. The double-c is a nod to the
 
 **Verified building blocks.** Every block in the registry carries property tests. When you compose blocks into a program, you know exactly what was tested and how.
 
-**IDE integration.** Hooks for Claude Code, Cursor, and Codex CLI intercept code-emission events and check the registry first. If a matching block already exists, it is served — no generation needed.
+**IDE integration.** Hooks for Claude Code, Cursor, Cline, and Continue.dev intercept code-emission events and check the registry first. If a matching block already exists, it is served — no generation needed.
 
 **Offline-first.** No API key is required for most operations. Shaving uses static TypeScript analysis by default. Vector search uses a local embedding model.
 
@@ -34,11 +34,9 @@ The name is a yak-shave joke that is also a thesis. The double-c is a nod to the
 # Install dependencies and build all packages
 pnpm install && pnpm build
 
-# Initialize yakcc in your project directory (creates .yakcc/, .claude/settings.json, .yakccrc.json)
+# Initialize yakcc in your project directory
+# Creates .yakcc/, wires IDE hooks for all detected IDEs, seeds the bootstrap corpus
 yakcc init
-
-# Optionally ingest the seed corpus (~20 blocks composing a JSON integer-list parser)
-yakcc seed
 
 # Assemble the parse-int-list demo
 yakcc compile examples/parse-int-list
@@ -58,10 +56,24 @@ parse-int-list demo — assembled by Yakcc v0
   listOfInts("[10,200,3000]") => [10,200,3000]
 ```
 
-`yakcc init` creates an empty registry, wires the Claude Code hook, and writes `.yakccrc.json` in one step. To initialize in a different directory or connect to a team registry peer:
+`yakcc init` is a single-command setup (per `DEC-CLI-INIT-002`): it creates the registry, auto-detects installed IDEs (Claude Code, Cursor, Cline, Continue.dev), wires each hook, and seeds the yakcc bootstrap corpus (~3k+ atoms) — all in one step. The ≤6-line summary tells you which IDEs were wired and that the seed ran.
+
+To initialize in a different directory or connect to a team registry peer:
 
 ```sh
 yakcc init --target my-project/ [--peer https://registry.example.com]
+```
+
+To remove yakcc from a project (preserves local registry data):
+
+```sh
+yakcc uninstall
+```
+
+To remove all yakcc data (hooks + registry):
+
+```sh
+yakcc uninstall --purge
 ```
 
 For the full walkthrough see `docs/USING_YAKCC.md`. Testing the v0.5.0-alpha? See `docs/ALPHA.md` for the alpha-specific tester guide.
@@ -84,23 +96,34 @@ yakcc bootstrap --verify
 
 ## IDE hook installation
 
+`yakcc init` automatically installs hooks for all detected IDEs. The commands below are for explicit control — re-wiring after a fresh IDE install, troubleshooting, or targeted installation.
+
 ```sh
 # Claude Code — writes a PreToolUse hook entry to .claude/settings.json
 # Intercepts Edit / Write / MultiEdit tool calls (DEC-HOOK-LAYER-001 D-HOOK-2)
 yakcc hooks claude-code install [--target <dir>]
-
-# Remove the hook from .claude/settings.json
 yakcc hooks claude-code install --uninstall [--target <dir>]
 
-# Cursor (WI-HOOK-LAYER Phase 4 — not yet implemented)
-# yakcc hooks cursor install
+# Cursor — wires the Cursor settings surface (shipped in WI-656-S1)
+yakcc hooks cursor install [--target <dir>]
+yakcc hooks cursor install --uninstall [--target <dir>]
 
-# Codex CLI (WI-HOOK-LAYER Phase 5 — conditional on demand)
-# yakcc hooks codex install
+# Cline — writes a marker file ~/.config/cline/yakcc-cline-hook.json
+# (DEC-CLI-HOOKS-CLINE-INSTALL-001; live settings.json wiring pending API stabilization)
+yakcc hooks cline install
+yakcc hooks cline install --uninstall
+
+# Continue.dev — writes a marker file ~/.continue/yakcc-continue-hook.json
+# (DEC-CLI-HOOKS-CONTINUE-INSTALL-001; live settings.json wiring pending API stabilization)
+yakcc hooks continue install
+yakcc hooks continue install --uninstall
+
+# Codex CLI — not yet wired; tracked at #220 (closed not-planned, conditional on demand)
 ```
 
 After installation, every `Edit`, `Write`, and `MultiEdit` tool call made by
-Claude Code will invoke `yakcc hook-intercept` before the code lands on disk.
+Claude Code (and Cursor, once their hook surface is fully wired) will invoke
+`yakcc hook-intercept` before the code lands on disk.
 The hook queries the local registry for a matching atom and captures telemetry
 (local-only by default per DEC-HOOK-LAYER-001 D-HOOK-5).
 

--- a/docs/ALPHA.md
+++ b/docs/ALPHA.md
@@ -43,11 +43,12 @@ Then in your own project:
 
 ```sh
 cd ~/my-project
-yakcc init                    # creates .yakcc/, .yakccrc.json, wires Claude Code hook
-yakcc seed --yakcc            # imports yakcc's ~4k atoms as your starter corpus
+yakcc init    # creates .yakcc/, .yakccrc.json, auto-detects + wires IDE hooks, seeds the bootstrap corpus
 ```
 
-Open Claude Code in the project. Ask it to do real work. Watch the hook fire.
+`yakcc init` is a single command (per `DEC-CLI-INIT-002`): it detects your installed IDEs (Claude Code, Cursor, Cline, Continue.dev), wires each hook, and seeds the yakcc bootstrap corpus (~4k atoms) in one step. No separate `yakcc seed --yakcc` call is needed.
+
+Open Claude Code (or Cursor) in the project. Ask it to do real work. Watch the hook fire.
 
 ### Known platform notes
 
@@ -106,7 +107,7 @@ We're not promising hotfixes for cosmetic issues. We are promising to read every
 ## What's in this alpha (one-paragraph CHANGELOG)
 
 `v0.5.0-alpha.0` ships:
-- **Hook layer** (#194) — Claude Code + Cursor adapters wired; intercepts `Edit|Write|MultiEdit`; routes through local registry first.
+- **Hook layer** (#194) — Claude Code + Cursor adapters wired with live `settings.json` hook injection; Cline and Continue.dev marker surfaces installed (per `DEC-CLI-HOOKS-CLINE-INSTALL-001`, `DEC-CLI-HOOKS-CONTINUE-INSTALL-001`); intercepts `Edit|Write|MultiEdit`; routes through local registry first.
 - **Corpus flywheel** (#362, PR #368) — every novel emission becomes an atom in your local registry, discoverable in the next session.
 - **Local registry + sqlite-vec** — content-addressed, embeddings-indexed, BLAKE3-keyed atom storage.
 - **F1 federation** — mirror/serve/pull a registry over HTTP; integrity check on every transfer.

--- a/docs/USING_YAKCC.md
+++ b/docs/USING_YAKCC.md
@@ -10,7 +10,7 @@ This document is for people who want to **use** yakcc in their own project. If y
 
 - **Node.js >= 22** — verify with `node --version`.
 - **pnpm >= 9** — install with `npm install -g pnpm` if needed.
-- **Claude Code** — install per [Claude Code docs](https://docs.claude.com/en/docs/claude-code). Cursor users see [§8 IDE adapters](#8-ide-adapters).
+- **Claude Code, Cursor, Cline, or Continue.dev** — install whichever IDE(s) you use. `yakcc init` auto-detects them. See [§8 IDE adapters](#8-ide-adapters) for the full list.
 - A TypeScript project you want to use yakcc with. The walkthrough assumes you are in its root.
 
 ---
@@ -53,19 +53,33 @@ cd ~/my-project
 yakcc init
 ```
 
-What this does (per `DEC-CLI-INIT-001` in `packages/cli/src/commands/init.ts`):
+What this does (per `DEC-CLI-INIT-001` and `DEC-CLI-INIT-002` in `packages/cli/src/commands/init.ts`):
 
 1. Creates `.yakcc/` for operational data — an empty SQLite registry at `.yakcc/registry.sqlite`, a `telemetry/` directory, and a `config/` directory.
-2. Writes `.yakccrc.json` at the project root with the registry path and (optionally) federation peers.
-3. Wires the Claude Code `PreToolUse` hook into `.claude/settings.json` (or creates the file if absent). The hook intercepts `Edit | Write | MultiEdit` tool calls and routes them through `yakcc hook-intercept` before they land on disk.
+2. Writes `.yakccrc.json` at the project root with the registry path, mode, installed hooks list, and (optionally) federation peers.
+3. Auto-detects installed IDEs (Claude Code, Cursor, Cline, Continue.dev) by probing their config directories (per `DEC-CLI-IDE-DETECT-SEMANTICS-001`), then wires the yakcc hook for each detected IDE.
+4. Seeds the yakcc bootstrap corpus (~3k+ atoms) into the local registry by default (per `DEC-CLI-INIT-002`). Pass `--no-seed` to skip this step.
+5. Prints a concise summary (<=6 lines) naming which IDEs were hooked and confirming the corpus was seeded.
 
 Verify the install:
 
 ```sh
 ls .yakcc/                              # registry/  telemetry/  config/  registry.sqlite
-cat .yakccrc.json                       # { "version": 1, "registry": { "path": ".yakcc/registry.sqlite" } }
-grep -A 5 yakcc .claude/settings.json   # PreToolUse hook entry with the yakcc-hook-v1 marker
+cat .yakccrc.json                       # { "version": 1, "mode": "local", "registry": { "path": ".yakcc/registry.sqlite" }, "installedHooks": [...] }
+grep -A 5 yakcc .claude/settings.json   # PreToolUse hook entry with the yakcc-hook-v1 marker (if Claude Code detected)
 ```
+
+### Init flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--target <dir>` | `.` (current dir) | Initialize a different directory |
+| `--peer <url>` | none | Connect to a team registry peer on first boot (http/https only) |
+| `--local` | (default) | Explicit local mode — offline-first, no peer |
+| `--airgapped` | off | Explicit airgap mode — semantically equivalent to `--local` today |
+| `--skip-hooks` | off | Skip IDE hook auto-install entirely |
+| `--ide <list>` | (auto-detect) | Comma-separated explicit IDE list, e.g. `--ide claude-code,cursor`. Skips auto-detection. Valid values: `claude-code`, `cursor`, `cline`, `continue` |
+| `--no-seed` | off | Skip the bootstrap corpus seed step |
 
 To initialize a *different* directory or connect to a team registry on first boot:
 
@@ -75,31 +89,37 @@ yakcc init --target ./some-other-project --peer https://registry.example.com
 
 `--peer` is validated strictly (must be `http:` or `https:`); the peer URL is stored under `federation.peers[]` in `.yakccrc.json` and immediately mirrored. See [§7 Federation](#7-federation).
 
+To wire hooks for specific IDEs only (skip auto-detection):
+
+```sh
+yakcc init --ide claude-code,cursor
+```
+
 ---
 
 ## 4. Verify the integration
 
-### 4a. Seed the yakcc bootstrap corpus (recommended day-1 step)
+### 4a. Verify the bootstrap corpus was seeded
 
-Before verifying the integration, seed the registry with yakcc's own atoms. This gives you ~3,800 real-shaved atoms covering yakcc's parsers, registry primitives, hook helpers, federation transport, and more — enough that your first Claude Code sessions hit the registry immediately instead of returning `synthesis-required` for every emission.
+`yakcc init` auto-seeds the yakcc bootstrap corpus by default (per `DEC-CLI-INIT-002`). This gives you ~3,800 real-shaved atoms covering yakcc's parsers, registry primitives, hook helpers, federation transport, and more — enough that your first Claude Code sessions hit the registry immediately instead of returning `synthesis-required` for every emission.
 
-```sh
-yakcc seed --yakcc
-```
-
-This is a one-time operation. It reads `bootstrap/yakcc.registry.sqlite` (in the yakcc repo clone) and imports every atom into your local registry via content-addressed storage. The import is idempotent — re-running is a no-op for already-present atoms.
-
-> **Why opt-in?** `yakcc init` deliberately does not auto-seed (per `DEC-CLI-INIT-001`). You may only want your own project's atoms. `yakcc seed --yakcc` is the explicit first-boot step when you want the full yakcc corpus day-1.
-
-> **Wall-time:** expect 20–60 seconds on a modern dev machine (mostly BLAKE3 + sqlite-vec embedding insertion).
-
-Confirm the import:
+Confirm the seed ran:
 
 ```sh
 yakcc query "store a block by content address"
 ```
 
-You should see at least one registry hit. If the query returns nothing, the bootstrap corpus was not imported — check that `bootstrap/yakcc.registry.sqlite` exists in your repo clone (`git status bootstrap/`).
+You should see at least one registry hit. If the query returns nothing and you did not pass `--no-seed`, check that `bootstrap/yakcc.registry.sqlite` exists in your repo clone (`git status bootstrap/`).
+
+To re-seed manually (the operation is idempotent):
+
+```sh
+yakcc seed --yakcc
+```
+
+> **Opt-out:** `yakcc init --no-seed` skips the seed step, restoring the quiet-init shape from before `DEC-CLI-INIT-002`. Use this if you only want your own project's atoms and prefer to seed on your own schedule.
+
+> **Wall-time:** expect 20-60 seconds on a modern dev machine (mostly BLAKE3 + sqlite-vec embedding insertion).
 
 ---
 
@@ -240,9 +260,11 @@ Then re-run `yakcc federation mirror --remote <new-url> --registry .yakcc/regist
 
 ## 8. IDE adapters
 
-### Claude Code (default)
+`yakcc init` auto-detects all four supported IDEs by probing their config directories (per `DEC-CLI-IDE-DETECT-SEMANTICS-001`). The explicit per-IDE commands below are for re-wiring after a fresh IDE install, troubleshooting, or targeted control.
 
-`yakcc init` wires this automatically. To manage it explicitly:
+### Claude Code
+
+`yakcc init` wires this automatically when `~/.claude/` is detected. To manage it explicitly:
 
 ```sh
 yakcc hooks claude-code install [--target <dir>]   # re-wire (idempotent)
@@ -253,6 +275,8 @@ The installer reads `.claude/settings.json`, adds (or removes) a single `PreTool
 
 ### Cursor
 
+`yakcc init` wires this automatically when the Cursor config directory is detected (platform-specific path per `DEC-CLI-IDE-DETECT-SEMANTICS-001`). To manage it explicitly:
+
 ```sh
 yakcc hooks cursor install [--target <dir>]
 yakcc hooks cursor install --uninstall
@@ -260,13 +284,81 @@ yakcc hooks cursor install --uninstall
 
 Same shape as the Claude Code installer; targets the Cursor settings surface.
 
+### Cline
+
+`yakcc init` writes a marker file `~/.config/cline/yakcc-cline-hook.json` when the Cline config directory is detected (per `DEC-CLI-HOOKS-CLINE-INSTALL-001`). The marker records the hook intent for when Cline's VS Code extension API surface stabilizes. No live settings.json wiring yet.
+
+To manage it explicitly:
+
+```sh
+yakcc hooks cline install         # write (or refresh) the marker file
+yakcc hooks cline install --uninstall   # remove the marker file
+```
+
+Cline detection probes `~/.config/cline/` and the VS Code extension dir `~/.vscode/extensions/saoudrizwan.claude-dev`.
+
+### Continue.dev
+
+`yakcc init` writes a marker file `~/.continue/yakcc-continue-hook.json` when the Continue.dev config directory is detected (per `DEC-CLI-HOOKS-CONTINUE-INSTALL-001`). Same pattern as Cline — the marker documents intent for when Continue.dev's extension API stabilizes. No live settings.json wiring yet.
+
+To manage it explicitly:
+
+```sh
+yakcc hooks continue install      # write (or refresh) the marker file
+yakcc hooks continue install --uninstall   # remove the marker file
+```
+
+Continue.dev detection probes `~/.continue/` and `~/.vscode/extensions/continue.continue`.
+
 ### Codex CLI
 
-Not yet wired. Tracked at issue [#220](https://github.com/cneckar/yakcc/issues/220) (conditional on demand).
+Not yet wired. Tracked at issue [#220](https://github.com/cneckar/yakcc/issues/220) (closed not-planned, conditional on demand).
 
 ---
 
-## 9. Telemetry — am I actually saving work?
+## 9. Removing yakcc
+
+To remove yakcc hooks from your project (preserves the local registry and `.yakcc/` data directory):
+
+```sh
+yakcc uninstall
+```
+
+What this does (per `DEC-CLI-UNINSTALL-COMMAND-001` and `DEC-CLI-UNINSTALL-DETECTION-001` in `packages/cli/src/commands/uninstall.ts`):
+
+1. Reads `.yakccrc.json` to discover which IDEs were installed (the `installedHooks` field written by `yakcc init`).
+2. Calls the per-IDE uninstaller for each detected IDE (idempotent — already-absent hooks log a message and exit 0).
+3. Updates `.yakccrc.json` to clear the `installedHooks` field.
+4. Prints a concise summary.
+
+The local registry (`.yakcc/registry.sqlite` and related data), telemetry files, and `.yakccrc.json` are preserved by default.
+
+### Uninstall flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--target <dir>` | `.` (current dir) | Uninstall from a different directory |
+| `--purge` | off | Also remove `.yakcc/` and `.yakccrc.json` — destructive; removes all local registry data |
+| `--ide <list>` | (all installed) | Comma-separated list of specific IDEs to uninstall. Valid values: `claude-code`, `cursor`, `cline`, `continue` |
+
+To remove all yakcc data from a project (hooks + registry + config):
+
+```sh
+yakcc uninstall --purge
+```
+
+To remove hooks for a specific IDE only:
+
+```sh
+yakcc uninstall --ide claude-code
+yakcc uninstall --ide cline,continue
+```
+
+Re-running `yakcc uninstall` is safe — it is idempotent. Running it on a project where yakcc was never initialized exits 0 with a no-op summary.
+
+---
+
+## 10. Telemetry — am I actually saving work?
 
 Every hook invocation appends one JSON line to `~/.yakcc/telemetry/<session-id>.jsonl` (per D-HOOK-5 in `docs/adr/hook-layer-architecture.md`). The file is **local-only**; nothing leaves your machine.
 
@@ -275,12 +367,12 @@ Schema (one event per emission):
 ```ts
 {
   t: 1715568000000,                // unix-ms timestamp
-  intentHash: "blake3:…",          // BLAKE3 of the emission text
+  intentHash: "blake3:...",        // BLAKE3 of the emission text
   toolName: "Edit" | "Write" | "MultiEdit",
   latencyMs: 12,
   outcome: "registry-hit" | "synthesis-required" | "passthrough",
   substituted: true,               // true iff Phase 2 substitution fired
-  substitutedAtomHash: "7f3a1c…"   // BMR[:8] of the substituted atom, or null
+  substitutedAtomHash: "7f3a1c..."   // BMR[:8] of the substituted atom, or null
 }
 ```
 
@@ -303,7 +395,7 @@ A dedicated `yakcc telemetry` subcommand is on the roadmap; until then `jq` is t
 
 ---
 
-## 10. Shaving your own codebase (optional)
+## 11. Shaving your own codebase (optional)
 
 If you already have a TypeScript package with conventions you want represented in the registry, bulk-ingest the whole tree:
 
@@ -327,13 +419,13 @@ yakcc registry rebuild --path .yakcc/registry.sqlite
 
 ---
 
-## 11. Troubleshooting
+## 12. Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | `yakcc: command not found` | PATH not set or build skipped | Re-run `pnpm -r build` and re-export PATH (see [§2](#2-installation)). |
 | Claude Code does not invoke the hook | `.claude/settings.json` missing the yakcc entry, or Claude Code not restarted after `yakcc init` | Run `yakcc hooks claude-code install` and restart Claude Code. Verify with `grep yakcc .claude/settings.json`. |
-| Registry seems empty after `yakcc init` | `init` deliberately does not auto-seed (per `DEC-CLI-INIT-001`) | Run `yakcc seed` (yakcc seed corpus) or `yakcc federation mirror --remote <peer-url> --registry .yakcc/registry.sqlite` (team registry). |
+| Registry seems empty after `yakcc init` | Seed was skipped (`--no-seed`) or the bootstrap corpus is missing | Run `yakcc seed --yakcc` to seed manually. If that fails, check that `bootstrap/yakcc.registry.sqlite` exists in your repo clone (`git status bootstrap/`). |
 | `federation mirror` fails with integrity error | Peer returned bytes that don't match the advertised BMR | Refuse the transfer (correct behavior). Contact the peer operator. |
 | Every emission shows `outcome: "passthrough"` | Embedding model mismatch after a yakcc upgrade | Re-embed the registry: `yakcc registry rebuild --path .yakcc/registry.sqlite`. |
 | Hook latency feels high (>200ms) | Cold embedding model on first call | Expected once per session; subsequent calls are warm-cached. If persistent, file an issue with a telemetry sample. |
@@ -342,7 +434,7 @@ yakcc registry rebuild --path .yakcc/registry.sqlite
 
 ---
 
-## 12. Where to go next
+## 13. Where to go next
 
 - [`README.md`](../README.md) — yakcc-the-project overview, monorepo layout, contributor quickstart.
 - [`MASTER_PLAN.md`](../MASTER_PLAN.md) — architecture decisions and work-item history.


### PR DESCRIPTION
## Summary

Closes #656 (S3 of 3, **final**). Docs-only reconciliation for the CLI UX collapse landed in #681 (S1) + #685 (S2).

- **3 files / +160/-44 LoC** — no source changes
- Removes stale "deliberately does not auto-seed" + "Phase 4 not yet implemented" claims
- Adds new §9 "Removing yakcc" to USING_YAKCC.md covering `yakcc uninstall` + flags
- Collapses ALPHA.md install from two-step to single-command `yakcc init`
- Extends CHANGELOG #194 bullet to name Cline + Continue.dev marker surfaces

## DEC annotations cited (verified present at source)

| DEC | Location |
|---|---|
| `DEC-CLI-INIT-002` | `packages/cli/src/init.ts:42-53` |
| `DEC-CLI-UNINSTALL-COMMAND-001` / `DETECTION-001` / `PURGE-001` | `packages/cli/src/uninstall.ts` |
| `DEC-CLI-HOOKS-CLINE-INSTALL-001` | `packages/cli/src/hooks-cline-install.ts:5` |
| `DEC-CLI-HOOKS-CONTINUE-INSTALL-001` | `packages/cli/src/hooks-continue-install.ts:5` |
| `DEC-CLI-IDE-DETECT-SEMANTICS-001` | `packages/cli/src/ide-detect.ts:14` |

## Stale claim sweep (post-edit)

- `deliberately does not auto-seed` / `does not auto-seed` → **0 hits**
- `Phase 4 not yet implemented` → **0 hits**
- Codex CLI in shipped-IDE tagline → removed (remaining 4 mentions are deferral context only, pointing to closed-not-planned #220)

## Predecessor PRs

- #681 — S1: ide-detect lib + per-IDE hooks installers + `DEC-CLI-INIT-002` auto-seed
- #685 — S2: `yakcc uninstall` command

## Test plan

- [ ] CI: lint / typecheck / build / branch-hygiene / B6a all green
- [ ] No source files touched (verify `gh pr diff` shows only `docs/` + `README.md`)
- [ ] MASTER_PLAN.md untouched (orchestrator-owned per directive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)