### PR TITLE
feat(cli): #764 add yakcc stats — Tier-1 telemetry metrics command (closes #764)

### DIFF
--- a/packages/cli/src/commands/stats.test.ts
+++ b/packages/cli/src/commands/stats.test.ts
@@ -1,0 +1,573 @@
+// SPDX-License-Identifier: MIT
+//
+// stats.test.ts — real-fs integration tests for `yakcc stats` (WI-764 T-1..T-11)
+//
+// All tests use mkdtempSync + real .jsonl fixture files (Sacred Practice #1).
+// No fs mocks, no reader stubs. CollectingLogger captures output.
+//
+// Tests cover the Evaluation Contract T-1..T-11 plus index.ts dispatch wiring.
+//
+// @decision DEC-CLI-STATS-SCOPE-001 — Tier-1 only metrics verified here.
+// @decision DEC-CLI-STATS-COMMAND-001 — command shape, --since, --json verified here.
+// @decision DEC-CLI-STATS-READER-SEAM-001 — single reader authority; stats.ts has no JSON.parse over telemetry lines.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CollectingLogger, runCli } from "../index.js";
+import { stats } from "./stats.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal valid TelemetryEvent JSON line. */
+function makeEvent(overrides: {
+  t?: number;
+  toolName?: string;
+  outcome?: string;
+  candidateCount?: number;
+  topScore?: number | null;
+}): string {
+  const event = {
+    t: overrides.t ?? Date.now(),
+    intentHash: "aabbccdd",
+    toolName: overrides.toolName ?? "Edit",
+    candidateCount: overrides.candidateCount ?? 0,
+    topScore: overrides.topScore ?? null,
+    substituted: false,
+    substitutedAtomHash: null,
+    latencyMs: 10,
+    outcome: overrides.outcome ?? "passthrough",
+  };
+  return JSON.stringify(event);
+}
+
+// ---------------------------------------------------------------------------
+// Test fixture + environment setup
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let telemetryDir: string;
+let origEnv: string | undefined;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "yakcc-stats-test-"));
+  telemetryDir = join(tmpDir, "telemetry");
+  origEnv = process.env.YAKCC_TELEMETRY_DIR;
+  process.env.YAKCC_TELEMETRY_DIR = telemetryDir;
+});
+
+afterEach(() => {
+  if (origEnv === undefined) {
+    Reflect.deleteProperty(process.env, "YAKCC_TELEMETRY_DIR");
+  } else {
+    process.env.YAKCC_TELEMETRY_DIR = origEnv;
+  }
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// T-1: Empty dir (non-existent) → graceful no-data message, exit 0
+// ---------------------------------------------------------------------------
+describe("T-1: empty dir (non-existent)", () => {
+  it("prints friendly no-data message and exits 0", async () => {
+    // telemetryDir does not exist at this point
+    const logger = new CollectingLogger();
+    const code = await stats([], logger);
+    expect(code).toBe(0);
+    const output = logger.logLines.join("\n");
+    expect(output).toMatch(/no telemetry/i);
+    expect(logger.errLines).toHaveLength(0);
+  });
+
+  it("--json: zero-state object, exit 0", async () => {
+    const logger = new CollectingLogger();
+    const code = await stats(["--json"], logger);
+    expect(code).toBe(0);
+    expect(logger.logLines).toHaveLength(1);
+    const parsed = JSON.parse(logger.logLines[0] as string);
+    expect(parsed.summary.totalEvents).toBe(0);
+    expect(parsed.summary.sessionCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-2: Empty-but-present dir → graceful no-data message, exit 0
+// ---------------------------------------------------------------------------
+describe("T-2: empty-but-present dir", () => {
+  it("prints friendly no-data message and exits 0", async () => {
+    mkdirSync(telemetryDir, { recursive: true });
+    const logger = new CollectingLogger();
+    const code = await stats([], logger);
+    expect(code).toBe(0);
+    const output = logger.logLines.join("\n");
+    expect(output).toMatch(/no telemetry/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-3: Files exist but are empty (zero events) → no-data message, exit 0
+// ---------------------------------------------------------------------------
+describe("T-3: files exist but zero events", () => {
+  it("prints friendly no-data message and exits 0", async () => {
+    mkdirSync(telemetryDir, { recursive: true });
+    writeFileSync(join(telemetryDir, "session-empty.jsonl"), "", "utf-8");
+    writeFileSync(join(telemetryDir, "session-blank.jsonl"), "\n\n", "utf-8");
+
+    const logger = new CollectingLogger();
+    const code = await stats([], logger);
+    expect(code).toBe(0);
+    const output = logger.logLines.join("\n");
+    expect(output).toMatch(/no telemetry/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-4: Single-session arithmetic — exact counts and percentages
+// ---------------------------------------------------------------------------
+describe("T-4: single-session arithmetic", () => {
+  it("reports exact outcome counts, per-tool hit rates", async () => {
+    mkdirSync(telemetryDir, { recursive: true });
+
+    // 4 Edit events: 1 registry-hit, 2 passthrough, 1 synthesis-required
+    // 2 Write events: both passthrough
+    // 1 MultiEdit event: 1 registry-hit
+    const lines = [
+      makeEvent({ toolName: "Edit", outcome: "registry-hit" }),
+      makeEvent({ toolName: "Edit", outcome: "passthrough" }),
+      makeEvent({ toolName: "Edit", outcome: "passthrough" }),
+      makeEvent({ toolName: "Edit", outcome: "synthesis-required" }),
+      makeEvent({ toolName: "Write", outcome: "passthrough" }),
+      makeEvent({ toolName: "Write", outcome: "passthrough" }),
+      makeEvent({ toolName: "MultiEdit", outcome: "registry-hit" }),
+    ];
+    writeFileSync(join(telemetryDir, "session-s4.jsonl"), `${lines.join("\n")}\n`, "utf-8");
+
+    const logger = new CollectingLogger();
+    const code = await stats([], logger);
+    expect(code).toBe(0);
+
+    const output = logger.logLines.join("\n");
+
+    // Total events
+    expect(output).toContain("7");
+
+    // Outcome breakdown — registry-hit: 2 of 7 ≈ 28.6%
+    expect(output).toContain("28.6%");
+
+    // synthesis-required: 1 of 7 ≈ 14.3%
+    expect(output).toContain("14.3%");
+
+    // passthrough: 4 of 7 ≈ 57.1%
+    expect(output).toContain("57.1%");
+  });
+
+  it("--json: correct counts in JSON output", async () => {
+    mkdirSync(telemetryDir, { recursive: true });
+
+    const lines = [
+      makeEvent({ toolName: "Edit", outcome: "registry-hit" }),
+      makeEvent({ toolName: "Edit", outcome: "passthrough" }),
+      makeEvent({ toolName: "Write", outcome: "passthrough" }),
+    ];
+    writeFileSync(join(telemetryDir, "session-s4j.jsonl"), `${lines.join("\n")}\n`, "utf-8");
+
+    const logger = new CollectingLogger();
+    const code = await stats(["--json"], logger);
+    expect(code).toBe(0);
+
+    const parsed = JSON.parse(logger.logLines[0] as string);
+    expect(parsed.summary.totalEvents).toBe(3);
+    expect(parsed.outcomeBreakdown.registryHit).toBe(1);
+    expect(parsed.outcomeBreakdown.passthrough).toBe(2);
+    expect(parsed.perToolBreakdown.Edit.total).toBe(2);
+    expect(parsed.perToolBreakdown.Edit.registryHits).toBe(1);
+    expect(parsed.perToolBreakdown.Write.total).toBe(1);
+    expect(parsed.perToolBreakdown.Write.registryHits).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-5: Multi-session aggregation — totals are sums; days-active counts distinct days
+// ---------------------------------------------------------------------------
+describe("T-5: multi-session aggregation", () => {
+  it("sums totals across sessions and counts distinct calendar days", async () => {
+    mkdirSync(telemetryDir, { recursive: true });
+
+    // Session A: 2 events on day 2025-01-01
+    const dayA = new Date("2025-01-01T10:00:00Z").getTime();
+    const sessionA = [
+      makeEvent({ t: dayA, toolName: "Edit", outcome: "passthrough" }),
+      makeEvent({ t: dayA + 1000, toolName: "Write", outcome: "passthrough" }),
+    ];
+    writeFileSync(join(telemetryDir, "session-a.jsonl"), `${sessionA.join("\n")}\n`, "utf-8");
+
+    // Session B: 3 events on day 2025-01-02
+    const dayB = new Date("2025-01-02T12:00:00Z").getTime();
+    const sessionB = [
+      makeEvent({ t: dayB, toolName: "Edit", outcome: "registry-hit" }),
+      makeEvent({ t: dayB + 1000, toolName: "MultiEdit", outcome: "passthrough" }),
+      makeEvent({ t: dayB + 2000, toolName: "Edit", outcome: "synthesis-required" }),
+    ];
+    writeFileSync(join(telemetryDir, "session-b.jsonl"), `${sessionB.join("\n")}\n`, "utf-8");
+
+    // Session C: 1 event also on day 2025-01-01 (same day as A — must not double-count)
+    const sessionC = [
+      makeEvent({ t: dayA + 3_600_000, toolName: "Write", outcome: "passthrough" }),
+    ];
+    writeFileSync(join(telemetryDir, "session-c.jsonl"), `${sessionC.join("\n")}\n`, "utf-8");
+
+    const logger = new CollectingLogger();
+    const code = await stats(["--json"], logger);
+    expect(code).toBe(0);
+
+    const parsed = JSON.parse(logger.logLines[0] as string);
+    expect(parsed.summary.totalEvents).toBe(6); // 2 + 3 + 1
+    expect(parsed.summary.sessionCount).toBe(3);
+    expect(parsed.summary.daysActive).toBe(2); // 2025-01-01 and 2025-01-02 only
+    expect(parsed.outcomeBreakdown.passthrough).toBe(4);
+    expect(parsed.outcomeBreakdown.registryHit).toBe(1);
+    expect(parsed.outcomeBreakdown.synthesisRequired).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-6: Corrupt-line skip — valid events still counted, skippedLines reported
+// ---------------------------------------------------------------------------
+describe("T-6: corrupt-line skip", () => {
+  it("skips malformed JSON and structurally-invalid objects; counts valid events", async () => {
+    mkdirSync(telemetryDir, { recursive: true });
+
+    const lines = [
+      makeEvent({ toolName: "Edit", outcome: "passthrough" }),
+      "this is not json at all",
+      makeEvent({ toolName: "Write", outcome: "registry-hit" }),
+      '{"t": 999}', // missing required toolName / outcome
+      makeEvent({ toolName: "Edit", outcome: "passthrough" }),
+      '{"t": 1, "outcome": "passthrough"', // truncated (unclosed brace)
+    ];
+    writeFileSync(
+      join(telemetryDir, "session-corrupt.jsonl"),
+      lines.join("\n"), // no trailing newline — extra robustness
+      "utf-8",
+    );
+
+    const logger = new CollectingLogger();
+    const code = await stats(["--json"], logger);
+    expect(code).toBe(0);
+
+    const parsed = JSON.parse(logger.logLines[0] as string);
+    // 3 valid events (lines 1, 3, 5)
+    expect(parsed.summary.totalEvents).toBe(3);
+    // 3 skipped: "not json", missing-toolName object, truncated line
+    expect(parsed.summary.skippedLines).toBe(3);
+  });
+
+  it("human output reports skipped-line count", async () => {
+    mkdirSync(telemetryDir, { recursive: true });
+
+    const lines = [
+      makeEvent({ toolName: "Edit", outcome: "passthrough" }),
+      "bad line",
+      makeEvent({ toolName: "Write", outcome: "passthrough" }),
+    ];
+    writeFileSync(join(telemetryDir, "session-skip.jsonl"), `${lines.join("\n")}\n`, "utf-8");
+
+    const logger = new CollectingLogger();
+    const code = await stats([], logger);
+    expect(code).toBe(0);
+    expect(logger.logLines.join("\n")).toMatch(/malformed line/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-7: --since windowing
+// ---------------------------------------------------------------------------
+describe("T-7: --since windowing", () => {
+  it("counts only events at/after the given ISO date", async () => {
+    mkdirSync(telemetryDir, { recursive: true });
+
+    const before = new Date("2025-01-01T00:00:00Z").getTime();
+    const after = new Date("2025-06-01T00:00:00Z").getTime();
+
+    const lines = [
+      makeEvent({ t: before, outcome: "passthrough" }), // excluded
+      makeEvent({ t: after, outcome: "registry-hit" }), // included (t === sinceMs boundary)
+      makeEvent({ t: after + 1000, outcome: "passthrough" }), // included
+    ];
+    writeFileSync(join(telemetryDir, "session-since.jsonl"), `${lines.join("\n")}\n`, "utf-8");
+
+    const logger = new CollectingLogger();
+    const code = await stats(["--since", "2025-06-01", "--json"], logger);
+    expect(code).toBe(0);
+
+    const parsed = JSON.parse(logger.logLines[0] as string);
+    expect(parsed.summary.totalEvents).toBe(2);
+    expect(parsed.outcomeBreakdown.registryHit).toBe(1);
+    expect(parsed.outcomeBreakdown.passthrough).toBe(1);
+  });
+
+  it("lifetime default (no --since) counts all events", async () => {
+    mkdirSync(telemetryDir, { recursive: true });
+
+    const lines = [
+      makeEvent({ t: new Date("2024-01-01").getTime(), outcome: "passthrough" }),
+      makeEvent({ t: new Date("2025-01-01").getTime(), outcome: "passthrough" }),
+    ];
+    writeFileSync(join(telemetryDir, "session-all.jsonl"), `${lines.join("\n")}\n`, "utf-8");
+
+    const logger = new CollectingLogger();
+    const code = await stats(["--json"], logger);
+    expect(code).toBe(0);
+    const parsed = JSON.parse(logger.logLines[0] as string);
+    expect(parsed.summary.totalEvents).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-8: --since with invalid date → exit 1 with usage hint
+// ---------------------------------------------------------------------------
+describe("T-8: --since invalid date", () => {
+  it("exits 1 with a usage hint for a non-parseable date string", async () => {
+    const logger = new CollectingLogger();
+    const code = await stats(["--since", "not-a-date"], logger);
+    expect(code).toBe(1);
+    const errOutput = logger.errLines.join("\n");
+    expect(errOutput).toMatch(/iso-8601/i);
+  });
+
+  it("exits 1 with a usage hint for a clearly non-parseable string", async () => {
+    // Note: "banana-2025" parses as a valid date on Node 22 (lenient Date.parse).
+    // Use a string that is definitively unparseable on all Node versions.
+    const logger = new CollectingLogger();
+    const code = await stats(["--since", "not-a-real-date-at-all-xyz"], logger);
+    expect(code).toBe(1);
+    expect(logger.errLines.join("\n")).toMatch(/iso-8601/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-9: --json shape validation
+// ---------------------------------------------------------------------------
+describe("T-9: --json shape", () => {
+  it("emits exactly one log line of valid JSON with required top-level keys", async () => {
+    mkdirSync(telemetryDir, { recursive: true });
+    const lines = [makeEvent({ toolName: "Edit", outcome: "passthrough" })];
+    writeFileSync(join(telemetryDir, "session-j.jsonl"), `${lines.join("\n")}\n`, "utf-8");
+
+    const logger = new CollectingLogger();
+    const code = await stats(["--json"], logger);
+    expect(code).toBe(0);
+
+    // Exactly one log line, no error lines
+    expect(logger.logLines).toHaveLength(1);
+    expect(logger.errLines).toHaveLength(0);
+
+    // Valid JSON
+    const parsed = JSON.parse(logger.logLines[0] as string);
+
+    // Required top-level keys (additive-forward schema — DEC-CLI-STATS-COMMAND-001)
+    expect(parsed).toHaveProperty("version");
+    expect(parsed).toHaveProperty("generatedAt");
+    expect(parsed).toHaveProperty("window");
+    expect(parsed).toHaveProperty("summary");
+    expect(parsed).toHaveProperty("outcomeBreakdown");
+    expect(parsed).toHaveProperty("perToolBreakdown");
+    expect(parsed).toHaveProperty("matchQuality");
+    expect(parsed).toHaveProperty("sessions");
+
+    // summary sub-keys
+    expect(parsed.summary).toHaveProperty("totalEvents");
+    expect(parsed.summary).toHaveProperty("sessionCount");
+    expect(parsed.summary).toHaveProperty("daysActive");
+    expect(parsed.summary).toHaveProperty("firstEventMs");
+    expect(parsed.summary).toHaveProperty("lastEventMs");
+    expect(parsed.summary).toHaveProperty("skippedLines");
+  });
+
+  it("zero-state --json is a well-formed object with zero counts", async () => {
+    // No telemetry dir at all (T-1 empty-dir case via --json)
+    const logger = new CollectingLogger();
+    const code = await stats(["--json"], logger);
+    expect(code).toBe(0);
+    expect(logger.logLines).toHaveLength(1);
+    const parsed = JSON.parse(logger.logLines[0] as string);
+    expect(parsed.summary.totalEvents).toBe(0);
+    expect(parsed.outcomeBreakdown.registryHit).toBe(0);
+    expect(parsed.matchQuality.scoredEvents).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-10: Unknown outcome resilience — grouped under "other", no crash
+// ---------------------------------------------------------------------------
+describe("T-10: unknown-outcome resilience", () => {
+  it("groups unknown outcome under 'other'; all known counts still correct; no crash", async () => {
+    mkdirSync(telemetryDir, { recursive: true });
+
+    const lines = [
+      makeEvent({ outcome: "passthrough" }),
+      makeEvent({ outcome: "future-outcome-not-in-schema-yet" }),
+      makeEvent({ outcome: "registry-hit" }),
+    ];
+    writeFileSync(join(telemetryDir, "session-unk.jsonl"), `${lines.join("\n")}\n`, "utf-8");
+
+    const logger = new CollectingLogger();
+    const code = await stats(["--json"], logger);
+    expect(code).toBe(0);
+
+    const parsed = JSON.parse(logger.logLines[0] as string);
+    expect(parsed.summary.totalEvents).toBe(3);
+    expect(parsed.outcomeBreakdown.other).toBe(1);
+    expect(parsed.outcomeBreakdown.passthrough).toBe(1);
+    expect(parsed.outcomeBreakdown.registryHit).toBe(1);
+  });
+
+  it("human output contains percentage markers and does not throw", async () => {
+    mkdirSync(telemetryDir, { recursive: true });
+
+    const lines = [
+      makeEvent({ outcome: "passthrough" }),
+      makeEvent({ outcome: "completely-unknown-future-value" }),
+    ];
+    writeFileSync(join(telemetryDir, "session-unk2.jsonl"), `${lines.join("\n")}\n`, "utf-8");
+
+    const logger = new CollectingLogger();
+    const code = await stats([], logger);
+    expect(code).toBe(0);
+    // Percentages must appear (50.0% for each)
+    expect(logger.logLines.join("\n")).toMatch(/%/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-11: Cosine distance bucket counts and median
+// ---------------------------------------------------------------------------
+describe("T-11: cosine distance buckets", () => {
+  it("assigns scores to correct buckets and computes correct median", async () => {
+    mkdirSync(telemetryDir, { recursive: true });
+
+    // 2 excellent (<0.10), 1 good (0.10–0.20), 1 acceptable (0.20–0.30), 1 borderline (≥0.30)
+    const lines = [
+      makeEvent({ topScore: 0.05, outcome: "registry-hit" }), // excellent
+      makeEvent({ topScore: 0.08, outcome: "registry-hit" }), // excellent
+      makeEvent({ topScore: 0.15, outcome: "registry-hit" }), // good
+      makeEvent({ topScore: 0.25, outcome: "registry-hit" }), // acceptable
+      makeEvent({ topScore: 0.4, outcome: "registry-hit" }), // borderline
+    ];
+    writeFileSync(join(telemetryDir, "session-buckets.jsonl"), `${lines.join("\n")}\n`, "utf-8");
+
+    const logger = new CollectingLogger();
+    const code = await stats(["--json"], logger);
+    expect(code).toBe(0);
+
+    const parsed = JSON.parse(logger.logLines[0] as string);
+    expect(parsed.matchQuality.buckets.excellent).toBe(2);
+    expect(parsed.matchQuality.buckets.good).toBe(1);
+    expect(parsed.matchQuality.buckets.acceptable).toBe(1);
+    expect(parsed.matchQuality.buckets.borderline).toBe(1);
+    expect(parsed.matchQuality.scoredEvents).toBe(5);
+
+    // Median of [0.05, 0.08, 0.15, 0.25, 0.40] sorted = 0.15
+    expect(parsed.matchQuality.medianTopScore).toBeCloseTo(0.15, 5);
+  });
+
+  it("human output shows 'no scored events' when all topScore values are null", async () => {
+    mkdirSync(telemetryDir, { recursive: true });
+
+    // Phase-1 passthrough events with null topScore (production reality)
+    const lines = [
+      makeEvent({ topScore: null, outcome: "passthrough" }),
+      makeEvent({ topScore: null, outcome: "passthrough" }),
+    ];
+    writeFileSync(join(telemetryDir, "session-noscore.jsonl"), `${lines.join("\n")}\n`, "utf-8");
+
+    const logger = new CollectingLogger();
+    const code = await stats([], logger);
+    expect(code).toBe(0);
+    expect(logger.logLines.join("\n")).toMatch(/no scored events/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Drift-alert sentinel exclusion (plan §2.6 — candidateCount === -1 are not real intercepts)
+// ---------------------------------------------------------------------------
+describe("drift-alert sentinel exclusion", () => {
+  it("excludes drift-alert events (candidateCount=-1) from intercept tallies", async () => {
+    mkdirSync(telemetryDir, { recursive: true });
+
+    const lines = [
+      makeEvent({ outcome: "passthrough", candidateCount: 0 }),
+      // drift-alert sentinel per DEC-HOOK-ENF-LAYER5-TELEMETRY-001
+      JSON.stringify({
+        t: Date.now(),
+        intentHash: "drift:passthrough_rate:abc12345",
+        toolName: "Edit",
+        candidateCount: -1,
+        topScore: null,
+        substituted: false,
+        substitutedAtomHash: null,
+        latencyMs: 0,
+        outcome: "drift-alert",
+      }),
+      makeEvent({ outcome: "passthrough", candidateCount: 0 }),
+    ];
+    writeFileSync(join(telemetryDir, "session-drift.jsonl"), `${lines.join("\n")}\n`, "utf-8");
+
+    const logger = new CollectingLogger();
+    const code = await stats(["--json"], logger);
+    expect(code).toBe(0);
+
+    const parsed = JSON.parse(logger.logLines[0] as string);
+    // Only 2 real events — drift-alert sentinel is excluded
+    expect(parsed.summary.totalEvents).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Index.ts dispatch wiring — compound integration test proving the full
+// production sequence: runCli → case "stats" → stats() → output
+// (Evaluation Contract: "exercised end-to-end through index.ts dispatch")
+// ---------------------------------------------------------------------------
+describe("index.ts dispatch wiring (compound production-sequence test)", () => {
+  it("runCli(['stats']) dispatches to stats command (empty-state)", async () => {
+    const logger = new CollectingLogger();
+    const code = await runCli(["stats"], logger);
+    expect(code).toBe(0);
+    expect(logger.logLines.join("\n")).toMatch(/no telemetry/i);
+  });
+
+  it("runCli(['stats', '--json']) dispatches to stats command (empty-state JSON)", async () => {
+    const logger = new CollectingLogger();
+    const code = await runCli(["stats", "--json"], logger);
+    expect(code).toBe(0);
+    expect(logger.logLines).toHaveLength(1);
+    const parsed = JSON.parse(logger.logLines[0] as string);
+    expect(parsed.summary.totalEvents).toBe(0);
+  });
+
+  it("runCli(['stats']) with real fixture data: full pipeline from file → output", async () => {
+    mkdirSync(telemetryDir, { recursive: true });
+    const lines = [
+      makeEvent({ toolName: "Edit", outcome: "registry-hit" }),
+      makeEvent({ toolName: "Write", outcome: "passthrough" }),
+    ];
+    writeFileSync(join(telemetryDir, "session-dispatch.jsonl"), `${lines.join("\n")}\n`, "utf-8");
+
+    const logger = new CollectingLogger();
+    const code = await runCli(["stats", "--json"], logger);
+    expect(code).toBe(0);
+    const parsed = JSON.parse(logger.logLines[0] as string);
+    expect(parsed.summary.totalEvents).toBe(2);
+    expect(parsed.outcomeBreakdown.registryHit).toBe(1);
+  });
+
+  it("runCli(['--help']) output contains 'stats' in COMMANDS block", async () => {
+    const logger = new CollectingLogger();
+    const code = await runCli(["--help"], logger);
+    expect(code).toBe(0);
+    expect(logger.logLines.join("\n")).toContain("stats");
+  });
+});

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -1,0 +1,532 @@
+// SPDX-License-Identifier: MIT
+//
+// stats.ts — handler for `yakcc stats [--since <iso-date>] [--json]`
+//
+// @decision DEC-CLI-STATS-SCOPE-001
+// @title `yakcc stats` (WI-764) ships Tier 1 only — telemetry-only metrics
+// @status accepted (WI-764)
+// @rationale
+//   Tier-2 headline metrics ("most-reused atoms", "LoC matched-to-atom") need
+//   registry-hit telemetry events with atom hashes. The production hook
+//   (hook-intercept.ts) hard-codes every event as outcome: "passthrough" with
+//   null atom hash — Phase-2 substitution is not yet wired. Additionally, the
+//   registry package exposes no public "list all blocks with createdAt" API.
+//   Tier 1 alone answers the operator's central question ("is the hook finding
+//   hits / no-oping?") at lowest cost, zero new registry coupling, and zero
+//   telemetry-schema change. Tier 2/3/4 are tracked as separate follow-up issues.
+//   See plans/wi-764-yakcc-stats.md §2.4 for full code-cited rationale.
+//
+// @decision DEC-CLI-STATS-COMMAND-001
+// @title `yakcc stats` command shape: --since + --json, parseArgs, injected Logger
+// @status accepted (WI-764)
+// @rationale
+//   Mirrors the established telemetry.ts command pattern (DEC-CLI-TELEMETRY-COMMAND-001)
+//   for consistency and testability via CollectingLogger. Additive-forward --json schema:
+//   top-level keys are designed so Tier-2 fields ("atoms": {...}) can be appended in a
+//   future WI without breaking existing consumers. --since uses Date.parse() with the
+//   inclusive t >= sinceMs semantics documented below. Non-interactive: never reads stdin.
+//
+// @decision DEC-CLI-STATS-READER-SEAM-001 (see @yakcc/hooks-base/telemetry.ts)
+//   All telemetry reads go through readTelemetrySessions() from @yakcc/hooks-base.
+//   stats.ts contains NO second JSONL reader, no JSON.parse over telemetry lines,
+//   no readFileSync line-splitting — only aggregation and formatting.
+//
+// --json schema forward-compatibility note:
+//   The top-level JSON object currently contains: version, generatedAt, window,
+//   summary, outcomeBreakdown, perToolBreakdown, matchQuality, sessions.
+//   Future Tier-2 fields (e.g. "atoms": {...}) will be added as new top-level keys.
+//   Consumers must tolerate unknown top-level keys (additive-forward contract).
+
+import { parseArgs } from "node:util";
+import {
+  type TelemetryEvent,
+  readTelemetrySessions,
+  resolveTelemetryDir,
+} from "@yakcc/hooks-base/telemetry.js";
+import type { Logger } from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** JSON schema version — bump when the shape changes incompatibly. */
+const JSON_SCHEMA_VERSION = 1;
+
+/**
+ * Known outcome values for three-way breakdown.
+ * Any outcome outside this set is grouped under "other".
+ * "drift-alert" events are excluded entirely (sentinel events, not real intercepts).
+ */
+const KNOWN_OUTCOMES = new Set([
+  "registry-hit",
+  "synthesis-required",
+  "passthrough",
+  "atomized",
+  "shave-on-miss-enqueued",
+  "shave-on-miss-completed",
+  "shave-on-miss-error",
+  "intent-too-broad",
+  "result-set-too-large",
+  "atom-size-too-large",
+  "descent-bypass-warning",
+]);
+
+/** Cosine-distance bucket boundaries for match-quality histogram. */
+const BUCKET_BOUNDARIES = [0.1, 0.2, 0.3] as const;
+const BUCKET_LABELS = [
+  "< 0.10 (excellent)",
+  "0.10–0.20 (good)",
+  "0.20–0.30 (acceptable)",
+  "≥ 0.30 (borderline)",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Aggregation types (internal)
+// ---------------------------------------------------------------------------
+
+interface OutcomeCounts {
+  "registry-hit": number;
+  "synthesis-required": number;
+  passthrough: number;
+  other: number;
+}
+
+interface PerToolStats {
+  total: number;
+  hits: number;
+}
+
+interface MatchQualityStats {
+  buckets: [number, number, number, number]; // excellent, good, acceptable, borderline
+  scores: number[]; // raw scores for median computation
+}
+
+interface AggregatedStats {
+  totalEvents: number;
+  outcomeCounts: OutcomeCounts;
+  perTool: Record<"Edit" | "Write" | "MultiEdit", PerToolStats>;
+  matchQuality: MatchQualityStats;
+  sessionCount: number;
+  daysActive: Set<string>; // ISO date strings YYYY-MM-DD
+  firstEventTs: number | null;
+  lastEventTs: number | null;
+  totalSkippedLines: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return true when the event is a drift-alert sentinel.
+ * Drift-alert events carry candidateCount === -1 (DEC-HOOK-ENF-LAYER5-TELEMETRY-001)
+ * and must be excluded from intercept counts and per-tool tallies.
+ */
+function isDriftAlert(event: TelemetryEvent): boolean {
+  return event.outcome === "drift-alert" || event.candidateCount === -1;
+}
+
+/** Convert a Unix-ms timestamp to a YYYY-MM-DD date string (UTC). */
+function toDateKey(tsMs: number): string {
+  return new Date(tsMs).toISOString().slice(0, 10);
+}
+
+/** Compute the median of an array of numbers. Returns null for empty input. */
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return ((sorted[mid - 1] as number) + (sorted[mid] as number)) / 2;
+  }
+  return sorted[mid] as number;
+}
+
+/** Format a number as a percentage string with one decimal place. */
+function pct(count: number, total: number): string {
+  if (total === 0) return "0.0%";
+  return `${((count / total) * 100).toFixed(1)}%`;
+}
+
+/** Format a Unix-ms timestamp as a readable local date/time string. */
+function fmtTimestamp(ts: number): string {
+  return new Date(ts).toLocaleString();
+}
+
+/**
+ * Assign a cosine-distance score to a bucket index (0..3).
+ * Bucket boundaries: <0.10 / 0.10–0.20 / 0.20–0.30 / ≥0.30.
+ */
+function scoreBucket(score: number): 0 | 1 | 2 | 3 {
+  if (score < BUCKET_BOUNDARIES[0]) return 0;
+  if (score < BUCKET_BOUNDARIES[1]) return 1;
+  if (score < BUCKET_BOUNDARIES[2]) return 2;
+  return 3;
+}
+
+// ---------------------------------------------------------------------------
+// Core aggregation
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregate a flat list of TelemetryEvent objects into summary statistics.
+ * Events are already filtered by --since before being passed here.
+ * Drift-alert sentinel events are excluded from all tallies.
+ */
+function aggregate(
+  events: readonly TelemetryEvent[],
+  sessionCount: number,
+  skippedLines: number,
+): AggregatedStats {
+  const stats: AggregatedStats = {
+    totalEvents: 0,
+    outcomeCounts: { "registry-hit": 0, "synthesis-required": 0, passthrough: 0, other: 0 },
+    perTool: {
+      Edit: { total: 0, hits: 0 },
+      Write: { total: 0, hits: 0 },
+      MultiEdit: { total: 0, hits: 0 },
+    },
+    matchQuality: { buckets: [0, 0, 0, 0], scores: [] },
+    sessionCount,
+    daysActive: new Set(),
+    firstEventTs: null,
+    lastEventTs: null,
+    totalSkippedLines: skippedLines,
+  };
+
+  for (const event of events) {
+    // Exclude drift-alert sentinels from all tallies.
+    if (isDriftAlert(event)) continue;
+
+    stats.totalEvents++;
+
+    // Timestamp tracking
+    if (stats.firstEventTs === null || event.t < stats.firstEventTs) stats.firstEventTs = event.t;
+    if (stats.lastEventTs === null || event.t > stats.lastEventTs) stats.lastEventTs = event.t;
+    stats.daysActive.add(toDateKey(event.t));
+
+    // Outcome counts
+    const outcome = event.outcome;
+    if (outcome === "registry-hit") {
+      stats.outcomeCounts["registry-hit"]++;
+    } else if (outcome === "synthesis-required") {
+      stats.outcomeCounts["synthesis-required"]++;
+    } else if (outcome === "passthrough") {
+      stats.outcomeCounts.passthrough++;
+    } else if (KNOWN_OUTCOMES.has(outcome)) {
+      // Other known outcomes (enforcement-layer, shave-on-miss-*) → "other"
+      stats.outcomeCounts.other++;
+    } else {
+      // Unknown/future outcomes → "other" (T-10: resilient to schema additions)
+      stats.outcomeCounts.other++;
+    }
+
+    // Per-tool counts
+    const tool = event.toolName;
+    if (tool === "Edit" || tool === "Write" || tool === "MultiEdit") {
+      stats.perTool[tool].total++;
+      if (outcome === "registry-hit") {
+        stats.perTool[tool].hits++;
+      }
+    }
+
+    // Match quality: topScore (cosine distance)
+    if (event.topScore !== null && event.topScore !== undefined) {
+      const idx = scoreBucket(event.topScore);
+      stats.matchQuality.buckets[idx]++;
+      stats.matchQuality.scores.push(event.topScore);
+    }
+  }
+
+  return stats;
+}
+
+// ---------------------------------------------------------------------------
+// Output formatters
+// ---------------------------------------------------------------------------
+
+/** Print the human-readable Tier-1 overview table. */
+function printHumanOutput(stats: AggregatedStats, logger: Logger): void {
+  const {
+    totalEvents,
+    outcomeCounts,
+    perTool,
+    matchQuality,
+    sessionCount,
+    daysActive,
+    firstEventTs,
+    lastEventTs,
+    totalSkippedLines,
+  } = stats;
+  const totalOutcome = totalEvents;
+
+  logger.log("=== yakcc stats (Tier-1 telemetry overview) ===");
+  logger.log("");
+
+  // --- Intercept summary ---
+  logger.log("TOOL-CALL INTERCEPTS");
+  logger.log(`  Total events:          ${totalEvents}`);
+  logger.log(`  Sessions:              ${sessionCount}`);
+  logger.log(`  Days active:           ${daysActive.size}`);
+
+  if (firstEventTs !== null && lastEventTs !== null) {
+    logger.log(`  First event:           ${fmtTimestamp(firstEventTs)}`);
+    logger.log(`  Last event:            ${fmtTimestamp(lastEventTs)}`);
+  }
+  logger.log("");
+
+  // --- Outcome breakdown ---
+  logger.log("OUTCOME BREAKDOWN");
+  logger.log(
+    `  registry-hit:          ${outcomeCounts["registry-hit"].toString().padStart(6)}  (${pct(outcomeCounts["registry-hit"], totalOutcome)})`,
+  );
+  logger.log(
+    `  synthesis-required:    ${outcomeCounts["synthesis-required"].toString().padStart(6)}  (${pct(outcomeCounts["synthesis-required"], totalOutcome)})`,
+  );
+  logger.log(
+    `  passthrough:           ${outcomeCounts.passthrough.toString().padStart(6)}  (${pct(outcomeCounts.passthrough, totalOutcome)})`,
+  );
+  if (outcomeCounts.other > 0) {
+    logger.log(
+      `  other:                 ${outcomeCounts.other.toString().padStart(6)}  (${pct(outcomeCounts.other, totalOutcome)})`,
+    );
+  }
+  logger.log("");
+
+  // --- Per-tool breakdown ---
+  logger.log("PER-TOOL BREAKDOWN");
+  for (const tool of ["Edit", "Write", "MultiEdit"] as const) {
+    const t = perTool[tool];
+    const hitRate = t.total > 0 ? pct(t.hits, t.total) : "n/a";
+    logger.log(
+      `  ${tool.padEnd(12)} total: ${t.total.toString().padStart(5)}  registry-hit: ${t.hits.toString().padStart(5)}  (${hitRate})`,
+    );
+  }
+  logger.log("");
+
+  // --- Match quality ---
+  logger.log("MATCH QUALITY (cosine distance — lower is better)");
+  const scoredTotal = matchQuality.buckets.reduce((a, b) => a + b, 0);
+  if (scoredTotal === 0) {
+    logger.log("  No scored events yet.");
+    logger.log(
+      "  (topScore is null in Phase-1 passthrough events — scores appear when registry-hit events are recorded)",
+    );
+  } else {
+    for (let i = 0; i < BUCKET_LABELS.length; i++) {
+      const count = matchQuality.buckets[i] as number;
+      logger.log(
+        `  ${(BUCKET_LABELS[i] as string).padEnd(26)} ${count.toString().padStart(5)}  (${pct(count, scoredTotal)})`,
+      );
+    }
+    const med = median(matchQuality.scores);
+    if (med !== null) {
+      logger.log(`  Median topScore: ${med.toFixed(4)}`);
+    }
+  }
+  logger.log("");
+
+  // --- Skipped lines ---
+  if (totalSkippedLines > 0) {
+    logger.log(`  (${totalSkippedLines} malformed line(s) skipped across all session files)`);
+    logger.log("");
+  }
+
+  // --- Footer ---
+  logger.log("For raw telemetry: yakcc telemetry --tail 100");
+}
+
+/** Emit the machine-readable --json one-liner. Schema is additive-forward (DEC-CLI-STATS-COMMAND-001). */
+function printJsonOutput(
+  stats: AggregatedStats,
+  windowSinceMs: number | null,
+  logger: Logger,
+): void {
+  const {
+    totalEvents,
+    outcomeCounts,
+    perTool,
+    matchQuality,
+    sessionCount,
+    daysActive,
+    firstEventTs,
+    lastEventTs,
+    totalSkippedLines,
+  } = stats;
+  const scoredTotal = matchQuality.buckets.reduce((a, b) => a + b, 0);
+  const med = median(matchQuality.scores);
+
+  const output = {
+    version: JSON_SCHEMA_VERSION,
+    generatedAt: Date.now(),
+    window: windowSinceMs !== null ? { sinceMs: windowSinceMs } : { sinceMs: null },
+    summary: {
+      totalEvents,
+      sessionCount,
+      daysActive: daysActive.size,
+      firstEventMs: firstEventTs,
+      lastEventMs: lastEventTs,
+      skippedLines: totalSkippedLines,
+    },
+    outcomeBreakdown: {
+      registryHit: outcomeCounts["registry-hit"],
+      synthesisRequired: outcomeCounts["synthesis-required"],
+      passthrough: outcomeCounts.passthrough,
+      other: outcomeCounts.other,
+    },
+    perToolBreakdown: {
+      Edit: { total: perTool.Edit.total, registryHits: perTool.Edit.hits },
+      Write: { total: perTool.Write.total, registryHits: perTool.Write.hits },
+      MultiEdit: { total: perTool.MultiEdit.total, registryHits: perTool.MultiEdit.hits },
+    },
+    matchQuality: {
+      scoredEvents: scoredTotal,
+      buckets: {
+        excellent: matchQuality.buckets[0],
+        good: matchQuality.buckets[1],
+        acceptable: matchQuality.buckets[2],
+        borderline: matchQuality.buckets[3],
+      },
+      medianTopScore: med,
+    },
+    sessions: Array.from(daysActive).sort(),
+    // Tier-2 fields (atoms, registry join) will be added here in a future WI.
+    // Consumers must tolerate unknown top-level keys (additive-forward contract).
+  };
+
+  logger.log(JSON.stringify(output));
+}
+
+// ---------------------------------------------------------------------------
+// Command handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handler for `yakcc stats [--since <iso-date>] [--json]`.
+ *
+ * Reads every *.jsonl file under resolveTelemetryDir() via readTelemetrySessions()
+ * from @yakcc/hooks-base (DEC-CLI-STATS-READER-SEAM-001 — single reader authority).
+ * Computes Tier-1 metrics (§2.6 of the plan) and prints either a human-readable
+ * table or a machine-readable JSON object.
+ *
+ * Empty telemetry states (dir missing / no files / zero events) → graceful
+ * "no telemetry yet" message, exit 0 (AC-5 / T-1..T-3).
+ *
+ * --since <iso-date>: window to events with t >= Date.parse(<iso-date>).
+ *   Invalid date → exit 1 with a usage hint naming ISO-8601.
+ *
+ * --json: emit one line of valid JSON (additive-forward top-level keys).
+ *
+ * NG6 non-interactive: never reads stdin.
+ *
+ * @param argv   - Remaining argv after `stats` has been consumed.
+ * @param logger - Output sink (CollectingLogger in tests, CONSOLE_LOGGER in production).
+ * @returns Process exit code (0 = success, 1 = usage or runtime error).
+ */
+export async function stats(argv: readonly string[], logger: Logger): Promise<number> {
+  // --- Argument parsing ---
+  let parsed: ReturnType<
+    typeof parseArgs<{
+      options: {
+        since: { type: "string" };
+        json: { type: "boolean" };
+      };
+    }>
+  >;
+
+  try {
+    parsed = parseArgs({
+      args: [...argv],
+      options: {
+        since: { type: "string" },
+        json: { type: "boolean" },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+  } catch (err) {
+    logger.error(`error: ${(err as Error).message}`);
+    logger.error("Usage: yakcc stats [--since <iso-date>] [--json]");
+    return 1;
+  }
+
+  // --- Validate --since (T-8: invalid date → exit 1) ---
+  let sinceMs: number | null = null;
+  const sinceRaw = parsed.values.since;
+  if (sinceRaw !== undefined) {
+    const parsed_ms = Date.parse(sinceRaw);
+    if (Number.isNaN(parsed_ms)) {
+      logger.error(`error: --since value is not a valid date: "${sinceRaw}"`);
+      logger.error(
+        "  Hint: use an ISO-8601 date, e.g. --since 2025-01-01 or --since 2025-01-01T00:00:00Z",
+      );
+      return 1;
+    }
+    sinceMs = parsed_ms;
+  }
+
+  const useJson = parsed.values.json === true;
+
+  // --- Read telemetry (single reader authority via @yakcc/hooks-base) ---
+  // The path is derived exclusively from resolveTelemetryDir() — no hard-coded
+  // ~/.yakcc/telemetry/ literal anywhere in this file (AC-9).
+  const dir = resolveTelemetryDir();
+  const sessions = readTelemetrySessions(dir);
+
+  // --- Collect events (apply --since window) ---
+  const totalEvents: TelemetryEvent[] = [];
+  let totalSkippedLines = 0;
+
+  for (const session of sessions) {
+    totalSkippedLines += session.skippedLines;
+    for (const event of session.events) {
+      if (sinceMs !== null && event.t < sinceMs) continue;
+      totalEvents.push(event);
+    }
+  }
+
+  // --- Empty-state detection (T-1 / T-2 / T-3 / AC-5) ---
+  const noData = totalEvents.length === 0;
+
+  if (useJson) {
+    if (noData) {
+      // Zero-state --json: well-formed object with all-zero counts.
+      const zeroStats = aggregate([], sessions.length, totalSkippedLines);
+      printJsonOutput(zeroStats, sinceMs, logger);
+      return 0;
+    }
+    const aggStats = aggregate(totalEvents, sessions.length, totalSkippedLines);
+    printJsonOutput(aggStats, sinceMs, logger);
+    return 0;
+  }
+
+  // Human output
+  if (noData) {
+    if (sessions.length === 0) {
+      logger.log("No telemetry data yet.");
+      logger.log("");
+      logger.log(
+        "Run Claude Code with the yakcc hook installed for a while, then run `yakcc stats` again.",
+      );
+      logger.log("To check the hook is wired: yakcc hooks claude-code install --target <project>");
+      logger.log("To inspect raw telemetry: yakcc telemetry");
+    } else if (sinceMs !== null) {
+      logger.log(`No events found after ${new Date(sinceMs).toISOString()}.`);
+      logger.log(
+        "Try a wider window or run `yakcc stats` (no --since) for the full lifetime view.",
+      );
+    } else {
+      logger.log("No telemetry events found in any session file.");
+      logger.log("");
+      logger.log(
+        "Run Claude Code with the yakcc hook installed for a while, then run `yakcc stats` again.",
+      );
+      logger.log("To inspect raw telemetry: yakcc telemetry");
+    }
+    return 0;
+  }
+
+  const aggStats = aggregate(totalEvents, sessions.length, totalSkippedLines);
+  printHumanOutput(aggStats, logger);
+  return 0;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -54,6 +54,7 @@ import { registryRebuild } from "./commands/registry-rebuild.js";
 import { search } from "./commands/search.js";
 import { seed } from "./commands/seed.js";
 import { shave } from "./commands/shave.js";
+import { stats } from "./commands/stats.js";
 import { telemetry } from "./commands/telemetry.js";
 import { uninstall } from "./commands/uninstall.js";
 
@@ -176,6 +177,7 @@ COMMANDS
   hooks continue install              Wire yakcc tool-call interception for Continue.dev
                 [--target <dir>]      Target project directory (default: .)
                 [--uninstall]         Remove the yakcc continue hook entry
+  stats [--since <iso-date>] [--json]  Show Tier-1 telemetry metrics (intercepts, outcomes, sessions, match quality)
   telemetry [--path] [--tail <n>]     Show telemetry sessions in ~/.yakcc/telemetry/ (or YAKCC_TELEMETRY_DIR)
   hook-intercept                      (internal -- invoked by IDE hook configs via PreToolUse)
   federation serve --registry <p>     Start a read-only HTTP registry server
@@ -386,6 +388,17 @@ export async function runCli(
       // Reads stdin, appends one telemetry JSONL line, ALWAYS exits 0 with empty stdout.
       const hookInterceptArgv = subcommand !== undefined ? [subcommand, ...rest] : rest;
       return hookIntercept(hookInterceptArgv, logger);
+    }
+
+    case "stats": {
+      // `yakcc stats [--since <iso-date>] [--json]` -- Tier-1 telemetry metrics (WI-764).
+      // Reads every *.jsonl under resolveTelemetryDir() via readTelemetrySessions()
+      // (@yakcc/hooks-base — single reader authority, DEC-CLI-STATS-READER-SEAM-001).
+      // Computes and prints intercept counts, outcome breakdown, per-tool hit rates,
+      // session/days-active summary, and cosine-distance match-quality buckets.
+      // Non-interactive: never reads stdin (NG6).
+      const statsArgv = subcommand !== undefined ? [subcommand, ...rest] : rest;
+      return stats(statsArgv, logger);
     }
 
     case "telemetry": {

--- a/packages/hooks-base/src/telemetry.ts
+++ b/packages/hooks-base/src/telemetry.ts
@@ -33,7 +33,7 @@
  *   the existing try/catch at call sites in index.ts is the outer safety net.
  */
 
-import { appendFileSync, existsSync, mkdirSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { blake3 } from "@noble/hashes/blake3.js";
@@ -360,6 +360,123 @@ export function appendTelemetryEvent(event: TelemetryEvent, sessionId: string, d
     // Backstop: sink implementations should catch their own errors, but if one
     // throws anyway we swallow here so the JSONL write is never affected.
   }
+}
+
+// ---------------------------------------------------------------------------
+// Telemetry JSONL reader — typed parser seam for `yakcc stats` (DEC-CLI-STATS-READER-SEAM-001)
+// ---------------------------------------------------------------------------
+
+/**
+ * One parsed session file: its events and the count of lines that failed to parse.
+ *
+ * @decision DEC-CLI-STATS-READER-SEAM-001
+ * @title Single JSONL→TelemetryEvent parser seam in @yakcc/hooks-base
+ * @status accepted (WI-764)
+ * @rationale
+ *   `telemetry.ts` already owns `TelemetryEvent` and `resolveTelemetryDir()`.
+ *   Placing the typed parser here keeps the schema and its parser co-located in
+ *   one module, enforcing Sacred Practice #12 (single source of truth). The
+ *   `yakcc stats` command and any future consumers read via this seam only —
+ *   they never contain a second JSON.parse loop over telemetry lines.
+ *   The `yakcc telemetry` command's raw-string helpers (countLines / lastNLines)
+ *   are unaffected — they serve a different need (display raw JSON) and this
+ *   export is additive.
+ */
+export interface ParsedSessionFile {
+  /** Filename minus ".jsonl" — the session identifier. */
+  readonly sessionId: string;
+  /** Absolute path to the JSONL file. */
+  readonly path: string;
+  /** Successfully parsed events in file order. */
+  readonly events: readonly TelemetryEvent[];
+  /** Count of lines that could not be parsed (corrupt / truncated). */
+  readonly skippedLines: number;
+}
+
+/**
+ * Minimal structural check: a value counts as a TelemetryEvent only when it
+ * has the required numeric `t` and string `outcome` and `toolName` fields.
+ * Full type-level validation is not attempted — any missing optional field is
+ * tolerated. Corrupt or structurally-invalid objects are counted as skipped.
+ */
+function isMinimalTelemetryEvent(value: unknown): value is TelemetryEvent {
+  if (typeof value !== "object" || value === null) return false;
+  const rec = value as Record<string, unknown>;
+  return (
+    typeof rec["t"] === "number" &&
+    typeof rec["outcome"] === "string" &&
+    typeof rec["toolName"] === "string"
+  );
+}
+
+/**
+ * Read and parse every `*.jsonl` file under `dir`.
+ *
+ * - Returns `[]` when `dir` does not exist (fresh installs with no telemetry yet).
+ * - Corrupt or truncated lines are skipped (never thrown); the count is recorded
+ *   in `ParsedSessionFile.skippedLines`.
+ * - Lines that pass `JSON.parse` but fail the minimal structural check (missing
+ *   `t`, `outcome`, or `toolName`) are also counted as skipped.
+ * - Events are returned in file-order within each session.
+ *
+ * @param dir - Absolute path to the telemetry directory (from `resolveTelemetryDir()`).
+ * @returns Parsed session files in readdir order (typically alphabetical / creation order).
+ */
+export function readTelemetrySessions(dir: string): readonly ParsedSessionFile[] {
+  if (!existsSync(dir)) {
+    return [];
+  }
+
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+
+  const results: ParsedSessionFile[] = [];
+
+  for (const entry of entries) {
+    if (!entry.endsWith(".jsonl")) continue;
+
+    const filePath = join(dir, entry);
+    const sessionId = entry.slice(0, -".jsonl".length);
+
+    let content: string;
+    try {
+      content = readFileSync(filePath, "utf-8");
+    } catch {
+      // Unreadable file: treat as empty session.
+      results.push({ sessionId, path: filePath, events: [], skippedLines: 0 });
+      continue;
+    }
+
+    const events: TelemetryEvent[] = [];
+    let skippedLines = 0;
+
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) continue; // blank / trailing newline
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        skippedLines++;
+        continue;
+      }
+
+      if (isMinimalTelemetryEvent(parsed)) {
+        events.push(parsed);
+      } else {
+        skippedLines++;
+      }
+    }
+
+    results.push({ sessionId, path: filePath, events, skippedLines });
+  }
+
+  return results;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Closes #764** (operator-originated: *"show users metrics so they can see how successful the platform is at doing what it does"*). Adds a `yakcc stats` CLI command that reads `~/.yakcc/telemetry/*.jsonl` and prints a coherent metrics summary answering "is yakcc working for me?" — replacing hand-rolled `jq` pipelines.
- **Tier-1 telemetry-only scope** (`DEC-CLI-STATS-SCOPE-001`): intercept count, outcome breakdown (registry-hit/synthesis-required/passthrough %), per-tool hit rates (Edit/Write/MultiEdit), session count + days active, cosine-distance match-quality buckets + median. Supports `--since <iso-date>` windowing and `--json`.
- **Tier 2 deferred** — most-reused-atoms and LoC-saved metrics need `registry-hit` telemetry events carrying atom hashes, but the production hook writer (`hook-intercept.ts`) currently emits every event as `passthrough` with `substitutedAtomHash: null` (Phase-1 telemetry). Computing Tier 2 today would silently report zeros on every real install. Tracked for a follow-up issue (orchestrator will file it).
- **Single reader authority** (`DEC-CLI-STATS-READER-SEAM-001`): all JSONL parsing goes through one new additive `readTelemetrySessions` export in `@yakcc/hooks-base/telemetry.ts` (the D-HOOK-5 schema authority). `stats.ts` has zero `JSON.parse`/`readFileSync` — Sacred Practice #12.

## Decisions recorded (annotated in source)
- `DEC-CLI-STATS-SCOPE-001` — Tier-1-only scope; Tier 2 blocked on Phase-2 telemetry atom linkage.
- `DEC-CLI-STATS-READER-SEAM-001` — single `readTelemetrySessions` parser in hooks-base.
- `DEC-CLI-STATS-COMMAND-001` — the `yakcc stats` command shape (`--since`/`--json`, graceful empty-state).

## Reviewer verdict
`ready_for_guardian` — **zero findings**. All 14 acceptance criteria verified: diff scope conformance (4 files), T-1..T-11 (24/24 tests pass, real-fs fixtures), single reader authority, no registry import, graceful empty-state, full-workspace gates clean, no new test regressions, NG6 non-interactive, arithmetic spot-checked, read-only fs (no security surface).

## Sibling-race note
A parallel sibling PR #766 also targets #764 (attempted Tier-2 LoC-saved metrics, which this WI deferred as not-yet-measurable). #766 is CI-red. This PR is Tier-1-only and reviewer-clean. If #766 fixes its CI and lands first, close this; otherwise this is the canonical path.

## Test plan
- [x] `pnpm --filter @yakcc/cli exec vitest run src/commands/stats.test.ts` — 24/24 pass (T-1..T-11 + dispatch wiring).
- [x] `@yakcc/hooks-base` suite — 601/601 pass (additive `readTelemetrySessions`).
- [x] Full-workspace `pnpm -w lint` (64 files) / `pnpm -w typecheck` (48/48) / `pnpm -r build` — clean.
- [x] `pnpm -r test` — no new failures vs main baseline (12 pre-existing `ide-detect`/`bootstrap`/`cli`/`init`/`registry-export` failures unchanged).
- [x] Smoke: empty telemetry dir → graceful no-data message + exit 0; populated fixture → metrics table + `--json`.
- [ ] CI nightly suites — pending after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)