### PR TITLE
chore(cli): bump @yakcc/cli to 0.5.0-alpha.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yakcc/cli",
-  "version": "0.5.0-alpha.0",
+  "version": "0.5.0-alpha.1",
   "description": "Yakcc — content-addressed block registry for assembling programs from verified, reusable building blocks.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

Single-line version bump: `@yakcc/cli` from `0.5.0-alpha.0` → `0.5.0-alpha.1`.

First publish at which `yakcc init` produces a working Claude Code PreToolUse hook end-to-end.

## Includes

- fix(cli): #753 alpha-blocker — `yakcc hook-intercept` Phase-1 + Cline/Continue dispatch (#754)
- chore(repo): #755 strip UTF-8 BOM + add `scripts/check-no-bom.mjs` CI gate (#757)
- docs(plan): WI-753 cascade + DEC-CLI-HOOK-INTERCEPT-{001,FAIL-SILENT,CONTINUE-PKG} (#756)

## Test plan

- [x] Single-line change, no behavior change
- [ ] Operator publishes `@yakcc/cli@0.5.0-alpha.1` to npm under the `alpha` dist-tag after merge
- [ ] Operator tags `v0.5.0-alpha.1` on the merge commit and creates the GitHub Release (pre-release)
- [ ] Existing testers upgrade via `npm install -g @yakcc/cli@alpha`, re-run `yakcc init`, verify Edit/Write/MultiEdit no longer trips the PreToolUse hook

---
_Generated by [Claude Code](https://claude.ai/code/session_018RFmeHWE8TTDvzT8PeotLq)_