### PR TITLE
fix(cli): #791 ide-detect tests fail on darwin — mock process.platform

### DIFF
--- a/packages/cli/src/lib/ide-detect.test.ts
+++ b/packages/cli/src/lib/ide-detect.test.ts
@@ -27,7 +27,7 @@
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { KNOWN_IDE_NAMES, buildCandidatePaths, detectInstalledIdes } from "./ide-detect.js";
 
 // ---------------------------------------------------------------------------
@@ -94,6 +94,18 @@ describe("detectInstalledIdes — claude-code detection", () => {
 });
 
 describe("detectInstalledIdes — cursor detection (linux path)", () => {
+  // These tests set up ~/.config/Cursor which is the linux cursor path.
+  // On darwin, buildCandidatePaths() only probes ~/Library/Application Support/Cursor,
+  // so without the platform mock the test setup would never match. Mock process.platform
+  // to "linux" for the entire block to make detection deterministic on all host OSes.
+  const origPlatformCursorLinux = process.platform;
+  beforeAll(() => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+  });
+  afterAll(() => {
+    Object.defineProperty(process, "platform", { value: origPlatformCursorLinux, configurable: true });
+  });
+
   it("detects cursor via ~/.config/Cursor/ on linux", () => {
     const configDir = join(fakeHome, ".config", "Cursor");
     mkdirAt(configDir);
@@ -230,6 +242,16 @@ describe("detectInstalledIdes — aider detection", () => {
 // ---------------------------------------------------------------------------
 
 describe("detectInstalledIdes — multiple IDEs simultaneously", () => {
+  // Cursor's linux path (~/.config/Cursor) is used in these tests. Mock process.platform
+  // to "linux" so buildCandidatePaths() selects the linux cursor candidate on all host OSes.
+  const origPlatformMultiIde = process.platform;
+  beforeAll(() => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+  });
+  afterAll(() => {
+    Object.defineProperty(process, "platform", { value: origPlatformMultiIde, configurable: true });
+  });
+
   it("detects all six IDEs when all config dirs exist", () => {
     mkdirAt(join(fakeHome, ".claude"));
     mkdirAt(join(fakeHome, ".config", "Cursor"));
@@ -366,6 +388,17 @@ describe("detectInstalledIdes — no false positives", () => {
 // ---------------------------------------------------------------------------
 
 describe("detectInstalledIdes — no shell-out (B6a air-gap gate)", () => {
+  // The runtime smoke test below creates ~/.config/Cursor (linux path) and expects 6
+  // detected IDEs. Mock process.platform to "linux" so buildCandidatePaths() probes the
+  // linux cursor candidate on all host OSes, making the assertion deterministic.
+  const origPlatformB6a = process.platform;
+  beforeAll(() => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+  });
+  afterAll(() => {
+    Object.defineProperty(process, "platform", { value: origPlatformB6a, configurable: true });
+  });
+
   it("ide-detect.ts source does not import node:child_process", async () => {
     // ESM namespace objects are non-configurable (vitest limitation documented
     // at https://vitest.dev/guide/browser/#limitations), so we cannot spy on

--- a/packages/cli/src/lib/ide-detect.test.ts
+++ b/packages/cli/src/lib/ide-detect.test.ts
@@ -103,7 +103,10 @@ describe("detectInstalledIdes — cursor detection (linux path)", () => {
     Object.defineProperty(process, "platform", { value: "linux", configurable: true });
   });
   afterAll(() => {
-    Object.defineProperty(process, "platform", { value: origPlatformCursorLinux, configurable: true });
+    Object.defineProperty(process, "platform", {
+      value: origPlatformCursorLinux,
+      configurable: true,
+    });
   });
 
   it("detects cursor via ~/.config/Cursor/ on linux", () => {


### PR DESCRIPTION
## Summary

Four tests in `packages/cli/src/lib/ide-detect.test.ts` fail on macOS (darwin) because they create linux-style cursor config dirs (`~/.config/Cursor`) but never mock `process.platform`. On darwin, `buildCandidatePaths()` only probes `~/Library/Application Support/Cursor`, so the test setup did not match the probe.

Fix mirrors the existing pattern at `ide-detect.test.ts:288-294`: `beforeAll`/`afterAll` pairs pin `process.platform = "linux"` for three affected `describe` blocks (cursor-linux-detection, multiple-IDEs-simultaneously, B6a-air-gap-gate), with the original value captured and restored on teardown.

No changes to `ide-detect.ts` — the implementation was correct.

Closes #791

## Commits

1. `fix(cli): #791 ide-detect tests fail on darwin — mock process.platform` — the test fix
2. `style(cli): biome format on #791 ide-detect.test.ts platform mocks` — biome auto-format on one `Object.defineProperty` call

## Test plan

- [x] `pnpm --filter @yakcc/cli exec vitest run src/lib/ide-detect.test.ts` — 31/31 pass on darwin
- [x] `pnpm --filter @yakcc/cli lint` — clean (biome)
- [x] No changes to `ide-detect.ts`
- [ ] CI run on PR

## Out of scope (pre-existing on main)

`@yakcc/cli` still has other pre-existing failures (`bootstrap.test.ts`, `cli.test.ts`, `init.test.ts`) with separate root causes, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)