### PR TITLE
fix(cli): cli.test.ts seed assertion uses regex (corpus grew past 20) (closes #801)

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -192,14 +192,19 @@ describe("registry init", () => {
 // ---------------------------------------------------------------------------
 
 describe("seed", () => {
-  it("ingested all 20 corpus blocks during beforeAll setup", async () => {
+  it("seed completes and emits a 'seeded N contracts' log line (DEC-CI-OFFLINE-006)", async () => {
     // Re-run seed to verify idempotency and output format.
+    // The seed corpus grows over time (was 20 atoms at WI-T05; now larger as
+    // new blocks are added to packages/seeds/src/blocks/). The test now
+    // asserts the log shape — `seeded N contracts; ids: …` — rather than a
+    // hard-coded count, so adding new seed blocks does not flake CI.
+    // (closes #801)
     const logger = new CollectingLogger();
     const code = await seed(["--registry", registryPath], logger, {
       embeddings: offlineEmbeddings,
     });
     expect(code).toBe(0);
-    expect(logger.logLines.some((l) => l.includes("seeded 20 contracts"))).toBe(true);
+    expect(logger.logLines.some((l) => /seeded \d+ contracts/.test(l))).toBe(true);
   });
 
   it("is idempotent — repeated seed via runCli top-level exits 0 with consistent count (DEC-CI-OFFLINE-006)", async () => {


### PR DESCRIPTION
## Summary

\`packages/cli/src/cli.test.ts:202\` asserted the literal substring \`"seeded 20 contracts"\` against the seed log line. The seed corpus (\`packages/seeds/src/blocks/\`) has grown past 20 blocks (currently 26), so the assertion stopped matching. Production log line is unchanged: \`seeded \${result.stored} contracts; ids: …\` — only the count varies.

**Fix:** match \`/seeded \d+ contracts/\` instead of a hard-coded count. Adding/removing seed blocks no longer flakes this test. Test title updated from "ingested all 20 corpus blocks" to "seed completes and emits a 'seeded N contracts' log line" so the intent is obvious.

No production behavior change. Test-only fix.

## Test plan

- [x] PR-CI required gates green (lint/typecheck/build/branch hygiene/B6a air-gap)
- [x] Regex matches today's log shape (verified locally by grep against \`packages/cli/src/commands/seed.ts:99\`)

Closes #801

---
_FuckGoblin orchestrator_