### PR TITLE
fix(tests): repair three test-suite failures (v1-wave-2-wasm-demo, v2-self-shave-poc)

### DIFF
--- a/examples/v1-wave-2-wasm-demo/package.json
+++ b/examples/v1-wave-2-wasm-demo/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit -p .",
-    "test": "vitest run --reporter=verbose"
+    "test": "vitest run --reporter=verbose --passWithNoTests"
   },
   "dependencies": {
     "@yakcc/compile": "workspace:*",

--- a/examples/v2-self-shave-poc/test/compile-self-integration.test.ts
+++ b/examples/v2-self-shave-poc/test/compile-self-integration.test.ts
@@ -280,8 +280,20 @@ describe("T3: compile-self integration — pipeline mechanics", () => {
 
   it("T3(d): P2 manifest entries carry sourcePkg, sourceFile, sourceOffset fields", () => {
     if (!registryAvailable || pipelineResult === null) return;
-    // P2 shape: manifest entries carry provenance fields (not just outputPath + blockMerkleRoot).
-    for (const entry of pipelineResult.manifest.slice(0, 20)) {
+    // P2 shape: for any manifest entry that carries provenance, sourcePkg and
+    // sourceFile must be strings and outputPath must equal sourceFile.
+    // Filter to provenance-carrying entries only: the bootstrap registry may have
+    // null-provenance atoms (R4 gap gate tracks this). Mirror T8's gating pattern —
+    // if zero entries carry provenance (all atoms are null-provenance), the
+    // invariant is untestable and we warn rather than hard-fail.
+    const provenanceEntries = pipelineResult.manifest.filter(
+      (e) => e.sourcePkg !== null && e.sourceFile !== null,
+    );
+    if (provenanceEntries.length === 0) {
+      console.warn(t8GapRateReport || "[T3(d)] No manifest entries carry provenance — bootstrap registry may be empty or all atoms are null-provenance.");
+      return;
+    }
+    for (const entry of provenanceEntries.slice(0, 20)) {
       // sourcePkg and sourceFile are non-null for all local atoms with provenance.
       expect(typeof entry.sourcePkg).toBe("string");
       expect(typeof entry.sourceFile).toBe("string");
@@ -853,9 +865,9 @@ describe("T7: glue-capture schema proof (#333)", () => {
     const { openRegistry, SCHEMA_VERSION } = await import("@yakcc/registry");
     const registry = await openRegistry(DEFAULT_REGISTRY_PATH, NULL_EMBEDDING_OPTS);
     try {
-      // SCHEMA_VERSION constant must be 9 (schema v9 adds block_occurrences table,
-      // DEC-V2-REGISTRY-SCHEMA-BUMP-V9-001 / WI-V2-STORAGE-IDEMPOTENT-RECOMPILE #355).
-      expect(SCHEMA_VERSION).toBe(9);
+      // SCHEMA_VERSION constant must be 10 (schema v10 adds source_file_state table,
+      // DEC-V2-REGISTRY-SCHEMA-BUMP-V10-001 / wi-363-shave-cache #363).
+      expect(SCHEMA_VERSION).toBe(10);
       // Verify v8 glue-capture surface still accessible.
       expect(typeof registry.storeSourceFileGlue).toBe("function");
       expect(typeof registry.getSourceFileGlue).toBe("function");


### PR DESCRIPTION
## Summary

Three test failures, all caused by test/script drift behind landed code changes:

- `examples/v1-wave-2-wasm-demo` — commit `429b12b` (#148) deleted every test file when ripping out the in-house TS→WASM lowerer, but left `vitest run` in the test script. Vitest v4 exits 1 on no-test-files. Added `--passWithNoTests`.
- `examples/v2-self-shave-poc` **T7(a)** — `expect(SCHEMA_VERSION).toBe(9)` was stale; commit `a71016e` (#363) bumped to 10 for the `source_file_state` migration. Updated assertion + comment (cites `DEC-V2-REGISTRY-SCHEMA-BUMP-V10-001` / `wi-363-shave-cache` #363).
- `examples/v2-self-shave-poc` **T3(d)** — test asserted all of the first 20 manifest entries carry string `sourcePkg`/`sourceFile`, but the local bootstrap registry currently has ~27% null-provenance atoms. The `beforeAll` already detects this and sets `t8GapRateBlocked` which T8 honors; T3(d) didn't. Updated T3(d) to filter to provenance-carrying entries before asserting shape, mirroring T8's gating pattern.

No `packages/**` source touched. Two files changed.

## Test plan

- [x] `pnpm --filter v1-wave-2-wasm-demo test` exits 0
- [x] `pnpm --filter @yakcc/v2-self-shave-poc test` — T7(a) and T3(d) both pass
- [x] `pnpm --filter @yakcc/v2-self-shave-poc typecheck`
- [ ] CI run on PR

## Out of scope (pre-existing on main)

Reviewer flagged that `@yakcc/seeds`, `@yakcc/cli`, and a few others have flaky failures under heavy turbo parallelism (`@yakcc/seeds` passes in 26s when run in isolation) plus darwin-specific `@yakcc/cli` ide-detect assumptions. None of these regressed in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)