### PR TITLE
feat(contracts,ir): polyglot IR envelope spec + raise-failure error types (closes #780)

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -299,3 +299,8 @@ export {
   type ExtractedSignature,
 } from "./source-extract.js";
 export { pickPrimaryDeclaration, type PrimaryDeclaration } from "./source-pick.js";
+export {
+  AmbiguousPurityError,
+  CannotRaiseToIRError,
+  type SourceLocation,
+} from "./polyglot-errors.js";

--- a/packages/contracts/src/polyglot-errors.test.ts
+++ b/packages/contracts/src/polyglot-errors.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import {
+  AmbiguousPurityError,
+  CannotRaiseToIRError,
+  type SourceLocation,
+} from "./polyglot-errors.js";
+
+const LOC: SourceLocation = { file: "src/foo.py", line: 12, col: 4 };
+
+describe("CannotRaiseToIRError", () => {
+  it("default message includes construct + file:line:col", () => {
+    const err = new CannotRaiseToIRError("async function", LOC);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(CannotRaiseToIRError);
+    expect(err.name).toBe("CannotRaiseToIRError");
+    expect(err.message).toBe("Cannot raise to IR: async function at src/foo.py:12:4");
+    expect(err.construct).toBe("async function");
+    expect(err.location).toEqual(LOC);
+  });
+
+  it("explicit message overrides the default", () => {
+    const err = new CannotRaiseToIRError("yield", LOC, "Python generators are not raiseable");
+    expect(err.message).toBe("Python generators are not raiseable");
+    expect(err.construct).toBe("yield");
+    expect(err.location).toEqual(LOC);
+  });
+
+  it("is throw/catch usable via instanceof", () => {
+    let caught: unknown = null;
+    try {
+      throw new CannotRaiseToIRError("decorator", LOC);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(CannotRaiseToIRError);
+    if (caught instanceof CannotRaiseToIRError) {
+      expect(caught.construct).toBe("decorator");
+    }
+  });
+});
+
+describe("AmbiguousPurityError", () => {
+  it("message includes reason + file:line:col", () => {
+    const err = new AmbiguousPurityError(
+      "dynamic dispatch through `getattr`",
+      LOC,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AmbiguousPurityError);
+    expect(err.name).toBe("AmbiguousPurityError");
+    expect(err.message).toBe(
+      "Ambiguous purity at src/foo.py:12:4: dynamic dispatch through `getattr`",
+    );
+    expect(err.reason).toBe("dynamic dispatch through `getattr`");
+    expect(err.location).toEqual(LOC);
+  });
+
+  it("distinct from CannotRaiseToIRError via instanceof", () => {
+    const err = new AmbiguousPurityError("opaque import", LOC);
+    expect(err).not.toBeInstanceOf(CannotRaiseToIRError);
+  });
+});

--- a/packages/contracts/src/polyglot-errors.ts
+++ b/packages/contracts/src/polyglot-errors.ts
@@ -1,0 +1,65 @@
+/**
+ * Typed errors emitted by per-language raise adapters when a source construct
+ * cannot be expressed in the TS-subset IR envelope.
+ *
+ * @decision DEC-POLYGLOT-IR-ENVELOPE-001 (held-the-line — option c)
+ * @title IR envelope is held at strict-subset TS; out-of-envelope constructs throw
+ * @status decided (ADR Q1: polyglot-architecture.md §Q1)
+ * @rationale
+ *   Per the polyglot architecture ADR, the IR envelope is NOT widened to absorb
+ *   Python generators, Rust lifetimes, Go channels, etc. When a per-language
+ *   raise adapter encounters such a construct, it throws CannotRaiseToIRError
+ *   so the developer either simplifies their function or leaves it unshaved.
+ *   AmbiguousPurityError is thrown when static purity analysis cannot decide
+ *   (dynamic dispatch, opaque imports); same hold-the-line stance.
+ * @scope @yakcc/contracts barrel re-exports both classes for use by future
+ *   adapters: @yakcc/shave-py (#782), @yakcc/shave-go, @yakcc/shave-rs.
+ */
+
+export interface SourceLocation {
+  readonly file: string;
+  readonly line: number;
+  readonly col: number;
+}
+
+/**
+ * Thrown when a per-language raise adapter encounters a source construct that
+ * cannot be expressed in the TS-subset IR envelope.
+ *
+ * Example callers (future):
+ *   - @yakcc/shave-py encountering `async def` or `yield`
+ *   - @yakcc/shave-go encountering goroutines or channels
+ *   - @yakcc/shave-rs encountering lifetimes or `unsafe`
+ */
+export class CannotRaiseToIRError extends Error {
+  constructor(
+    public readonly construct: string,
+    public readonly location: SourceLocation,
+    message?: string,
+  ) {
+    super(
+      message ??
+        `Cannot raise to IR: ${construct} at ${location.file}:${location.line}:${location.col}`,
+    );
+    this.name = "CannotRaiseToIRError";
+  }
+}
+
+/**
+ * Thrown when a per-language raise adapter's purity-inference pass cannot
+ * decide whether a function is pure (e.g. dynamic dispatch, opaque imports).
+ *
+ * Distinct from CannotRaiseToIRError: a construct that is conditionally pure
+ * is not banned by the envelope — the adapter just lacks the information to
+ * make the call. Surfacing this separately lets future adapters offer a
+ * specific remediation ("annotate this dispatch as pure / impure").
+ */
+export class AmbiguousPurityError extends Error {
+  constructor(
+    public readonly reason: string,
+    public readonly location: SourceLocation,
+  ) {
+    super(`Ambiguous purity at ${location.file}:${location.line}:${location.col}: ${reason}`);
+    this.name = "AmbiguousPurityError";
+  }
+}

--- a/packages/ir/docs/ir-envelope.md
+++ b/packages/ir/docs/ir-envelope.md
@@ -1,0 +1,105 @@
+# TS-subset IR Expressive Envelope
+
+**Status:** load-bearing spec
+**Decision:** `DEC-POLYGLOT-IR-ENVELOPE-001` — hold the line (ADR Q1)
+**Parent design:** `docs/archive/developer/adr/polyglot-architecture.md` (Q1)
+**Work item:** [#780 WI-POLYGLOT-IR-ENVELOPE](https://github.com/cneckar/yakcc/issues/780)
+
+## Why this document exists
+
+`@yakcc/ir` defines the strict-subset TypeScript grammar that every shaved atom
+must be expressible in. As the project moves toward polyglot raise adapters
+(Python in `@yakcc/shave-py`, Go and Rust later), every adapter needs an
+unambiguous reference for which native constructs are raiseable into IR and
+which must throw `CannotRaiseToIRError`.
+
+This file is that reference. It is the machine-readable companion to ADR §Q1
+and the source of truth invoked by:
+
+- `@yakcc/contracts.CannotRaiseToIRError` (thrown by adapters)
+- `@yakcc/contracts.AmbiguousPurityError` (thrown by adapters)
+- per-language raise adapters' acceptance test suites
+- future IR-widening RFCs (which must explicitly amend this table)
+
+## Hold-the-line stance
+
+The IR envelope is **NOT** widened to absorb constructs that exist only in a
+source language. Widening would inflate the IR with shapes the TS runtime
+cannot use and would invalidate the 6238-atom bootstrap corpus.
+
+When a per-language raise adapter encounters an out-of-envelope construct, it
+throws `CannotRaiseToIRError` carrying:
+
+- the offending construct name (e.g. `"async function"`, `"yield"`)
+- the source location (file/line/col)
+
+When purity-inference cannot decide (dynamic dispatch, opaque imports), the
+adapter throws `AmbiguousPurityError` instead — distinct so future tooling
+can offer a specific remediation (annotate the call site).
+
+## Per-construct raise-status table
+
+| Language construct | IR status |
+|---|---|
+| Pure functions, no closures over mutable state | ✓ raiseable |
+| Primitive types: number, string, boolean, null, undefined | ✓ raiseable |
+| ADT-style data: plain objects, arrays, tuples | ✓ raiseable |
+| Optional chaining, nullish coalescing | ✓ raiseable |
+| `Array.map`, `Array.filter`, `Array.reduce` | ✓ raiseable |
+| Synchronous control flow: if/else, for, while, switch | ✓ raiseable |
+| Throws (typed Error subclasses only) | ✓ raiseable |
+| `eval`, `Function()`, `new Function()` | ✗ banned by IR |
+| `async`/`await`, generators, iterators | ✗ outside envelope |
+| DOM APIs, Node built-ins beyond pure math/string/array | ✗ outside envelope |
+| Decorators, class inheritance beyond plain data | ✗ outside envelope |
+| Native FFI, C-extension calls | ✗ outside envelope |
+| Concurrency primitives (goroutines, Rust threads) | ✗ outside envelope |
+
+## Per-language raise-failure taxonomy
+
+### Python (`@yakcc/shave-py`, WI-POLYGLOT-SHAVE-PY-MVP #782)
+
+Throws `CannotRaiseToIRError` for:
+- `async def`, generators (`yield`)
+- context managers (`with`)
+- class inheritance beyond plain data
+- numpy/scipy/pandas calls
+- mutable default arguments
+
+Throws `AmbiguousPurityError` for:
+- dynamic dispatch (`getattr`, `setattr` with computed names)
+- opaque imports that cannot be statically resolved
+
+### Go (`@yakcc/shave-go`, future)
+
+Throws `CannotRaiseToIRError` for:
+- goroutines, channels
+- interfaces (unless trivially inlined)
+- pointer arithmetic
+- struct embedding
+
+### Rust (`@yakcc/shave-rs`, future)
+
+Throws `CannotRaiseToIRError` for:
+- lifetimes, ownership transfers (non-Copy types by value)
+- trait objects
+- unsafe blocks
+- async executor calls
+- `impl Trait` in return position
+
+Pure functional Rust subsets (numeric algorithms, string processing) map
+cleanly into the IR envelope.
+
+## Amending this document
+
+This file is the machine-checkable spec referenced by adapter test suites.
+Any IR envelope widening must:
+
+1. Be motivated by a written RFC that explicitly enumerates which existing
+   atoms would need re-shaving.
+2. Update this table and the ADR §Q1 decision in the same change set.
+3. Bump the IR envelope version (see `@yakcc/ir/src/envelope-version.ts`,
+   future).
+
+Out-of-band edits (table changes without a DEC entry) are treated as drift
+and rejected by reviewer.


### PR DESCRIPTION
## Summary

Implements WI-POLYGLOT-IR-ENVELOPE per ADR Q1 (`DEC-POLYGLOT-IR-ENVELOPE-001` — hold the line).

- **`packages/contracts/src/polyglot-errors.ts`** (new): exports `CannotRaiseToIRError`, `AmbiguousPurityError`, and shared `SourceLocation` type. Both errors carry construct/reason + `{file,line,col}` location. `CannotRaiseToIRError` allows a custom message; default message format is `Cannot raise to IR: <construct> at <file>:<line>:<col>`.
- **`packages/contracts/src/polyglot-errors.test.ts`** (new): unit tests covering default-message format, custom-message override, throw/catch via `instanceof`, distinct-class invariant.
- **`packages/contracts/src/index.ts`**: barrel re-exports `CannotRaiseToIRError`, `AmbiguousPurityError`, `SourceLocation`.
- **`packages/ir/docs/ir-envelope.md`** (new): the per-construct raise-status table — same content as ADR §Q1, plus per-language failure taxonomy (Python, Go, Rust) and an "amending this document" section requiring RFC + DEC for any future widening.

## Test plan

- [x] `pnpm --filter @yakcc/contracts test` — new tests in `polyglot-errors.test.ts`
- [x] `pnpm --filter @yakcc/contracts typecheck`
- [x] PR-CI required gates green (lint/typecheck/build/branch hygiene/B6a air-gap)

## Acceptance (from #780)

- [x] `docs/ir-envelope.md` documents the per-construct raise-status table; references DEC-POLYGLOT-IR-ENVELOPE-001
- [x] `CannotRaiseToIRError` and `AmbiguousPurityError` exported from `@yakcc/contracts/src/index.ts`
- [x] `pnpm --filter @yakcc/contracts test` green (verified by pr-ci typecheck job which runs unit tests inline)
- [x] `pnpm --filter @yakcc/contracts typecheck` green (verified by pr-ci)

Closes #780

---
_FuckGoblin orchestrator_