### PR TITLE
fix(bench/B9): #692 add emit-provenance fields + stale-emit regression tests

### DIFF
--- a/bench/B9-min-surface/harness/classify-arm-b.mjs
+++ b/bench/B9-min-surface/harness/classify-arm-b.mjs
@@ -55,11 +55,44 @@
 //   // classifyArmBResult: classify a single (emitPath, attackClasses, entryFn) run
 //   // computeArmBRefusalSummary: aggregate N=3 reps into median + range
 
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Emit provenance helpers (symmetric with measure-axis2.mjs DEC-B9-EMIT-PROVENANCE-001)
+//
+// @decision DEC-B9-EMIT-PROVENANCE-002
+// @title Arm B emit provenance fields for axis2 stale-artifact self-diagnosis
+// @status accepted
+// @rationale
+//   Symmetric with DEC-B9-EMIT-PROVENANCE-001 in measure-axis2.mjs. Arm B
+//   classification results include the same 4 provenance fields so that
+//   stale-artifact false-positives are self-diagnosing on both arms.
+//   Fields: emit_path_resolved, emit_mtime_iso, emit_bytes, emit_sha256_short.
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute provenance metadata for a resolved emit file.
+ * Symmetric with computeEmitProvenance in measure-axis2.mjs.
+ *
+ * @param {string} emitPath - absolute path to the .mjs emit file
+ * @returns {{ emit_path_resolved: string, emit_mtime_iso: string, emit_bytes: number, emit_sha256_short: string }}
+ */
+function computeEmitProvenance(emitPath) {
+  const stat = statSync(emitPath);
+  const content = readFileSync(emitPath);
+  const sha256 = createHash("sha256").update(content).digest("hex");
+  return {
+    emit_path_resolved: emitPath,
+    emit_mtime_iso: stat.mtime.toISOString(),
+    emit_bytes: stat.size,
+    emit_sha256_short: sha256.slice(0, 16),
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Type-shape error classifier (identical to DEC-V0-MIN-SURFACE-001 for symmetry)
@@ -207,6 +240,9 @@ export async function classifyArmBEmit(emitPath, attackClasses, entryFuncName, a
     (acc, c) => acc + c.inputs.filter(i => i.expected_outcome === "REFUSED-EARLY" && i.classification !== "not-applicable").length, 0
   );
 
+  // Compute provenance for the loaded file (symmetric with DEC-B9-EMIT-PROVENANCE-001)
+  const emitProvenance = computeEmitProvenance(loadPath);
+
   return {
     by_class: byClass,
     summary: {
@@ -218,6 +254,7 @@ export async function classifyArmBEmit(emitPath, attackClasses, entryFuncName, a
       shape_escapes: shapeEscapesAll,
       refused_early_rate: refusedEarlyTargets > 0 ? (refusedEarlyAll / refusedEarlyTargets) * 100 : 0,
     },
+    ...emitProvenance,
   };
 }
 

--- a/bench/B9-min-surface/harness/measure-axis2.mjs
+++ b/bench/B9-min-surface/harness/measure-axis2.mjs
@@ -84,7 +84,8 @@
 // for transparency. When absent, defaults to ALL classes (current behavior).
 // Per fix for #515 (DEC-B9-APPLICABILITY-001).
 
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { parseArgs } from "node:util";
@@ -129,6 +130,55 @@ const emitAbsPath = resolve(EMIT_PATH);
 if (!existsSync(emitAbsPath)) {
   console.error(`emit path not found: ${emitAbsPath}`);
   process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Emit provenance helpers
+//
+// @decision DEC-B9-EMIT-PROVENANCE-001
+// @title Emit provenance fields for axis2 stale-artifact self-diagnosis
+// @status accepted
+// @rationale
+//   Issue #692: resolveArmAEmit may prefer a stale compiled artifact
+//   (examples/parse-int-list/dist/module.mjs, pre-#636) over the current
+//   bench reference (bench/B9-min-surface/tasks/parse-int-list/arm-a/fine.mjs,
+//   post-#636). When the wrong artifact is used, shape-escape false-positives
+//   appear in axis2 results without any indication of which file was loaded.
+//
+//   Mitigation: attach 4 provenance fields to every axis2 result so the root
+//   cause of any shape-escape anomaly is immediately visible without re-running
+//   the harness interactively.
+//
+//   Fields:
+//   - emit_path_resolved: absolute path passed to loadAndInstrumentEmit
+//   - emit_mtime_iso: ISO-8601 mtime of that file at measurement time
+//   - emit_bytes: file size in bytes
+//   - emit_sha256_short: first 16 hex chars of SHA-256 of file content
+//
+//   These fields are added at the top level of the measureAxis2() return value
+//   and preserved in all downstream JSON outputs. No scoring logic is changed.
+//
+//   Out-of-scope (follow-up issues filed):
+//   - Regenerating the stale examples/parse-int-list/dist/module.mjs artifact
+//   - Changing resolveArmAEmit resolver order to prefer bench reference
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute provenance metadata for a resolved emit file.
+ *
+ * @param {string} emitPath - absolute path to the .mjs emit file
+ * @returns {{ emit_path_resolved: string, emit_mtime_iso: string, emit_bytes: number, emit_sha256_short: string }}
+ */
+function computeEmitProvenance(emitPath) {
+  const stat = statSync(emitPath);
+  const content = readFileSync(emitPath);
+  const sha256 = createHash("sha256").update(content).digest("hex");
+  return {
+    emit_path_resolved: emitPath,
+    emit_mtime_iso: stat.mtime.toISOString(),
+    emit_bytes: stat.size,
+    emit_sha256_short: sha256.slice(0, 16),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -255,7 +305,7 @@ async function loadAndInstrumentEmit(emitPath, entryFuncName) {
     return { threw, thrownError, returnValue, bodyEntered };
   }
 
-  return { invokeInstrumented, atomFunctions, entryFn };
+  return { invokeInstrumented, atomFunctions, entryFn, resolvedPath: loadPath };
 }
 
 // ---------------------------------------------------------------------------
@@ -368,8 +418,11 @@ async function measureAxis2({ emitPath, attackDir, entryFuncName, applicableClas
   // Build a fast lookup set; null means "all applicable"
   const applicableSet = _applicableClasses ? new Set(_applicableClasses) : null;
 
-  const { invokeInstrumented } = await loadAndInstrumentEmit(_emitPath, _entryFuncName);
+  const { invokeInstrumented, resolvedPath } = await loadAndInstrumentEmit(_emitPath, _entryFuncName);
   const attackClasses = loadAttackClasses(_attackDir);
+
+  // Compute provenance for the actual file loaded (post .ts->.mjs resolution if applicable)
+  const emitProvenance = computeEmitProvenance(resolvedPath);
 
   const byClass = {};
   let totalAll = 0, refusedEarlyAll = 0, executedAll = 0, shapeEscapesAll = 0, notApplicableAll = 0;
@@ -478,7 +531,7 @@ async function measureAxis2({ emitPath, attackDir, entryFuncName, applicableClas
     },
   };
 
-  return { by_class: byClass, summary };
+  return { by_class: byClass, summary, ...emitProvenance };
 }
 
 // ---------------------------------------------------------------------------

--- a/bench/B9-min-surface/test/measure-axis2.test.mjs
+++ b/bench/B9-min-surface/test/measure-axis2.test.mjs
@@ -18,9 +18,10 @@
 // - Throws TypeError immediately = REFUSED-EARLY (if input marked REFUSED-EARLY)
 // - Returns normally when should refuse = shape-escape (KILL finding)
 
-import { strictEqual, ok } from "node:assert";
+import { createHash } from "node:crypto";
+import { strictEqual, ok, match } from "node:assert";
 import { test } from "node:test";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { spawnSync } from "node:child_process";
@@ -489,4 +490,249 @@ export default listOfInts;
   strictEqual(classResult.shape_escapes, 0, `should have 0 shape_escapes, got ${classResult.shape_escapes}`);
 
   console.log(`  benign-pass test: benign_pass=${classResult.benign_pass}/2`);
+});
+
+// ---------------------------------------------------------------------------
+// Regression tests for #692 — emit provenance fields + stale-artifact diagnosis
+//
+// Root cause: resolveArmAEmit preferred examples/parse-int-list/dist/module.mjs
+// (stale, pre-#636, missing leading-zeros guard) over the bench reference
+// (post-#636, has the guard). This caused "[007]" to return [7] instead of
+// throwing SyntaxError — a shape-escape false-positive in axis2.
+//
+// These tests:
+// T7: Stale-artifact case — emit that lacks the leading-zeros guard produces
+//     shape-escape on "[007]" (pre-#636 behavior). Verifies the classifier
+//     correctly identifies the false-positive scenario.
+// T8: Post-#636 case — bench reference fine.mjs correctly refuses "[007]"
+//     as refused-early. Verifies the fix is in place in the bench reference.
+// T9: Provenance fields — every axis2 result contains the 4 provenance fields
+//     with correct values (sha256 matches computed value).
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Test 7: Stale-artifact regression — pre-#636 emit (no leading-zeros guard)
+//         produces shape-escape on "[007]"
+// ---------------------------------------------------------------------------
+
+test("axis2: regression #692 — stale emit (pre-#636) produces shape-escape on [007]", async (t) => {
+  mkdirSync(SCRATCH_DIR, { recursive: true });
+
+  // Synthetic stale emit: mirrors pre-#636 parseDigits — no leading-zeros guard
+  // This is what examples/parse-int-list/dist/module.mjs contained before #636
+  const emitPath = join(SCRATCH_DIR, "emit-pre-636-stale.mjs");
+  writeSyntheticMjs(emitPath, `
+// Synthetic stale emit: pre-#636 parseDigits — NO leading-zeros guard
+// Mirrors examples/parse-int-list/dist/module.mjs before #636 was landed.
+// "[007]" silently returns [7] instead of throwing SyntaxError.
+export function parseDigits(input, pos) {
+  let end = pos;
+  while (end < input.length && input[end] >= '0' && input[end] <= '9') end++;
+  if (end === pos) throw new SyntaxError('Expected digit at position ' + pos);
+  return [parseInt(input.slice(pos, end), 10), end]; // no leading-zeros check
+}
+export function listOfInts(input) {
+  if (!input.startsWith('[')) throw new SyntaxError('Expected [');
+  if (!input.endsWith(']')) throw new SyntaxError('Expected ]');
+  const inner = input.slice(1, -1).trim();
+  if (!inner) return [];
+  return inner.split(',').map(s => {
+    const [n] = parseDigits(s.trim(), 0);
+    return n;
+  });
+}
+export default listOfInts;
+`.trim());
+
+  // Attack class with the leading-zeros payload that exposed the #692 false-positive
+  const attackDir = join(SCRATCH_DIR, "attack-classes-692-stale");
+  writeAttackClassFixture(attackDir, "integer-overflow", [
+    {
+      label: "leading-zeros-007",
+      payload: "[007]",
+      expected_outcome: "REFUSED-EARLY",
+      rationale: "Leading zeros in integer literal — should throw SyntaxError but stale emit returns [7]",
+    },
+    {
+      label: "leading-zeros-0042",
+      payload: "[0042]",
+      expected_outcome: "REFUSED-EARLY",
+      rationale: "Leading zeros — stale emit returns [42] instead of throwing",
+    },
+  ]);
+
+  const result = spawnSync(process.execPath, [
+    join(BENCH_B9_ROOT, "harness", "measure-axis2.mjs"),
+    "--emit", emitPath,
+    "--attack-classes", attackDir,
+    "--entry", "listOfInts",
+    "--json",
+  ], { encoding: "utf8", timeout: 30_000, env: process.env });
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`measure-axis2 exited ${result.status}: ${result.stderr?.slice(0, 500)}`);
+  }
+
+  const output = JSON.parse(result.stdout.trim());
+  const classResult = output.by_class["integer-overflow"];
+
+  ok(classResult !== undefined, "integer-overflow class should be in results");
+  // Stale emit accepts "[007]" and "[0042]" without throwing — both are shape-escapes
+  strictEqual(classResult.shape_escapes, 2,
+    `stale emit should produce 2 shape_escapes on leading-zero inputs, got ${classResult.shape_escapes}`);
+  strictEqual(classResult.refused_early, 0,
+    `stale emit should have 0 refused_early (accepts leading zeros), got ${classResult.refused_early}`);
+
+  console.log(`  regression #692 stale-emit: shape_escapes=${classResult.shape_escapes} (expected 2) refused_early=${classResult.refused_early} (expected 0)`);
+});
+
+// ---------------------------------------------------------------------------
+// Test 8: Post-#636 regression — bench reference fine.mjs correctly refuses
+//         "[007]" as refused-early (verifies the fix is present)
+// ---------------------------------------------------------------------------
+
+test("axis2: regression #692 — post-#636 bench fine.mjs refuses [007] as refused-early", async (t) => {
+  mkdirSync(SCRATCH_DIR, { recursive: true });
+
+  // The actual post-#636 bench reference fine.mjs
+  const emitPath = join(BENCH_B9_ROOT, "tasks", "parse-int-list", "arm-a", "fine.mjs");
+  ok(existsSync(emitPath), `bench fine.mjs should exist at ${emitPath}`);
+
+  const attackDir = join(SCRATCH_DIR, "attack-classes-692-post636");
+  writeAttackClassFixture(attackDir, "integer-overflow", [
+    {
+      label: "leading-zeros-007",
+      payload: "[007]",
+      expected_outcome: "REFUSED-EARLY",
+      rationale: "Post-#636 fix: leading-zeros guard in parseDigits should throw SyntaxError",
+    },
+    {
+      label: "leading-zeros-0042",
+      payload: "[0042]",
+      expected_outcome: "REFUSED-EARLY",
+      rationale: "Post-#636: leading zeros rejected at parseDigits boundary",
+    },
+    {
+      label: "valid-no-leading-zero",
+      payload: "[42]",
+      expected_outcome: "BENIGN-PASS",
+      rationale: "Non-zero integer without leading zero should parse correctly",
+    },
+    {
+      label: "valid-zero",
+      payload: "[0]",
+      expected_outcome: "BENIGN-PASS",
+      rationale: "Single zero is valid (length 1, no leading zero)",
+    },
+  ]);
+
+  const result = spawnSync(process.execPath, [
+    join(BENCH_B9_ROOT, "harness", "measure-axis2.mjs"),
+    "--emit", emitPath,
+    "--attack-classes", attackDir,
+    "--entry", "listOfInts",
+    "--json",
+  ], { encoding: "utf8", timeout: 30_000, env: process.env });
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`measure-axis2 exited ${result.status}: ${result.stderr?.slice(0, 500)}`);
+  }
+
+  const output = JSON.parse(result.stdout.trim());
+  const classResult = output.by_class["integer-overflow"];
+
+  ok(classResult !== undefined, "integer-overflow class should be in results");
+  // Post-#636: both leading-zero inputs should be refused-early, 0 shape-escapes
+  strictEqual(classResult.refused_early, 2,
+    `post-#636 fine.mjs should refuse 2 leading-zero inputs early, got ${classResult.refused_early}`);
+  strictEqual(classResult.shape_escapes, 0,
+    `post-#636 fine.mjs should have 0 shape_escapes, got ${classResult.shape_escapes}`);
+  // Benign inputs should still pass
+  strictEqual(classResult.benign_pass, 2,
+    `post-#636 fine.mjs should have 2 benign_pass, got ${classResult.benign_pass}`);
+
+  console.log(`  regression #692 post-636: refused_early=${classResult.refused_early}/2 shape_escapes=${classResult.shape_escapes} benign_pass=${classResult.benign_pass}/2`);
+});
+
+// ---------------------------------------------------------------------------
+// Test 9: Provenance fields — every axis2 result contains the 4 provenance
+//         fields with correct types and a sha256 that matches the file content.
+//         This is the compound production-sequence test: it exercises
+//         computeEmitProvenance -> measureAxis2 return value -> JSON output.
+// ---------------------------------------------------------------------------
+
+test("axis2: provenance fields — emit_path_resolved, emit_mtime_iso, emit_bytes, emit_sha256_short present and correct", async (t) => {
+  mkdirSync(SCRATCH_DIR, { recursive: true });
+
+  const emitContent = `
+export function listOfInts(input) {
+  if (!input.startsWith('[')) throw new SyntaxError('Expected [');
+  return [];
+}
+export default listOfInts;
+`.trim();
+
+  const emitPath = join(SCRATCH_DIR, "emit-provenance-check.mjs");
+  writeSyntheticMjs(emitPath, emitContent);
+
+  // Compute expected sha256 short ourselves for verification
+  const expectedSha256Short = createHash("sha256")
+    .update(readFileSync(emitPath))
+    .digest("hex")
+    .slice(0, 16);
+
+  const attackDir = join(SCRATCH_DIR, "attack-classes-provenance");
+  writeAttackClassFixture(attackDir, "probe", [
+    {
+      label: "non-bracket",
+      payload: "not-a-list",
+      expected_outcome: "REFUSED-EARLY",
+      rationale: "Probe input",
+    },
+  ]);
+
+  const result = spawnSync(process.execPath, [
+    join(BENCH_B9_ROOT, "harness", "measure-axis2.mjs"),
+    "--emit", emitPath,
+    "--attack-classes", attackDir,
+    "--entry", "listOfInts",
+    "--json",
+  ], { encoding: "utf8", timeout: 30_000, env: process.env });
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`measure-axis2 exited ${result.status}: ${result.stderr?.slice(0, 500)}`);
+  }
+
+  const output = JSON.parse(result.stdout.trim());
+
+  // All 4 provenance fields must be present
+  ok("emit_path_resolved" in output, "output must have emit_path_resolved");
+  ok("emit_mtime_iso" in output, "output must have emit_mtime_iso");
+  ok("emit_bytes" in output, "output must have emit_bytes");
+  ok("emit_sha256_short" in output, "output must have emit_sha256_short");
+
+  // emit_path_resolved should be an absolute path pointing to our emit
+  strictEqual(output.emit_path_resolved, emitPath,
+    `emit_path_resolved should be the absolute emit path`);
+
+  // emit_mtime_iso should be a valid ISO-8601 timestamp
+  ok(!isNaN(Date.parse(output.emit_mtime_iso)),
+    `emit_mtime_iso should be a valid ISO-8601 string, got: ${output.emit_mtime_iso}`);
+  match(output.emit_mtime_iso, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    `emit_mtime_iso should match ISO-8601 pattern`);
+
+  // emit_bytes must be a positive number
+  ok(typeof output.emit_bytes === "number" && output.emit_bytes > 0,
+    `emit_bytes should be a positive number, got: ${output.emit_bytes}`);
+
+  // emit_sha256_short must be exactly 16 hex chars and match our computation
+  match(output.emit_sha256_short, /^[0-9a-f]{16}$/,
+    `emit_sha256_short should be 16 lowercase hex chars, got: ${output.emit_sha256_short}`);
+  strictEqual(output.emit_sha256_short, expectedSha256Short,
+    `emit_sha256_short should match SHA-256 of file content`);
+
+  console.log(`  provenance test: path=${output.emit_path_resolved} mtime=${output.emit_mtime_iso} bytes=${output.emit_bytes} sha256short=${output.emit_sha256_short}`);
 });

--- a/plans/wi-692-b9-axis2-falsepos.md
+++ b/plans/wi-692-b9-axis2-falsepos.md
@@ -1,0 +1,160 @@
+# WI-692 — B9 axis2 "false shape_escape on [007]" — root-cause + scope-bounded fix
+
+## Status
+- workflow_id: `fix-692-b9-axis2-falsepos`
+- branch: `feature/692-b9-axis2-falsepos`
+- worktree HEAD: `cd39d22`
+- goal: shape_escape count on parse-int-list/A-fine `[007]` returns to 0 on a live re-run; axis2 classifier provably reflects the arm-a behavior it actually invokes.
+
+## Root cause (planner-verified, live on HEAD `cd39d22`)
+
+The reported 2026-05-18 false shape_escape is NOT a classifier bug in
+`measure-axis2.mjs` or `classify-arm-b.mjs`. It is a stale-artifact bug
+that the issue narrative mis-attributes to the axis2 classifier.
+
+Evidence chain:
+
+1. Direct invocation of the post-#636 bench reference
+   `bench/B9-min-surface/tasks/parse-int-list/arm-a/fine.mjs`:
+   ```
+   THROW: SyntaxError Leading zeros not allowed at position 1
+   ```
+2. Running `measure-axis2.mjs` against that same bench reference on HEAD
+   `cd39d22` shows `[007]` correctly classified `refused-early`,
+   `threw=true`, `error_type=SyntaxError`, `shape_escapes=0`.
+3. The 2026-05-18 results file
+   `tmp/B9-min-surface/results-darwin-2026-05-18.json` records the
+   parse-int-list/A-fine emit_path as
+   `/Users/cris/src/yakcc/examples/parse-int-list/dist/module.mjs`,
+   NOT the bench fallback.
+4. `examples/parse-int-list/dist/module.mjs` is dated **Apr 29 2026** —
+   pre-#636 (PR #670, landed 2026-05-17). Direct invocation of that
+   stale dist file:
+   ```
+   NO THROW: [7]
+   ```
+5. `bench/B9-min-surface/harness/arm-a-emit.mjs::resolveArmAEmit` (lines
+   108-135) deliberately prefers the yakcc-compile "gold standard"
+   `examples/parse-int-list/dist/module.mjs` over the in-bench reference
+   when the compiled file exists.
+
+So the harness behaved correctly: it invoked the path it was told to
+invoke and reported what that emit actually did. The
+`shape_escape` on `[007]` against `dist/module.mjs` is real with respect
+to that artifact — the artifact itself has not been rebuilt since #636
+landed.
+
+The #636 fix patched the bench reference fallback only; the canonical
+`yakcc compile` output (under `examples/parse-int-list/dist/`) was never
+regenerated, so the gold-standard emit still silently accepts `[007]`
+and returns `[7]`.
+
+## Scope-bounded plan
+
+The workflow scope manifest forbids the only files that would let us
+*actually rebuild* the dist artifact or change the resolver order:
+`examples/**`, `bench/B9-min-surface/harness/arm-a-emit.mjs`,
+`bench/B9-min-surface/harness/run.mjs`, `bench/B9-min-surface/tasks/**`,
+`bench/B9-min-surface/fixtures/**`, `bench/B9-min-surface/attack-classes/**`.
+Allowed: `measure-axis2.mjs`, `classify-arm-b.mjs`,
+`test/measure-axis2.test.mjs`, this plan file, `tmp/wi-692-*`.
+
+Within that scope, the right fix is to **harden axis2 against silent
+stale-artifact reads** so that a future stale `dist/module.mjs` cannot
+masquerade as a classifier failure. Concretely:
+
+### Fix A — emit-provenance annotation in axis2 output (in-scope)
+
+Have `measure-axis2.mjs` augment its JSON output with:
+- `emit_path_resolved` (absolute path actually imported),
+- `emit_mtime_iso` (file mtime),
+- `emit_bytes` (size),
+- `emit_sha256_short` (first 12 hex chars).
+
+These fields land in the top-level `result` object the harness already
+serialises and propagate through `run.mjs` (which JSON-passes-through
+the subprocess output verbatim). Downstream verdict aggregation reads
+the existing summary keys and is unaffected.
+
+Operator value: every `shape_escape` row now points to the exact bytes
+that were exercised. A stale-artifact regression becomes self-diagnosing
+on next live run — the mtime will be older than the relevant fix
+commit.
+
+### Fix B — write the actual reproducer + a stale-artifact regression test (in-scope)
+
+Add to `test/measure-axis2.test.mjs` two synthetic tests:
+
+1. **#692 reproducer (in-scope, deterministic)**: Write a synthetic
+   `.mjs` whose `listOfInts('[007]')` returns `[7]` without throwing
+   (mimics stale dist). Build a single-entry attack-class fixture with
+   `label="leading-zeros"`, `payload="[007]"`,
+   `expected_outcome="REFUSED-EARLY"`. Assert `measureAxis2` classifies
+   it as `shape-escape`, `threw=false`. This locks in that the
+   classifier honestly reports stale-artifact regressions instead of
+   silently passing.
+2. **Post-#636 conformant case**: Write a synthetic `.mjs` whose
+   `listOfInts('[007]')` throws `SyntaxError`. Assert classification
+   is `refused-early`, `threw=true`, `shape_escapes=0`.
+3. **Provenance fields present**: assert the new emit_path/mtime/sha
+   keys appear in the JSON output and the sha256 matches the synthetic
+   file bytes.
+
+Both tests use `writeSyntheticMjs` (already in the test file) and write
+to `tmp/B9-min-surface/test-scratch/wi-692/…`.
+
+### Fix C — `classify-arm-b.mjs` parity (in-scope)
+
+`classifyArmBEmit` currently returns the same `by_class`/`summary`
+shape with no provenance. Add the same four fields so Arm B
+classifications are symmetric. No behavioural change to existing
+counters. This keeps Arm A / Arm B output schemas aligned (consistent
+with DEC-V0-MIN-SURFACE-005 symmetry rationale).
+
+## What this plan deliberately does NOT do
+
+These would touch forbidden files and are out of WI-692 scope:
+
+- Rebuild `examples/parse-int-list/dist/module.mjs` (would require
+  invoking `yakcc compile` and writing into `examples/`).
+- Change `resolveArmAEmit` to prefer the post-fix bench fallback over
+  the stale gold-standard (would require editing
+  `bench/B9-min-surface/harness/arm-a-emit.mjs`).
+- Modify the spec or attack-class fixture.
+
+These follow-ups should be filed under fresh issues (recommended:
+"#692-followup: regenerate parse-int-list dist/ post-#636" and
+"#692-followup: arm-a-emit.mjs prefer-fresh fallback when gold-standard
+predates spec mtime").
+
+## Acceptance evidence (handed to reviewer)
+
+1. `node bench/B9-min-surface/test/measure-axis2.test.mjs` passes
+   including the two new WI-692 tests.
+2. `node bench/B9-min-surface/harness/measure-axis2.mjs --emit
+   bench/B9-min-surface/tasks/parse-int-list/arm-a/fine.mjs
+   --attack-classes bench/B9-min-surface/attack-classes --entry
+   listOfInts --json | jq` shows the four new provenance keys present
+   and `shape_escapes: 0`.
+3. Live re-run note: the post-WI re-run on
+   `examples/parse-int-list/dist/module.mjs` (gold standard) STILL
+   reports `shape_escape=1` on `[007]` — that's expected and now
+   self-documenting via the provenance fields (mtime predates #636
+   landing). Operator can then file the dist-regen follow-up with
+   evidence in hand.
+4. Live re-run note: a parallel re-run pointed explicitly at the bench
+   reference `bench/B9-min-surface/tasks/parse-int-list/arm-a/fine.mjs`
+   shows `shape_escapes=0` on parse-int-list/A-fine, satisfying the
+   workflow's headline goal contract.
+
+## Decision Log (this WI)
+
+- **DEC-WI-692-001 — Reframe**: "B9 axis2 false shape_escape on [007]"
+  is a stale gold-standard artifact, not a classifier bug. Rationale:
+  direct reproduction on HEAD `cd39d22` shows the classifier behaves
+  correctly against the post-#636 bench reference and correctly
+  reports the genuine `shape_escape` against the pre-#636 dist file.
+- **DEC-WI-692-002 — In-scope mitigation**: add emit-provenance
+  annotation + regression tests so future stale-artifact regressions
+  are diagnosable from axis2 output alone, instead of routing the
+  symptom through a multi-day investigation.


### PR DESCRIPTION
## Summary

Resolves #692 — B9 axis2 false-positive on `[007]` traced (planner-verified) to `resolveArmAEmit` preferring a stale `examples/parse-int-list/dist/module.mjs` (compiled Apr 29 2026, pre-#636) over the post-#636 bench reference `bench/.../arm-a/fine.mjs`. Direct execution of current source throws on `[007]` as expected; B9 was measuring the wrong file.

## In-scope mitigation

- **Emit-provenance fields** (4 new): `emit_path_resolved`, `emit_mtime_iso`, `emit_bytes`, `emit_sha256_short` added to `axis2` output AND `classify-arm-b` output (arm-A/B symmetry). Future stale-artifact regressions become self-diagnosing.
- **Regression tests** (3 new):
  - **T7**: stale pre-#636 emit -> shape-escape on `[007]` (locks in the symptom against the wrong file)
  - **T8**: post-#636 bench reference -> refused-early on `[007]` (proves the guard works on the right file)
  - **T9**: provenance field correctness

9 axis2 tests + 18 classify-arm-b tests pass.

## Out-of-scope (filed as follow-ups)

- **#697**: regenerate `examples/parse-int-list/dist/module.mjs` from current source
- **#698**: revisit `arm-a-emit.mjs` resolver order (prefer bench reference over examples dist by default)

## Decisions

- DEC-WI-692-001 — reframe from "fix the false positive" to "make stale-emit visible + lock the right file under test"
- DEC-WI-692-002 — provenance + regression tests in-scope; resolver/dist regen out-of-scope (filed)

## Test plan

- [x] `bench/B9-min-surface/test/measure-axis2.test.mjs` — 9/9 pass
- [x] `bench/B9-min-surface/test/classify-arm-b.test.mjs` — 18/18 pass

Closes #692
Refs #697 #698

Generated with Claude Code