### PR TITLE
fix(bench/B9): #698 freshness guard in resolveArmAEmit — fall back to bench reference when dist is stale

### DIFF
--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -1826,6 +1826,14 @@ Six tasks = mid-range of 5-8 corridor per #446. Tasks 2–6 are authored in this
 | W-B9-S1-11 | Add `bench:min-surface` script to root `package.json`; document `--dry-run` and `--no-network` flags (latter per Gap 11) | S | W-B9-S1-10 | none | 5 |
 | W-B9-S1-12 | First honest measurement run on Windows; commit `results-windows-<date>.json`; append observed values to `DEC-BENCH-B9-SLICE1-001` (no KILL pre-data per #167 Principle 1) | M | W-B9-S1-11 | review | 6 |
 
+**B9 Slice 1 bug-class follow-ups (per #167 Principle 6 — bugs vs tuning).** Defects discovered during or after the Slice 1 honest run are tracked here as independent slices, not as edits to the Slice 1 W-B9-S1-N table above. Each row links to its issue/PR and its plan file under `plans/`.
+
+| ID | Title | Weight | Deps | Gate | Status |
+|----|-------|--------|------|------|--------|
+| W-B9-S1-BUG-692 | B9 axis2 false `shape_escape` on `[007]` — emit-provenance fields (path/mtime/bytes/sha256) surfaced in axis2 JSON output for self-diagnosing stale-artifact false-positives | M | W-B9-S1-4 | review | done — `plans/wi-692-b9-axis2-falsepos.md`; DEC-B9-EMIT-PROVENANCE-001 landed in `measure-axis2.mjs` |
+| W-B9-S1-BUG-697 | Regenerate stale `examples/parse-int-list/dist/module.mjs` from current source (post-#636 — currently Apr-29 pre-fix artifact) | S | — | review | in flight — issue [#697](https://github.com/cneckar/yakcc/issues/697) |
+| W-B9-S1-BUG-698 | `arm-a-emit.mjs` freshness guard — fall back to bench reference (with stderr warning + new `source: "bench-reference-stale-fallback"` enum value) when dist mtime predates fallback; `--force-gold-standard` / `{forceGoldStandard:true}` opt-in override; `@decision DEC-B9-EMIT-FRESHNESS-GUARD-001` and `-002` documented file-local | S | W-B9-S1-7 | review | planned — issue [#698](https://github.com/cneckar/yakcc/issues/698); plan `plans/wi-fix-698-arm-a-emit-freshness-guard.md` |
+
 **Critical path:** 6 waves. **Max width:** 4 (Wave 2: axis1 + attack-classes + axis3 + llm-baseline + arm-a-emit all parallelize once skeleton is locked).
 
 **Slice 1 directional targets** (per #167 Principle 1 + #446 Gap 12 — KILL columns struck; replaced with "Directional target (no KILL pre-data)"):

--- a/bench/B9-min-surface/harness/arm-a-emit.mjs
+++ b/bench/B9-min-surface/harness/arm-a-emit.mjs
@@ -3,25 +3,25 @@
 // bench/B9-min-surface/harness/arm-a-emit.mjs
 //
 // @decision DEC-V0-MIN-SURFACE-004
-// @title Arm A granularity sweep — three strategies per task
+// @title Arm A granularity sweep -- three strategies per task
 // @status accepted
 // @rationale
 //   GRANULARITY SWEEP DEFINITION (per #446 Gap 3 + MASTER_PLAN.md Slice 1)
 //   Arm A is not a single point but a sweep over three decomposition strategies:
 //
-//   A-fine: maximally atomic — deepest decomposition the registry/bench permits.
+//   A-fine: maximally atomic -- deepest decomposition the registry/bench permits.
 //     Each atom handles exactly one structural concern (one ASCII check, one delimiter
 //     assertion, one digit parser, etc.). Maximises the number of distinct atoms so
 //     the Axis 1 reachable-function count is minimised per-call and Axis 2 shape
 //     refusal fires at the shallowest atom.
 //     Location: bench/B9-min-surface/tasks/<task>/arm-a/fine.mjs
 //
-//   A-medium: composite blocks — atoms grouped at natural task-component boundaries
+//   A-medium: composite blocks -- atoms grouped at natural task-component boundaries
 //     (e.g., "validate prefix" = ASCII check + opening delimiter check). Represents
 //     the natural mid-point between maximum atomization and a monolithic function.
 //     Location: bench/B9-min-surface/tasks/<task>/arm-a/medium.mjs
 //
-//   A-coarse: single broad block per task — minimal decomposition, one function
+//   A-coarse: single broad block per task -- minimal decomposition, one function
 //     handles the entire spec. Structurally closer to an LLM emit. Used to measure
 //     how much of the attack-surface reduction comes from the block boundary rather
 //     than from deep atomization.
@@ -39,17 +39,17 @@
 //   The bench/B9-min-surface/tasks/parse-int-list/arm-a/fine.mjs is a fallback reference.
 //
 //   REJECTED ALTERNATIVES:
-//   - Single A-fine only: doesn't produce the frontier — the cost/surface trade-off
+//   - Single A-fine only: doesn't produce the frontier -- the cost/surface trade-off
 //     is the primary research question for B9.
 //   - Continuous granularity (N > 3 strategies): diminishing returns; 3 strategies
 //     span the design space (fine/medium/coarse) at tractable measurement cost.
 //
 //   Cross-references:
-//   DEC-V0-MIN-SURFACE-001 (REFUSED-EARLY) — harness/measure-axis2.mjs
-//   DEC-V0-MIN-SURFACE-002 (reachability) — harness/measure-axis1.mjs
-//   DEC-V0-MIN-SURFACE-004 (this annotation) — harness/arm-a-emit.mjs
-//   DEC-V0-MIN-SURFACE-005 (Arm B classifier) — harness/classify-arm-b.mjs
-//   DEC-BENCH-B9-SLICE1-COST-001 (cost cap) — harness/run.mjs
+//   DEC-V0-MIN-SURFACE-001 (REFUSED-EARLY) -- harness/measure-axis2.mjs
+//   DEC-V0-MIN-SURFACE-002 (reachability) -- harness/measure-axis1.mjs
+//   DEC-V0-MIN-SURFACE-004 (this annotation) -- harness/arm-a-emit.mjs
+//   DEC-V0-MIN-SURFACE-005 (Arm B classifier) -- harness/classify-arm-b.mjs
+//   DEC-BENCH-B9-SLICE1-COST-001 (cost cap) -- harness/run.mjs
 //
 // Usage:
 //   node bench/B9-min-surface/harness/arm-a-emit.mjs --task <taskId> --strategy <fine|medium|coarse>
@@ -58,7 +58,7 @@
 // Or import as a module:
 //   import { resolveArmAEmit, ARM_A_STRATEGIES } from './arm-a-emit.mjs';
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
@@ -90,6 +90,42 @@ export const TASK_ENTRY_FUNCTIONS = {
 };
 
 // ---------------------------------------------------------------------------
+// @decision DEC-B9-EMIT-FRESHNESS-GUARD-001
+// @title Compare mtime of compiled gold-standard vs bench fallback; fall back when stale.
+// @status accepted
+// @rationale
+//   PROBLEM: resolveArmAEmit() previously preferred examples/parse-int-list/dist/module.mjs
+//   unconditionally whenever it existed. Because the dist file has no freshness contract
+//   relative to the bench fallback, a stale dist file (mtime older than bench fallback) can
+//   silently route B9 axis2 through the wrong implementation -- producing false-positive or
+//   false-negative results. This was the root cause of the 2026-05-18 B9 axis2 false-positive
+//   captured in issue #692 (dist mtime Apr 29 2026, bench fallback mtime post-#636 May 17 2026).
+//
+//   THREE CANDIDATES CONSIDERED:
+//   (A) Silent fallback + stderr warning (ACCEPTED): When dist mtime < bench fallback mtime,
+//       return bench fallback path and print a greppable WARN to stderr. The source enum
+//       value "bench-reference-stale-fallback" signals the fallback in JSON output.
+//       Override: --force-gold-standard (CLI) / { forceGoldStandard: true } (module API).
+//   (B) Throw StaleEmitError unless --force-gold-standard set: Rejected -- breaks run.mjs
+//       sweep iteration (per-task try/catch turns into "skip task" rather than "use bench
+//       fallback", producing incomplete sweeps without addressing the root cause).
+//   (C) Content-hash allowlist: Rejected -- adds maintenance surface (known-good-shas.json)
+//       without a corresponding gain; SHA mismatch is a strict subset of mtime drift.
+//
+//   ACCEPTED RATIONALE:
+//   - Bench runs always produce a working measurement against the freshest reference.
+//   - The stderr WARN is loud and greppable for any honest operator.
+//   - The "bench-reference-stale-fallback" source enum value in JSON output enables
+//     post-hoc detection from results-*.json inspection.
+//   - The opt-in { forceGoldStandard: true } preserves deliberate stale-artifact
+//     measurement (e.g. pre/post-#636 comparison runs).
+//   - Guard is disabled via override, not removed -- dist is still preferred when fresh.
+//
+//   Cross-reference: DEC-V0-MIN-SURFACE-004 (Arm A granularity sweep -- parent decision)
+//   Issue: #698  |  Companion: #697 (regenerate the stale dist artifact)
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
 // Resolve Arm A emit path for a given (task, strategy)
 // ---------------------------------------------------------------------------
 
@@ -97,25 +133,59 @@ export const TASK_ENTRY_FUNCTIONS = {
  * Resolve the .mjs path for the Arm A granularity sweep at the given strategy.
  *
  * For parse-int-list A-fine, if the yakcc compile output is present
- * (examples/parse-int-list/dist/module.mjs or module.ts transpiled to .mjs),
- * that is used as the gold standard. Otherwise, the bench reference is used.
+ * (examples/parse-int-list/dist/module.mjs) AND its mtime is >= the bench
+ * fallback mtime, it is used as the gold standard. When the dist file is older
+ * than the bench fallback (stale artifact) a stderr warning is emitted and the
+ * bench fallback is returned instead. Pass { forceGoldStandard: true } to
+ * bypass the freshness guard and always prefer the dist file when present.
  *
  * @param {string} repoRoot
  * @param {string} taskId
  * @param {"A-fine"|"A-medium"|"A-coarse"} strategy
- * @returns {{ emitPath: string, source: "yakcc-compile"|"bench-reference" }}
+ * @param {{ forceGoldStandard?: boolean }} [options={}]
+ * @returns {{ emitPath: string, source: "yakcc-compile"|"bench-reference"|"bench-reference-stale-fallback" }}
  */
-export function resolveArmAEmit(repoRoot, taskId, strategy) {
+export function resolveArmAEmit(repoRoot, taskId, strategy, options = {}) {
   const strategyDir = STRATEGY_DIR[strategy];
   if (!strategyDir) {
     throw new Error(`Unknown strategy: ${strategy}. Valid values: ${ARM_A_STRATEGIES.join(", ")}`);
   }
 
-  // For parse-int-list A-fine: prefer yakcc compile output if it exists
+  // For parse-int-list A-fine: prefer yakcc compile output if it exists and is fresh
   if (taskId === "parse-int-list" && strategy === "A-fine") {
     // Check for pre-transpiled .mjs from the compile pipeline
     const compiledMjs = join(repoRoot, "examples", "parse-int-list", "dist", "module.mjs");
     if (existsSync(compiledMjs)) {
+      // DEC-B9-EMIT-FRESHNESS-GUARD-001: Freshness guard
+      // When forceGoldStandard is set, bypass the mtime check and prefer dist unconditionally.
+      const forceGoldStandard = options.forceGoldStandard === true;
+      if (forceGoldStandard) {
+        return { emitPath: compiledMjs, source: "yakcc-compile" };
+      }
+
+      // Compute bench fallback path for mtime comparison
+      const benchPath = join(BENCH_B9_ROOT, "tasks", taskId, "arm-a", `${strategyDir}.mjs`);
+
+      if (existsSync(benchPath)) {
+        const compiledStat = statSync(compiledMjs);
+        const benchStat = statSync(benchPath);
+
+        if (compiledStat.mtimeMs < benchStat.mtimeMs) {
+          // Dist file is older than bench fallback -- staleness guard fires.
+          // Emit a greppable stderr warning and fall back to bench reference.
+          const compiledMtimeIso = new Date(compiledStat.mtimeMs).toISOString();
+          const benchMtimeIso = new Date(benchStat.mtimeMs).toISOString();
+          process.stderr.write(
+            `[arm-a-emit] WARN: yakcc-compile artifact at ${compiledMjs} mtime=${compiledMtimeIso} ` +
+            `is older than bench fallback at ${benchPath} mtime=${benchMtimeIso}; ` +
+            `falling back to bench reference. Pass --force-gold-standard or ` +
+            `{forceGoldStandard:true} to override.\n`
+          );
+          return { emitPath: benchPath, source: "bench-reference-stale-fallback" };
+        }
+      }
+
+      // Dist is fresh (mtime >= bench fallback) or bench fallback does not exist
       return { emitPath: compiledMjs, source: "yakcc-compile" };
     }
     // Note: module.ts would need transpilation; that's handled by the run.mjs orchestrator
@@ -143,9 +213,10 @@ export function resolveArmAEmit(repoRoot, taskId, strategy) {
  *
  * @param {string} repoRoot
  * @param {string[]} taskIds
+ * @param {{ forceGoldStandard?: boolean }} [options={}]
  * @returns {Array<{ taskId, strategy, emitPath, entryFunction, source }>}
  */
-export function listAllArmAEmits(repoRoot, taskIds) {
+export function listAllArmAEmits(repoRoot, taskIds, options = {}) {
   const emits = [];
   for (const taskId of taskIds) {
     const entryFunction = TASK_ENTRY_FUNCTIONS[taskId];
@@ -154,7 +225,7 @@ export function listAllArmAEmits(repoRoot, taskIds) {
     }
     for (const strategy of ARM_A_STRATEGIES) {
       try {
-        const { emitPath, source } = resolveArmAEmit(repoRoot, taskId, strategy);
+        const { emitPath, source } = resolveArmAEmit(repoRoot, taskId, strategy, options);
         emits.push({ taskId, strategy, emitPath, entryFunction, source });
       } catch (err) {
         // Report missing emits but don't abort listing
@@ -177,6 +248,7 @@ const { values: cliArgs } = parseArgs({
     list: { type: "boolean", default: false },
     "repo-root": { type: "string" },
     json: { type: "boolean", default: false },
+    "force-gold-standard": { type: "boolean", default: false },
   },
   strict: false,
   allowPositionals: false,
@@ -208,10 +280,11 @@ if (isMain) {
     }
 
     const REPO_ROOT = cliArgs["repo-root"] ?? findRepoRoot(resolve(BENCH_B9_ROOT, "..", ".."));
+    const resolveOptions = { forceGoldStandard: cliArgs["force-gold-standard"] };
 
     if (cliArgs["list"]) {
       const taskIds = Object.keys(TASK_ENTRY_FUNCTIONS);
-      const emits = listAllArmAEmits(REPO_ROOT, taskIds);
+      const emits = listAllArmAEmits(REPO_ROOT, taskIds, resolveOptions);
       if (cliArgs["json"]) {
         process.stdout.write(JSON.stringify(emits, null, 2) + "\n");
       } else {
@@ -222,7 +295,7 @@ if (isMain) {
       }
     } else if (cliArgs["task"] && cliArgs["strategy"]) {
       try {
-        const { emitPath, source } = resolveArmAEmit(REPO_ROOT, cliArgs["task"], cliArgs["strategy"]);
+        const { emitPath, source } = resolveArmAEmit(REPO_ROOT, cliArgs["task"], cliArgs["strategy"], resolveOptions);
         const entryFunction = TASK_ENTRY_FUNCTIONS[cliArgs["task"]];
         const result = { task_id: cliArgs["task"], strategy: cliArgs["strategy"], emit_path: emitPath, entry_function: entryFunction, source };
         if (cliArgs["json"]) {
@@ -239,8 +312,8 @@ if (isMain) {
         process.exit(1);
       }
     } else {
-      console.error("Usage: arm-a-emit.mjs --task <taskId> --strategy <A-fine|A-medium|A-coarse> [--json]");
-      console.error("   or: arm-a-emit.mjs --list [--json]");
+      console.error("Usage: arm-a-emit.mjs --task <taskId> --strategy <A-fine|A-medium|A-coarse> [--json] [--force-gold-standard]");
+      console.error("   or: arm-a-emit.mjs --list [--json] [--force-gold-standard]");
       process.exit(1);
     }
   })();

--- a/bench/B9-min-surface/test/arm-a-emit.test.mjs
+++ b/bench/B9-min-surface/test/arm-a-emit.test.mjs
@@ -5,19 +5,29 @@
 // Unit tests for harness/arm-a-emit.mjs
 //
 // Tests:
-// 1. resolveArmAEmit returns correct path for each (task, strategy) combination
-// 2. resolveArmAEmit throws for unknown task or unknown strategy
-// 3. listAllArmAEmits returns 18 entries (6 tasks × 3 strategies) with no errors
-// 4. All resolved emit paths actually exist on disk
-// 5. CLI --list produces output for all 18 emits
-// 6. CLI --task + --strategy produces JSON with correct fields
+// 1. ARM_A_STRATEGIES constant is correct
+// 2. TASK_ENTRY_FUNCTIONS has all 6 tasks
+// 3. resolveArmAEmit returns valid paths for all tasks/strategies
+//    (source enum extended: also accepts "bench-reference-stale-fallback")
+// 4. resolveArmAEmit throws for unknown strategy
+// 5. resolveArmAEmit throws for unknown taskId
+// 6. listAllArmAEmits returns 18 entries (6 tasks x 3 strategies) with no errors
+// 7. All A-fine emit files importable and have entry function
+// 8. CLI --list produces output for all 18 emits
+// 9. CLI --task + --strategy produces JSON with correct fields
+// 10. freshness guard: falls back to bench reference when dist mtime older than fallback
+// 11. freshness guard: returns yakcc-compile when dist mtime newer than fallback
+// 12. freshness guard: --force-gold-standard bypasses guard even when dist is stale
+// 13. freshness guard: stderr warning emitted via CLI when guard fires (subprocess)
 
 import { strictEqual, ok, deepEqual } from "node:assert";
 import { test } from "node:test";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync, utimesSync } from "node:fs";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 
 import {
   resolveArmAEmit,
@@ -55,9 +65,12 @@ test("arm-a-emit: TASK_ENTRY_FUNCTIONS has all 6 tasks", () => {
 
 // ---------------------------------------------------------------------------
 // Test 3: resolveArmAEmit returns valid paths for all tasks/strategies
+// NOTE: source enum extended -- now also accepts "bench-reference-stale-fallback"
+//       (DEC-B9-EMIT-FRESHNESS-GUARD-001: the guard may fire against the real dist
+//        file if it is stale relative to the bench fallback at the time tests run)
 // ---------------------------------------------------------------------------
 
-test("arm-a-emit: resolveArmAEmit — all (task, strategy) pairs resolve", () => {
+test("arm-a-emit: resolveArmAEmit -- all (task, strategy) pairs resolve", () => {
   const taskIds = Object.keys(TASK_ENTRY_FUNCTIONS);
   for (const taskId of taskIds) {
     for (const strategy of ARM_A_STRATEGIES) {
@@ -68,8 +81,8 @@ test("arm-a-emit: resolveArmAEmit — all (task, strategy) pairs resolve", () =>
         `emit file should exist for ${taskId}/${strategy}: ${emitPath}`
       );
       ok(
-        source === "bench-reference" || source === "yakcc-compile",
-        `source should be bench-reference or yakcc-compile for ${taskId}/${strategy}, got: ${source}`
+        source === "bench-reference" || source === "yakcc-compile" || source === "bench-reference-stale-fallback",
+        `source should be bench-reference, yakcc-compile, or bench-reference-stale-fallback for ${taskId}/${strategy}, got: ${source}`
       );
       console.log(`  [OK] ${taskId}/${strategy} -> ${source}`);
     }
@@ -80,7 +93,7 @@ test("arm-a-emit: resolveArmAEmit — all (task, strategy) pairs resolve", () =>
 // Test 4: resolveArmAEmit throws for unknown strategy
 // ---------------------------------------------------------------------------
 
-test("arm-a-emit: resolveArmAEmit — throws for unknown strategy", () => {
+test("arm-a-emit: resolveArmAEmit -- throws for unknown strategy", () => {
   let threw = false;
   try {
     resolveArmAEmit(WORKTREE_ROOT, "parse-int-list", "A-nonexistent");
@@ -95,7 +108,7 @@ test("arm-a-emit: resolveArmAEmit — throws for unknown strategy", () => {
 // Test 5: resolveArmAEmit throws for unknown taskId
 // ---------------------------------------------------------------------------
 
-test("arm-a-emit: resolveArmAEmit — throws for unknown taskId", () => {
+test("arm-a-emit: resolveArmAEmit -- throws for unknown taskId", () => {
   let threw = false;
   try {
     resolveArmAEmit(WORKTREE_ROOT, "nonexistent-task", "A-fine");
@@ -111,11 +124,11 @@ test("arm-a-emit: resolveArmAEmit — throws for unknown taskId", () => {
 // Test 6: listAllArmAEmits returns 18 entries, all resolved, no errors
 // ---------------------------------------------------------------------------
 
-test("arm-a-emit: listAllArmAEmits — 18 entries, all present", () => {
+test("arm-a-emit: listAllArmAEmits -- 18 entries, all present", () => {
   const taskIds = Object.keys(TASK_ENTRY_FUNCTIONS);
   const emits = listAllArmAEmits(WORKTREE_ROOT, taskIds);
 
-  strictEqual(emits.length, 18, `expected 18 emits (6 tasks × 3 strategies), got ${emits.length}`);
+  strictEqual(emits.length, 18, `expected 18 emits (6 tasks x 3 strategies), got ${emits.length}`);
 
   const missing = emits.filter(e => e.error);
   if (missing.length > 0) {
@@ -131,7 +144,7 @@ test("arm-a-emit: listAllArmAEmits — 18 entries, all present", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Test 7: listAllArmAEmits — each emit file is actually loadable as a module
+// Test 7: listAllArmAEmits -- each emit file is actually loadable as a module
 //         (basic syntax/export check via dynamic import of the .mjs path)
 // ---------------------------------------------------------------------------
 
@@ -225,4 +238,254 @@ test("arm-a-emit: CLI --task --strategy --json output", () => {
   ok(existsSync(output.emit_path), `emit_path should exist: ${output.emit_path}`);
 
   console.log(`  CLI --task digits-to-sum --strategy A-medium -> emit_path exists, entry_function=${output.entry_function}`);
+});
+
+// ---------------------------------------------------------------------------
+// Freshness guard tests (Tests 10-13)
+// ---------------------------------------------------------------------------
+// Helper: build a minimal fixture repo tree under a temp directory.
+// Structure mirrors the real repo layout the guard expects:
+//   <fixtureRoot>/
+//     examples/parse-int-list/dist/module.mjs   (stub compiled dist)
+//     bench/B9-min-surface/tasks/parse-int-list/arm-a/fine.mjs  (stub bench fallback)
+//
+// IMPORTANT: we point repoRoot at fixtureRoot but BENCH_B9_ROOT inside the
+// imported resolveArmAEmit is hardcoded to the real bench directory. The
+// function computes benchPath as:
+//   join(BENCH_B9_ROOT, "tasks", taskId, "arm-a", `${strategyDir}.mjs`)
+// where BENCH_B9_ROOT is the module-level constant pointing at the real
+// bench/B9-min-surface tree. That means for mtime comparison, the real bench
+// fallback file is used -- which is what we want: the guard must compare the
+// fixture's dist mtime against the REAL bench fallback mtime.
+//
+// To simulate "dist is older than bench fallback", we backdate the fixture
+// dist file to a Unix epoch (Jan 1, 1970) -- well before any real bench file.
+// To simulate "dist is newer", we set the fixture dist mtime to far future.
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a minimal fixture repo root with stub dist/module.mjs.
+ * Returns { fixtureRoot, distPath, realBenchPath } so caller can manipulate mtimes.
+ */
+function buildFixture(label) {
+  const fixtureRoot = mkdtempSync(join(WORKTREE_ROOT, "tmp", `wi-fix-698-fixtures-${label}-`));
+  const distDir = join(fixtureRoot, "examples", "parse-int-list", "dist");
+  mkdirSync(distDir, { recursive: true });
+  const distPath = join(distDir, "module.mjs");
+  // Minimal stub module -- just needs to exist, content doesn't matter for mtime test
+  writeFileSync(distPath, "export function listOfInts(s) { return []; }\n", "utf8");
+
+  const realBenchPath = join(BENCH_B9_ROOT, "tasks", "parse-int-list", "arm-a", "fine.mjs");
+  return { fixtureRoot, distPath, realBenchPath };
+}
+
+// ---------------------------------------------------------------------------
+// Test 10: freshness guard -- falls back to bench reference when dist is stale
+//   GIVEN dist mtime older than bench fallback mtime (backdated to epoch)
+//   AND options.forceGoldStandard !== true
+//   THEN returns { source: "bench-reference-stale-fallback", emitPath: <bench fallback path> }
+// ---------------------------------------------------------------------------
+
+test("arm-a-emit: freshness guard -- falls back to bench reference when dist mtime older than fallback", async () => {
+  const { fixtureRoot, distPath, realBenchPath } = buildFixture("stale");
+  try {
+    // Backdate dist to Unix epoch (well before any real bench file)
+    const epoch = new Date(0);
+    utimesSync(distPath, epoch, epoch);
+    console.log(`  fixture dist mtime: ${new Date(0).toISOString()} (epoch)`);
+    console.log(`  real bench fallback: ${realBenchPath}`);
+
+    // Capture stderr to verify the warning is emitted
+    const stderrLines = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk, ...rest) => {
+      stderrLines.push(String(chunk));
+      return origWrite(chunk, ...rest);
+    };
+
+    let result;
+    try {
+      result = resolveArmAEmit(fixtureRoot, "parse-int-list", "A-fine");
+    } finally {
+      process.stderr.write = origWrite;
+    }
+
+    strictEqual(
+      result.source,
+      "bench-reference-stale-fallback",
+      `expected source="bench-reference-stale-fallback", got: ${result.source}`
+    );
+    strictEqual(
+      result.emitPath,
+      realBenchPath,
+      `expected emitPath to be the real bench fallback path`
+    );
+
+    const warnText = stderrLines.join("");
+    ok(warnText.includes("WARN"), `stderr should contain "WARN", got: ${warnText.slice(0, 200)}`);
+    ok(warnText.includes("mtime"), `stderr should contain "mtime", got: ${warnText.slice(0, 200)}`);
+    ok(warnText.includes(realBenchPath) || warnText.includes("fine.mjs"),
+      `stderr should reference bench fallback path, got: ${warnText.slice(0, 300)}`);
+
+    console.log(`  [OK] source=${result.source}, emitPath=<bench fallback>`);
+    console.log(`  [OK] stderr WARN: ${warnText.trim().slice(0, 120)}`);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Test 11: freshness guard -- returns yakcc-compile when dist mtime newer than fallback
+//   GIVEN dist mtime in the far future (newer than bench fallback)
+//   THEN returns { source: "yakcc-compile", emitPath: <dist path> }
+//   AND no warning is written to stderr
+// ---------------------------------------------------------------------------
+
+test("arm-a-emit: freshness guard -- returns yakcc-compile when dist mtime newer than fallback", async () => {
+  const { fixtureRoot, distPath, realBenchPath } = buildFixture("fresh");
+  try {
+    // Forward-date dist to far future (year 2099) -- definitely newer than any bench file
+    const future = new Date("2099-01-01T00:00:00.000Z");
+    utimesSync(distPath, future, future);
+    console.log(`  fixture dist mtime: ${future.toISOString()} (future)`);
+
+    // Capture stderr to verify NO warning is emitted
+    const stderrLines = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk, ...rest) => {
+      stderrLines.push(String(chunk));
+      return origWrite(chunk, ...rest);
+    };
+
+    let result;
+    try {
+      result = resolveArmAEmit(fixtureRoot, "parse-int-list", "A-fine");
+    } finally {
+      process.stderr.write = origWrite;
+    }
+
+    strictEqual(
+      result.source,
+      "yakcc-compile",
+      `expected source="yakcc-compile", got: ${result.source}`
+    );
+    strictEqual(
+      result.emitPath,
+      distPath,
+      `expected emitPath to be the fixture dist path`
+    );
+
+    const warnText = stderrLines.join("");
+    strictEqual(warnText, "", `stderr should be empty when dist is fresh, got: ${warnText.slice(0, 200)}`);
+
+    console.log(`  [OK] source=${result.source}, emitPath=<dist path>`);
+    console.log(`  [OK] stderr empty (guard did not fire)`);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Test 12: freshness guard -- force-gold-standard bypasses guard even when dist is stale
+//   GIVEN dist mtime older than bench fallback (backdated to epoch)
+//   AND options.forceGoldStandard === true
+//   THEN returns { source: "yakcc-compile", emitPath: <dist path> }
+//   AND no warning is written to stderr
+// ---------------------------------------------------------------------------
+
+test("arm-a-emit: freshness guard -- force-gold-standard bypasses guard even when dist is stale", async () => {
+  const { fixtureRoot, distPath, realBenchPath } = buildFixture("force-override");
+  try {
+    // Backdate dist to epoch -- would normally trigger the guard
+    const epoch = new Date(0);
+    utimesSync(distPath, epoch, epoch);
+    console.log(`  fixture dist mtime: ${new Date(0).toISOString()} (epoch, would be stale)`);
+
+    // Capture stderr to verify NO warning is emitted when forceGoldStandard=true
+    const stderrLines = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk, ...rest) => {
+      stderrLines.push(String(chunk));
+      return origWrite(chunk, ...rest);
+    };
+
+    let result;
+    try {
+      result = resolveArmAEmit(fixtureRoot, "parse-int-list", "A-fine", { forceGoldStandard: true });
+    } finally {
+      process.stderr.write = origWrite;
+    }
+
+    strictEqual(
+      result.source,
+      "yakcc-compile",
+      `expected source="yakcc-compile" with forceGoldStandard, got: ${result.source}`
+    );
+    strictEqual(
+      result.emitPath,
+      distPath,
+      `expected emitPath to be the fixture dist path (override active)`
+    );
+
+    const warnText = stderrLines.join("");
+    strictEqual(warnText, "", `stderr should be empty with forceGoldStandard, got: ${warnText.slice(0, 200)}`);
+
+    console.log(`  [OK] source=${result.source} (override active, no warning)`);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Test 13: freshness guard -- CLI emits stderr WARN when guard fires (subprocess)
+//   Uses the real dist file (stale if #697 not yet landed) OR a fixture via --repo-root.
+//   Builds a fixture with a backdated dist, invokes the CLI with --repo-root pointing
+//   at it, and asserts the WARN appears in stderr.
+// ---------------------------------------------------------------------------
+
+test("arm-a-emit: freshness guard -- CLI emits WARN to stderr when guard fires", () => {
+  const { fixtureRoot, distPath, realBenchPath } = buildFixture("cli-warn");
+  try {
+    // Backdate dist to epoch so guard fires
+    const epoch = new Date(0);
+    utimesSync(distPath, epoch, epoch);
+
+    const result = spawnSync(process.execPath, [
+      join(BENCH_B9_ROOT, "harness", "arm-a-emit.mjs"),
+      "--task", "parse-int-list",
+      "--strategy", "A-fine",
+      "--json",
+      "--repo-root", fixtureRoot,
+    ], {
+      encoding: "utf8",
+      timeout: 15_000,
+      env: process.env,
+    });
+
+    if (result.error) throw result.error;
+    // CLI should still exit 0 -- it returns a result even when the guard fires
+    if (result.status !== 0) {
+      throw new Error(`arm-a-emit CLI exited ${result.status}: ${result.stderr?.slice(0, 500)}`);
+    }
+
+    // stderr must contain the WARN
+    const stderr = result.stderr ?? "";
+    ok(stderr.includes("WARN"), `stderr should contain "WARN", got: ${stderr.slice(0, 300)}`);
+    ok(stderr.includes("mtime"), `stderr should contain "mtime", got: ${stderr.slice(0, 300)}`);
+
+    // stdout JSON should show source = bench-reference-stale-fallback
+    let output;
+    try {
+      output = JSON.parse(result.stdout.trim());
+    } catch (err) {
+      throw new Error(`CLI output is not valid JSON: ${result.stdout.slice(0, 200)}`);
+    }
+    strictEqual(output.source, "bench-reference-stale-fallback",
+      `expected source="bench-reference-stale-fallback" in JSON output, got: ${output.source}`);
+
+    console.log(`  [OK] CLI WARN in stderr: ${stderr.trim().slice(0, 120)}`);
+    console.log(`  [OK] CLI JSON source=${output.source}`);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
 });

--- a/plans/wi-fix-698-arm-a-emit-freshness-guard.md
+++ b/plans/wi-fix-698-arm-a-emit-freshness-guard.md
@@ -1,0 +1,285 @@
+# WI-fix-698 — arm-a-emit.mjs freshness guard (prevent stale gold-standard preference)
+
+- **Workflow ID:** `fix-698-arm-a-emit-freshness-guard`
+- **Goal ID:** `g-fix-698-arm-a-emit-freshness-guard`
+- **Implementer work item:** `fix-698-arm-a-emit-freshness-guard-impl`
+- **Branch:** `feature/fix-698-arm-a-emit-freshness-guard`
+- **Worktree:** `C:/src/yakcc/.worktrees/feature-fix-698-arm-a-emit-freshness-guard`
+- **Ticket:** [#698](https://github.com/cneckar/yakcc/issues/698)
+- **Companion ticket (parallel slice, disjoint scope):** [#697](https://github.com/cneckar/yakcc/issues/697) — regenerates the stale `examples/parse-int-list/dist/module.mjs`
+- **Predecessor plan:** [`plans/wi-692-b9-axis2-falsepos.md`](./wi-692-b9-axis2-falsepos.md) — root-cause diagnosis + provenance fields landed in PR #693/#700
+- **Initiative:** v1 — Benchmark Suite Characterisation Pass → B9 Slice 1 — bug-class follow-ups (per #167 Principle 6)
+- **Complexity tier:** **Tier 2 (Standard)** — single source file + single test file, but introduces a new "freshness guard" semantic surface inside an existing authority (`resolveArmAEmit`), is guardian-bound, requires an explicit @decision annotation for the new policy, and ships with a regression test that simulates stale-artifact conditions.
+
+## 1. Problem statement
+
+`bench/B9-min-surface/harness/arm-a-emit.mjs::resolveArmAEmit()` unconditionally
+prefers the yakcc-compile output (`examples/parse-int-list/dist/module.mjs`)
+over the bench fallback reference whenever the dist file exists (current
+`arm-a-emit.mjs` lines 114-123). This "always prefer the gold-standard if
+present" rule is unsafe in practice: the gold-standard artifact has no
+freshness contract relative to the bench fallback, so when the dist file
+predates a relevant fix commit, the harness silently routes through the
+**stale** artifact while reporting "yakcc-compile" as the source.
+
+This is exactly the failure mode that produced the 2026-05-18 B9 axis2
+false-positive captured in #692:
+
+- `examples/parse-int-list/dist/module.mjs` mtime: **Apr 29 2026**
+- Bench fallback `bench/B9-min-surface/tasks/parse-int-list/arm-a/fine.mjs`
+  mtime: **post-#636 (May 17 2026)** with the leading-zeros guard
+- Result: `listOfInts('[007]')` returned `[7]` against the stale dist file
+  instead of throwing the `SyntaxError` the bench reference would throw
+
+The provenance fields added in WI-692 (`emit_mtime_iso`, `emit_sha256_short`,
+`emit_path_resolved`, `emit_bytes`) make the *symptom* self-diagnosing post hoc,
+but they do not *prevent* the next stale-artifact false-positive — they just
+make the forensic root-cause faster.
+
+**Why this is a #167 Principle 6 bug-class WI, not a tuning knob.**
+The B9 sweep's headline reads "yakcc atomic emission refuses adversarial
+shape inputs." If the harness silently invokes a stale artifact that *doesn't*
+refuse, the headline is a measurement artefact, not a property of the
+atomization pipeline. Defence-in-depth here keeps the bench honest the next
+time a fix lands without a corresponding `yakcc compile` re-run.
+
+This is **complementary** to #697 (regenerate the stale dist artifact).
+#697 cures *today's* stale file; this WI prevents the *next* recurrence and
+catches it loud rather than silent.
+
+## 2. Architecture / state-authority map
+
+This WI touches a single state authority: **B9 emit-resolution**.
+
+- **Canonical authority:** `bench/B9-min-surface/harness/arm-a-emit.mjs::resolveArmAEmit()` — the sole owner of `(taskId, strategy) → emitPath` resolution.
+- **Adjacent authorities (read-only consumers, NOT modified):**
+  - `bench/B9-min-surface/harness/run.mjs` (line 449/483) — destructures `resolveArmAEmit` from `arm-a-emit.mjs` and calls it inside the per-task loop. Receives `{ emitPath, source }` today; will continue to receive the same shape (source enum is extended, not narrowed).
+  - `bench/B9-min-surface/harness/measure-axis2.mjs` — does not call `resolveArmAEmit` directly; receives `--emit <path>` from the orchestrator. **Not modified.**
+  - `bench/B9-min-surface/harness/listAllArmAEmits()` — uses `resolveArmAEmit` internally inside the same file. Continues to work; will surface the guard's new `source` value through `listAllArmAEmits`'s entry shape.
+- **Adjacent authorities (NOT touched, deliberately out of scope):**
+  - `examples/parse-int-list/dist/module.mjs` — that's #697's scope. This WI must NOT regenerate, delete, or `touch` the artifact. Touching it would defeat the test: a stale-artifact scenario requires a stale artifact.
+  - `bench/B10-import-replacement/harness/arm-a-emit.mjs` — B10 has its own `resolveArmAEmit` analog. B10 is out of scope; if B10 needs the same guard it is a follow-up WI.
+- **No new DEC ledger entry, but one new file-local @decision annotation.** The new freshness-guard policy is a *refinement* of `DEC-V0-MIN-SURFACE-004` (Arm A granularity sweep) and is documented inline in `arm-a-emit.mjs` as `DEC-B9-EMIT-FRESHNESS-GUARD-001`. It is not a kernel-level decision so it does not need a row in the MASTER_PLAN Decision Log (per Tier 2's policy that file-local refinements live at the call site).
+
+**Architecture preservation check (per CLAUDE.md "Architecture Preservation"):**
+- One authority per fact (emit resolution). ✓
+- Hooks-as-adapters: this is harness internal logic, not a hook. ✓
+- No parallel authorities — the guard extends the existing authority rather than introducing a sibling resolver. ✓
+- Bundle change (source + invariant test + provenance source enum) lands in one PR. ✓
+
+## 3. Design decisions (file-local, not kernel)
+
+### DEC-B9-EMIT-FRESHNESS-GUARD-001 — Guard semantics
+
+**@decision DEC-B9-EMIT-FRESHNESS-GUARD-001**
+**@title Compare mtime of compiled gold-standard vs bench fallback; fall back when stale.**
+**@status accepted by planner; landed in code by implementer.**
+
+**Three candidates considered:**
+
+| Candidate | Behaviour when dist is older than bench fallback | Pros | Cons |
+|---|---|---|---|
+| **(A) Silent fallback + stderr warning** | Return bench fallback path; print `[arm-a-emit] WARN: yakcc-compile artifact at <path> mtime=<dist-mtime> is older than bench fallback at <fallback-path> mtime=<fallback-mtime>; falling back to bench reference. Pass --force-gold-standard or {forceGoldStandard:true} to override.` to stderr. | Bench runs always produce a working measurement against the freshest reference. Operator gets a loud, greppable warning in stderr. Backward-compatible with the existing `{ emitPath, source }` return shape. | Operator might miss the warning if they only inspect stdout/JSON. |
+| **(B) Throw unless `--force-gold-standard` set** | Throw `StaleEmitError`; require explicit opt-in. | Cannot be missed — bench fails closed. | Breaks `run.mjs` and `listAllArmAEmits()` flow when any dev forgets to regenerate `dist/module.mjs` after a touched-source commit. Heavy-handed for a sweep harness whose primary purpose is "produce numbers." |
+| **(C) Content-hash allowlist** | Maintain a `known-good-shas.json` of accepted dist SHAs; mismatch → fallback. | Catches *semantic* drift, not just temporal. | Requires hash list maintenance across every dist regenerate. Doubles the surface that can rot. Brittle and gives the appearance of safety without solving the root issue (mtime drift between fixes). |
+
+**Recommendation accepted: (A) silent fallback + stderr warning + opt-in override.**
+
+Rationale (binding for implementer):
+- B9 axis2 callers (`run.mjs` per-task loop, `listAllArmAEmits` enumeration) want a *working measurement* against the freshest available reference, not a hard fail that requires operator intervention.
+- The stderr warning is loud enough for any honest operator to notice; the JSON output additionally carries the `source` enum value `bench-reference-stale-fallback` so post-hoc inspection of `results-*.json` shows the fallback path was used.
+- The opt-in override `--force-gold-standard` (CLI) / `{ forceGoldStandard: true }` (module API) preserves the ability to deliberately measure the older artifact — e.g., regression testing the dist file before regeneration, or comparing pre/post-#636 axis2 numbers.
+- (B) is rejected because it breaks `run.mjs`'s sweep iteration on every stale-artifact case; the existing per-task `try/catch` in `run.mjs` would turn into "skip task" rather than "use bench fallback," which produces incomplete results without addressing the root cause.
+- (C) is rejected as adding maintenance surface without a corresponding gain: SHA mismatch is a strict subset of mtime drift (any content change updates mtime), and the SHA list itself becomes a new authority to keep in sync.
+
+### DEC-B9-EMIT-FRESHNESS-GUARD-002 — Caller-signalling mechanism
+
+**@decision DEC-B9-EMIT-FRESHNESS-GUARD-002**
+**@title Dual signalling: CLI flag `--force-gold-standard` for direct invocation; options-object `{ forceGoldStandard: true }` for module callers.**
+**@status accepted.**
+
+`resolveArmAEmit()` is invoked through two paths today:
+
+1. **Module path:** `import { resolveArmAEmit } from './arm-a-emit.mjs'` (`run.mjs` line 449/483; `listAllArmAEmits()` line 157; `test/arm-a-emit.test.mjs`).
+2. **CLI path:** `node bench/B9-min-surface/harness/arm-a-emit.mjs --task <id> --strategy <s>`.
+
+**Decision:** the new signal is exposed as an **optional fourth parameter** to `resolveArmAEmit(repoRoot, taskId, strategy, options = {})`, where `options.forceGoldStandard` is the override boolean. The CLI section of the file already uses `parseArgs`; it gains a `"force-gold-standard": { type: "boolean", default: false }` option and forwards `{ forceGoldStandard: cliArgs["force-gold-standard"] }` to `resolveArmAEmit`. `listAllArmAEmits()` receives the same options object as a new optional parameter so callers can choose to enumerate with the override.
+
+Rationale:
+- The options-object pattern is JS-idiomatic and backward-compatible (existing 3-arg callers — `run.mjs` line 483, the existing tests' 3-arg calls — keep working unchanged; `options` defaults to `{}` which means "guard enabled, no override").
+- Mirrors the existing `parseArgs` style in the CLI block so the CLI surface is uniform with the rest of the file's options.
+- Avoids the `process.argv` scan inside `resolveArmAEmit()` itself — making the guard library-pure (no global state read), which the existing unit test convention requires.
+
+**Rejected alternatives:**
+- Read `process.argv` from inside `resolveArmAEmit()`: makes the function dependent on global state and untestable without process-arg mocking. Rejected.
+- Environment variable `B9_FORCE_GOLD_STANDARD=1`: invisible from the function signature, makes the unit test rely on `process.env` mutation. Rejected.
+- Default-on override: defeats the whole point of the guard. Rejected per "do not use `--force-gold-standard` as the DEFAULT" rule in the planner contract.
+
+## 4. Implementer task list (commit-boundary suggestions)
+
+The implementer may collapse these into a single commit if the diff stays tight, but the suggested ordering reflects how to keep `pnpm -w typecheck` green at each step.
+
+**Commit 1 — Guard implementation + provenance enum + @decision annotation.**
+- Add `import { statSync } from "node:fs"` to the existing `node:fs` import group in `arm-a-emit.mjs`.
+- Extend `resolveArmAEmit(repoRoot, taskId, strategy, options = {})` signature.
+- Inside the `parse-int-list` + `A-fine` branch (current lines 114-123):
+  1. If `compiledMjs` does not exist → fall through to bench reference (unchanged behaviour).
+  2. If `compiledMjs` exists AND `options.forceGoldStandard === true` → return `{ emitPath: compiledMjs, source: "yakcc-compile" }` (unchanged behaviour modulo the override).
+  3. If `compiledMjs` exists AND `options.forceGoldStandard !== true`: stat both `compiledMjs` and the bench-reference path. If `compiledMjsStat.mtimeMs >= benchStat.mtimeMs` → return `{ emitPath: compiledMjs, source: "yakcc-compile" }` (today's path when dist is fresh). If `compiledMjsStat.mtimeMs < benchStat.mtimeMs` → emit the stderr warning and return `{ emitPath: benchPath, source: "bench-reference-stale-fallback" }`.
+- Add the `@decision DEC-B9-EMIT-FRESHNESS-GUARD-001` block as a comment-header preceding the modified branch (mirror the format of the existing `DEC-V0-MIN-SURFACE-004` header at the top of the file).
+- Update the JSDoc for `resolveArmAEmit` to document the new `options` parameter and the extended `source` enum: `"yakcc-compile" | "bench-reference" | "bench-reference-stale-fallback"`.
+- Extend `listAllArmAEmits(repoRoot, taskIds, options = {})` to thread `options` through to its internal `resolveArmAEmit` call.
+- Extend the CLI `parseArgs` options block with `"force-gold-standard": { type: "boolean", default: false }`. Forward `{ forceGoldStandard: cliArgs["force-gold-standard"] }` to both `resolveArmAEmit` and `listAllArmAEmits` in the CLI dispatch.
+- Update the CLI usage string (lines 242-243) to document `--force-gold-standard`.
+
+**Commit 2 — Unit tests.**
+- Append to `bench/B9-min-surface/test/arm-a-emit.test.mjs` (do **not** create a new test file — the existing file is the canonical home for `arm-a-emit.mjs` tests per the codebase convention).
+- Add three tests:
+  1. `arm-a-emit: freshness guard — falls back to bench reference when dist mtime older than fallback` — uses `node:fs/promises.utimes` to backdate a *temporary copy* of the dist file inside `tmp/wi-fix-698-*`, points `repoRoot` at the temp tree (so we don't mutate the real `examples/parse-int-list/dist/module.mjs`), and asserts the return value `{ source: "bench-reference-stale-fallback", emitPath: <bench fallback path> }`.
+  2. `arm-a-emit: freshness guard — returns yakcc-compile path when dist mtime newer than fallback` — same setup with a forward-dated dist mtime; asserts `{ source: "yakcc-compile" }`.
+  3. `arm-a-emit: --force-gold-standard override returns yakcc-compile path even when dist is stale` — same stale setup, but `resolveArmAEmit(..., { forceGoldStandard: true })`; asserts `{ source: "yakcc-compile" }`. Stderr capture asserts no warning is printed.
+- The fixture-building helper writes a minimal stub `dist/module.mjs` and a sibling `tasks/parse-int-list/arm-a/fine.mjs` under a `tmp/wi-fix-698-fixtures/<test-name>/` tree, then backdates whichever file needs to be "older." This avoids any mutation under `examples/` or `bench/B9-min-surface/tasks/`. Use `import { mkdtempSync } from "node:fs"` to create the fixture root if a helper does not already exist.
+- A fourth test asserts the **stderr warning content** when the guard fires: captures stderr (via `child_process.spawnSync` invoking the CLI with `--task parse-int-list --strategy A-fine --json` against a stale-fixture repo root), asserts the warning string contains `WARN`, `mtime`, and the fallback path. (Subprocess form mirrors existing Test 8/Test 9 spawnSync pattern in the same file.)
+- An optional fifth test (NICE-TO-HAVE, not required for Eval Contract): asserts the CLI `--force-gold-standard` flag round-trips through `parseArgs` and is honoured.
+
+**Commit 3 (optional) — README/inline note.**
+- If there is a `bench/B9-min-surface/README.md` section on Arm A reference selection, append a single paragraph documenting the freshness guard. Skip if no such section exists; the @decision block in source is the authoritative documentation.
+
+The implementer should land all three commits before declaring `READY_FOR_REVIEWER`. Do **not** split this WI across multiple PRs.
+
+## 5. Evaluation Contract (binding for implementer + reviewer)
+
+### required_tests
+- `node --test bench/B9-min-surface/test/arm-a-emit.test.mjs` — all existing tests still pass (Tests 1-9 from the current file).
+- The three new tests from Commit 2 pass on a clean run:
+  - GIVEN `compiledMjs` mtime *older* than `benchPath` mtime AND `options.forceGoldStandard !== true` → `resolveArmAEmit` returns `{ source: "bench-reference-stale-fallback", emitPath: <bench fallback path> }` AND prints a warning to stderr containing `WARN`, `mtime`, and the bench fallback path.
+  - GIVEN `compiledMjs` mtime *newer* than `benchPath` mtime → `resolveArmAEmit` returns `{ source: "yakcc-compile", emitPath: <compiled dist path> }` AND prints nothing to stderr.
+  - GIVEN `compiledMjs` mtime *older* than `benchPath` mtime AND `options.forceGoldStandard === true` → `resolveArmAEmit` returns `{ source: "yakcc-compile", emitPath: <compiled dist path> }` AND prints nothing to stderr.
+- Existing B9 axis2 behavior unchanged on the real repo today: `pnpm exec node bench/B9-min-surface/harness/arm-a-emit.mjs --task parse-int-list --strategy A-fine --json` returns whichever source is correct given the **actual** mtimes at HEAD time (today, post-#697 landing, that should be `yakcc-compile`; pre-#697, it is `bench-reference-stale-fallback` and the warning fires — both are correct behaviors).
+
+### required_evidence
+- Reviewer attaches the unified diff of `arm-a-emit.mjs` showing the new `@decision DEC-B9-EMIT-FRESHNESS-GUARD-001` block, the extended function signature, and the three-branch resolution logic.
+- Reviewer attaches the unified diff of `test/arm-a-emit.test.mjs` showing the three new tests.
+- Reviewer attaches the full `node --test bench/B9-min-surface/test/arm-a-emit.test.mjs` output (must show all 12 tests passing — 9 existing + 3 new; the optional 4th-stderr-content / 5th-CLI-flag tests, if added, raise the count further).
+- Reviewer attaches stderr capture from one stale-fixture test confirming the warning string format.
+
+### required_real_path_checks
+- `pnpm -w lint` — green across full workspace (NEVER `--filter <pkg>` per memory `feedback_eval_contract_match_ci_checks.md`).
+- `pnpm -w typecheck` — green across full workspace (NEVER `--filter <pkg>`).
+- `node --test bench/B9-min-surface/test/arm-a-emit.test.mjs` — green (the directly-touched test file, all tests including new ones).
+- `node bench/B9-min-surface/harness/arm-a-emit.mjs --list --json` — succeeds with exit 0; output JSON parses; 18 entries present; no entry has `error` set. (Smoke test that the existing CLI path still works post-refactor.)
+
+### required_authority_invariants
+- `resolveArmAEmit` remains the sole authority over `(taskId, strategy) → emitPath` resolution. No new sibling resolver is introduced.
+- The `source` enum is **extended**, not redefined: `"yakcc-compile"` and `"bench-reference"` retain their existing semantics; `"bench-reference-stale-fallback"` is a new third value indicating the guard fired. Existing consumers (`run.mjs`, `listAllArmAEmits`, tests) that switch on `source === "bench-reference" || source === "yakcc-compile"` will see the new value pass-through; the existing Test 3 assertion `source === "bench-reference" || source === "yakcc-compile"` MUST be updated to also accept `"bench-reference-stale-fallback"` (this is the single mechanical change to an existing test; flag in the diff).
+- `DEC-V0-MIN-SURFACE-004` (Arm A granularity sweep) remains authoritative; `DEC-B9-EMIT-FRESHNESS-GUARD-001` is a file-local *refinement* of that DEC, not a replacement.
+- No mutation of `examples/parse-int-list/dist/module.mjs` mtime or contents in any test or harness code. The stale-condition must be simulated under `tmp/`.
+- No mutation of `bench/B9-min-surface/tasks/parse-int-list/arm-a/fine.mjs` mtime or contents in any test or harness code. Same reason.
+
+### required_integration_points
+- `run.mjs` line 483 destructure `const { emitPath } = resolveArmAEmit(REPO_ROOT, taskId, strategy);` continues to work unchanged (3-arg call form, `options` defaults to `{}`). Verify by inspecting `run.mjs` post-implementation — no changes required, but the destructure must not break. Reviewer confirms in the change summary.
+- `listAllArmAEmits(WORKTREE_ROOT, taskIds)` in `test/measure-axis5.test.mjs` line 248 continues to work unchanged (2-arg call form, `options` defaults to `{}`). Reviewer confirms.
+- CLI `arm-a-emit.mjs --task <id> --strategy <s>` continues to print the existing 5 fields (`task_id`, `strategy`, `emit_path`, `entry_function`, `source`). The `source` field may now carry the new third enum value; the CLI text-output formatter does not need changes (it already just prints whatever `source` is).
+
+### forbidden_shortcuts
+- Do NOT modify `examples/parse-int-list/dist/*` in any way (regenerate, touch, delete) — that is #697's exclusive scope. This WI must succeed even on a worktree where `dist/module.mjs` is the stale Apr-29 file.
+- Do NOT remove or invert the gold-standard preference — the rule remains "prefer dist when fresh; fall back only when stale or absent." Inverting it (always prefer bench fallback) is a wholly different design and is rejected per (C) discussion above.
+- Do NOT use `--force-gold-standard` as the DEFAULT — guard must be ON by default; override is opt-in.
+- Do NOT use `it.skip`, `t.skip`, `test.skipIf(...)`, or any equivalent on any failing test. If a test cannot pass, escalate to planner via `BLOCKED_BY_PLAN` per the implementer protocol.
+- Do NOT broaden scope to refactor `arm-a-emit.mjs` beyond the freshness-guard addition (no helper-function extraction, no CLI option-block restructure beyond adding the one flag, no JSDoc rewrite beyond updating the `resolveArmAEmit` block).
+- Do NOT touch `bench/B10-import-replacement/harness/arm-a-emit.mjs` — B10 is out of scope; if it needs the same guard it is a follow-up WI.
+- Do NOT touch `bench/B9-min-surface/harness/measure-axis2.mjs` — the provenance fields landed in WI-692 already cover the diagnostic surface; this WI is the *prevention* surface, owned by `arm-a-emit.mjs` exclusively.
+- Do NOT introduce cross-package imports (`../../../packages/...`) — only `node:` builtins and same-package relative imports are permitted per memory `feedback_no_cross_package_imports.md`.
+- Do NOT mutate global state (`process.env`, `process.argv`, module-level `let` mutation) inside `resolveArmAEmit`. The guard must remain a pure function of its arguments.
+
+### rollback_boundary
+Per-file revert is clean. The change is contained to two files (`arm-a-emit.mjs` + `arm-a-emit.test.mjs`). The new `source` enum value is additive — consumers that don't know about it will still see a valid string. Reverting this WI restores today's "always prefer dist when present" behavior without touching any other file.
+
+### ready_for_guardian_definition
+- All `required_tests` pass at the implementer's pushed HEAD SHA.
+- All four `required_real_path_checks` are green on the implementer's pushed HEAD SHA.
+- All `required_authority_invariants` are met (reviewer-verified by inspection of the diff).
+- All `required_integration_points` are met (reviewer-verified by inspection of `run.mjs` / `test/measure-axis5.test.mjs` / CLI path — no edits to those files; existing callers unaffected).
+- Reviewer issues `REVIEW_VERDICT: ready_for_guardian` against the pushed HEAD SHA.
+- PR exists with `closes #698` in the body, links to this plan, and references PR #697 (companion).
+- No Guardian-merge-to-main dispatch (per memory `feedback_pr_not_guardian_merge.md`); PR landed via GitHub merge button after CI green + reviewer approval.
+
+## 6. Scope Manifest (mirror in `tmp/scope-fix-698-arm-a-emit-freshness-guard.json`)
+
+### allowed_paths
+- `bench/B9-min-surface/harness/arm-a-emit.mjs` — the freshness guard source.
+- `bench/B9-min-surface/test/arm-a-emit.test.mjs` — the freshness guard tests (existing file; append new tests; minimally modify Test 3 source-enum assertion).
+- `plans/wi-fix-698-arm-a-emit-freshness-guard.md` — this plan, owned by planner.
+- `tmp/scope-fix-698-arm-a-emit-freshness-guard.json` — machine scope manifest, owned by planner.
+- `tmp/wi-fix-698-*/**` — implementer-owned scratchlane for test fixtures (temp dist+bench file trees for stale-mtime simulation).
+- `MASTER_PLAN.md` — owned by planner; **single row append** under the B9 Slice 1 bug-class follow-ups note (see §7 below). Planner-only; implementer must NOT modify.
+
+### required_paths
+- `bench/B9-min-surface/harness/arm-a-emit.mjs` — required: the new guard + @decision block + extended signature.
+- `bench/B9-min-surface/test/arm-a-emit.test.mjs` — required: 3 new tests + 1 mechanical Test-3 enum-assertion widening.
+
+### forbidden_paths
+- `examples/**` — out of scope. Specifically `examples/parse-int-list/dist/module.mjs` is #697's responsibility; touching its mtime or contents from this WI defeats the test premise.
+- `bench/B10-import-replacement/**` — B10 has its own analog; out of scope.
+- `bench/B9-min-surface/harness/measure-axis2.mjs` — provenance fields already cover the diagnostic surface; this WI owns the prevention surface only.
+- `bench/B9-min-surface/harness/measure-axis1.mjs`, `measure-axis3.mjs`, `measure-axis5.mjs`, `classify-arm-b.mjs`, `llm-baseline.mjs`, `run.mjs` — adjacent harness modules; not modified.
+- `bench/B9-min-surface/tasks/**`, `bench/B9-min-surface/attack-classes/**`, `bench/B9-min-surface/fixtures/**` — not modified.
+- All other `bench/**` directories — `B1`, `B2`, `B4-tokens`, `B4-tokens-v3`, `B6`, `B7`, etc. — out of scope.
+- `packages/**` — no package source/test changes. The shave engine, registry, compile pipeline, contracts, IR, CLI, hooks, federation, variance, seeds — none of those are touched.
+- `scripts/**`, `tools/**`, `bootstrap/**`, `docs/**`, `patches/**`, `.github/**`, `.claude/**` — not modified.
+- `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `package.json`, `tsconfig.base.json`, `turbo.json`, `biome.json` — root configs untouched.
+- All other `plans/**` files — predecessor plan `wi-692-b9-axis2-falsepos.md` is sealed; companion plan for #697 (if/when filed) is a separate slice.
+
+### state_domains
+- `b9_emit_resolution` (this WI's authority — read+write: extends behavior with the freshness guard and new `source` enum value).
+- `b9_test_invariants` (append-only: 3 new test cases + 1 mechanical assertion widening).
+
+### authority_domains
+*(no new control-plane authority created. `DEC-B9-EMIT-FRESHNESS-GUARD-001` and `-002` are file-local refinements of `DEC-V0-MIN-SURFACE-004`, documented at the implementation site.)*
+
+## 7. MASTER_PLAN.md row (append under B9 Slice 1 bug-class follow-ups)
+
+Append a single row to the existing "B9 Slice 1 bug-class follow-ups" ledger area (immediately following the Slice 1 work item table around line 1828). If no such sub-section exists, the planner adds a short sub-heading `**B9 Slice 1 bug-class follow-ups (per #167 Principle 6).**` after the Slice 1 work item table and seeds it with one row for this WI plus a back-reference row for WI-692 / #697.
+
+Row format (mirror existing W-B9-S1-N ledger format):
+
+| ID | Title | Weight | Deps | Gate | Status |
+|----|-------|--------|------|------|--------|
+| W-B9-S1-BUG-692 | B9 axis2 false `shape_escape` on `[007]` — provenance fields surface emit path/mtime/SHA in JSON output | M | W-B9-S1-4 | review | done — landed via #693 (per `plans/wi-692-b9-axis2-falsepos.md`) |
+| W-B9-S1-BUG-697 | Regenerate stale `examples/parse-int-list/dist/module.mjs` from current source (post-#636) | S | — | review | in flight — issue #697 |
+| W-B9-S1-BUG-698 | arm-a-emit.mjs freshness guard — fall back to bench reference when dist mtime predates fallback; `--force-gold-standard` opt-in override; `@decision DEC-B9-EMIT-FRESHNESS-GUARD-001` | S | W-B9-S1-7 | review | planned — issue #698 (this plan) |
+
+The implementer does NOT modify MASTER_PLAN.md. The planner appends this section as part of plan delivery (alongside the plan file itself).
+
+## 8. Standing rules referenced
+
+- `memory/feedback_eval_contract_match_ci_checks.md` — full-workspace `pnpm -w lint` AND `pnpm -w typecheck` in eval contract; NEVER `--filter <pkg>`.
+- `memory/feedback_pr_not_guardian_merge.md` — land via PR with `closes #698`, NOT via Guardian merge to main.
+- `memory/feedback_fetch_before_pr.md` — `git fetch origin && git pull --ff-only origin main` inside the worktree immediately before `gh pr create`.
+- `memory/feedback_no_cross_package_imports.md` — N/A (no new package-crossing imports; only `node:` builtins and same-file logic).
+- `memory/feedback_planner_writes_to_wrong_cwd.md` — all plan artifacts written inside `C:/src/yakcc/.worktrees/feature-fix-698-arm-a-emit-freshness-guard/`, not main.
+- `memory/feedback_worktree_naming_convention.md` — worktree path is `.worktrees/feature-fix-698-arm-a-emit-freshness-guard` (correct `feature-` prefix for `cc-policy worktree retire`).
+- `memory/feedback_zero_byte_output_not_failure.md` — N/A here (no API-bearing calls).
+- Sacred Practice #2 — no source edits on main; all implementation in the worktree.
+- Sacred Practice #4 — nothing done until tested. Required tests are explicit; the implementer must run them locally pre-push.
+- Sacred Practice #12 — single source of truth. `resolveArmAEmit` remains the sole emit-resolution authority; the guard is integrated into the existing authority rather than added as a sibling.
+
+## 9. Quality Gate (planner self-check)
+
+- ✅ All dependencies and state authorities are explicitly mapped (§2).
+- ✅ Guardian-bound work item has an Evaluation Contract with executable acceptance criteria (§5).
+- ✅ Guardian-bound work item has a Scope Manifest with explicit allowed/required/forbidden files (§6).
+- ✅ No work item relies on narrative completion language — every contract clause names a runnable command, a greppable string, or a structural invariant.
+- ✅ DEC-B9-EMIT-FRESHNESS-GUARD-001 and -002 are documented inline at the implementation site (file-local refinements, not kernel-level — per the Architecture Preservation rules for Tier 2).
+- ✅ Three guard-semantic candidates (A/B/C) were explicitly weighed; (A) selected with explicit rationale (§3).
+- ✅ Two caller-signal mechanisms (options-object vs `process.argv` scan vs env var) were explicitly weighed; options-object selected with explicit rationale (§3).
+- ✅ Forbidden-shortcuts list explicitly bans the most-likely scope-creep paths: `examples/parse-int-list/dist/` (overlap with #697), `it.skip` evasions, default-on override, sibling resolver, global-state reads, and adjacent-file scope creep.
+- ✅ Test strategy explicitly avoids mutating real artifacts (`examples/**`, `bench/B9-min-surface/tasks/**`) by simulating staleness under `tmp/wi-fix-698-*/`.
+- ✅ Row append plan for MASTER_PLAN.md is planner-only and identifies the exact section (B9 Slice 1 bug-class follow-ups), preserving the immutable Slice 1 work-item table above it.
+
+## 10. Next action
+
+After this plan is written into the worktree, the planner emits
+`PLAN_VERDICT: next_work_item` and the runtime dispatches Guardian
+(provision) for `fix-698-arm-a-emit-freshness-guard-impl`, followed by
+the implementer + reviewer + Guardian (land) canonical chain.


### PR DESCRIPTION
## Summary

- Adds a freshness guard to `resolveArmAEmit()` in `bench/B9-min-surface/harness/arm-a-emit.mjs`: when `examples/parse-int-list/dist/module.mjs` mtime is older than the bench fallback (`bench/B9-min-surface/tasks/parse-int-list/arm-a/fine.mjs`), the function emits a greppable stderr WARN and returns `{ source: "bench-reference-stale-fallback" }` instead of silently routing through the stale compiled artifact.
- Extends the `source` enum with a third additive value `"bench-reference-stale-fallback"` (backward-compatible; existing consumers seeing `"bench-reference"` or `"yakcc-compile"` are unaffected).
- Adds `{ forceGoldStandard: true }` (module API) / `--force-gold-standard` (CLI) opt-in override to bypass the guard and prefer the dist unconditionally.
- Documents the design decision inline as `DEC-B9-EMIT-FRESHNESS-GUARD-001` (variant A rationale vs rejected B/C candidates).
- Adds 4 new unit tests (Tests 10–13) and widens Test 3 source enum assertion to accept the new value.

## Root Cause Reference

This guard prevents the silent false-positive captured in #692 (dist mtime Apr 29 2026, bench fallback mtime post-#636 May 17 2026, causing `listOfInts('[007]')` to return `[7]` instead of throwing `SyntaxError`). Companion: #697 (regenerate the stale dist artifact — disjoint scope).

## Test Plan

- [ ] `node --test bench/B9-min-surface/test/arm-a-emit.test.mjs` — all 13 tests pass (9 pre-existing + 4 new)
- [ ] Test 10 verified: stale fixture dist (epoch mtime) → `source="bench-reference-stale-fallback"` + WARN on stderr
- [ ] Test 11 verified: fresh fixture dist (year 2099 mtime) → `source="yakcc-compile"` + no stderr
- [ ] Test 12 verified: stale fixture + `forceGoldStandard=true` → `source="yakcc-compile"` + no stderr
- [ ] Test 13 verified: CLI subprocess with `--repo-root` stale fixture → WARN in stderr + JSON `source="bench-reference-stale-fallback"`
- [ ] `node bench/B9-min-surface/harness/arm-a-emit.mjs --list --json` → 18 entries, 0 errors
- [ ] `pnpm -w lint` / `pnpm -w typecheck` — pre-existing `@yakcc/ir` lint failure (CRLF line-ending in untracked fixture dirs, not introduced by this WI; confirmed on main before this branch)

closes #698
refs #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)