### PR TITLE
Add `yakcc telemetry` command and telemetry-path discoverability (closes #760)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 .env
 .env.local
 .yakcc/
+.yakccrc.json
 tmp/
 # NOTE: tmp/discovery-eval/baseline-single-vector-2026-05-10.json and
 # tmp/discovery-eval/measurement-first-decision.md are committed via `git add --force`

--- a/docs/ALPHA.md
+++ b/docs/ALPHA.md
@@ -116,10 +116,12 @@ The template asks for:
 - What you tried (exact commands)
 - What you expected
 - What happened
-- Telemetry sample (last ~10 lines of `~/.yakcc/telemetry/*.jsonl`)
+- Telemetry sample (run `yakcc telemetry --tail 10` to get the last 10 events from your latest session)
 - Any error output / logs
 
 The telemetry sample is the most useful diagnostic we have. Please include it. It's local-only, never leaves your machine until you paste it into a GitHub issue.
+
+> **Note:** telemetry lives in `~/.yakcc/telemetry/` (your home dir), not in `<project>/.yakcc/`. Run `yakcc telemetry --path` to confirm the location. See [`docs/USING_YAKCC.md §4d`](USING_YAKCC.md) for the full two-directory layout explanation.
 
 ### Triage SLA
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -2,7 +2,7 @@
 
 Common failures, diagnostic steps, and fixes. Each entry follows the pattern: symptom → diagnostic command → fix → related issue.
 
-If your problem is not here, [file an issue](https://github.com/cneckar/yakcc/issues/new?template=alpha-feedback.md). Include the output of `yakcc --version` and the last 10 lines of `~/.yakcc/telemetry/*.jsonl`.
+If your problem is not here, [file an issue](https://github.com/cneckar/yakcc/issues/new?template=alpha-feedback.md). Include the output of `yakcc --version` and the output of `yakcc telemetry --tail 10`.
 
 ---
 
@@ -31,7 +31,32 @@ Then restart the IDE. Re-running is idempotent — it will not create duplicate 
 
 ---
 
-## 2. Claude Code doesn't fire the hook on Edit/Write/MultiEdit
+## 2. Telemetry files not found — looking in the wrong directory
+
+**Symptom:** You ran `yakcc init`, completed a Claude Code session with Edits or Writes, then looked in `<project>/.yakcc/telemetry/` and found it empty. You conclude the hook is broken or no-oping.
+
+**Explanation:** yakcc creates **two directories named `.yakcc`** with different purposes:
+
+| Directory | Contents |
+|---|---|
+| `<project>/.yakcc/` | Registry SQLite, mode config — per-project data |
+| `~/.yakcc/` | Telemetry JSONL files — per-user, cross-project |
+
+Telemetry is written to `~/.yakcc/telemetry/<session-id>.jsonl`, **not** to `<project>/.yakcc/`. This is by design: a Claude Code session can span multiple projects, so telemetry is user-scoped (D-HOOK-5).
+
+**Diagnostic:**
+
+```sh
+yakcc telemetry           # list session files with event counts + timestamps
+yakcc telemetry --path    # print the exact telemetry directory path
+yakcc telemetry --tail 5  # show the last 5 raw telemetry events
+```
+
+If `yakcc telemetry` shows no sessions, the hook has not fired yet. See §3 (Claude Code hook not firing) below.
+
+---
+
+## 3. Claude Code doesn't fire the hook on Edit/Write/MultiEdit
 
 **Symptom:** Claude Code sessions proceed but `~/.yakcc/telemetry/` stays empty or the telemetry file is not updated after edits.
 
@@ -56,7 +81,7 @@ If the entry is present and Claude Code has been restarted but the telemetry fil
 
 ---
 
-## 3. Registry seems empty after `yakcc init`
+## 4. Registry seems empty after `yakcc init`
 
 **Symptom:** `yakcc query "any query"` returns no results, or `yakcc search "anything"` returns nothing, immediately after running `yakcc init`.
 
@@ -93,7 +118,7 @@ yakcc query "store a block by content address"
 
 ---
 
-## 4. Every emission shows `outcome: "passthrough"`
+## 5. Every emission shows `outcome: "passthrough"`
 
 **Symptom:** Telemetry shows `"outcome": "passthrough"` for every hook invocation, even after seeding the registry.
 
@@ -116,7 +141,7 @@ This regenerates all embedding vectors for the current default model (`bge-small
 
 ---
 
-## 5. `outcome: "synthesis-required"` for most emissions
+## 6. `outcome: "synthesis-required"` for most emissions
 
 **Symptom:** Telemetry mostly shows `"outcome": "synthesis-required"` — the registry has atoms but nothing matches your code.
 
@@ -130,7 +155,7 @@ This regenerates all embedding vectors for the current default model (`bge-small
 
 ---
 
-## 6. Federation mirror fails with integrity error
+## 7. Federation mirror fails with integrity error
 
 **Symptom:** `yakcc federation mirror` exits with an integrity error like `BlockMerkleRoot mismatch` or `integrity check failed`.
 
@@ -151,7 +176,7 @@ yakcc federation mirror --remote <peer-url> --registry .yakcc/registry.sqlite --
 
 ---
 
-## 7. Bootstrap is slow
+## 8. Bootstrap is slow
 
 **Symptom:** `yakcc bootstrap` or `yakcc seed --yakcc` takes 30+ minutes when prior runs completed in ~5 minutes.
 
@@ -171,7 +196,7 @@ If the regression persists after pulling, check issue [#377](https://github.com/
 
 ---
 
-## 8. Windows-specific issues
+## 9. Windows-specific issues
 
 **`yakcc init` produces no output / no-ops on Windows:**
 

--- a/docs/USING_YAKCC.md
+++ b/docs/USING_YAKCC.md
@@ -153,6 +153,27 @@ What you'll see:
 
 ---
 
+### 4d. Local directory layout — where things live
+
+yakcc creates **two directories named `.yakcc`** in normal use. They are in different parent directories and hold different state:
+
+| Directory | Contents | Created by |
+|---|---|---|
+| `<project>/.yakcc/` | `registry.sqlite` (atom store), `config/`, `registry/` | `yakcc init` |
+| `~/.yakcc/` | `telemetry/<session-id>.jsonl` — one per Claude Code session | Hook on first Edit/Write |
+
+**Telemetry is always written to `~/.yakcc/telemetry/`, not `<project>/.yakcc/`.** This is intentional: a single Claude Code session can touch multiple projects, so telemetry is aggregated per-user rather than fragmented per-project (D-HOOK-5).
+
+Use the `yakcc telemetry` command to inspect it without having to remember the path:
+
+```sh
+yakcc telemetry           # list session files with event counts + timestamps
+yakcc telemetry --tail 5  # print the last 5 events from the latest session
+yakcc telemetry --path    # print the resolved telemetry directory
+```
+
+---
+
 ## 5. Walking through a registry hit
 
 When the hook substitutes a registry atom, the emitted code carries an inline contract comment showing exactly which atom was used (per D-HOOK-4 in [`docs/archive/developer/adr/hook-layer-architecture.md`](archive/developer/adr/hook-layer-architecture.md)):

--- a/packages/cli/src/commands/hooks-install.ts
+++ b/packages/cli/src/commands/hooks-install.ts
@@ -16,6 +16,7 @@
 // Supersedes DEC-CLI-HOOKS-INSTALL-001 (v0 CLAUDE.md stub; WI-009).
 
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import type { Logger } from "../index.js";
@@ -227,11 +228,13 @@ export async function hooksClaudeCodeInstall(
     }
   }
 
+  const telemetryDir = process.env.YAKCC_TELEMETRY_DIR ?? join(homedir(), ".yakcc", "telemetry");
   if (alreadyInstalled) {
     logger.log(`yakcc hook already installed at ${settingsPath} (idempotent).`);
   } else {
     logger.log(`yakcc hook installed at ${settingsPath}`);
     logger.log(`tool-call interception: ${HOOK_MATCHER} → ${HOOK_COMMAND}`);
+    logger.log(`telemetry will land in ${telemetryDir}/<session>.jsonl`);
   }
   // --- WI-759: update .yakccrc.json.installedHooks ---
   try {

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -597,7 +597,13 @@ describe("init — summary output (G6: ≤6 lines on happy path)", () => {
     expect(allLog).toContain("claude-code");
   });
 
-  it("success output is ≤6 lines on default happy path (G6)", async () => {
+  it("success output is ≤8 lines on default happy path (G6 + WI-760 telemetry lines)", async () => {
+    // @decision DEC-CLI-INIT-WI760-G6-UPDATE-001
+    // title: G6 line-count limit raised from 6 to 8 to accommodate WI-760 telemetry discoverability
+    // status: accepted (WI-760)
+    // rationale: WI-760 adds a "telemetry will land in" line from hooksClaudeCodeInstall and a
+    //   "Telemetry:" summary line from init itself. Both are required per the WI-760 acceptance
+    //   criteria. The prior G6=6 constraint is updated to G6=8 to reflect these two additions.
     const fakeHome = join(tmpDir, "fakehome");
     mkdirSync(join(fakeHome, ".claude"), { recursive: true });
 
@@ -608,7 +614,7 @@ describe("init — summary output (G6: ≤6 lines on happy path)", () => {
 
     // Count non-empty log lines
     const nonEmptyLines = logger.logLines.filter((l) => l.trim().length > 0);
-    expect(nonEmptyLines.length).toBeLessThanOrEqual(6);
+    expect(nonEmptyLines.length).toBeLessThanOrEqual(8);
   });
 
   // EC-S7-T1: no-detect path surfaces a structured hint (DEC-CLI-INIT-NO-IDE-HINT-001)

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -53,6 +53,7 @@
 //   Backward compat preserved: --target and --peer semantics unchanged.
 
 import { existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import { type Registry, openRegistry } from "@yakcc/registry";
@@ -525,8 +526,10 @@ export async function init(
         ? "Hooks: skipped (--skip-hooks)."
         : "Hooks: no IDEs detected.";
 
+  const telemetryDir = process.env.YAKCC_TELEMETRY_DIR ?? join(homedir(), ".yakcc", "telemetry");
   logger.log("");
   logger.log(`Installed in ${targetDir}. ${hookedLine} Registry: ${seedCount} atoms.`);
+  logger.log(`Telemetry: ${telemetryDir}/<session>.jsonl (written on next Edit/Write tool call)`);
 
   // @decision DEC-CLI-INIT-NO-IDE-HINT-001 (WI-687-S7 / #746 AC2)
   // title: When auto-detect finds nothing and --skip-hooks was not passed, surface a

--- a/packages/cli/src/commands/telemetry.test.ts
+++ b/packages/cli/src/commands/telemetry.test.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+//
+// telemetry.test.ts — integration tests for `yakcc telemetry`
+//
+// Tests:
+//   1. --path prints the resolved telemetry directory (honouring YAKCC_TELEMETRY_DIR).
+//   2. Default listing when no sessions exist: prints dir + empty state message.
+//   3. Default listing with session files: prints file names, event counts, timestamps.
+//   4. --tail N: prints last N events from the newest session file.
+//   5. --tail with invalid value: exits 1 with error.
+//   6. Unknown flag: exits 1 with error.
+//   7. Dispatch via runCli().
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CollectingLogger, runCli } from "../index.js";
+import { telemetry } from "./telemetry.js";
+
+let tmpDir: string;
+let telemetryDir: string;
+let origEnv: string | undefined;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "yakcc-telemetry-test-"));
+  telemetryDir = join(tmpDir, "telemetry");
+  origEnv = process.env.YAKCC_TELEMETRY_DIR;
+  process.env.YAKCC_TELEMETRY_DIR = telemetryDir;
+});
+
+afterEach(() => {
+  if (origEnv === undefined) {
+    delete process.env.YAKCC_TELEMETRY_DIR;
+  } else {
+    process.env.YAKCC_TELEMETRY_DIR = origEnv;
+  }
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("telemetry command", () => {
+  it("--path prints the resolved telemetry directory", async () => {
+    const logger = new CollectingLogger();
+    const code = await telemetry(["--path"], logger);
+    expect(code).toBe(0);
+    expect(logger.logLines).toHaveLength(1);
+    expect(logger.logLines[0]).toBe(telemetryDir);
+  });
+
+  it("default listing when directory does not exist: prints dir + empty message", async () => {
+    const logger = new CollectingLogger();
+    const code = await telemetry([], logger);
+    expect(code).toBe(0);
+    expect(logger.logLines.join("\n")).toContain(telemetryDir);
+    expect(logger.logLines.join("\n")).toContain("no sessions yet");
+  });
+
+  it("default listing when directory exists but is empty: prints dir + empty message", async () => {
+    mkdirSync(telemetryDir, { recursive: true });
+    const logger = new CollectingLogger();
+    const code = await telemetry([], logger);
+    expect(code).toBe(0);
+    expect(logger.logLines.join("\n")).toContain("no session files yet");
+  });
+
+  it("default listing with session files: shows file names and event counts", async () => {
+    mkdirSync(telemetryDir, { recursive: true });
+    const sessionFile = join(telemetryDir, "session-abc.jsonl");
+    const events = [
+      '{"t":1000,"outcome":"passthrough","toolName":"Edit"}',
+      '{"t":2000,"outcome":"registry-hit","toolName":"Write"}',
+    ].join("\n") + "\n";
+    writeFileSync(sessionFile, events, "utf-8");
+
+    const logger = new CollectingLogger();
+    const code = await telemetry([], logger);
+    expect(code).toBe(0);
+    const output = logger.logLines.join("\n");
+    expect(output).toContain("session-abc.jsonl");
+    expect(output).toContain("2 events");
+    expect(output).toContain("yakcc telemetry --tail");
+  });
+
+  it("--tail N: prints last N lines from newest session", async () => {
+    mkdirSync(telemetryDir, { recursive: true });
+    const lines = [
+      '{"t":1,"outcome":"passthrough"}',
+      '{"t":2,"outcome":"registry-hit"}',
+      '{"t":3,"outcome":"synthesis-required"}',
+    ];
+    writeFileSync(join(telemetryDir, "session-xyz.jsonl"), lines.join("\n") + "\n", "utf-8");
+
+    const logger = new CollectingLogger();
+    const code = await telemetry(["--tail", "2"], logger);
+    expect(code).toBe(0);
+    expect(logger.logLines).toHaveLength(2);
+    expect(logger.logLines[0]).toBe(lines[1]);
+    expect(logger.logLines[1]).toBe(lines[2]);
+  });
+
+  it("--tail with invalid value: exits 1 with error message", async () => {
+    const logger = new CollectingLogger();
+    const code = await telemetry(["--tail", "banana"], logger);
+    expect(code).toBe(1);
+    expect(logger.errLines.some((l) => l.includes("positive integer"))).toBe(true);
+  });
+
+  it("unknown flag: exits 1 with error message", async () => {
+    const logger = new CollectingLogger();
+    const code = await telemetry(["--unknown-flag"], logger);
+    expect(code).toBe(1);
+    expect(logger.errLines.length).toBeGreaterThan(0);
+  });
+
+  it("dispatches via runCli(['telemetry', '--path'])", async () => {
+    const logger = new CollectingLogger();
+    const code = await runCli(["telemetry", "--path"], logger);
+    expect(code).toBe(0);
+    expect(logger.logLines[0]).toBe(telemetryDir);
+  });
+});

--- a/packages/cli/src/commands/telemetry.test.ts
+++ b/packages/cli/src/commands/telemetry.test.ts
@@ -31,7 +31,7 @@ beforeEach(() => {
 
 afterEach(() => {
   if (origEnv === undefined) {
-    process.env.YAKCC_TELEMETRY_DIR = undefined;
+    Reflect.deleteProperty(process.env, "YAKCC_TELEMETRY_DIR");
   } else {
     process.env.YAKCC_TELEMETRY_DIR = origEnv;
   }

--- a/packages/cli/src/commands/telemetry.test.ts
+++ b/packages/cli/src/commands/telemetry.test.ts
@@ -31,7 +31,7 @@ beforeEach(() => {
 
 afterEach(() => {
   if (origEnv === undefined) {
-    delete process.env.YAKCC_TELEMETRY_DIR;
+    process.env.YAKCC_TELEMETRY_DIR = undefined;
   } else {
     process.env.YAKCC_TELEMETRY_DIR = origEnv;
   }
@@ -66,10 +66,10 @@ describe("telemetry command", () => {
   it("default listing with session files: shows file names and event counts", async () => {
     mkdirSync(telemetryDir, { recursive: true });
     const sessionFile = join(telemetryDir, "session-abc.jsonl");
-    const events = [
+    const events = `${[
       '{"t":1000,"outcome":"passthrough","toolName":"Edit"}',
       '{"t":2000,"outcome":"registry-hit","toolName":"Write"}',
-    ].join("\n") + "\n";
+    ].join("\n")}\n`;
     writeFileSync(sessionFile, events, "utf-8");
 
     const logger = new CollectingLogger();
@@ -88,7 +88,7 @@ describe("telemetry command", () => {
       '{"t":2,"outcome":"registry-hit"}',
       '{"t":3,"outcome":"synthesis-required"}',
     ];
-    writeFileSync(join(telemetryDir, "session-xyz.jsonl"), lines.join("\n") + "\n", "utf-8");
+    writeFileSync(join(telemetryDir, "session-xyz.jsonl"), `${lines.join("\n")}\n`, "utf-8");
 
     const logger = new CollectingLogger();
     const code = await telemetry(["--tail", "2"], logger);

--- a/packages/cli/src/commands/telemetry.ts
+++ b/packages/cli/src/commands/telemetry.ts
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+//
+// telemetry.ts — handler for `yakcc telemetry [--path] [--tail N]`
+//
+// @decision DEC-CLI-TELEMETRY-COMMAND-001
+// title: `yakcc telemetry` surfaces telemetry-dir location and session event logs
+// status: accepted (WI-760)
+// rationale:
+//   Alpha testers look in <project>/.yakcc/telemetry/ (intuitive but wrong) and
+//   conclude the hook is broken. This command provides a CLI affordance to discover
+//   and inspect ~/.yakcc/telemetry/ without knowing the path a priori. Three
+//   sub-actions: --path (print resolved dir), --tail N (last N lines from newest
+//   session), and the default listing (session files with event counts + last-seen
+//   timestamps). Zero network I/O; pure local reads (B6 air-gap compliance).
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+import { resolveTelemetryDir } from "@yakcc/hooks-base/telemetry.js";
+import type { Logger } from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Count the number of non-empty JSONL lines in a file. */
+function countLines(filePath: string): number {
+  try {
+    const content = readFileSync(filePath, "utf-8");
+    return content.split("\n").filter((l) => l.trim().length > 0).length;
+  } catch {
+    return 0;
+  }
+}
+
+/** Read the last N non-empty lines from a file. */
+function lastNLines(filePath: string, n: number): string[] {
+  try {
+    const content = readFileSync(filePath, "utf-8");
+    const lines = content.split("\n").filter((l) => l.trim().length > 0);
+    return lines.slice(-n);
+  } catch {
+    return [];
+  }
+}
+
+/** Format a Date as a human-readable relative timestamp. */
+function relativeTime(ms: number): string {
+  const diffMs = Date.now() - ms;
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin} min ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDays = Math.floor(diffHr / 24);
+  return `${diffDays}d ago`;
+}
+
+// ---------------------------------------------------------------------------
+// Command handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handler for `yakcc telemetry [--path] [--tail <n>]`.
+ *
+ * Default (no flags): lists all session JSONL files in the telemetry dir with
+ * event counts and last-modified timestamps.
+ *
+ * --path: prints the resolved telemetry directory (honouring YAKCC_TELEMETRY_DIR).
+ * --tail N: prints the last N events from the most recent session JSONL file.
+ *
+ * @param argv   - Remaining argv after `telemetry` has been consumed.
+ * @param logger - Output sink.
+ * @returns Process exit code (0 = success, 1 = error).
+ */
+export async function telemetry(argv: readonly string[], logger: Logger): Promise<number> {
+  let parsed: ReturnType<
+    typeof parseArgs<{
+      options: {
+        path: { type: "boolean" };
+        tail: { type: "string" };
+      };
+    }>
+  >;
+
+  try {
+    parsed = parseArgs({
+      args: [...argv],
+      options: {
+        path: { type: "boolean" },
+        tail: { type: "string" },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+  } catch (err) {
+    logger.error(`error: ${(err as Error).message}`);
+    logger.error("Usage: yakcc telemetry [--path] [--tail <n>]");
+    return 1;
+  }
+
+  const dir = resolveTelemetryDir();
+
+  // --path: just print the resolved directory
+  if (parsed.values.path === true) {
+    logger.log(dir);
+    return 0;
+  }
+
+  // Validate --tail early (before any I/O) so bad values always error regardless of dir state.
+  const tailRaw = parsed.values.tail;
+  let tailN: number | undefined;
+  if (tailRaw !== undefined) {
+    const n = Number.parseInt(tailRaw, 10);
+    if (Number.isNaN(n) || n < 1) {
+      logger.error(`error: --tail requires a positive integer, got: ${tailRaw}`);
+      return 1;
+    }
+    tailN = n;
+  }
+
+  // Ensure the directory exists (may never have been written to yet)
+  if (!existsSync(dir)) {
+    logger.log(`${dir}`);
+    logger.log("  (no sessions yet — use Claude Code with the hook installed to generate telemetry)");
+    return 0;
+  }
+
+  // Collect .jsonl files
+  let files: string[];
+  try {
+    files = readdirSync(dir)
+      .filter((f) => f.endsWith(".jsonl"))
+      .map((f) => join(dir, f));
+  } catch (err) {
+    logger.error(`error: cannot read telemetry dir ${dir}: ${String(err)}`);
+    return 1;
+  }
+
+  if (files.length === 0) {
+    logger.log(`${dir}`);
+    logger.log("  (no session files yet — use Claude Code with the hook installed to generate telemetry)");
+    return 0;
+  }
+
+  // Sort by mtime descending (newest first)
+  const withStats = files
+    .map((f) => {
+      try {
+        const st = statSync(f);
+        return { path: f, name: f.split("/").pop() ?? f, mtime: st.mtimeMs };
+      } catch {
+        return { path: f, name: f.split("/").pop() ?? f, mtime: 0 };
+      }
+    })
+    .sort((a, b) => b.mtime - a.mtime);
+
+  // --tail N: print last N events from the newest session (tailN already validated above)
+  if (tailN !== undefined) {
+    const newest = withStats[0];
+    if (newest === undefined) {
+      logger.log("(no sessions)");
+      return 0;
+    }
+    const lines = lastNLines(newest.path, tailN);
+    if (lines.length === 0) {
+      logger.log(`(${newest.name} — no events)`);
+      return 0;
+    }
+    for (const line of lines) {
+      logger.log(line);
+    }
+    return 0;
+  }
+
+  // Default: listing
+  logger.log(`${dir}`);
+  for (const { name, path: filePath, mtime } of withStats) {
+    const count = countLines(filePath);
+    const rel = mtime > 0 ? relativeTime(mtime) : "unknown";
+    logger.log(`  ${name}   (${count} events, latest ${rel})`);
+  }
+  logger.log("");
+  logger.log(`Tip: yakcc telemetry --tail 10   to inspect recent events`);
+  logger.log(`     yakcc telemetry --path        to print the directory path`);
+
+  return 0;
+}

--- a/packages/cli/src/commands/telemetry.ts
+++ b/packages/cli/src/commands/telemetry.ts
@@ -13,7 +13,7 @@
 //   session), and the default listing (session files with event counts + last-seen
 //   timestamps). Zero network I/O; pure local reads (B6 air-gap compliance).
 
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import { resolveTelemetryDir } from "@yakcc/hooks-base/telemetry.js";
@@ -123,7 +123,9 @@ export async function telemetry(argv: readonly string[], logger: Logger): Promis
   // Ensure the directory exists (may never have been written to yet)
   if (!existsSync(dir)) {
     logger.log(`${dir}`);
-    logger.log("  (no sessions yet — use Claude Code with the hook installed to generate telemetry)");
+    logger.log(
+      "  (no sessions yet — use Claude Code with the hook installed to generate telemetry)",
+    );
     return 0;
   }
 
@@ -140,7 +142,9 @@ export async function telemetry(argv: readonly string[], logger: Logger): Promis
 
   if (files.length === 0) {
     logger.log(`${dir}`);
-    logger.log("  (no session files yet — use Claude Code with the hook installed to generate telemetry)");
+    logger.log(
+      "  (no session files yet — use Claude Code with the hook installed to generate telemetry)",
+    );
     return 0;
   }
 
@@ -182,8 +186,8 @@ export async function telemetry(argv: readonly string[], logger: Logger): Promis
     logger.log(`  ${name}   (${count} events, latest ${rel})`);
   }
   logger.log("");
-  logger.log(`Tip: yakcc telemetry --tail 10   to inspect recent events`);
-  logger.log(`     yakcc telemetry --path        to print the directory path`);
+  logger.log("Tip: yakcc telemetry --tail 10   to inspect recent events");
+  logger.log("     yakcc telemetry --path        to print the directory path");
 
   return 0;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -54,6 +54,7 @@ import { registryRebuild } from "./commands/registry-rebuild.js";
 import { search } from "./commands/search.js";
 import { seed } from "./commands/seed.js";
 import { shave } from "./commands/shave.js";
+import { telemetry } from "./commands/telemetry.js";
 import { uninstall } from "./commands/uninstall.js";
 
 // Re-export ContractId for callers who import from @yakcc/cli.
@@ -175,6 +176,7 @@ COMMANDS
   hooks continue install              Wire yakcc tool-call interception for Continue.dev
                 [--target <dir>]      Target project directory (default: .)
                 [--uninstall]         Remove the yakcc continue hook entry
+  telemetry [--path] [--tail <n>]     Show telemetry sessions in ~/.yakcc/telemetry/ (or YAKCC_TELEMETRY_DIR)
   hook-intercept                      (internal -- invoked by IDE hook configs via PreToolUse)
   federation serve --registry <p>     Start a read-only HTTP registry server
                 [--port <n>] [--host <h>]
@@ -384,6 +386,12 @@ export async function runCli(
       // Reads stdin, appends one telemetry JSONL line, ALWAYS exits 0 with empty stdout.
       const hookInterceptArgv = subcommand !== undefined ? [subcommand, ...rest] : rest;
       return hookIntercept(hookInterceptArgv, logger);
+    }
+
+    case "telemetry": {
+      // `yakcc telemetry [--path] [--tail <n>]` -- inspect local telemetry (WI-760).
+      const telemetryArgv = subcommand !== undefined ? [subcommand, ...rest] : rest;
+      return telemetry(telemetryArgv, logger);
     }
 
     case undefined:


### PR DESCRIPTION
## Summary

- **New `yakcc telemetry` CLI command** (`packages/cli/src/commands/telemetry.ts`): lists session JSONL files with event counts + timestamps; `--tail N` prints the last N events from the newest session; `--path` prints the resolved directory (honouring `YAKCC_TELEMETRY_DIR`). Zero network I/O (B6 air-gap compliant).
- **`yakcc init` and `yakcc hooks claude-code install`** now print the telemetry directory path after a successful install so testers know where to look without reading source (WI-760 §B).
- **Docs** (`USING_YAKCC.md §4d`, `ALPHA.md`, `TROUBLESHOOTING.md §2`): two-directory layout table, `yakcc telemetry` usage, and a dedicated troubleshooting entry for "I looked in `<project>/.yakcc/telemetry/` and found nothing."
- **G6 line-count constraint** in `init.test.ts` updated from ≤6 to ≤8 to accommodate the two new required telemetry-path lines (decision annotated as `DEC-CLI-INIT-WI760-G6-UPDATE-001`).

## Test evidence

```
 Test Files  2 failed | 25 passed | 2 skipped (29)
      Tests  3 failed | 466 passed | 10 skipped (479)
```

The 3 failures (`src/cli.test.ts`) are pre-existing on `main` before this branch — verified by running baseline tests on a clean checkout. All 8 new telemetry tests pass. All previously-passing tests continue to pass.

Closes #760

🤖 Picked up by FuckGoblin

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPiaE199fXPLB4e8XRoKcb)_