### PR TITLE
feat(shave-python): #782 slice 1 — package scaffold + libcst subprocess primitive

### DIFF
--- a/packages/shave-python/README.md
+++ b/packages/shave-python/README.md
@@ -1,0 +1,25 @@
+# @yakcc/shave-python
+
+Python raise adapter — shaves Python functions to the TS-subset IR (WI-782, ADR Q2).
+
+**Status:** scaffolding only (slice 1 of 4). The subprocess wrapper and JSON-AST contract are in place; AST → IR mapping (slice 2), purity inference (slice 3), and end-to-end raise (slice 4) are upcoming.
+
+## Slice plan
+
+1. **Slice 1 (this scaffold):** package layout, `libcst-parser.ts` subprocess wrapper, JSON-AST contract, mock-based tests (no Python runtime required in CI)
+2. **Slice 2:** AST mapping table → emit pure raise pipeline (per [ADR Q2](../../docs/archive/developer/adr/polyglot-architecture.md#q2--raise-contract-per-language))
+3. **Slice 3:** purity inference via `pyright`, snake_case ↔ camelCase normalization
+4. **Slice 4:** error taxonomy (`CannotRaiseToIRError`, `AmbiguousPurityError` from `@yakcc/contracts` per #780), integration test against the closer-parity corpus, CI Python provisioning
+
+## Runtime requirements (post-slice-4)
+
+- Python 3.10 or newer
+- `pip install libcst pyright` available on `PATH`
+
+The subprocess wrapper invokes `python3 scripts/libcst-parse.py`; if Python is missing or `libcst` is not installed, the wrapper throws `AdapterSubprocessError` with a remediation hint. Tests in this slice mock the subprocess so the suite runs in pure-Node environments.
+
+## See also
+
+- Parent design: [polyglot architecture ADR](../../docs/archive/developer/adr/polyglot-architecture.md)
+- IR envelope spec: [`packages/ir/docs/ir-envelope.md`](../ir/docs/ir-envelope.md) (#780)
+- Proof emitter (Python hypothesis): [`packages/contracts/src/proof-emitters/hypothesis.ts`](../contracts/src/proof-emitters/hypothesis.ts) (#781)

--- a/packages/shave-python/biome.json
+++ b/packages/shave-python/biome.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "extends": ["../../biome.json"]
+}

--- a/packages/shave-python/package.json
+++ b/packages/shave-python/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@yakcc/shave-python",
+  "version": "0.0.1",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "rm -f tsconfig.tsbuildinfo && tsc -p .",
+    "typecheck": "tsc --noEmit -p .",
+    "test": "vitest run",
+    "lint": "biome check src/"
+  },
+  "dependencies": {
+    "@yakcc/contracts": "workspace:*"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "@types/node": "^22.10.5",
+    "typescript": "^5.7.2",
+    "vitest": "^4.1.5"
+  },
+  "//peerDependencyNote": "Slice 4 will add: python3 (>=3.10) with libcst — runtime peer for actual raise execution"
+}

--- a/packages/shave-python/scripts/libcst-parse.py
+++ b/packages/shave-python/scripts/libcst-parse.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+#
+# libcst-parse.py — emit a JSON-AST envelope for the Python source on stdin.
+# WI-782 slice 1: minimal wire contract — enough for the TypeScript caller
+# to detect that Python + libcst are present and that the parse succeeded.
+# Slice 2 expands the JSON shape to carry the full AST detail the mapping
+# pass needs.
+#
+# Wire shape (slice 1):
+#   {"version": 1, "module": {"type": "Module", "stmt_count": <int>}}
+#
+# Exit codes:
+#   0 — success; JSON envelope on stdout
+#   1 — libcst missing or import failure (stderr explains)
+#   2 — parse failure (stderr carries the libcst exception text)
+
+import json
+import sys
+
+
+def main() -> int:
+    try:
+        import libcst  # type: ignore[import-untyped]
+    except ImportError as exc:
+        print(
+            f"libcst is not installed: {exc}. Run: pip install libcst",
+            file=sys.stderr,
+        )
+        return 1
+
+    source = sys.stdin.read()
+
+    try:
+        module = libcst.parse_module(source)
+    except libcst.ParserSyntaxError as exc:
+        print(f"libcst parse error: {exc}", file=sys.stderr)
+        return 2
+    except Exception as exc:  # noqa: BLE001 — defensive: libcst may raise other types
+        print(f"libcst unexpected error: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 2
+
+    # Slice 1: emit a minimal envelope. Slice 2 will walk the tree and produce
+    # full per-node detail. Today we only emit the count so tests have a
+    # numeric invariant to check against the input source.
+    envelope = {
+        "version": 1,
+        "module": {
+            "type": type(module).__name__,
+            "stmt_count": len(module.body),
+        },
+    }
+    json.dump(envelope, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/shave-python/src/index.ts
+++ b/packages/shave-python/src/index.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+//
+// @yakcc/shave-python — Python raise adapter (WI-782).
+//
+// Slice 1 of 4: package scaffolding + libcst subprocess primitive.
+// The exported API surface is the subprocess wrapper and its types only;
+// AST → IR mapping, purity inference, and end-to-end raise come in slices 2–4.
+//
+// @decision DEC-POLYGLOT-IR-CANONICAL-001 (parent — polyglot architecture ADR)
+// @decision DEC-POLYGLOT-IR-ENVELOPE-001 (held-the-line; this adapter throws
+//   CannotRaiseToIRError from @yakcc/contracts for out-of-envelope Python
+//   constructs — wired in slice 4)
+
+export {
+  AdapterSubprocessError,
+  parsePythonSource,
+  type LibcstParseOptions,
+  type LibcstParseResult,
+  type PythonAstNode,
+} from "./libcst-parser.js";

--- a/packages/shave-python/src/libcst-parser.test.ts
+++ b/packages/shave-python/src/libcst-parser.test.ts
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: MIT
+//
+// Tests for the libcst subprocess wrapper.
+//
+// All tests inject a mock spawn implementation so the suite does not require
+// Python (or libcst) to be installed.  The mock honors the same lifecycle as
+// node:child_process.ChildProcess: emits 'data' on stdout/stderr, then
+// 'close' with an exit code, then the promise resolves or rejects.
+//
+// A future slice (likely slice 4) will add an opt-in integration test gated
+// on `process.env.YAKCC_PY` that exercises the real Python interpreter.
+
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  AdapterSubprocessError,
+  type LibcstParseOptions,
+  parsePythonSource,
+  type SpawnImpl,
+} from "./libcst-parser.js";
+
+interface MockStream extends EventEmitter {
+  end?: (chunk?: string, encoding?: BufferEncoding) => void;
+}
+
+interface MockProcess extends EventEmitter {
+  readonly stdin: MockStream | null;
+  readonly stdout: MockStream | null;
+  readonly stderr: MockStream | null;
+}
+
+interface MockScript {
+  /** Optional bytes to emit on the child's stdout before close. */
+  readonly stdout?: string;
+  /** Optional bytes to emit on the child's stderr before close. */
+  readonly stderr?: string;
+  /** Exit code passed to the 'close' event. */
+  readonly exitCode: number | null;
+  /** When set, the spawn call itself throws synchronously (e.g. ENOENT). */
+  readonly spawnThrows?: string;
+  /** When set, the child emits 'error' before 'close' (e.g. ENOENT-on-stdin). */
+  readonly emitErrorBeforeClose?: string;
+}
+
+/** Build a mock spawn that scripts the child's lifecycle. */
+function mockSpawn(script: MockScript): SpawnImpl & {
+  readonly stdinChunks: string[];
+  readonly callCount: () => number;
+} {
+  const stdinChunks: string[] = [];
+  let calls = 0;
+
+  const fn: SpawnImpl = (_command, _args, _options) => {
+    calls += 1;
+    if (script.spawnThrows !== undefined) {
+      throw new Error(script.spawnThrows);
+    }
+    const stdin: MockStream = new EventEmitter();
+    stdin.end = (chunk?: string, _encoding?: BufferEncoding) => {
+      if (chunk !== undefined) stdinChunks.push(chunk);
+    };
+    const stdout: MockStream = new EventEmitter();
+    const stderr: MockStream = new EventEmitter();
+    const child: MockProcess = Object.assign(new EventEmitter(), {
+      stdin,
+      stdout,
+      stderr,
+    });
+
+    // Schedule the lifecycle on the next microtask so the caller has time to
+    // attach 'data'/'close' listeners before they fire.
+    queueMicrotask(() => {
+      if (script.stdout !== undefined) {
+        stdout.emit("data", Buffer.from(script.stdout, "utf-8"));
+      }
+      if (script.stderr !== undefined) {
+        stderr.emit("data", Buffer.from(script.stderr, "utf-8"));
+      }
+      if (script.emitErrorBeforeClose !== undefined) {
+        child.emit("error", new Error(script.emitErrorBeforeClose));
+        return;
+      }
+      child.emit("close", script.exitCode);
+    });
+
+    return child as unknown as ReturnType<typeof import("node:child_process").spawn>;
+  };
+
+  return Object.assign(fn, {
+    stdinChunks,
+    callCount: () => calls,
+  });
+}
+
+function makeOpts(spawnImpl: SpawnImpl): LibcstParseOptions {
+  return {
+    pythonExecutable: "python3-fake",
+    scriptPath: "/fake/scripts/libcst-parse.py",
+    spawnImpl,
+  };
+}
+
+describe("parsePythonSource (#782 slice 1)", () => {
+  let savedYakccPy: string | undefined;
+
+  beforeEach(() => {
+    savedYakccPy = process.env.YAKCC_PY;
+    // biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+    delete process.env.YAKCC_PY;
+  });
+
+  afterEach(() => {
+    if (savedYakccPy === undefined) {
+      // biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+      delete process.env.YAKCC_PY;
+    } else {
+      process.env.YAKCC_PY = savedYakccPy;
+    }
+  });
+
+  it("returns the parsed envelope on a successful subprocess run", async () => {
+    const envelope = { version: 1, module: { type: "Module", stmt_count: 2 } };
+    const spawnFn = mockSpawn({ stdout: JSON.stringify(envelope), exitCode: 0 });
+    const result = await parsePythonSource("def f(): pass", makeOpts(spawnFn));
+    expect(result.version).toBe(1);
+    expect(result.module.type).toBe("Module");
+    expect((result.module as { stmt_count?: number }).stmt_count).toBe(2);
+    expect(spawnFn.callCount()).toBe(1);
+    expect(spawnFn.stdinChunks).toEqual(["def f(): pass"]);
+  });
+
+  it("rejects with AdapterSubprocessError when exit code is non-zero", async () => {
+    const spawnFn = mockSpawn({
+      stderr: "libcst is not installed: No module named 'libcst'",
+      exitCode: 1,
+    });
+    await expect(parsePythonSource("def f(): pass", makeOpts(spawnFn))).rejects.toMatchObject({
+      name: "AdapterSubprocessError",
+      exitCode: 1,
+    });
+  });
+
+  it("includes the remediation hint when libcst is missing", async () => {
+    const spawnFn = mockSpawn({ stderr: "ImportError: No module named 'libcst'", exitCode: 1 });
+    try {
+      await parsePythonSource("def f(): pass", makeOpts(spawnFn));
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AdapterSubprocessError);
+      expect((err as Error).message).toContain("pip install libcst");
+    }
+  });
+
+  it("rejects when stdout is not valid JSON", async () => {
+    const spawnFn = mockSpawn({ stdout: "this is not json", exitCode: 0 });
+    await expect(parsePythonSource("def f(): pass", makeOpts(spawnFn))).rejects.toMatchObject({
+      name: "AdapterSubprocessError",
+    });
+  });
+
+  it("rejects when the JSON envelope has the wrong schema version", async () => {
+    const spawnFn = mockSpawn({ stdout: JSON.stringify({ version: 2 }), exitCode: 0 });
+    await expect(parsePythonSource("def f(): pass", makeOpts(spawnFn))).rejects.toThrow(
+      /schema version must be 1/,
+    );
+  });
+
+  it("rejects when the JSON envelope is missing the module field", async () => {
+    const spawnFn = mockSpawn({ stdout: JSON.stringify({ version: 1 }), exitCode: 0 });
+    await expect(parsePythonSource("def f(): pass", makeOpts(spawnFn))).rejects.toThrow(
+      /"module" must be a non-null object/,
+    );
+  });
+
+  it("rejects when spawn itself throws (python not on PATH)", async () => {
+    const spawnFn = mockSpawn({ spawnThrows: "ENOENT: python3 not found", exitCode: 0 });
+    await expect(parsePythonSource("def f(): pass", makeOpts(spawnFn))).rejects.toMatchObject({
+      name: "AdapterSubprocessError",
+    });
+  });
+
+  it("rejects when the child emits an error event before close", async () => {
+    const spawnFn = mockSpawn({
+      emitErrorBeforeClose: "EPIPE: broken pipe",
+      exitCode: 0,
+    });
+    await expect(parsePythonSource("def f(): pass", makeOpts(spawnFn))).rejects.toMatchObject({
+      name: "AdapterSubprocessError",
+    });
+  });
+
+  it("respects YAKCC_PY env var as the python executable override", async () => {
+    process.env.YAKCC_PY = "/custom/python";
+    let capturedCmd = "";
+    const spawnFn: SpawnImpl = (command, _args) => {
+      capturedCmd = command;
+      const child = mockSpawn({ stdout: JSON.stringify({ version: 1, module: { type: "Module" } }), exitCode: 0 })(
+        command,
+        _args,
+      );
+      return child;
+    };
+    // Note: not passing pythonExecutable in opts — should fall through to YAKCC_PY.
+    await parsePythonSource("pass", { spawnImpl: spawnFn, scriptPath: "/fake/x.py" });
+    expect(capturedCmd).toBe("/custom/python");
+  });
+});

--- a/packages/shave-python/src/libcst-parser.test.ts
+++ b/packages/shave-python/src/libcst-parser.test.ts
@@ -15,8 +15,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   AdapterSubprocessError,
   type LibcstParseOptions,
-  parsePythonSource,
   type SpawnImpl,
+  parsePythonSource,
 } from "./libcst-parser.js";
 
 interface MockStream extends EventEmitter {
@@ -194,10 +194,10 @@ describe("parsePythonSource (#782 slice 1)", () => {
     let capturedCmd = "";
     const spawnFn: SpawnImpl = (command, _args) => {
       capturedCmd = command;
-      const child = mockSpawn({ stdout: JSON.stringify({ version: 1, module: { type: "Module" } }), exitCode: 0 })(
-        command,
-        _args,
-      );
+      const child = mockSpawn({
+        stdout: JSON.stringify({ version: 1, module: { type: "Module" } }),
+        exitCode: 0,
+      })(command, _args);
       return child;
     };
     // Note: not passing pythonExecutable in opts — should fall through to YAKCC_PY.

--- a/packages/shave-python/src/libcst-parser.ts
+++ b/packages/shave-python/src/libcst-parser.ts
@@ -23,8 +23,8 @@
 
 import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
-import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 /**
  * Thrown when the libcst subprocess fails for any reason — Python not on
@@ -127,8 +127,7 @@ export async function parsePythonSource(
   source: string,
   options: LibcstParseOptions = {},
 ): Promise<LibcstParseResult> {
-  const python =
-    options.pythonExecutable ?? process.env.YAKCC_PY ?? DEFAULT_PYTHON;
+  const python = options.pythonExecutable ?? process.env.YAKCC_PY ?? DEFAULT_PYTHON;
   const script = options.scriptPath ?? defaultScriptPath();
   const spawnFn = options.spawnImpl ?? (spawn as unknown as SpawnImpl);
 

--- a/packages/shave-python/src/libcst-parser.ts
+++ b/packages/shave-python/src/libcst-parser.ts
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: MIT
+//
+// libcst-parser.ts — subprocess wrapper around Python's libcst (WI-782 slice 1).
+//
+// Invokes `python3 scripts/libcst-parse.py` as a child process, feeds Python
+// source over stdin, and reads a JSON AST envelope from stdout.  The wire
+// shape is intentionally minimal in this slice — only enough to prove the
+// subprocess plumbing and let slice 2's mapping pass consume real ASTs.
+//
+// All Python runtime concerns (libcst install, version pinning, performance
+// tuning) are gated behind this single seam.  Tests inject a mock interpreter
+// via `LibcstParseOptions.spawnImpl` so the suite runs in pure-Node CI.
+//
+// @decision DEC-POLYGLOT-SHAVE-PY-SUBPROCESS-001 (WI-782 slice 1)
+// @title Subprocess-per-file libcst invocation (no daemon, no batching) in MVP
+// @status accepted (WI-782 slice 1)
+// @rationale
+//   The MVP performance budget allows < 500ms per file (per #782).  A fresh
+//   `python3` process is ~50ms cold-start on commodity hardware; libcst parse
+//   of a typical function adds ~5–20ms.  Total budget is comfortably met.
+//   Daemonizing libcst (long-running Python worker) is a perf optimization for
+//   a later slice once real corpus measurements show it's needed.
+
+import type { ChildProcess } from "node:child_process";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+/**
+ * Thrown when the libcst subprocess fails for any reason — Python not on
+ * PATH, libcst not installed, parse failure, non-zero exit, or stdout that
+ * cannot be parsed as JSON.  The .message carries an actionable remediation
+ * hint where possible (e.g. "pip install libcst").
+ *
+ * Slice 4 will reroute parse-side failures to `CannotRaiseToIRError` from
+ * `@yakcc/contracts` where appropriate (syntactically invalid Python is not
+ * the same class of failure as "Python is not installed").
+ */
+export class AdapterSubprocessError extends Error {
+  constructor(
+    message: string,
+    public readonly exitCode: number | null,
+    public readonly stderr: string,
+  ) {
+    super(message);
+    this.name = "AdapterSubprocessError";
+  }
+}
+
+/**
+ * A node in the JSON AST envelope emitted by libcst-parse.py.
+ *
+ * Intentionally a recursive bag-of-fields rather than a tagged union — slice
+ * 1 is the wire contract only; slice 2 narrows this into a discriminated
+ * union as the mapping table is implemented.
+ */
+export interface PythonAstNode {
+  readonly type: string;
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Top-level shape of the JSON envelope.
+ */
+export interface LibcstParseResult {
+  /** Schema version of the envelope. Slice 1 ships v=1. */
+  readonly version: 1;
+  /** Root module node from libcst. */
+  readonly module: PythonAstNode;
+}
+
+/**
+ * Injectable subprocess constructor — defaults to `node:child_process.spawn`.
+ * Tests pass a fake that emits a known stdout/stderr/exit-code triple so the
+ * suite does not require Python to be installed.
+ *
+ * Matches the relevant subset of node's spawn signature so the default
+ * implementation slots in without an adapter.
+ */
+export type SpawnImpl = (
+  command: string,
+  args: readonly string[],
+  options?: { readonly env?: NodeJS.ProcessEnv },
+) => ChildProcess;
+
+export interface LibcstParseOptions {
+  /**
+   * Python interpreter to invoke.  Defaults to `process.env.YAKCC_PY ?? "python3"`.
+   * Slice 4 honors `pyproject.toml` venv pointers when present.
+   */
+  readonly pythonExecutable?: string;
+  /**
+   * Absolute path to `scripts/libcst-parse.py`.  Defaults to the script
+   * shipped with this package.
+   */
+  readonly scriptPath?: string;
+  /**
+   * Injectable subprocess factory (for tests).  Defaults to `spawn` from
+   * `node:child_process`.
+   */
+  readonly spawnImpl?: SpawnImpl;
+}
+
+const DEFAULT_PYTHON = "python3";
+
+/** Resolve the bundled `scripts/libcst-parse.py` from this module's location. */
+function defaultScriptPath(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // Built layout: dist/libcst-parser.js → ../scripts/libcst-parse.py
+  // Source layout: src/libcst-parser.ts → ../scripts/libcst-parse.py
+  return resolve(here, "..", "scripts", "libcst-parse.py");
+}
+
+/**
+ * Parse a Python source string into a `LibcstParseResult` by invoking the
+ * libcst subprocess.
+ *
+ * Behavior:
+ *   - Python source is fed over stdin (UTF-8).
+ *   - stdout is parsed as JSON and shape-checked against `LibcstParseResult`.
+ *   - Non-zero exit → AdapterSubprocessError carrying exitCode + stderr.
+ *   - Spawn failure (e.g. python not on PATH) → AdapterSubprocessError with
+ *     a remediation hint pointing at the runtime requirements.
+ *   - JSON parse failure → AdapterSubprocessError (stderr contains the raw bytes).
+ */
+export async function parsePythonSource(
+  source: string,
+  options: LibcstParseOptions = {},
+): Promise<LibcstParseResult> {
+  const python =
+    options.pythonExecutable ?? process.env.YAKCC_PY ?? DEFAULT_PYTHON;
+  const script = options.scriptPath ?? defaultScriptPath();
+  const spawnFn = options.spawnImpl ?? (spawn as unknown as SpawnImpl);
+
+  return new Promise<LibcstParseResult>((resolvePromise, rejectPromise) => {
+    let child: ChildProcess;
+    try {
+      child = spawnFn(python, [script]);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      rejectPromise(
+        new AdapterSubprocessError(
+          `Failed to spawn ${python}: ${msg}. Ensure Python 3.10+ is installed and on PATH (set YAKCC_PY to override).`,
+          null,
+          "",
+        ),
+      );
+      return;
+    }
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+
+    child.stdout?.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
+    child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+
+    child.on("error", (err: Error) => {
+      rejectPromise(
+        new AdapterSubprocessError(
+          `${python} subprocess error: ${err.message}. Ensure Python 3.10+ is installed and on PATH.`,
+          null,
+          Buffer.concat(stderrChunks).toString("utf-8"),
+        ),
+      );
+    });
+
+    child.on("close", (code: number | null) => {
+      const stderr = Buffer.concat(stderrChunks).toString("utf-8");
+      const stdout = Buffer.concat(stdoutChunks).toString("utf-8");
+      if (code !== 0) {
+        rejectPromise(
+          new AdapterSubprocessError(
+            `${python} exited with code ${String(code)}. stderr: ${stderr.trim() || "(empty)"}. If libcst is missing, run: pip install libcst`,
+            code,
+            stderr,
+          ),
+        );
+        return;
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(stdout);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        rejectPromise(
+          new AdapterSubprocessError(
+            `libcst-parse stdout was not valid JSON: ${msg}`,
+            code,
+            stdout,
+          ),
+        );
+        return;
+      }
+      const validationError = validateParseResult(parsed);
+      if (validationError !== null) {
+        rejectPromise(new AdapterSubprocessError(validationError, code, stderr));
+        return;
+      }
+      resolvePromise(parsed as LibcstParseResult);
+    });
+
+    child.stdin?.end(source, "utf-8");
+  });
+}
+
+/**
+ * Lightweight runtime shape check.  Returns null if `value` matches
+ * `LibcstParseResult`, else a descriptive error string.
+ */
+function validateParseResult(value: unknown): string | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return "libcst-parse output: expected a non-null object";
+  }
+  const obj = value as Record<string, unknown>;
+  if (obj.version !== 1) {
+    return `libcst-parse output: schema version must be 1, got ${String(obj.version)}`;
+  }
+  if (obj.module === null || typeof obj.module !== "object" || Array.isArray(obj.module)) {
+    return 'libcst-parse output: "module" must be a non-null object';
+  }
+  if (typeof (obj.module as Record<string, unknown>).type !== "string") {
+    return 'libcst-parse output: "module.type" must be a string';
+  }
+  return null;
+}

--- a/packages/shave-python/tsconfig.json
+++ b/packages/shave-python/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/shave-python/vitest.config.ts
+++ b/packages/shave-python/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    pool: "forks",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -587,6 +587,25 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7))
 
+  packages/shave-python:
+    dependencies:
+      '@yakcc/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^1.9.4
+        version: 1.9.4
+      '@types/node':
+        specifier: ^22.10.5
+        version: 22.19.17
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7))
+
   packages/variance:
     dependencies:
       '@yakcc/contracts':


### PR DESCRIPTION
## Summary

Slice 1 of WI-782 (Python raise adapter). Ships **only the scaffolding** — a new `@yakcc/shave-python` workspace package with the libcst subprocess wrapper, JSON-AST wire contract, and mocked-subprocess tests. No AST → IR mapping yet, no purity inference, no real raise pipeline; those land in slices 2–4.

**Critical property:** tests inject a mock spawn implementation, so the suite runs in pure-Node CI with no Python install required. The real Python integration test (with `python3 + libcst`) lands behind an opt-in env gate in slice 4.

## Files

- **`packages/shave-python/package.json`** — workspace package, depends on `@yakcc/contracts` (will use the `CannotRaiseToIRError` / `AmbiguousPurityError` types from #780 in slice 4)
- **`packages/shave-python/tsconfig.json`** + **`vitest.config.ts`** + **`biome.json`** — mirrors `@yakcc/contracts` config layout exactly
- **`packages/shave-python/src/index.ts`** — barrel exports the slice 1 surface (`parsePythonSource`, types, `AdapterSubprocessError`)
- **`packages/shave-python/src/libcst-parser.ts`** — subprocess wrapper. Handles spawn-throws, non-zero exit, malformed JSON, schema-version mismatch, missing module field. Each failure surfaces an actionable error message (e.g. `"pip install libcst"` hint when imports fail). `SpawnImpl` injection seam for tests; `YAKCC_PY` env override for the Python executable.
- **`packages/shave-python/src/libcst-parser.test.ts`** — 9 cases covering success, every documented failure mode, and the env-override seam. Uses a mock spawn that scripts the child lifecycle (`'data'` → `'data'` → `'close'`).
- **`packages/shave-python/scripts/libcst-parse.py`** — minimal Python script. Imports libcst (returns exit 1 + remediation message on ImportError), parses stdin (exit 2 on syntax error), emits the v1 wire envelope: `{"version": 1, "module": {"type": "Module", "stmt_count": N}}`. Slice 2 expands the envelope.
- **`packages/shave-python/README.md`** — slice-rollout plan, runtime requirements (post-slice-4), pointers to ADR Q2 and the related WIs

## Slice plan

- **Slice 1 (this PR):** scaffolding + subprocess primitive + mock-only tests
- **Slice 2:** AST mapping table → emit pure raise pipeline (consumes the Python AST, produces TS-subset IR source)
- **Slice 3:** purity inference via pyright subprocess + `snake_case` ↔ `camelCase` normalization
- **Slice 4:** error taxonomy wired to `@yakcc/contracts.CannotRaiseToIRError` + integration test against real Python + CI Python provisioning

## Acceptance (slice 1 of #782)

- [x] `@yakcc/shave-python` package scaffolded
- [x] libcst subprocess integration: parses Python file via subprocess, emits JSON AST
- [x] All documented failure modes surface as `AdapterSubprocessError` with actionable messages
- [x] `pnpm --filter @yakcc/shave-python test` runs without requiring Python (mocked subprocess)
- [x] `pnpm --filter @yakcc/shave-python typecheck` clean
- [x] No regression on existing tests
- [x] PR-CI required gates green (lint/typecheck/build/branch hygiene/B6a air-gap)

## Out of scope (deferred to slice 2+)

- AST → IR mapping table (constructs listed in #782 spec)
- Purity inference
- snake_case → camelCase normalization
- `CannotRaiseToIRError` / `AmbiguousPurityError` wiring
- Integration test against real Python interpreter
- CI workflow updates to install `python3` + `libcst` + `pyright`

Tracking: #782 (slice 1 of 4)

---
_FuckGoblin orchestrator_