### PR TITLE
fix(cli): init mirror — bump timeout 10s→60s + distinguish timeout/error/exit codes (closes #790)

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -632,9 +632,7 @@ export async function init(
         );
       } else if (mirrorCode === MIRROR_FAIL_EXCEPTION) {
         const detail =
-          mirrorException instanceof Error
-            ? `${mirrorException.message}`
-            : String(mirrorException);
+          mirrorException instanceof Error ? `${mirrorException.message}` : String(mirrorException);
         logger.error(
           `Note: mirror from ${effectivePeerUrl} threw an error (${detail}) — run 'yakcc federation mirror --remote ${effectivePeerUrl} --registry ${registryPath}' to see full output.`,
         );

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -153,7 +153,25 @@ const DEFAULT_REGISTRY_PEER_URL = "https://registry.yakcc.com";
  * indefinitely when registry.yakcc.com is temporarily unreachable.
  * (DEC-WPE-DEFAULT-PEER-001 — graceful degradation)
  */
-const MIRROR_TIMEOUT_MS = 10_000;
+// @decision DEC-WPE-MIRROR-TIMEOUT-002 (closes #790)
+// title: bump mirror-on-init timeout from 10s → 60s to match real corpus size
+// status: accepted (FuckGoblin #790 triage 2026-05-27)
+// rationale:
+//   The original 10s bound (WI-WPE-C #771) was tight: the public corpus pulls
+//   ~4 MB and routinely takes several seconds on a healthy network. When the
+//   bound fired, the user saw a spurious "Note: could not reach …" even though
+//   `yakcc federation mirror` succeeded seconds later from the same shell.
+//   60s gives the mirror room to finish on commodity broadband. The user
+//   explicitly invoked `yakcc init` and is actively waiting; the 60s ceiling
+//   still guards against the genuine unreachable case (DNS fail, TLS error,
+//   server outage) where the underlying socket I/O surfaces a failure quickly.
+//   Sentinel exit codes below distinguish timeout from non-zero-exit from
+//   exception so the surfaced log message points at the actual cause.
+const MIRROR_TIMEOUT_MS = 60_000;
+
+/** Sentinel exit codes used internally to differentiate mirror failure modes. */
+const MIRROR_FAIL_TIMEOUT = 124; // POSIX timeout convention
+const MIRROR_FAIL_EXCEPTION = 125;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -588,20 +606,43 @@ export async function init(
 
     const mirrorArgs = ["mirror", "--remote", effectivePeerUrl, "--registry", registryPath];
 
+    // DEC-WPE-MIRROR-TIMEOUT-002 (#790): distinguish timeout / exception / non-zero-exit
+    // so the surfaced log message points at the actual cause instead of the generic
+    // "could not reach" that obscured real reachability errors.
     let mirrorCode: number;
+    let mirrorException: unknown = null;
     try {
       mirrorCode = await Promise.race([
         federationRunner(mirrorArgs, logger),
-        new Promise<number>((resolve) => setTimeout(() => resolve(1), MIRROR_TIMEOUT_MS)),
+        new Promise<number>((resolve) =>
+          setTimeout(() => resolve(MIRROR_FAIL_TIMEOUT), MIRROR_TIMEOUT_MS),
+        ),
       ]);
-    } catch {
-      mirrorCode = 1;
+    } catch (err) {
+      mirrorException = err;
+      mirrorCode = MIRROR_FAIL_EXCEPTION;
     }
 
     if (mirrorCode !== 0) {
-      logger.error(
-        `Note: could not reach ${effectivePeerUrl} — run 'yakcc federation mirror' later.`,
-      );
+      if (mirrorCode === MIRROR_FAIL_TIMEOUT) {
+        logger.error(
+          `Note: mirror from ${effectivePeerUrl} did not complete within ${
+            MIRROR_TIMEOUT_MS / 1000
+          }s — run 'yakcc federation mirror --remote ${effectivePeerUrl} --registry ${registryPath}' to retry without the time bound.`,
+        );
+      } else if (mirrorCode === MIRROR_FAIL_EXCEPTION) {
+        const detail =
+          mirrorException instanceof Error
+            ? `${mirrorException.message}`
+            : String(mirrorException);
+        logger.error(
+          `Note: mirror from ${effectivePeerUrl} threw an error (${detail}) — run 'yakcc federation mirror --remote ${effectivePeerUrl} --registry ${registryPath}' to see full output.`,
+        );
+      } else {
+        logger.error(
+          `Note: mirror from ${effectivePeerUrl} exited ${mirrorCode} — run 'yakcc federation mirror --remote ${effectivePeerUrl} --registry ${registryPath}' to see full output.`,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

`yakcc init`'s mirror-on-init path was logging a spurious `Note: could not reach https://registry.yakcc.com — run 'yakcc federation mirror' later.` even when the registry was live and a manual `yakcc federation mirror` seconds later succeeded. Two root causes:

1. **10s timeout too tight.** The public corpus pulls ~4 MB and routinely takes more than 10s on a healthy network. The `Promise.race` bound was firing before the underlying `federation mirror` had time to finish.
2. **Generic error message swallowed the cause.** Any non-zero result (timeout, exception, real network failure) collapsed to the same `could not reach` line, so the user could not tell whether to retry, wait, or investigate.

**Fix:**

- **`MIRROR_TIMEOUT_MS` bumped to 60s** with a `DEC-WPE-MIRROR-TIMEOUT-002` rationale block citing #790. The user explicitly invoked `yakcc init` and is actively waiting; the 60s ceiling still guards against genuine unreachable cases (DNS / TLS / outage) where socket I/O surfaces a failure quickly.
- **Sentinel exit codes** (`MIRROR_FAIL_TIMEOUT=124`, `MIRROR_FAIL_EXCEPTION=125`) distinguish timeout vs exception vs real non-zero exit. The catch block captures `mirrorException` so the surfaced log message includes the error text.
- **Three distinct log messages** instead of one generic "could not reach":
  - Timeout: `Note: mirror from <url> did not complete within 60s — run 'yakcc federation mirror --remote <url> --registry <path>' to retry without the time bound.`
  - Exception: `Note: mirror from <url> threw an error (<message>) — run 'yakcc federation mirror …' to see full output.`
  - Non-zero exit: `Note: mirror from <url> exited <code> — run 'yakcc federation mirror …' to see full output.`

Each message includes the exact recovery command the user can copy/paste.

## Acceptance (from #790)

- [x] `yakcc init` against a reachable peer either succeeds silently OR reports a specific actionable error (not the generic "could not reach")
- [x] If the bounded mirror needs more than 10s — surfaces with timeout-specific message + retry command (bound is now 60s, with the retry command bypassing it)
- [ ] If `init`'s mirror path uses a different endpoint than explicit `federation mirror`, reconcile them — verified by code inspection: same `runFederation(["mirror", "--remote", url, "--registry", path], …)` seam is used in both places (init.ts:589 and federation.ts handler); no endpoint divergence
- [ ] Repro in a CI integration test that exercises the live URL or a fixture mock — deferred follow-up; this fix is pure error-surface improvement and is exercised by the existing init.test.ts suite

## Test plan

- [x] PR-CI required gates green (lint/typecheck/build/branch hygiene/B6a air-gap)
- [x] Existing init test suite (1252 lines) covers the mirror-on-init success and stub-injection paths; existing tests already exercise the `mirrorCode !== 0` branch with `runFederation` returning 1, which now exercises the "exit code" message branch

Closes #790

---
_FuckGoblin orchestrator_