### PR TITLE
feat(registry): SQLite concurrency hardening — WAL pragmas, write lock, docs (closes #777)

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -248,6 +248,45 @@ If you hit a Windows failure not listed here, file at [github.com/cneckar/yakcc/
 
 ---
 
+## 10. `Registry write lock held by PID …`
+
+**Symptom:** A `yakcc shave`, `yakcc bootstrap`, `yakcc federation mirror`, `yakcc federation pull`, or `yakcc registry rebuild` command prints:
+
+```
+Registry write lock held by PID 12345 (since 2026-05-27T10:00:00.000Z);
+if that process is dead, remove .yakcc/.write.lock manually
+```
+
+and exits with a non-zero code.
+
+**Explanation:** Yakcc enforces a single-writer policy per registry file. Only one write-path process may hold the lock at a time. If another process is actively writing, it will release the lock when it finishes. If the timeout expires before the lock is released, yakcc gives up and prints the message above.
+
+**Diagnostic:**
+
+```sh
+# Check whether PID 12345 is actually running.
+ps -p 12345
+
+# Inspect the lock file contents.
+cat .yakcc/.write.lock
+```
+
+**Fix — holder is still running:** Wait for the other `yakcc` process to finish. Use `YAKCC_WRITE_LOCK_TIMEOUT_MS=60000` to extend the wait window if needed.
+
+**Fix — holder is dead (kill -9 or crash):** Remove the stale lock file manually:
+
+```sh
+rm .yakcc/.write.lock
+```
+
+Then re-run your command. Yakcc detects dead PIDs automatically on the next retry cycle (~100 ms), but if the process table reuses the PID for a different unrelated process, automatic detection may not fire. Manual removal is always safe.
+
+**Fix — NFS / network mount:** File locking is unreliable over NFS. Do not place `.yakcc/registry.sqlite` on a network mount. Each developer should use a local registry; federation (mirror/pull) handles cross-machine sharing.
+
+**Related:** See [§12 Concurrency model](USING_YAKCC.md#12-concurrency-model) in `USING_YAKCC.md`.
+
+---
+
 ## Still stuck?
 
 - Check [github.com/cneckar/yakcc/issues](https://github.com/cneckar/yakcc/issues) for known open issues.

--- a/docs/USING_YAKCC.md
+++ b/docs/USING_YAKCC.md
@@ -440,7 +440,43 @@ yakcc registry rebuild --path .yakcc/registry.sqlite
 
 ---
 
-## 12. Troubleshooting
+## 12. Concurrency model
+
+Yakcc uses SQLite in WAL (Write-Ahead Logging) mode. Understanding the concurrency model helps you avoid lock errors in team workflows.
+
+### Many concurrent readers — always safe
+
+Any number of `yakcc query`, `yakcc search`, `yakcc compile`, and hook-intercept processes can read the registry simultaneously. WAL mode allows readers to proceed concurrently with a single writer without blocking.
+
+### Exactly one writer at a time per registry
+
+Write operations — `yakcc shave`, `yakcc bootstrap`, `yakcc federation pull`, `yakcc federation mirror`, and `yakcc registry rebuild` — acquire a cooperative cross-process write lock (`.yakcc/.write.lock`) at startup and release it on exit. If a second writer arrives while the lock is held, it waits up to 30 seconds (configurable via `YAKCC_WRITE_LOCK_TIMEOUT_MS`) before exiting with an error:
+
+```
+Registry write lock held by PID 12345 (since 2026-05-27T10:00:00.000Z);
+if that process is dead, remove .yakcc/.write.lock manually
+```
+
+If the lock file is stale (the holder process has died), yakcc detects this automatically and steals the lock within one poll cycle (~100 ms).
+
+### Multi-developer teams
+
+Each developer's local clone has their own `.yakcc/registry.sqlite`. Do **not** share a single registry file over an NFS mount or network share — file locking over NFS is unreliable. Use `yakcc federation mirror` for cross-developer atom sharing: each developer's registry acts as a peer, and atoms flow between registries via content-addressed pull/mirror operations.
+
+### CI environments
+
+CI is the canonical single-writer environment for `yakcc bootstrap` (see `.github/workflows/bootstrap-accumulate.yml`). Jobs that run bootstrap are single-process by design; they do not require special lock configuration.
+
+### Configuring the write-lock timeout
+
+```sh
+# Wait up to 60 seconds before giving up (default is 30 000 ms).
+YAKCC_WRITE_LOCK_TIMEOUT_MS=60000 yakcc shave src/
+```
+
+---
+
+## 13. Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
@@ -455,7 +491,7 @@ yakcc registry rebuild --path .yakcc/registry.sqlite
 
 ---
 
-## 13. Where to go next
+## 14. Where to go next
 
 - [`README.md`](../README.md) — yakcc-the-project overview, monorepo layout, contributor quickstart.
 - [`docs/CONTRIBUTING.md`](CONTRIBUTING.md) — contributor orientation and pointers into the developer-docs archive.

--- a/packages/cli/src/commands/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap.ts
@@ -77,7 +77,7 @@ import type {
   RegistryOptions,
   SourceFileGlueEntry,
 } from "@yakcc/registry";
-import { openRegistry } from "@yakcc/registry";
+import { acquireWriteLock, openRegistry } from "@yakcc/registry";
 import { shave as shaveImpl } from "@yakcc/shave";
 import type { Logger } from "../index.js";
 import { PLUMBING_INCLUDE_GLOBS, plumbingPathAllowed } from "./plumbing-globs.js";
@@ -999,11 +999,23 @@ export async function bootstrap(argv: ReadonlyArray<string>, logger: Logger): Pr
     mkdirSync(dirname(outputPath), { recursive: true });
   }
 
+  // Acquire write lock before opening the registry (DEC-CONCURRENCY-LOCK-001).
+  // Bootstrap is a bulk writer; no concurrent writer should race with it.
+  // mkdirSync above ensures lockDir exists before we attempt to create the lock file.
+  let releaseLock: () => void;
+  try {
+    releaseLock = await acquireWriteLock(registryPath);
+  } catch (err) {
+    logger.error(`error: failed to acquire registry write lock at ${registryPath}: ${(err as Error).message}`);
+    return 1;
+  }
+
   // Open registry with zero-embedding provider (DEC-V2-BOOTSTRAP-EMBEDDING-001).
   let registry: Registry;
   try {
     registry = await openRegistry(registryPath, BOOTSTRAP_EMBEDDING_OPTS);
   } catch (err) {
+    releaseLock();
     logger.error(`error: failed to open registry at ${registryPath}: ${(err as Error).message}`);
     return 1;
   }
@@ -1325,6 +1337,7 @@ export async function bootstrap(argv: ReadonlyArray<string>, logger: Logger): Pr
   } catch (err) {
     logger.error(`error: workspace plumbing capture failed: ${(err as Error).message}`);
     await registry.close();
+    releaseLock();
     return 1;
   }
 
@@ -1362,11 +1375,13 @@ export async function bootstrap(argv: ReadonlyArray<string>, logger: Logger): Pr
   } catch (err) {
     logger.error(`error: failed to export manifest: ${(err as Error).message}`);
     await registry.close();
+    releaseLock();
     return 1;
   }
 
   // Close registry — done with the shave-run DB.
   await registry.close();
+  releaseLock();
 
   // --- Additive merge (DEC-BOOTSTRAP-MANIFEST-ACCUMULATE-001 part (a)) ---
   // Load prior entries from the committed manifest (if it exists) and merge

--- a/packages/cli/src/commands/federation.ts
+++ b/packages/cli/src/commands/federation.ts
@@ -33,7 +33,7 @@ import {
 } from "@yakcc/federation";
 import type { ServeHandle, Transport } from "@yakcc/federation";
 import type { Registry, RegistryOptions } from "@yakcc/registry";
-import { openRegistry } from "@yakcc/registry";
+import { acquireWriteLock, openRegistry } from "@yakcc/registry";
 import type { Logger } from "../index.js";
 
 // ---------------------------------------------------------------------------
@@ -238,10 +238,19 @@ async function runFederationMirror(
     return 1;
   }
 
+  let releaseLock: () => void;
+  try {
+    releaseLock = await acquireWriteLock(registryPath);
+  } catch (err) {
+    logger.error(`error: failed to open registry at ${registryPath}: ${String(err)}`);
+    return 1;
+  }
+
   let registry: Registry;
   try {
     registry = await openRegistry(registryPath, { embeddings: opts?.embeddings });
   } catch (err) {
+    releaseLock();
     logger.error(`error: failed to open registry at ${registryPath}: ${String(err)}`);
     return 1;
   }
@@ -262,6 +271,7 @@ async function runFederationMirror(
     return 1;
   } finally {
     await registry.close();
+    releaseLock();
   }
 }
 
@@ -347,10 +357,19 @@ async function runFederationPull(
   // Open registry BEFORE pull: fail-fast on bad path (DEC-CLI-PULL-PERSIST-001).
   // Only opened when --registry is present.
   let registry: Registry | null = null;
+  // Acquire write lock only when we will actually persist to a registry.
+  let releaseLock: () => void = () => {};
   if (hasRegistry) {
+    try {
+      releaseLock = await acquireWriteLock(registryPath as string);
+    } catch (err) {
+      logger.error(`error: failed to open registry at ${registryPath as string}: ${String(err)}`);
+      return 1;
+    }
     try {
       registry = await openRegistry(registryPath as string, { embeddings: opts?.embeddings });
     } catch (err) {
+      releaseLock();
       logger.error(`error: failed to open registry at ${registryPath as string}: ${String(err)}`);
       return 1;
     }
@@ -386,10 +405,11 @@ async function runFederationPull(
     logger.error(`error: pull failed: ${String(err)}`);
     return 1;
   } finally {
-    // Resource-cleanup invariant: close registry handle on all paths.
+    // Resource-cleanup invariant: close registry handle and release lock on all paths.
     if (registry !== null) {
       await registry.close();
     }
+    releaseLock();
   }
 }
 

--- a/packages/cli/src/commands/registry-rebuild.ts
+++ b/packages/cli/src/commands/registry-rebuild.ts
@@ -26,6 +26,7 @@ import { parseArgs } from "node:util";
 import {
   type Registry,
   type RegistryOptions,
+  acquireWriteLock,
   openRegistry,
   rebuildRegistry,
 } from "@yakcc/registry";
@@ -90,10 +91,19 @@ export async function registryRebuild(
     embeddingProvider = createLocalEmbeddingProvider();
   }
 
+  let releaseLock: () => void;
+  try {
+    releaseLock = await acquireWriteLock(registryPath);
+  } catch (err) {
+    logger.error(`error: failed to acquire registry write lock at ${registryPath}: ${String(err)}`);
+    return 1;
+  }
+
   let registry: Registry;
   try {
     registry = await openRegistry(registryPath, { embeddings: embeddingProvider });
   } catch (err) {
+    releaseLock();
     logger.error(`error: failed to open registry at ${registryPath}: ${String(err)}`);
     return 1;
   }
@@ -122,5 +132,6 @@ export async function registryRebuild(
     return 1;
   } finally {
     await registry.close();
+    releaseLock();
   }
 }

--- a/packages/cli/src/commands/shave.ts
+++ b/packages/cli/src/commands/shave.ts
@@ -19,7 +19,7 @@
 import { resolve } from "node:path";
 import { parseArgs } from "node:util";
 import type { Registry } from "@yakcc/registry";
-import { openRegistry } from "@yakcc/registry";
+import { acquireWriteLock, openRegistry } from "@yakcc/registry";
 import {
   FOREIGN_POLICY_DEFAULT,
   type ForeignPolicy,
@@ -96,10 +96,19 @@ export async function shave(argv: ReadonlyArray<string>, logger: Logger): Promis
   const registryPath = parsed.values.registry ?? ".yakcc/registry.sqlite";
   const offline = parsed.values.offline === true;
 
+  let releaseLock: () => void;
+  try {
+    releaseLock = await acquireWriteLock(resolve(registryPath));
+  } catch (err) {
+    logger.error(`error: failed to open registry at ${registryPath}: ${(err as Error).message}`);
+    return 1;
+  }
+
   let registry: Registry;
   try {
     registry = await openRegistry(resolve(registryPath));
   } catch (err) {
+    releaseLock();
     logger.error(`error: failed to open registry at ${registryPath}: ${(err as Error).message}`);
     return 1;
   }
@@ -154,5 +163,6 @@ export async function shave(argv: ReadonlyArray<string>, logger: Logger): Promis
     return 1;
   } finally {
     await registry.close();
+    releaseLock();
   }
 }

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -1132,3 +1132,4 @@ export {
   type RebuildRegistryOptions,
   type RebuildResult,
 } from "./rebuild.js";
+export { acquireWriteLock, type WriteLockOptions, type Release } from "./lock.js";

--- a/packages/registry/src/lock.test.ts
+++ b/packages/registry/src/lock.test.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+// Tests for packages/registry/src/lock.ts (WI-777)
+//
+// Coverage:
+//   - :memory: path: immediate no-op release
+//   - normal acquire/release lifecycle
+//   - lock file contains valid PID + ISO timestamp
+//   - stale-lock detection (dead PID → steal)
+//   - timeout with live holder
+
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { acquireWriteLock } from "./lock.js";
+
+let tmpDir: string;
+let dbPath: string;
+let lockPath: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "yakcc-lock-test-"));
+  dbPath = join(tmpDir, "registry.sqlite");
+  lockPath = join(tmpDir, ".write.lock");
+});
+
+afterEach(async () => {
+  // Clean up temp dir; ignore errors (already cleaned).
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("acquireWriteLock — :memory: path", () => {
+  it("returns a no-op release immediately without creating any file", async () => {
+    const release = await acquireWriteLock(":memory:");
+    expect(typeof release).toBe("function");
+    // Calling release must not throw.
+    expect(() => release()).not.toThrow();
+  });
+});
+
+describe("acquireWriteLock — normal lifecycle", () => {
+  it("creates a lock file with pid and timestamp", async () => {
+    const release = await acquireWriteLock(dbPath);
+    expect(existsSync(lockPath)).toBe(true);
+
+    const content = JSON.parse(readFileSync(lockPath, "utf8")) as {
+      pid: number;
+      timestamp: string;
+    };
+    expect(content.pid).toBe(process.pid);
+    expect(typeof content.timestamp).toBe("string");
+    // Timestamp must be a valid ISO-8601 string.
+    expect(new Date(content.timestamp).getTime()).toBeGreaterThan(0);
+
+    release();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("calling release twice does not throw", async () => {
+    const release = await acquireWriteLock(dbPath);
+    release();
+    expect(() => release()).not.toThrow();
+  });
+});
+
+describe("acquireWriteLock — stale lock detection", () => {
+  it("steals a lock file whose PID is not alive", async () => {
+    // Write a lock file with a PID that is guaranteed to not exist.
+    // PID 0 is invalid on all POSIX systems (process.kill(0, 0) throws EINVAL or EPERM).
+    // We want a PID that throws ESRCH (no such process). Use a high value that is
+    // extremely unlikely to be in use: 2^31 - 1 is above any real PID limit.
+    const deadPid = 2_147_483_647;
+    writeFileSync(
+      lockPath,
+      JSON.stringify({ pid: deadPid, timestamp: new Date().toISOString() }),
+    );
+
+    // acquireWriteLock should detect the dead PID and steal the lock.
+    const release = await acquireWriteLock(dbPath, { timeoutMs: 2000 });
+    expect(existsSync(lockPath)).toBe(true);
+
+    const content = JSON.parse(readFileSync(lockPath, "utf8")) as { pid: number };
+    // The new lock must be owned by the current process, not the dead one.
+    expect(content.pid).toBe(process.pid);
+
+    release();
+  });
+});
+
+describe("acquireWriteLock — timeout", () => {
+  it("throws with reason='write_lock_timeout' when lock is held by a live process", async () => {
+    // Write a lock file with this process's own PID (guaranteed alive).
+    writeFileSync(lockPath, JSON.stringify({ pid: process.pid, timestamp: new Date().toISOString() }));
+
+    // Use a very short timeout so the test doesn't take long.
+    const err = await acquireWriteLock(dbPath, { timeoutMs: 150 }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error & { reason: string }).reason).toBe("write_lock_timeout");
+    expect((err as Error).message).toContain("Registry write lock held by");
+    expect((err as Error).message).toContain(lockPath);
+
+    // Clean up the pre-written lock file.
+    unlinkSync(lockPath);
+  });
+});

--- a/packages/registry/src/lock.ts
+++ b/packages/registry/src/lock.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+// @decision DEC-CONCURRENCY-LOCK-001
+// title: Cross-process advisory write lock via O_CREAT|O_EXCL
+// status: decided (WI-777 — SQLite concurrency hardening)
+// rationale: Writer-writer contention is the real hazard under WAL mode; readers
+//   run concurrently with no lock. A cross-process file lock (not an in-process
+//   Mutex) is required because Node.js processes share no memory. O_CREAT|O_EXCL
+//   is atomic on local POSIX filesystems. Stale-lock detection via
+//   process.kill(pid, 0) lets a second writer steal a lock whose holder died
+//   mid-write (e.g. kill -9). NFS is explicitly unsupported (out-of-scope WI-777).
+//
+// Lock file location: <dirname(dbPath)>/.write.lock
+// Lock file content:  JSON { pid: number, timestamp: ISO-string }
+// Env override:       YAKCC_WRITE_LOCK_TIMEOUT_MS (overrides opts.timeoutMs)
+
+import { closeSync, openSync, readFileSync, unlinkSync, writeSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export interface WriteLockOptions {
+  /** Milliseconds to wait before giving up. Default: 30 000. */
+  timeoutMs?: number;
+}
+
+/** Calling this function releases the write lock (idempotent). */
+export type Release = () => void;
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const POLL_INTERVAL_MS = 100;
+
+/**
+ * Acquire a cross-process advisory write lock for the registry at `dbPath`.
+ *
+ * The lock file is placed at `<dirname(dbPath)>/.write.lock`. Returns a
+ * `Release` callback; callers MUST call it in a `try-finally` block to
+ * guarantee cleanup even on thrown errors.
+ *
+ * For `:memory:` registries no lock file is created and a no-op release is
+ * returned immediately.
+ *
+ * @throws {Error} with `.reason === "write_lock_timeout"` if the lock cannot
+ *   be acquired within `timeoutMs` (env `YAKCC_WRITE_LOCK_TIMEOUT_MS` overrides).
+ */
+export async function acquireWriteLock(dbPath: string, opts?: WriteLockOptions): Promise<Release> {
+  if (dbPath === ":memory:") {
+    return () => {};
+  }
+
+  const envMs =
+    typeof process.env.YAKCC_WRITE_LOCK_TIMEOUT_MS === "string"
+      ? Number.parseInt(process.env.YAKCC_WRITE_LOCK_TIMEOUT_MS, 10)
+      : Number.NaN;
+  const timeoutMs = Number.isFinite(envMs) && envMs > 0 ? envMs : (opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+  const lockDir = dirname(dbPath);
+  const lockPath = join(lockDir, ".write.lock");
+
+  const deadline = Date.now() + timeoutMs;
+
+  while (true) {
+    // Attempt atomic exclusive create.
+    try {
+      const fd = openSync(lockPath, "wx"); // O_WRONLY | O_CREAT | O_EXCL
+      writeSync(fd, JSON.stringify({ pid: process.pid, timestamp: new Date().toISOString() }));
+      closeSync(fd);
+
+      return () => {
+        try {
+          unlinkSync(lockPath);
+        } catch {
+          // Best-effort: ignore ENOENT / any cleanup error.
+        }
+      };
+    } catch (createErr) {
+      if ((createErr as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw createErr;
+      }
+    }
+
+    // Lock file exists. Read holder metadata to check for staleness.
+    let holderPid: number | null = null;
+    let holderTimestamp: string | null = null;
+
+    try {
+      const raw = readFileSync(lockPath, "utf8");
+      const info = JSON.parse(raw) as { pid?: unknown; timestamp?: unknown };
+      if (typeof info.pid === "number") holderPid = info.pid;
+      if (typeof info.timestamp === "string") holderTimestamp = info.timestamp;
+    } catch {
+      // File removed between EEXIST check and read, or content is corrupt.
+      // Either way, retry immediately from the top of the loop.
+      continue;
+    }
+
+    if (holderPid !== null) {
+      let holderAlive = true;
+      try {
+        process.kill(holderPid, 0); // throws ESRCH if process does not exist
+      } catch {
+        holderAlive = false;
+      }
+
+      if (!holderAlive) {
+        // Holder is dead — steal the lock by removing the stale file.
+        try {
+          unlinkSync(lockPath);
+        } catch {
+          // Another racer may have removed it first; that's fine.
+        }
+        continue;
+      }
+    }
+
+    // Holder is alive (or PID unknown). Check timeout.
+    if (Date.now() >= deadline) {
+      const pidStr = holderPid !== null ? `PID ${holderPid}` : "unknown PID";
+      const timeStr = holderTimestamp !== null ? ` (since ${holderTimestamp})` : "";
+      const err = new Error(
+        `Registry write lock held by ${pidStr}${timeStr}; if that process is dead, remove ${lockPath} manually`,
+      );
+      (err as Error & { reason: string }).reason = "write_lock_timeout";
+      throw err;
+    }
+
+    await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+}

--- a/packages/registry/src/storage.ts
+++ b/packages/registry/src/storage.ts
@@ -2066,6 +2066,13 @@ export async function openRegistry(path: string, options?: RegistryOptions): Pro
   //       where durability-on-crash is irrelevant. OFF was considered and rejected
   //       (evaluation contract §6 — forbidden shortcut).
   db.pragma("synchronous = NORMAL");
+  // @decision DEC-CONCURRENCY-LOCK-001 (busy_timeout layer)
+  // 5 s busy wait before SQLite returns SQLITE_BUSY. This is the second defensive
+  // layer: the cooperative write lock (lock.ts) should prevent concurrent writers,
+  // but busy_timeout guards against races during lock acquisition and any tool that
+  // bypasses the lock entirely (e.g. direct sqlite3 CLI usage). Most contention
+  // windows are <100 ms; 5 000 ms is generous but finite.
+  db.pragma("busy_timeout = 5000");
   // Enable foreign key enforcement.
   db.pragma("foreign_keys = ON");
 


### PR DESCRIPTION
## Summary

- **Layer 1 (SQLite pragmas):** Added `busy_timeout = 5000` to `openRegistry` in `storage.ts`. WAL mode, `synchronous = NORMAL`, and `foreign_keys = ON` were already set; this adds the 5 s graceful BUSY wait as a second defensive line.
- **Layer 2 (cooperative write lock):** New `packages/registry/src/lock.ts` — `acquireWriteLock(dbPath, opts)` creates `.yakcc/.write.lock` via `O_CREAT|O_EXCL`, stores `{ pid, timestamp }`, detects stale locks via `process.kill(pid, 0)`, polls up to `YAKCC_WRITE_LOCK_TIMEOUT_MS` (default 30 s), and returns a `Release` callback.
- **Wire-up:** All five writer CLI paths — `shave`, `bootstrap`, `federation mirror`, `federation pull` (persist), `registry rebuild` — acquire the lock before opening the registry and release it in `finally`. Reader paths (`query`, `search`, `compile`, `hook-intercept`) are untouched.
- **Docs:** `docs/USING_YAKCC.md` §12 Concurrency model section; `docs/TROUBLESHOOTING.md` §10 write-lock diagnostic entry.

## Test evidence

```
 Test Files  17 passed (17)
      Tests  308 passed | 19 skipped (327)
   Start at  04:30:19
   Duration  32.53s
```

(2 pre-existing CLI test failures unrelated to this WI — `/no/such/dir/` exists in the test container, confirmed failing on main before this branch.)

Closes #777

🤖 Picked up by FuckGoblin

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbmRAXCnwTEhVeaaCH6bGy)_