### PR TITLE
docs(master-plan): #656 WI-CLI-UX-COLLAPSE ledger row (closes #690)

### DIFF
--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -1709,6 +1709,7 @@ Status: **active 2026-05-10.** Parent initiative at [#194](https://github.com/cn
 | Sub | WI-V05-CLI-INSTALL-RETIRE-FACADE | [#203](https://github.com/cneckar/yakcc/issues/203) | blocked on #194 Phase 0 | Replaces the v0 facade in `packages/cli/src/commands/hooks-install.ts` with real wiring (settings.json hook / MCP server / both per #194's chosen surface). |
 | Sub | WI-V05-INIT-COMMAND | [#204](https://github.com/cneckar/yakcc/issues/204) | blocked on #203 | New `yakcc init` CLI command for fresh-project setup. The "first 30 seconds" surface. |
 | Sub | WI-V05-USER-WALKTHROUGH | [#205](https://github.com/cneckar/yakcc/issues/205) | blocked on #194 Phase 1+, #203, #204 | `docs/USING_YAKCC.md` end-user walkthrough. |
+| Sub | WI-CLI-UX-COLLAPSE | [#656](https://github.com/cneckar/yakcc/issues/656) | **closed 2026-05-18** | Single-command `yakcc init` (auto-seed + 4-IDE auto-detect + hook auto-install for Claude Code / Cursor / Cline / Continue.dev) + symmetric `yakcc uninstall`. Landed via PRs #681 / #685 / #688. |
 | Benchmark | WI-BENCHMARK-B3 | [#187](https://github.com/cneckar/yakcc/issues/187) | gated on hook + discovery v3 | Cache hit rate on 3-day human-engineer sprint |
 | Benchmark | WI-BENCHMARK-B4 | [#188](https://github.com/cneckar/yakcc/issues/188) | gated on hook | Token expenditure reduction (single-point A/B) |
 | Benchmark | WI-BENCHMARK-B5 | [#189](https://github.com/cneckar/yakcc/issues/189) | gated on hook + contract-surfacing | Hallucination rebound / multi-turn coherence |


### PR DESCRIPTION
## Summary

Closes #690. Adds the WI-CLI-UX-COLLAPSE row to the WI-HOOK-LAYER sub-cascade table at `MASTER_PLAN.md:1711` — the specific ledger update Wrath was unable to land via planner-subagent dispatch due to the upstream `cc-policy` actor-resolution bug.

Row added:

```
| Sub | WI-CLI-UX-COLLAPSE | [#656](https://github.com/cneckar/yakcc/issues/656) | **closed 2026-05-18** | Single-command `yakcc init` (auto-seed + 4-IDE auto-detect + hook auto-install for Claude Code / Cursor / Cline / Continue.dev) + symmetric `yakcc uninstall`. Landed via PRs #681 / #685 / #688. |
```

## Why this instead of upstream fix

Per operator decision 2026-05-18 on #690 (*"we are not in control of the control plane"*): the upstream `cc-policy` fix in claude-ctrl is not being pursued. Wrath's standing instruction is to ship product PRs via closing-keywords + plan files, with MASTER_PLAN.md ledger drift accepted as a known gap.

This PR is the orchestrator-side handover when ledger updates accumulate: orchestrator (acting as a direct-write authority, not via planner-subagent dispatch) lands the specific row.

## What this does NOT do

Other ledger drift exists for WIs that closed without their MASTER_PLAN.md rows updated. This PR is **scoped to the single row #690 specifies**. Future ledger backfills can be filed as separate ticketed work.

## Test plan

- [x] No code changes — pure docs row addition
- [x] `git diff` shows 1 line added, 0 removed
- [x] No lint / typecheck / build impact

Closes #690

https://claude.ai/code/session_018RFmeHWE8TTDvzT8PeotLq

---
_Generated by [Claude Code](https://claude.ai/code/session_018RFmeHWE8TTDvzT8PeotLq)_