### PR TITLE
chore(cli): bump @yakcc/cli to 0.5.0-alpha.2 (#774)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yakcc/cli",
-  "version": "0.5.0-alpha.1",
+  "version": "0.5.0-alpha.2",
   "description": "Yakcc — content-addressed block registry for assembling programs from verified, reusable building blocks.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

Bumps `@yakcc/cli` from `0.5.0-alpha.1` → `0.5.0-alpha.2` to publish the 5 commits landed since alpha.1 (May 19).

## Included since alpha.1
- fix(hooks-base) #769/#770 — telemetry POST path + telemetry-wire export-map (#772)
- feat(cli) #771 — registry.yakcc.com default mirror-on-init (#773)
- feat(cli) #764 — `yakcc stats` Tier-1 telemetry-metrics command (#767)
- feat(cli) #760 — `yakcc telemetry` command + telemetry-path discoverability (#765)
- feat(cli) #759 — `yakccrc.ts` single-source-of-truth for installedHooks

## Acceptance (issue #774)
- [x] `packages/cli/package.json` version updated
- [x] Reviewer verdict: `ready_for_guardian` on head `758fe00`
- [x] Test state: `pass` (no test-affecting changes)
- [ ] CI green on this PR
- [ ] Merged to main

## Out of scope (next step — user-gated)
- `npm publish @yakcc/cli@0.5.0-alpha.2` — operator must confirm dist-tag strategy. `latest` currently still points to `0.5.0-alpha.0`; this publish should likely go to `--tag next` (or alpha) unless the operator explicitly wants to advance `latest`.

Closes #774 on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)