### PR TITLE
fix(v1-wave-3): cache.test.ts cold/warm determinism — store entry on wasError (closes #798)

### DIFF
--- a/examples/v1-wave-3-wasm-lower-demo/test/corpus-loader.ts
+++ b/examples/v1-wave-3-wasm-lower-demo/test/corpus-loader.ts
@@ -827,10 +827,15 @@ export async function regenerateCorpus(
       cacheMisses++;
       if (result.wasError) {
         shaveFailures++;
-      } else {
-        // Store new rows in cache (createdAt=0 for byte-stability)
-        cacheEntries[contentHash] = result.rows.map((r) => serializeRow({ ...r, createdAt: 0 }));
       }
+      // Store entry unconditionally (createdAt=0 for byte-stability).
+      // On wasError, result.rows is [], so we store an empty entry —
+      // this preserves the cold/warm determinism contract: warm pass for
+      // this file will be a cache hit producing the same (empty) rows.
+      // Without this, a transient/persistent shave error on cold pass would
+      // cause a cache miss on warm pass, breaking
+      // "cold-then-warm produces byte-identical atoms" (closes #798).
+      cacheEntries[contentHash] = result.rows.map((r) => serializeRow({ ...r, createdAt: 0 }));
     }
 
     // Map every blockMerkleRoot produced by this file to its source path.


### PR DESCRIPTION
## Summary

Fixes the 16-day nightly CI red on `test/cache.test.ts > regenerateCorpus — integrated determinism > cold-then-warm produces byte-identical atoms` by storing a cache entry unconditionally — including when `shave()` errors.

**Root cause (in `examples/v1-wave-3-wasm-lower-demo/test/corpus-loader.ts:826-833`):** When cold-pass `shave()` errors (`wasError=true`), the old code incremented `shaveFailures` but DID NOT store an entry under `contentHash`. On warm pass, the same file's `contentHash` produced `cacheEntries[contentHash] === undefined` → another cache miss instead of a hit.

This violated the cold/warm determinism contract the test asserts: `expect(result2.cacheMisses).toBe(0)`.

**Fix:** Move the `cacheEntries[contentHash] = ...` assignment outside the `else` branch, so it always runs after a miss. On `wasError`, `result.rows` is `[]`, so we store an empty entry — warm pass becomes a hit producing the same (empty) rows. `cold === warm` (the byte-identical assertion) still holds because both passes produce no rows for the erroring file.

**What this does NOT do:** This does not fix the underlying transient/persistent shave error on one of the seed files (`packages/seeds/src/blocks/{digit,comma}/impl.ts`). That's a separate concern — `shaveFailures` still increments and would surface in the corpus-walk telemetry. The fix only restores the cold/warm determinism contract so the test stops false-positive-failing nightly.

Per #798's own guidance: *"Triage the linked run and fix or suppress before the next nightly."* — this is the cleanest fix path (no test gate weakening).

## Test plan

- [x] PR-CI required gates green (lint/typecheck/build/branch hygiene/B6a air-gap — none of these run the failing test)
- [ ] Next nightly run shows wave-3 closer parity green
- [ ] If shave still errors on a seed file, `shaveFailures > 0` will be visible in cold-pass output for follow-up

Closes #798

---
_FuckGoblin orchestrator_