### PR TITLE
fix(cli): standalone hooks-*-install commands update .yakccrc.json installedHooks (closes #759)

### DIFF
--- a/packages/cli/src/commands/hooks-aider-install.ts
+++ b/packages/cli/src/commands/hooks-aider-install.ts
@@ -38,6 +38,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import type { Logger } from "../index.js";
+import { removeInstalledHooks, updateInstalledHooks } from "../lib/rc-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -99,6 +100,7 @@ export async function hooksAiderInstall(
   argv: readonly string[],
   logger: Logger,
   overrideAiderDir?: string,
+  overrideTargetDir?: string,
 ): Promise<number> {
   let parsed: ReturnType<
     typeof parseArgs<{
@@ -128,6 +130,9 @@ export async function hooksAiderInstall(
   // overrideAiderDir is the injection seam for tests; production uses ~/.aider/.
   const aiderDir = overrideAiderDir ?? join(homedir(), ".aider");
   const markerPath = join(aiderDir, AIDER_HOOK_MARKER_FILENAME);
+  // Project dir for .yakccrc.json: overrideTargetDir for tests, or --target flag.
+  // Undefined when neither is provided (called from yakcc init, which manages rc itself).
+  const targetDir = overrideTargetDir ?? parsed.values.target;
 
   try {
     mkdirSync(aiderDir, { recursive: true });
@@ -148,6 +153,7 @@ export async function hooksAiderInstall(
       logger.error(`error: cannot remove ${markerPath}: ${String(err)}`);
       return 1;
     }
+    if (targetDir !== undefined) removeInstalledHooks(targetDir, ["aider"]);
     logger.log(`yakcc aider hook marker removed: ${markerPath}`);
     return 0;
   }
@@ -181,6 +187,7 @@ export async function hooksAiderInstall(
     return 1;
   }
 
+  if (targetDir !== undefined) updateInstalledHooks(targetDir, ["aider"]);
   logger.log(`yakcc aider hook marker installed: ${markerPath}`);
   logger.log(
     "note: Aider hook wiring via --lint-cmd/--test-cmd deferred — see marker for details.",

--- a/packages/cli/src/commands/hooks-cline-install.ts
+++ b/packages/cli/src/commands/hooks-cline-install.ts
@@ -37,6 +37,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import type { Logger } from "../index.js";
+import { removeInstalledHooks, updateInstalledHooks } from "../lib/rc-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -98,6 +99,7 @@ export async function hooksClineInstall(
   argv: readonly string[],
   logger: Logger,
   overrideClineDir?: string,
+  overrideTargetDir?: string,
 ): Promise<number> {
   let parsed: ReturnType<
     typeof parseArgs<{
@@ -127,6 +129,9 @@ export async function hooksClineInstall(
   // overrideClineDir is the injection seam for tests; production uses ~/.config/cline/.
   const clineDir = overrideClineDir ?? join(homedir(), ".config", "cline");
   const markerPath = join(clineDir, CLINE_HOOK_MARKER_FILENAME);
+  // Project dir for .yakccrc.json: overrideTargetDir for tests, or --target flag.
+  // Undefined when neither is provided (called from yakcc init, which manages rc itself).
+  const targetDir = overrideTargetDir ?? parsed.values.target;
 
   try {
     mkdirSync(clineDir, { recursive: true });
@@ -147,6 +152,7 @@ export async function hooksClineInstall(
       logger.error(`error: cannot remove ${markerPath}: ${String(err)}`);
       return 1;
     }
+    if (targetDir !== undefined) removeInstalledHooks(targetDir, ["cline"]);
     logger.log(`yakcc cline hook marker removed: ${markerPath}`);
     return 0;
   }
@@ -178,6 +184,7 @@ export async function hooksClineInstall(
     return 1;
   }
 
+  if (targetDir !== undefined) updateInstalledHooks(targetDir, ["cline"]);
   logger.log(`yakcc cline hook marker installed: ${markerPath}`);
   logger.log("note: Cline tool-call interception API not yet stable — see marker for details.");
   return 0;

--- a/packages/cli/src/commands/hooks-continue-install.ts
+++ b/packages/cli/src/commands/hooks-continue-install.ts
@@ -33,6 +33,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import type { Logger } from "../index.js";
+import { removeInstalledHooks, updateInstalledHooks } from "../lib/rc-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -94,6 +95,7 @@ export async function hooksContinueInstall(
   argv: readonly string[],
   logger: Logger,
   overrideContinueDir?: string,
+  overrideTargetDir?: string,
 ): Promise<number> {
   let parsed: ReturnType<
     typeof parseArgs<{
@@ -123,6 +125,9 @@ export async function hooksContinueInstall(
   // overrideContinueDir is the injection seam for tests; production uses ~/.continue/.
   const continueDir = overrideContinueDir ?? join(homedir(), ".continue");
   const markerPath = join(continueDir, CONTINUE_HOOK_MARKER_FILENAME);
+  // Project dir for .yakccrc.json: overrideTargetDir for tests, or --target flag.
+  // Undefined when neither is provided (called from yakcc init, which manages rc itself).
+  const targetDir = overrideTargetDir ?? parsed.values.target;
 
   try {
     mkdirSync(continueDir, { recursive: true });
@@ -143,6 +148,7 @@ export async function hooksContinueInstall(
       logger.error(`error: cannot remove ${markerPath}: ${String(err)}`);
       return 1;
     }
+    if (targetDir !== undefined) removeInstalledHooks(targetDir, ["continue"]);
     logger.log(`yakcc continue hook marker removed: ${markerPath}`);
     return 0;
   }
@@ -174,6 +180,7 @@ export async function hooksContinueInstall(
     return 1;
   }
 
+  if (targetDir !== undefined) updateInstalledHooks(targetDir, ["continue"]);
   logger.log(`yakcc continue hook marker installed: ${markerPath}`);
   logger.log(
     "note: Continue.dev tool-call interception API not yet stable — see marker for details.",

--- a/packages/cli/src/commands/hooks-cursor-install.ts
+++ b/packages/cli/src/commands/hooks-cursor-install.ts
@@ -29,6 +29,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import type { Logger } from "../index.js";
+import { removeInstalledHooks, updateInstalledHooks } from "../lib/rc-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -170,6 +171,7 @@ export async function hooksCursorInstall(argv: readonly string[], logger: Logger
       logger.error(`error: cannot write ${settingsPath}: ${String(err)}`);
       return 1;
     }
+    removeInstalledHooks(targetDir, ["cursor"]);
     logger.log(`yakcc cursor hook removed from ${settingsPath}`);
     return 0;
   }
@@ -209,6 +211,7 @@ export async function hooksCursorInstall(argv: readonly string[], logger: Logger
     // Non-fatal: the settings.json update succeeded.
   }
 
+  updateInstalledHooks(targetDir, ["cursor"]);
   if (alreadyInstalled) {
     logger.log(`yakcc cursor hook already installed at ${settingsPath} (idempotent).`);
   } else {

--- a/packages/cli/src/commands/hooks-install.ts
+++ b/packages/cli/src/commands/hooks-install.ts
@@ -19,6 +19,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import type { Logger } from "../index.js";
+import { removeInstalledHooks, updateInstalledHooks } from "../lib/rc-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -197,6 +198,7 @@ export async function hooksClaudeCodeInstall(
       logger.error(`error: cannot write ${settingsPath}: ${String(err)}`);
       return 1;
     }
+    removeInstalledHooks(targetDir, ["claude-code"]);
     logger.log(`yakcc hook removed from ${settingsPath}`);
     return 0;
   }
@@ -220,6 +222,7 @@ export async function hooksClaudeCodeInstall(
     }
   }
 
+  updateInstalledHooks(targetDir, ["claude-code"]);
   if (alreadyInstalled) {
     logger.log(`yakcc hook already installed at ${settingsPath} (idempotent).`);
   } else {

--- a/packages/cli/src/commands/hooks-rc-bookkeeping.test.ts
+++ b/packages/cli/src/commands/hooks-rc-bookkeeping.test.ts
@@ -1,0 +1,243 @@
+/**
+ * hooks-rc-bookkeeping.test.ts
+ *
+ * Integration tests verifying that each standalone hooks-*-install command
+ * correctly maintains .yakccrc.json installedHooks when --target (or the
+ * overrideTargetDir injection seam) is provided.
+ *
+ * Acceptance criteria from issue #759:
+ *   - Install adds the IDE name to installedHooks (with existing rc).
+ *   - Install creates a minimal rc when no .yakccrc.json exists.
+ *   - Install is idempotent (no duplicate entries).
+ *   - Uninstall removes the IDE name from installedHooks.
+ *   - yakcc init behavior is unchanged (tested via init.test.ts; not re-tested here).
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CollectingLogger } from "../index.js";
+import { hooksAiderInstall } from "./hooks-aider-install.js";
+import { hooksClineInstall } from "./hooks-cline-install.js";
+import { hooksContinueInstall } from "./hooks-continue-install.js";
+import { hooksCursorInstall } from "./hooks-cursor-install.js";
+import { hooksClaudeCodeInstall } from "./hooks-install.js";
+import { hooksWindsurfInstall } from "./hooks-windsurf-install.js";
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "yakcc-rc-bookkeeping-test-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function readRc(dir: string): Record<string, unknown> | null {
+  const p = join(dir, ".yakccrc.json");
+  if (!existsSync(p)) return null;
+  return JSON.parse(readFileSync(p, "utf-8")) as Record<string, unknown>;
+}
+
+function writeRc(dir: string, rc: Record<string, unknown>): void {
+  writeFileSync(join(dir, ".yakccrc.json"), `${JSON.stringify(rc, null, 2)}\n`, "utf-8");
+}
+
+function fakeIdeDir(subPath: string): string {
+  const d = join(tmpDir, subPath);
+  mkdirSync(d, { recursive: true });
+  return d;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: run all 6 installers with their respective install args
+// ---------------------------------------------------------------------------
+
+type InstallerFn = (
+  targetDir: string,
+  overrideDir: string,
+  uninstall?: boolean,
+) => Promise<number>;
+
+const installers: Array<{ name: string; ideName: string; run: InstallerFn }> = [
+  {
+    name: "claude-code",
+    ideName: "claude-code",
+    run: (targetDir, _overrideDir, uninstall) =>
+      hooksClaudeCodeInstall(
+        uninstall ? ["--target", targetDir, "--uninstall"] : ["--target", targetDir],
+        new CollectingLogger(),
+      ),
+  },
+  {
+    name: "cursor",
+    ideName: "cursor",
+    run: (targetDir, _overrideDir, uninstall) =>
+      hooksCursorInstall(
+        uninstall ? ["--target", targetDir, "--uninstall"] : ["--target", targetDir],
+        new CollectingLogger(),
+      ),
+  },
+  {
+    name: "windsurf",
+    ideName: "windsurf",
+    run: (targetDir, _overrideDir, uninstall) =>
+      hooksWindsurfInstall(
+        uninstall ? ["--target", targetDir, "--uninstall"] : ["--target", targetDir],
+        new CollectingLogger(),
+      ),
+  },
+  {
+    name: "cline",
+    ideName: "cline",
+    run: (targetDir, overrideDir, uninstall) =>
+      hooksClineInstall(
+        uninstall ? ["--uninstall"] : [],
+        new CollectingLogger(),
+        overrideDir,
+        targetDir,
+      ),
+  },
+  {
+    name: "continue",
+    ideName: "continue",
+    run: (targetDir, overrideDir, uninstall) =>
+      hooksContinueInstall(
+        uninstall ? ["--uninstall"] : [],
+        new CollectingLogger(),
+        overrideDir,
+        targetDir,
+      ),
+  },
+  {
+    name: "aider",
+    ideName: "aider",
+    run: (targetDir, overrideDir, uninstall) =>
+      hooksAiderInstall(
+        uninstall ? ["--uninstall"] : [],
+        new CollectingLogger(),
+        overrideDir,
+        targetDir,
+      ),
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Suite A: rc file exists with installedHooks — install adds ide name
+// ---------------------------------------------------------------------------
+
+describe("rc bookkeeping — install adds IDE name to existing rc", () => {
+  for (const { name, ideName, run } of installers) {
+    it(`${name}: install adds "${ideName}" to existing rc.installedHooks`, async () => {
+      writeRc(tmpDir, { version: 1, registry: { path: ".yakcc/registry.sqlite" }, installedHooks: [] });
+      const overrideDir = fakeIdeDir(`.fake-${name}`);
+
+      const code = await run(tmpDir, overrideDir);
+      expect(code).toBe(0);
+
+      const rc = readRc(tmpDir);
+      expect(rc).not.toBeNull();
+      expect(Array.isArray(rc!.installedHooks)).toBe(true);
+      expect((rc!.installedHooks as string[]).includes(ideName)).toBe(true);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Suite B: no rc file — install creates one with installedHooks: [ide]
+// ---------------------------------------------------------------------------
+
+describe("rc bookkeeping — install creates rc when none exists", () => {
+  for (const { name, ideName, run } of installers) {
+    it(`${name}: install creates .yakccrc.json with installedHooks: ["${ideName}"]`, async () => {
+      expect(existsSync(join(tmpDir, ".yakccrc.json"))).toBe(false);
+      const overrideDir = fakeIdeDir(`.fake-${name}`);
+
+      const code = await run(tmpDir, overrideDir);
+      expect(code).toBe(0);
+
+      const rc = readRc(tmpDir);
+      expect(rc).not.toBeNull();
+      expect(Array.isArray(rc!.installedHooks)).toBe(true);
+      expect((rc!.installedHooks as string[]).includes(ideName)).toBe(true);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Suite C: idempotency — install twice does not duplicate the ide name
+// ---------------------------------------------------------------------------
+
+describe("rc bookkeeping — install is idempotent (no duplicate entries)", () => {
+  for (const { name, ideName, run } of installers) {
+    it(`${name}: running install twice keeps exactly one "${ideName}" in installedHooks`, async () => {
+      const overrideDir = fakeIdeDir(`.fake-${name}`);
+
+      await run(tmpDir, overrideDir);
+      await run(tmpDir, overrideDir);
+
+      const rc = readRc(tmpDir);
+      expect(rc).not.toBeNull();
+      const hooks = rc!.installedHooks as string[];
+      expect(hooks.filter((h) => h === ideName).length).toBe(1);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Suite D: uninstall removes ide name from installedHooks
+// ---------------------------------------------------------------------------
+
+describe("rc bookkeeping — uninstall removes IDE name from rc", () => {
+  for (const { name, ideName, run } of installers) {
+    it(`${name}: uninstall removes "${ideName}" from installedHooks`, async () => {
+      const overrideDir = fakeIdeDir(`.fake-${name}`);
+
+      // Install first
+      await run(tmpDir, overrideDir, false);
+      const rcAfterInstall = readRc(tmpDir);
+      expect((rcAfterInstall!.installedHooks as string[]).includes(ideName)).toBe(true);
+
+      // Uninstall
+      const code = await run(tmpDir, overrideDir, true);
+      expect(code).toBe(0);
+
+      const rcAfterUninstall = readRc(tmpDir);
+      expect(rcAfterUninstall).not.toBeNull();
+      expect((rcAfterUninstall!.installedHooks as string[]).includes(ideName)).toBe(false);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Suite E: preserves other fields in existing rc on install/uninstall
+// ---------------------------------------------------------------------------
+
+describe("rc bookkeeping — preserves existing rc fields", () => {
+  for (const { name, ideName, run } of installers) {
+    it(`${name}: install does not clobber other rc fields`, async () => {
+      writeRc(tmpDir, {
+        version: 1,
+        mode: "local",
+        registry: { path: ".yakcc/custom.sqlite" },
+        installedHooks: ["other-ide"],
+      });
+      const overrideDir = fakeIdeDir(`.fake-${name}`);
+
+      await run(tmpDir, overrideDir);
+
+      const rc = readRc(tmpDir);
+      expect(rc!.mode).toBe("local");
+      expect((rc!.registry as Record<string, string>).path).toBe(".yakcc/custom.sqlite");
+      const hooks = rc!.installedHooks as string[];
+      expect(hooks.includes("other-ide")).toBe(true);
+      expect(hooks.includes(ideName)).toBe(true);
+    });
+  }
+});

--- a/packages/cli/src/commands/hooks-windsurf-install.ts
+++ b/packages/cli/src/commands/hooks-windsurf-install.ts
@@ -28,6 +28,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import type { Logger } from "../index.js";
+import { removeInstalledHooks, updateInstalledHooks } from "../lib/rc-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -172,6 +173,7 @@ export async function hooksWindsurfInstall(
       logger.error(`error: cannot write ${settingsPath}: ${String(err)}`);
       return 1;
     }
+    removeInstalledHooks(targetDir, ["windsurf"]);
     logger.log(`yakcc windsurf hook removed from ${settingsPath}`);
     return 0;
   }
@@ -211,6 +213,7 @@ export async function hooksWindsurfInstall(
     // Non-fatal: the settings.json update succeeded.
   }
 
+  updateInstalledHooks(targetDir, ["windsurf"]);
   if (alreadyInstalled) {
     logger.log(`yakcc windsurf hook already installed at ${settingsPath} (idempotent).`);
   } else {

--- a/packages/cli/src/commands/uninstall.test.ts
+++ b/packages/cli/src/commands/uninstall.test.ts
@@ -157,10 +157,13 @@ describe("uninstall — default, installedHooks-driven (EC-S2-T1)", () => {
 describe("uninstall — fallback to detectInstalledIdes() (EC-S2-T2)", () => {
   it("removes claude-code hook when no .yakccrc.json and overrideHome has .claude/", async () => {
     const fakeHome = join(tmpDir, "fakehome-t2");
-    // Install claude-code hook manually (bypass init to skip writing .yakccrc.json)
+    // Install claude-code hook manually, then remove the rc to force Tier 3 detection.
+    // (hooksClaudeCodeInstall now writes .yakccrc.json as part of #759 fix;
+    // deleting it here tests the Tier 3 filesystem-detection fallback path.)
     mkdirSync(join(fakeHome, ".claude"), { recursive: true });
     const { hooksClaudeCodeInstall } = await import("./hooks-install.js");
     await hooksClaudeCodeInstall(["--target", tmpDir], new CollectingLogger());
+    rmSync(join(tmpDir, ".yakccrc.json"), { force: true });
 
     // Confirm hook is present and no rc exists
     expect(claudeCodeHookPresent(tmpDir)).toBe(true);

--- a/packages/cli/src/lib/rc-helpers.ts
+++ b/packages/cli/src/lib/rc-helpers.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+//
+// rc-helpers.ts — shared helpers for reading/writing .yakccrc.json installedHooks
+//
+// @decision DEC-CLI-RC-BOOKKEEPING-001
+// title: Shared updateInstalledHooks/removeInstalledHooks helpers so standalone
+//        hooks-*-install commands update .yakccrc.json consistently with `yakcc init`
+// status: accepted (closes #759)
+// rationale:
+//   The standalone install commands (hooks-install.ts, hooks-cursor-install.ts,
+//   hooks-windsurf-install.ts, hooks-cline-install.ts, hooks-continue-install.ts,
+//   hooks-aider-install.ts) previously never read or wrote .yakccrc.json, leaving
+//   installedHooks stale when hooks were installed outside `yakcc init`.
+//   A shared helper avoids six copy-pasted merge loops and keeps the rc format
+//   consistent with what init.ts already writes.
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const RC_FILENAME = ".yakccrc.json";
+
+interface RcFile {
+  version: number;
+  installedHooks?: string[];
+  [key: string]: unknown;
+}
+
+function readRcFile(targetDir: string): RcFile | null {
+  const p = join(targetDir, RC_FILENAME);
+  if (!existsSync(p)) return null;
+  try {
+    return JSON.parse(readFileSync(p, "utf-8")) as RcFile;
+  } catch {
+    return null;
+  }
+}
+
+function writeRcFile(targetDir: string, rc: RcFile): void {
+  writeFileSync(join(targetDir, RC_FILENAME), `${JSON.stringify(rc, null, 2)}\n`, "utf-8");
+}
+
+/**
+ * Idempotently adds ide names to .yakccrc.json installedHooks in targetDir.
+ * Creates a minimal rc file if none exists. Non-fatal on write error.
+ */
+export function updateInstalledHooks(targetDir: string, idesToAdd: string[]): void {
+  if (idesToAdd.length === 0) return;
+  const rc = readRcFile(targetDir);
+  try {
+    if (rc === null) {
+      writeRcFile(targetDir, {
+        version: 1,
+        registry: { path: ".yakcc/registry.sqlite" },
+        installedHooks: [...new Set(idesToAdd)],
+      });
+    } else {
+      const existing = rc.installedHooks ?? [];
+      writeRcFile(targetDir, {
+        ...rc,
+        installedHooks: [...new Set([...existing, ...idesToAdd])],
+      });
+    }
+  } catch {
+    // Non-fatal: the IDE-specific install already succeeded; rc update is best-effort.
+  }
+}
+
+/**
+ * Removes ide names from .yakccrc.json installedHooks in targetDir.
+ * No-op if no rc file exists. Non-fatal on write error.
+ */
+export function removeInstalledHooks(targetDir: string, idesToRemove: string[]): void {
+  if (idesToRemove.length === 0) return;
+  const rc = readRcFile(targetDir);
+  if (rc === null) return;
+  const existing = rc.installedHooks ?? [];
+  const filtered = existing.filter((h) => !idesToRemove.includes(h));
+  try {
+    writeRcFile(targetDir, { ...rc, installedHooks: filtered });
+  } catch {
+    // Non-fatal.
+  }
+}


### PR DESCRIPTION
## Summary

- Introduces `packages/cli/src/lib/rc-helpers.ts` with shared `updateInstalledHooks` / `removeInstalledHooks` helpers that read-modify-write `.yakccrc.json` idempotently
- Wires all 6 standalone install commands (`hooks-install.ts`, `hooks-cursor-install.ts`, `hooks-windsurf-install.ts`, `hooks-cline-install.ts`, `hooks-continue-install.ts`, `hooks-aider-install.ts`) to call these helpers on install and uninstall
- Adds `overrideTargetDir` injection seam to the home-dir-based installers (cline, continue, aider) so tests can control the rc-write location without touching the real CWD
- Updates `uninstall.test.ts` EC-S2-T2 to explicitly remove the rc after install so the Tier 3 (`detectInstalledIdes`) fallback path is still exercised as designed

## Test evidence

```
 ✓ src/commands/hooks-rc-bookkeeping.test.ts (30 tests)
   ✓ rc bookkeeping — install adds IDE name to existing rc (6 tests)
   ✓ rc bookkeeping — install creates rc when none exists (6 tests)
   ✓ rc bookkeeping — install is idempotent (no duplicate entries) (6 tests)
   ✓ rc bookkeeping — uninstall removes IDE name from rc (6 tests)
   ✓ rc bookkeeping — preserves existing rc fields (6 tests)
 ✓ src/commands/uninstall.test.ts (27 tests)
 ✓ src/commands/hooks-install.test.ts (13 tests)
 ✓ src/commands/hooks-cline-install.test.ts (10 tests)
 ✓ src/commands/hooks-continue-install.test.ts (10 tests)

Tests  3 failed (pre-existing on main) | 396 passed | 10 skipped (409 total)
```

Closes #759

🤖 Picked up by FuckGoblin

---
_Generated by [Claude Code](https://claude.ai/code/session_01T2aB2JWnwdH2VUFL49zGLZ)_