### PR TITLE
fix(cli): init.ts adds InitOptions.embeddings seam; seed-default test uses offline stub (closes #802)

### DIFF
--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -553,7 +553,7 @@ describe("init — --no-seed flag", () => {
 describe("init — seed by default", () => {
   it(
     "default (no --no-seed) calls seedYakccCorpus and registry is non-empty when corpus exists",
-    { timeout: 300_000 },
+    { timeout: 60_000 },
     async () => {
       // Find the bootstrap corpus path (worktree-aware walk)
       const { existsSync: eSync } = await import("node:fs");
@@ -579,20 +579,27 @@ describe("init — seed by default", () => {
         return;
       }
 
+      // Inject the offline-blake3-stub embedding provider so the seed path
+      // does not load the BGE model. The model load was making this test
+      // exceed its 300s timeout (closes #802); with the stub, seed completes
+      // well under 60s on commodity hardware.
+      const { createOfflineEmbeddingProvider } = await import("@yakcc/contracts");
+      const offlineEmbeddings = createOfflineEmbeddingProvider();
+
       const logger = new CollectingLogger();
       // noOpMirror: this test cares about seed behaviour, not mirror
       const code = await init(["--target", tmpDir, "--skip-hooks"], logger, {
         overrideHome: tmpDir,
         corpusPath,
         runFederation: noOpMirror,
+        embeddings: offlineEmbeddings,
       });
       expect(code).toBe(0);
 
       // Registry should have atoms from the bootstrap corpus.
-      const { createOfflineEmbeddingProvider } = await import("@yakcc/contracts");
       const registryPath = join(tmpDir, ".yakcc", "registry.sqlite");
       const reg = await openRegistry(registryPath, {
-        embeddings: createOfflineEmbeddingProvider(),
+        embeddings: offlineEmbeddings,
       });
       const manifest = await reg.exportManifest();
       await reg.close();

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -311,6 +311,16 @@ export interface InitOptions {
    *   (argv: string[], logger: Logger) => Promise<number>
    */
   runFederation?: (argv: string[], logger: Logger) => Promise<number>;
+  /**
+   * Optional embedding provider to use when seeding the registry. When
+   * omitted, openRegistry's default resolver is used (env var or local BGE).
+   *
+   * Tests inject an offline-blake3-stub provider to avoid the multi-second
+   * BGE model load that otherwise dominates the seed integration test's
+   * runtime (closes #802). Production callers should leave this undefined
+   * so the user's actual provider configuration applies.
+   */
+  embeddings?: import("@yakcc/contracts").EmbeddingProvider;
 }
 
 // ---------------------------------------------------------------------------
@@ -515,7 +525,10 @@ export async function init(
   if (!noSeed) {
     let registry: Registry | null = null;
     try {
-      registry = await openRegistry(registryPath);
+      registry = await openRegistry(
+        registryPath,
+        opts?.embeddings !== undefined ? { embeddings: opts.embeddings } : undefined,
+      );
     } catch (err) {
       logger.error(`warning: cannot open registry for seed: ${String(err)} — continuing`);
     }


### PR DESCRIPTION
## Summary

The seed-default integration test was timing out at 300s because `init.ts:513` called `openRegistry(registryPath)` with no embedding provider, falling through to the BGE-small default. Loading the BGE model on first use is multi-second and dominated the test's runtime; the test had been bumped to a 5-minute timeout and was still flaking past it.

**Fix:**

1. **`InitOptions.embeddings?: EmbeddingProvider`** — new optional injection seam on `InitOptions`. Mirrors the existing `runFederation` test seam pattern. When omitted (production), `openRegistry`'s default resolver chain applies (env var → BGE-small). When provided (tests), threaded into `openRegistry`'s `embeddings` option.

2. **`packages/cli/src/commands/init.ts:513`** — `openRegistry(registryPath, opts?.embeddings ? { embeddings: opts.embeddings } : undefined)` so the test can inject the offline-blake3-stub provider.

3. **`packages/cli/src/commands/init.test.ts:556`** — Suite 13 test now injects `createOfflineEmbeddingProvider()` via the new seam, and its timeout drops from `300_000` → `60_000`. The downstream `openRegistry(registryPath, { embeddings: offlineEmbeddings })` is also updated to reuse the same provider instance.

No production behavior change. Default `init` continues to use the user's configured embedding provider per DEC-EMBED-ENV-RESOLUTION-001.

## Test plan

- [x] PR-CI required gates green (lint/typecheck/build/branch hygiene/B6a air-gap)
- [x] Suite 13 (`init — seed by default`) now uses the offline stub via the new seam
- [x] Timeout reduced from 300s → 60s to fail fast if performance regresses again

## Acceptance (from #802)

- [x] Test passes deterministically in well under 60 seconds on commodity hardware (offline stub bypasses BGE model load)
- [x] Integration replaced with stub-based variant (the bootstrap corpus is still seeded; only the embedding provider is stubbed)

Closes #802

---
_FuckGoblin orchestrator_