### PR TITLE
feat(cli): #823 slice 4b — extend commons-push wiring to bootstrap/seed/propose/compile-self (closes #823)

### DIFF
--- a/packages/cli/src/commands/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap.ts
@@ -80,6 +80,8 @@ import type {
 import { acquireWriteLock, openRegistry } from "@yakcc/registry";
 import { shave as shaveImpl } from "@yakcc/shave";
 import type { Logger } from "../index.js";
+import { makeCommonsBinding } from "../lib/commons-submit.js";
+import { readRc } from "../lib/yakccrc.js";
 import { PLUMBING_INCLUDE_GLOBS, plumbingPathAllowed } from "./plumbing-globs.js";
 
 // ---------------------------------------------------------------------------
@@ -1008,15 +1010,27 @@ export async function bootstrap(argv: ReadonlyArray<string>, logger: Logger): Pr
     return 1;
   }
 
+  // Commons-push binding (WI-823 slice 4b). Bootstrap can produce 3000+ atoms
+  // in a single run; each novel insert fires a fire-and-forget POST. Air-gap or
+  // :memory: gating in makeCommonsBinding skips push entirely.
+  const rc = readRc(".");
+  const airgapped = rc?.mode === "airgapped";
+  const commonsBinding = makeCommonsBinding({ registryPath, airgapped });
+
   // Open registry with zero-embedding provider (DEC-V2-BOOTSTRAP-EMBEDDING-001).
   let registry: Registry;
   try {
-    registry = await openRegistry(registryPath, BOOTSTRAP_EMBEDDING_OPTS);
+    const openOpts: RegistryOptions = { ...BOOTSTRAP_EMBEDDING_OPTS };
+    if (commonsBinding.commonsSubmit !== undefined) {
+      openOpts.commonsSubmit = commonsBinding.commonsSubmit;
+    }
+    registry = await openRegistry(registryPath, openOpts);
   } catch (err) {
     releaseBootstrapLock();
     logger.error(`error: failed to open registry at ${registryPath}: ${(err as Error).message}`);
     return 1;
   }
+  commonsBinding.bind(registry);
 
   // Adapt Registry → ShaveRegistryView (same pattern as shave.ts lines ~79-87).
   //

--- a/packages/cli/src/commands/compile-self.ts
+++ b/packages/cli/src/commands/compile-self.ts
@@ -49,8 +49,10 @@ import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { parseArgs } from "node:util";
 import { openRegistry } from "@yakcc/registry";
-import type { BlockTripletRow, Registry } from "@yakcc/registry";
+import type { BlockTripletRow, Registry, RegistryOptions } from "@yakcc/registry";
 import type { Logger } from "../index.js";
+import { makeCommonsBinding } from "../lib/commons-submit.js";
+import { readRc } from "../lib/yakccrc.js";
 
 // ---------------------------------------------------------------------------
 // CLI argument parsing options
@@ -345,7 +347,17 @@ async function _runPipeline(
   sourceFilesEmitted: number;
   plumbingFilesEmitted: number;
 }> {
-  const registry: Registry = await openRegistry(registryPath, NULL_EMBEDDING_OPTS);
+  // Commons-push binding (WI-823 slice 4b).
+  const rc = readRc(".");
+  const airgapped = rc?.mode === "airgapped";
+  const commonsBinding = makeCommonsBinding({ registryPath, airgapped });
+
+  const openOpts: RegistryOptions = { ...NULL_EMBEDDING_OPTS };
+  if (commonsBinding.commonsSubmit !== undefined) {
+    openOpts.commonsSubmit = commonsBinding.commonsSubmit;
+  }
+  const registry: Registry = await openRegistry(registryPath, openOpts);
+  commonsBinding.bind(registry);
 
   try {
     // Step 1: Enumerate all atoms via exportManifest (single authority — Sacred Practice #12).

--- a/packages/cli/src/commands/propose.ts
+++ b/packages/cli/src/commands/propose.ts
@@ -14,6 +14,8 @@ import { parseArgs } from "node:util";
 import { type SpecYak, parseGranularity, specHash } from "@yakcc/contracts";
 import { type Registry, type RegistryOptions, openRegistry } from "@yakcc/registry";
 import type { Logger } from "../index.js";
+import { makeCommonsBinding } from "../lib/commons-submit.js";
+import { readRc } from "../lib/yakccrc.js";
 
 /** Internal options for propose — embeddings seam for test injection. */
 export interface ProposeOptions {
@@ -82,14 +84,25 @@ export async function propose(
 
   const hash = specHash(spec);
 
+  // Commons-push binding (WI-823 slice 4b).
+  const rc = readRc(".");
+  const airgapped = rc?.mode === "airgapped";
+  const commonsBinding = makeCommonsBinding({ registryPath, airgapped });
+
   // Open the registry and check for a match.
   let registry: Registry;
   try {
-    registry = await openRegistry(registryPath, { embeddings: opts?.embeddings });
+    const openOpts: RegistryOptions = {};
+    if (opts?.embeddings !== undefined) openOpts.embeddings = opts.embeddings;
+    if (commonsBinding.commonsSubmit !== undefined) {
+      openOpts.commonsSubmit = commonsBinding.commonsSubmit;
+    }
+    registry = await openRegistry(registryPath, openOpts);
   } catch (err) {
     logger.error(`error: failed to open registry at ${registryPath}: ${String(err)}`);
     return 1;
   }
+  commonsBinding.bind(registry);
 
   try {
     const roots = await registry.selectBlocks(hash);

--- a/packages/cli/src/commands/seed.ts
+++ b/packages/cli/src/commands/seed.ts
@@ -14,6 +14,8 @@ import { parseArgs } from "node:util";
 import { type Registry, type RegistryOptions, openRegistry } from "@yakcc/registry";
 import { seedRegistry } from "@yakcc/seeds";
 import type { Logger } from "../index.js";
+import { makeCommonsBinding } from "../lib/commons-submit.js";
+import { readRc } from "../lib/yakccrc.js";
 import { DEFAULT_REGISTRY_PATH } from "./registry-init.js";
 import { seedYakccCorpus } from "./seed-yakcc.js";
 
@@ -69,13 +71,25 @@ export async function seed(
   const registryPath = values.registry ?? DEFAULT_REGISTRY_PATH;
   const useYakccCorpus = values.yakcc === true;
 
+  // Commons-push binding (WI-823 slice 4b / DEC-COMMONS-SUBMIT-AT-STOREBLOCK-001).
+  // Gated automatically on :memory:, airgapped, or YAKCC_AIRGAP=1.
+  const rc = readRc(".");
+  const airgapped = rc?.mode === "airgapped";
+  const commonsBinding = makeCommonsBinding({ registryPath, airgapped });
+
   let registry: Registry;
   try {
-    registry = await openRegistry(registryPath, { embeddings: opts?.embeddings });
+    const openOpts: RegistryOptions = {};
+    if (opts?.embeddings !== undefined) openOpts.embeddings = opts.embeddings;
+    if (commonsBinding.commonsSubmit !== undefined) {
+      openOpts.commonsSubmit = commonsBinding.commonsSubmit;
+    }
+    registry = await openRegistry(registryPath, openOpts);
   } catch (err) {
     logger.error(`error: failed to open registry at ${registryPath}: ${String(err)}`);
     return 1;
   }
+  commonsBinding.bind(registry);
 
   try {
     if (useYakccCorpus) {


### PR DESCRIPTION
## Summary

Follow-up to closed WI-794. Extends the commons-push wiring from `yakcc shave` (PR #822) to the remaining production storeBlock callers. Each call site gets the same 3-line pattern: read rc, build binding, thread `commonsSubmit` into `openRegistry`.

**Files touched:**

- `packages/cli/src/commands/seed.ts` — first-init seed of the 20-block corpus
- `packages/cli/src/commands/propose.ts` — interactive shave-and-persist flow
- `packages/cli/src/commands/bootstrap.ts` — heavy write path (~3000–6000 atoms per full bootstrap)
- `packages/cli/src/commands/compile-self.ts` — self-shave compilation path

For each: new imports of `makeCommonsBinding` and `readRc`, then before the existing `openRegistry` call, build the binding from registry path + airgapped mode (read from `.yakccrc.json`), thread `commonsSubmit` into options, and call `binding.bind(registry)` after open. No behavior change when `:memory:` or air-gapped (gates short-circuit to no-op).

## Deliberately out of scope

- **Federation pull paths** (`packages/cli/src/commands/federation.ts`): atoms pulled FROM the commons are already on the commons. Resubmitting would be a server-side no-op via `BlockMerkleRoot` dedupe — wasteful, no functional gain. Federation writers explicitly skip the push.
- **Registry rebuild** (`registry-rebuild.ts`): only re-embeds existing atoms; no new storeBlocks.
- **IDE hook-intercept paths**: hooks-* packages call storeBlock via the registry handle they're given — wiring lives at the CLI layer that constructs the registry, not in the hook code itself. Already covered by the four CLI wirings above.

## Acceptance (from #823)

- [x] bootstrap, seed, propose, compile-self thread `commonsSubmit` through `openRegistry`
- [x] Air-gap (`mode: "airgapped"` or `YAKCC_AIRGAP=1`) and `:memory:` gates honored uniformly via `makeCommonsBinding`
- [x] No interface changes (Registry mocks not touched)
- [x] PR-CI required gates green (lint/typecheck/build/branch hygiene/B6a air-gap)

Closes #823

---
_FuckGoblin orchestrator_