### PR TITLE
feat(federation): #794 slice 2 — POST /v1/blocks/submit write endpoint

### DIFF
--- a/packages/federation/src/serve.test.ts
+++ b/packages/federation/src/serve.test.ts
@@ -688,3 +688,101 @@ describe("serveRegistry compound-interaction: full F1 production sequence", () =
     expect(sv.schemaVersion).toBe(SCHEMA_VERSION);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Suite: POST /v1/blocks/submit (DEC-COMMONS-SUBMIT-WRITE-ENDPOINT-001 / #794 slice 2)
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/blocks/submit (#794 slice 2)", () => {
+  let registry: Registry;
+  let handle: ServeHandle;
+
+  beforeEach(async () => {
+    registry = await openRegistry(":memory:", { embeddings: ZERO_EMBEDDINGS });
+    handle = await serveRegistry(registry, { port: 0, host: "127.0.0.1" });
+  });
+
+  afterEach(async () => {
+    await handle.close();
+    await registry.close();
+  });
+
+  async function postSubmit(body: string | Uint8Array, contentType = "application/json") {
+    return fetch(`${handle.url}/v1/blocks/submit`, {
+      method: "POST",
+      headers: { "Content-Type": contentType },
+      body,
+    });
+  }
+
+  it("accepts a valid wire envelope and stores the block", async () => {
+    const row = makeRow(SPEC_A, "submit-v1", "// submit artifact");
+    const { serializeWireBlockTriplet } = await import("./wire.js");
+    const envelope = serializeWireBlockTriplet(row);
+
+    const r = await postSubmit(JSON.stringify(envelope));
+    expect(r.status).toBe(200);
+    const j = (await r.json()) as { accepted: boolean };
+    expect(j.accepted).toBe(true);
+
+    // Verify the block landed in the registry
+    const stored = await registry.getBlock(row.blockMerkleRoot);
+    expect(stored).not.toBeNull();
+    expect(stored?.blockMerkleRoot).toBe(row.blockMerkleRoot);
+  });
+
+  it("is idempotent: re-submitting the same envelope returns 200 (no-op via storeBlock dedupe)", async () => {
+    const row = makeRow(SPEC_A, "submit-idem", "// idempotent artifact");
+    const { serializeWireBlockTriplet } = await import("./wire.js");
+    const envelope = serializeWireBlockTriplet(row);
+    const body = JSON.stringify(envelope);
+
+    const r1 = await postSubmit(body);
+    expect(r1.status).toBe(200);
+    const r2 = await postSubmit(body);
+    expect(r2.status).toBe(200);
+  });
+
+  it("rejects malformed JSON with 400 bad_request + reason=malformed_json", async () => {
+    const r = await postSubmit("{ this is not valid json");
+    expect(r.status).toBe(400);
+    const j = (await r.json()) as { error: string; reason: string };
+    expect(j.error).toBe("bad_request");
+    expect(j.reason).toBe("malformed_json");
+  });
+
+  it("rejects a structurally invalid wire envelope with 400 bad_request", async () => {
+    const r = await postSubmit(JSON.stringify({ foo: "bar" }));
+    expect(r.status).toBe(400);
+    const j = (await r.json()) as { error: string; reason?: string };
+    expect(j.error).toBe("bad_request");
+    // The reason carries the deserialize error message — must mention a missing field.
+    expect(typeof j.reason).toBe("string");
+  });
+
+  it("rejects GET on /v1/blocks/submit with 405 method_not_allowed", async () => {
+    const r = await fetch(`${handle.url}/v1/blocks/submit`);
+    expect(r.status).toBe(405);
+    expect(r.headers.get("Allow")).toBe("POST");
+  });
+
+  it("rejects an oversized body with 413 body_too_large", async () => {
+    // 6 MiB > 5 MiB ceiling
+    const big = "x".repeat(6 * 1024 * 1024);
+    const r = await postSubmit(big);
+    expect(r.status).toBe(413);
+    const j = (await r.json()) as { error: string };
+    expect(j.error).toBe("body_too_large");
+  });
+
+  it("does not break the existing GET /schema-version after a write", async () => {
+    const row = makeRow(SPEC_A, "submit-then-read", "// after-write read");
+    const { serializeWireBlockTriplet } = await import("./wire.js");
+    await postSubmit(JSON.stringify(serializeWireBlockTriplet(row)));
+
+    const sv = await fetch(`${handle.url}/schema-version`);
+    expect(sv.status).toBe(200);
+    const svj = (await sv.json()) as { schemaVersion: number };
+    expect(svj.schemaVersion).toBe(SCHEMA_VERSION);
+  });
+});

--- a/packages/federation/src/serve.ts
+++ b/packages/federation/src/serve.ts
@@ -52,7 +52,27 @@ import type { IncomingMessage, Server, ServerResponse } from "node:http";
 import type { BlockMerkleRoot, SpecHash } from "@yakcc/contracts";
 import type { Registry } from "@yakcc/registry";
 import { SCHEMA_VERSION } from "@yakcc/registry";
-import { serializeWireBlockTriplet } from "./wire.js";
+import { deserializeWireBlockTriplet, serializeWireBlockTriplet } from "./wire.js";
+
+// ---------------------------------------------------------------------------
+// @decision DEC-COMMONS-SUBMIT-WRITE-ENDPOINT-001 (WI-794 slice 2)
+// @title POST /v1/blocks/submit — anonymous unauthenticated write endpoint
+// @status accepted (WI-794 slice 2)
+// @rationale
+//   DEC-COMMONS-NO-AUTH-001 mandates anonymous writes for the commons. This
+//   route is the server-side half of the auto-submit flywheel: any client
+//   that has captured a novel atom POSTs the JSON wire envelope here, and
+//   the server inserts via storeBlock. storeBlock is idempotent on
+//   BlockMerkleRoot, so re-submission is a no-op (returns 200 with
+//   {accepted: true, novel: false}). All wire-format validation is delegated
+//   to deserializeWireBlockTriplet, which throws structured TypeErrors on
+//   malformed input — those surface as 400 bad_request to the caller.
+//   This slice ships only the server route; the client-side fire-and-forget
+//   push wiring at the storeBlock seam is slice 3 (WI-794).
+// ---------------------------------------------------------------------------
+
+/** Maximum bytes accepted in a POST /v1/blocks/submit request body. */
+const SUBMIT_MAX_BODY_BYTES = 5 * 1024 * 1024; // 5 MiB — generous; typical envelope is < 64 KiB
 
 // ---------------------------------------------------------------------------
 // Options
@@ -277,25 +297,134 @@ async function handleListCatalogPage(
 }
 
 // ---------------------------------------------------------------------------
+// POST /v1/blocks/submit — anonymous commons-push write endpoint
+// (DEC-COMMONS-SUBMIT-WRITE-ENDPOINT-001 / WI-794 slice 2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the request body as a UTF-8 string, bounded by SUBMIT_MAX_BODY_BYTES.
+ * Resolves to the body string on success, or rejects with an Error whose
+ * .message names the failure mode ("body_too_large" | "read_error").
+ */
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    req.on("data", (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > SUBMIT_MAX_BODY_BYTES) {
+        reject(new Error("body_too_large"));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      resolve(Buffer.concat(chunks).toString("utf-8"));
+    });
+    req.on("error", (err) => {
+      reject(new Error(`read_error: ${err.message}`));
+    });
+  });
+}
+
+/**
+ * POST /v1/blocks/submit handler.
+ *
+ * Wire format: a WireBlockTriplet JSON body (the same shape returned by
+ * GET /v1/block/<root>). On accept: storeBlock is called and 200 is returned.
+ * Idempotency: storeBlock dedupes on BlockMerkleRoot, so re-submitting the
+ * same atom is a server-side no-op — the response is still 200.
+ *
+ * Failure modes:
+ *   - body > 5 MiB → 413 body_too_large
+ *   - malformed JSON → 400 bad_request (with reason="malformed_json")
+ *   - wire-format violation → 400 bad_request (with reason from deserializeWireBlockTriplet)
+ *   - storeBlock unexpected throw → 500 internal_error
+ */
+async function handleSubmitBlock(
+  req: IncomingMessage,
+  res: ServerResponse,
+  local: Registry,
+): Promise<void> {
+  let body: string;
+  try {
+    body = await readBody(req);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg === "body_too_large") {
+      sendError(res, 413, "body_too_large");
+      return;
+    }
+    sendError(res, 400, "bad_request");
+    return;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    sendJson(res, 400, { error: "bad_request", reason: "malformed_json" });
+    return;
+  }
+
+  let row: import("@yakcc/registry").BlockTripletRow;
+  try {
+    row = deserializeWireBlockTriplet(parsed);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    sendJson(res, 400, { error: "bad_request", reason });
+    return;
+  }
+
+  try {
+    await local.storeBlock(row);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    sendJson(res, 500, { error: "internal_error", reason });
+    return;
+  }
+
+  // 200 OK on accept (or no-op via BlockMerkleRoot dedupe). The wire response
+  // is deliberately minimal — no per-atom metadata, no novelty flag — to
+  // preserve the anonymous-by-construction property (DEC-COMMONS-NO-AUTH-001).
+  sendJson(res, 200, { accepted: true });
+}
+
+// ---------------------------------------------------------------------------
 // Request dispatcher
 // ---------------------------------------------------------------------------
 
 /**
  * Parse the incoming request and route it to the appropriate handler.
  *
- * All non-GET methods return 405 with the §3 error envelope.
- * Unknown GET paths return 404 with { error: "not_found" }.
+ * POST /v1/blocks/submit is the only write endpoint (WI-794 slice 2 /
+ * DEC-COMMONS-SUBMIT-WRITE-ENDPOINT-001). All other paths are read-only;
+ * non-GET methods on those paths return 405 with the §3 error envelope.
+ * Unknown paths return 404 with { error: "not_found" }.
  */
 async function dispatch(req: IncomingMessage, res: ServerResponse, local: Registry): Promise<void> {
-  // All non-GET methods return 405 (DEC-V1-WAVE-1-SCOPE-001: read-only).
+  // Parse path — strip query string.
+  const rawPath = (req.url ?? "/").split("?")[0] ?? "/";
+
+  // POST /v1/blocks/submit is the sole write endpoint
+  // (DEC-COMMONS-SUBMIT-WRITE-ENDPOINT-001 / WI-794 slice 2).
+  // All other paths are read-only (DEC-V1-WAVE-1-SCOPE-001) — non-GET → 405.
+  if (rawPath === "/v1/blocks/submit") {
+    if (req.method !== "POST") {
+      res.setHeader("Allow", "POST");
+      sendError(res, 405, "method_not_allowed");
+      return;
+    }
+    await handleSubmitBlock(req, res, local);
+    return;
+  }
+
   if (req.method !== "GET") {
     res.setHeader("Allow", "GET");
     sendError(res, 405, "method_not_allowed");
     return;
   }
-
-  // Parse path — strip query string.
-  const rawPath = (req.url ?? "/").split("?")[0] ?? "/";
 
   // Route: GET /schema-version
   if (rawPath === "/schema-version") {


### PR DESCRIPTION
## Summary

Slice 2 of WI-794. Adds the **server-side** half of the commons-push flywheel: a single anonymous POST endpoint that accepts a `WireBlockTriplet` envelope and routes it through `storeBlock`. No auth, no per-user identity, idempotent on `BlockMerkleRoot`.

**Changes:**

- **`packages/federation/src/serve.ts`** — refactored `dispatch()` to allow POST on `/v1/blocks/submit` while keeping every other endpoint GET-only (preserves `DEC-V1-WAVE-1-SCOPE-001` for the read surface). New `handleSubmitBlock` reads the body (≤5 MiB), parses JSON, delegates wire validation to the existing `deserializeWireBlockTriplet`, and calls `local.storeBlock(row)`. Idempotency comes for free via storeBlock's `BlockMerkleRoot` dedupe.

- **`packages/federation/src/serve.test.ts`** — new suite (7 cases): happy-path accept + verify in registry, idempotent re-submit, malformed JSON → 400+reason, structurally invalid envelope → 400+reason, GET on submit route → 405, 6 MiB body → 413, read-endpoint unaffected after a write.

**Failure modes are differentiated** in the response body so future client code (slice 3) can decide whether to retry, drop, or surface to the user:
- 400 + `reason: "malformed_json"` — non-JSON body
- 400 + `reason: <deserialize error>` — wire-format violation
- 413 + `error: "body_too_large"` — body > 5 MiB ceiling
- 500 + `error: "internal_error"` + `reason` — unexpected storeBlock failure (should not happen with a valid wire payload)
- 200 + `{accepted: true}` — accepted-or-no-op (anonymous; no novelty flag per `DEC-COMMONS-NO-AUTH-001`)

## Why this slice, not the whole thing

Per the slice plan from PR #818 (slice 1):

- **Slice 1 (#818, MERGED):** schema column + local-queue helpers
- **Slice 2 (this PR):** server-side `POST /v1/blocks/submit` endpoint
- **Slice 3 (next):** client-side async push at storeBlock + air-gap detection + synthetic filter (`:memory:` registries)
- **Slice 4 (next):** offline queue flush + `yakcc atom add` manual command + `docs/USING_YAKCC.md` commons section

No client wires this endpoint yet, so nothing in production behavior changes until slice 3 lands.

## Acceptance (slice 2 of #794)

- [x] `POST /v1/blocks/submit` route added; accepts anonymous payload
- [x] Wire validation delegated to existing `deserializeWireBlockTriplet`
- [x] storeBlock dedupes on `BlockMerkleRoot`; re-submit is a 200 no-op
- [x] No PII / no client-id headers in the response or wire path
- [x] Body size capped at 5 MiB (defensive against accidental flooding)
- [x] PR-CI required gates green (lint/typecheck/build/branch hygiene/B6a air-gap)
- [x] All other endpoints remain GET-only; non-GET → 405 with `Allow: GET`

Tracking: #794 (slice 2 of 4)

---
_FuckGoblin orchestrator_