### PR TITLE
fix(registry): openRegistry guard only fires on explicit provider intent (closes #811)

### DIFF
--- a/packages/registry/src/storage.test.ts
+++ b/packages/registry/src/storage.test.ts
@@ -4308,3 +4308,131 @@ describe("migration 8: storeSourceFileGlue / getSourceFileGlue / listSourceFileG
     await registry.close();
   });
 });
+
+// ---------------------------------------------------------------------------
+// DEC-EMBED-REGISTRY-META-002 / issue #811 — open-time guard only fires on
+// explicit provider intent (options.embeddings OR YAKCC_EMBEDDING_PROVIDER).
+// Default openRegistry calls from non-embedding paths (registry init, propose,
+// bootstrap) must not throw on a stored/default mismatch.
+// ---------------------------------------------------------------------------
+
+function makeMockProviderWithId(modelId: string, dim = 384): EmbeddingProvider {
+  return {
+    modelId,
+    dimension: dim,
+    async embed(text: string): Promise<Float32Array> {
+      const vec = new Float32Array(dim);
+      for (let i = 0; i < dim; i++) {
+        vec[i] = (text.charCodeAt(i % text.length) || 0) / 128;
+      }
+      return vec;
+    },
+  };
+}
+
+describe("openRegistry — DEC-EMBED-REGISTRY-META-002 (#811) — explicit-intent guard", () => {
+  let savedEnv: string | undefined;
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    savedEnv = process.env.YAKCC_EMBEDDING_PROVIDER;
+    // biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+    delete process.env.YAKCC_EMBEDDING_PROVIDER;
+    const { mkdtempSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    tmpDir = mkdtempSync(join(tmpdir(), "yakcc-issue811-test-"));
+    dbPath = join(tmpDir, "r.sqlite");
+  });
+
+  afterEach(async () => {
+    if (savedEnv === undefined) {
+      // biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+      delete process.env.YAKCC_EMBEDDING_PROVIDER;
+    } else {
+      process.env.YAKCC_EMBEDDING_PROVIDER = savedEnv;
+    }
+    const { rmSync } = await import("node:fs");
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("default re-open (no explicit provider, no env) does NOT throw even when stored model differs", async () => {
+    // Seed with explicit "mock/seeded-provider"
+    const reg1 = await openRegistry(dbPath, {
+      embeddings: makeMockProviderWithId("mock/seeded-provider"),
+    });
+    const spec = makeSpecYak("Seeded model spec");
+    await reg1.storeBlock(makeBlockRow(spec));
+    await reg1.close();
+
+    // Re-open with NO options, NO env var — must NOT throw (#811 fix).
+    const reg2 = await openRegistry(dbPath);
+    expect(reg2).toBeDefined();
+    await reg2.close();
+  });
+
+  it("default re-open does NOT overwrite the stored embedding_model_id", async () => {
+    const reg1 = await openRegistry(dbPath, {
+      embeddings: makeMockProviderWithId("mock/seeded-provider"),
+    });
+    const spec = makeSpecYak("Seeded model spec — stored id preserved");
+    await reg1.storeBlock(makeBlockRow(spec));
+    expect(await reg1.getStoredEmbeddingModelId()).toBe("mock/seeded-provider");
+    await reg1.close();
+
+    // Re-open with no options/env — stored model id must remain unchanged.
+    const reg2 = await openRegistry(dbPath);
+    expect(await reg2.getStoredEmbeddingModelId()).toBe("mock/seeded-provider");
+    await reg2.close();
+  });
+
+  it("explicit options.embeddings with mismatching modelId DOES throw (guard preserved)", async () => {
+    const reg1 = await openRegistry(dbPath, {
+      embeddings: makeMockProviderWithId("mock/seeded-provider"),
+    });
+    const spec = makeSpecYak("Seeded model spec for explicit-intent guard");
+    await reg1.storeBlock(makeBlockRow(spec));
+    await reg1.close();
+
+    // Re-open with an EXPLICIT different provider — must throw with reason embedding_model_mismatch.
+    await expect(
+      openRegistry(dbPath, { embeddings: makeMockProviderWithId("mock/other-provider") }),
+    ).rejects.toMatchObject({
+      reason: "embedding_model_mismatch",
+    });
+  });
+
+  it("YAKCC_EMBEDDING_PROVIDER set to mismatching model DOES throw (guard preserved)", async () => {
+    const reg1 = await openRegistry(dbPath, {
+      embeddings: makeMockProviderWithId("mock/seeded-provider"),
+    });
+    const spec = makeSpecYak("Seeded model spec for env-intent guard");
+    await reg1.storeBlock(makeBlockRow(spec));
+    await reg1.close();
+
+    // Re-open with YAKCC_EMBEDDING_PROVIDER=local — env-set explicit intent should throw
+    // because the default local provider (Xenova/bge-small-en-v1.5) mismatches the
+    // stored mock/seeded-provider.
+    process.env.YAKCC_EMBEDDING_PROVIDER = "local";
+    await expect(openRegistry(dbPath)).rejects.toMatchObject({
+      reason: "embedding_model_mismatch",
+    });
+  });
+
+  it("autoRebuild bypasses the guard even when explicit intent mismatches", async () => {
+    const reg1 = await openRegistry(dbPath, {
+      embeddings: makeMockProviderWithId("mock/seeded-provider"),
+    });
+    const spec = makeSpecYak("Seeded model spec for autoRebuild bypass");
+    await reg1.storeBlock(makeBlockRow(spec));
+    await reg1.close();
+
+    // Explicit mismatch + autoRebuild=true → no throw, opens normally.
+    const reg2 = await openRegistry(dbPath, {
+      embeddings: makeMockProviderWithId("mock/other-provider"),
+      autoRebuild: true,
+    });
+    expect(reg2).toBeDefined();
+    await reg2.close();
+  });
+});

--- a/packages/registry/src/storage.test.ts
+++ b/packages/registry/src/storage.test.ts
@@ -4341,8 +4341,9 @@ describe("openRegistry — DEC-EMBED-REGISTRY-META-002 (#811) — explicit-inten
     delete process.env.YAKCC_EMBEDDING_PROVIDER;
     const { mkdtempSync } = await import("node:fs");
     const { tmpdir } = await import("node:os");
-    tmpDir = mkdtempSync(join(tmpdir(), "yakcc-issue811-test-"));
-    dbPath = join(tmpDir, "r.sqlite");
+    const { join: pathJoin } = await import("node:path");
+    tmpDir = mkdtempSync(pathJoin(tmpdir(), "yakcc-issue811-test-"));
+    dbPath = pathJoin(tmpDir, "r.sqlite");
   });
 
   afterEach(async () => {

--- a/packages/registry/src/storage.ts
+++ b/packages/registry/src/storage.ts
@@ -2232,7 +2232,14 @@ export async function openRegistry(path: string, options?: RegistryOptions): Pro
 
   // Resolve the embedding provider: use provided, or check env vars, or use local default.
   // Priority: explicit options.embeddings > YAKCC_EMBEDDING_PROVIDER env var > local BGE-small.
+  // Track whether the caller expressed explicit provider intent — used below to
+  // decide whether a stored/current mismatch should fail-loud or silently use
+  // the stored model (issue #811: non-embedding paths like `registry init` open
+  // the registry without caring about embeddings; they must not blow up just
+  // because the registry was seeded with a different model than the BGE default).
   let embeddingProvider: EmbeddingProvider;
+  const callerSetExplicitProvider =
+    options?.embeddings !== undefined || process.env.YAKCC_EMBEDDING_PROVIDER !== undefined;
   if (options?.embeddings !== undefined) {
     embeddingProvider = options.embeddings;
   } else {
@@ -2246,6 +2253,13 @@ export async function openRegistry(path: string, options?: RegistryOptions): Pro
   // embedding_model_id and compare it against the current provider's modelId.
   // Mismatch with existing embeddings → throw a clear error pointing at rebuild.
   // No stored ID (fresh registry or pre-v11 first open) → store the current one.
+  // @decision DEC-EMBED-REGISTRY-META-002 (closes #811): the open-time guard only
+  // fail-louds when the CALLER set an explicit provider (options.embeddings or
+  // YAKCC_EMBEDDING_PROVIDER). When neither is set, the caller has no embedding
+  // intent — non-embedding CLI paths (registry init, propose, bootstrap) just
+  // need the file open; they must not throw on a stored/default mismatch.
+  // In that case we trust the stored model and leave it unchanged; the attached
+  // default embeddingProvider is only exercised when someone actually embeds.
   const storedModelIdRow = db
     .prepare<[string], { value: string }>("SELECT value FROM registry_meta WHERE key = ?")
     .get("embedding_model_id");
@@ -2264,7 +2278,11 @@ export async function openRegistry(path: string, options?: RegistryOptions): Pro
     // When autoRebuild is true (explicit opt-in), the caller is about to rebuild
     // anyway (e.g. `yakcc registry rebuild`). Suppress the throw so the registry
     // opens successfully; rebuildRegistry will fix the vectors immediately after.
-    if (embCount > 0 && !(options?.autoRebuild ?? false)) {
+    if (
+      embCount > 0 &&
+      !(options?.autoRebuild ?? false) &&
+      callerSetExplicitProvider
+    ) {
       throw Object.assign(
         new Error(
           `Registry was embedded with model "${storedModelId}", but the current ` +
@@ -2278,14 +2296,23 @@ export async function openRegistry(path: string, options?: RegistryOptions): Pro
   }
 
   // Upsert the current provider's metadata so future opens can detect mismatches.
-  db.prepare("INSERT OR REPLACE INTO registry_meta(key, value) VALUES (?, ?)").run(
-    "embedding_model_id",
-    embeddingProvider.modelId,
-  );
-  db.prepare("INSERT OR REPLACE INTO registry_meta(key, value) VALUES (?, ?)").run(
-    "embedding_dimension",
-    String(embeddingProvider.dimension),
-  );
+  // @decision DEC-EMBED-REGISTRY-META-002 (closes #811): only overwrite the stored
+  // model when the caller expressed explicit intent (options.embeddings or
+  // YAKCC_EMBEDDING_PROVIDER), OR when nothing is stored yet (fresh registry).
+  // Otherwise we leave the stored model as-is so a default `openRegistry` call
+  // from a non-embedding path (registry init, propose, etc.) does not silently
+  // rewrite the stored model id from e.g. "yakcc/offline-blake3-stub" to BGE.
+  const shouldUpdateStored = storedModelId === null || callerSetExplicitProvider;
+  if (shouldUpdateStored) {
+    db.prepare("INSERT OR REPLACE INTO registry_meta(key, value) VALUES (?, ?)").run(
+      "embedding_model_id",
+      embeddingProvider.modelId,
+    );
+    db.prepare("INSERT OR REPLACE INTO registry_meta(key, value) VALUES (?, ?)").run(
+      "embedding_dimension",
+      String(embeddingProvider.dimension),
+    );
+  }
 
   return new SqliteRegistry(db, embeddingProvider, options?.autoRebuild ?? false);
 }


### PR DESCRIPTION
## Summary

Fixes the regression introduced by PR #799 (BYO embeddings). \`openRegistry()\` was throwing \`embedding_model_mismatch\` from non-embedding CLI paths (\`registry init\`, \`propose\`, possibly \`bootstrap\`/\`shave\`) because it always fail-louded when the stored model differed from the resolved provider's model, even when the caller never expressed any embedding intent.

**Fix (DEC-EMBED-REGISTRY-META-002):** the open-time guard now only fires when the caller explicitly set a provider via \`options.embeddings\` OR \`YAKCC_EMBEDDING_PROVIDER\`. With no explicit intent (the default path used by non-embedding commands), \`openRegistry\` returns successfully and leaves the stored \`embedding_model_id\` unchanged. The attached default provider is only exercised when the caller actually calls embedding APIs.

This combines the two preferred design options from #811:
- **Option #1 spirit**: non-embedding paths no longer fail-loud.
- **Option #2 spirit**: defaults respect the stored model rather than silently overwriting it with BGE.

The guard still fires (with the original enriched error message) when:
- An explicit \`options.embeddings\` provider mismatches stored.
- A \`YAKCC_EMBEDDING_PROVIDER\` env-set provider mismatches stored.

\`autoRebuild: true\` continues to bypass the guard entirely (preserved per DEC-EMBED-REGISTRY-META-001).

## Tests

New describe block in \`packages/registry/src/storage.test.ts\`:
- default re-open (no options, no env) does NOT throw even when stored model differs
- default re-open does NOT overwrite stored \`embedding_model_id\`
- explicit \`options.embeddings\` mismatch DOES throw \`embedding_model_mismatch\`
- \`YAKCC_EMBEDDING_PROVIDER\` set to mismatching model DOES throw \`embedding_model_mismatch\`
- \`autoRebuild: true\` bypasses the guard

All five tests use a real file path (mkdtempSync) so re-open behavior is exercised against a persistent DB.

## Test plan

- [x] PR-CI required gates green (lint/typecheck/build/branch hygiene/B6a air-gap)
- [x] New tests cover the regression and confirm the guard still fires on explicit intent
- [ ] Manual reproduction from #811 (\`yakcc registry init\` × 2) — fixed by the open-time gate

Closes #811

Related: regressed by #799, exposed in #800/#801/#802/#804 test failures.

---
_FuckGoblin orchestrator_