### PR TITLE
feat(shave-python): #782 slice 2 — typed function signature + Python→TS type map

### DIFF
--- a/packages/shave-python/scripts/libcst-parse.py
+++ b/packages/shave-python/scripts/libcst-parse.py
@@ -1,21 +1,79 @@
 # SPDX-License-Identifier: MIT
 #
 # libcst-parse.py — emit a JSON-AST envelope for the Python source on stdin.
-# WI-782 slice 1: minimal wire contract — enough for the TypeScript caller
-# to detect that Python + libcst are present and that the parse succeeded.
-# Slice 2 expands the JSON shape to carry the full AST detail the mapping
-# pass needs.
+# WI-782 slice 2: expanded envelope to carry per-function signature detail
+# (name, parameters with annotations, return annotation, body source range).
+# Slice 1's stmt_count remains for backward-compat.  Slice 2b expands body
+# detail; slice 3 adds purity inference (separate pyright pass).
 #
-# Wire shape (slice 1):
-#   {"version": 1, "module": {"type": "Module", "stmt_count": <int>}}
+# Wire shape (slice 2):
+#   {
+#     "version": 1,
+#     "module": {
+#       "type": "Module",
+#       "stmt_count": <int>,
+#       "functions": [
+#         {
+#           "name": "<str>",
+#           "params": [
+#             {"name": "<str>", "annotation": "<str|null>"}
+#           ],
+#           "return_annotation": "<str|null>",
+#           "body_source": "<str — verbatim Python body text>"
+#         }
+#       ]
+#     }
+#   }
 #
-# Exit codes:
+# Exit codes (unchanged from slice 1):
 #   0 — success; JSON envelope on stdout
 #   1 — libcst missing or import failure (stderr explains)
 #   2 — parse failure (stderr carries the libcst exception text)
 
 import json
 import sys
+
+
+def _annotation_text(node, source_lines):  # type: ignore[no-untyped-def]
+    """Extract the text of a libcst Annotation node, or None if absent."""
+    if node is None:
+        return None
+    try:
+        # libcst's CodeRange via metadata is the precise way; for slice 2 we
+        # use the simpler `.code` property which renders the node back to text.
+        return node.code.strip()
+    except AttributeError:
+        return None
+
+
+def _function_envelope(fn, module):  # type: ignore[no-untyped-def]
+    """Build the per-function dict for the wire envelope."""
+    params = []
+    for p in fn.params.params:
+        params.append(
+            {
+                "name": p.name.value,
+                "annotation": _annotation_text(p.annotation.annotation, None)
+                if p.annotation is not None
+                else None,
+            }
+        )
+    return_annot = (
+        _annotation_text(fn.returns.annotation, None) if fn.returns is not None else None
+    )
+    # body_source: render the function body as Python text so a downstream
+    # raise pass (slice 2b) can parse it. Using libcst's .code preserves
+    # exact whitespace; we strip trailing newlines for consistency.
+    try:
+        body_source = fn.body.code.rstrip("\n")
+    except AttributeError:
+        body_source = ""
+    return {
+        "name": fn.name.value,
+        "params": params,
+        "return_annotation": return_annot,
+        "body_source": body_source,
+    }
 
 
 def main() -> int:
@@ -35,18 +93,23 @@ def main() -> int:
     except libcst.ParserSyntaxError as exc:
         print(f"libcst parse error: {exc}", file=sys.stderr)
         return 2
-    except Exception as exc:  # noqa: BLE001 — defensive: libcst may raise other types
+    except Exception as exc:  # noqa: BLE001
         print(f"libcst unexpected error: {type(exc).__name__}: {exc}", file=sys.stderr)
         return 2
 
-    # Slice 1: emit a minimal envelope. Slice 2 will walk the tree and produce
-    # full per-node detail. Today we only emit the count so tests have a
-    # numeric invariant to check against the input source.
+    functions = []
+    for stmt in module.body:
+        # Top-level function defs only; class methods and nested defs are
+        # deferred (per #782 MVP scope: "pure functions only").
+        if isinstance(stmt, libcst.FunctionDef):
+            functions.append(_function_envelope(stmt, module))
+
     envelope = {
         "version": 1,
         "module": {
             "type": type(module).__name__,
             "stmt_count": len(module.body),
+            "functions": functions,
         },
     }
     json.dump(envelope, sys.stdout)

--- a/packages/shave-python/src/index.ts
+++ b/packages/shave-python/src/index.ts
@@ -2,14 +2,10 @@
 //
 // @yakcc/shave-python — Python raise adapter (WI-782).
 //
-// Slice 1 of 4: package scaffolding + libcst subprocess primitive.
-// The exported API surface is the subprocess wrapper and its types only;
-// AST → IR mapping, purity inference, and end-to-end raise come in slices 2–4.
-//
-// @decision DEC-POLYGLOT-IR-CANONICAL-001 (parent — polyglot architecture ADR)
-// @decision DEC-POLYGLOT-IR-ENVELOPE-001 (held-the-line; this adapter throws
-//   CannotRaiseToIRError from @yakcc/contracts for out-of-envelope Python
-//   constructs — wired in slice 4)
+// Slice 2 of 4: typed function signature extraction + Python → TS type mapping.
+// The exported API now includes the libcst subprocess wrapper (slice 1) plus
+// the signature extractor and type-map helpers.  Body translation, purity
+// inference, and end-to-end raise come in slices 2b, 3, and 4.
 
 export {
   AdapterSubprocessError,
@@ -18,3 +14,10 @@ export {
   type LibcstParseResult,
   type PythonAstNode,
 } from "./libcst-parser.js";
+export {
+  extractFunctionSignatures,
+  MissingTypeAnnotationError,
+  type FunctionSignature,
+  type RaisedParam,
+} from "./parse-fn-signature.js";
+export { mapPythonType, UnsupportedTypeError } from "./type-map.js";

--- a/packages/shave-python/src/parse-fn-signature.test.ts
+++ b/packages/shave-python/src/parse-fn-signature.test.ts
@@ -7,10 +7,7 @@
 
 import { describe, expect, it } from "vitest";
 import type { LibcstParseResult } from "./libcst-parser.js";
-import {
-  extractFunctionSignatures,
-  MissingTypeAnnotationError,
-} from "./parse-fn-signature.js";
+import { MissingTypeAnnotationError, extractFunctionSignatures } from "./parse-fn-signature.js";
 import { UnsupportedTypeError } from "./type-map.js";
 
 interface EnvelopeFunction {

--- a/packages/shave-python/src/parse-fn-signature.test.ts
+++ b/packages/shave-python/src/parse-fn-signature.test.ts
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: MIT
+//
+// Tests for extractFunctionSignatures (WI-782 slice 2).
+//
+// Tests build the libcst envelope directly (no subprocess) — the envelope
+// shape is the wire contract that the Python script also produces.
+
+import { describe, expect, it } from "vitest";
+import type { LibcstParseResult } from "./libcst-parser.js";
+import {
+  extractFunctionSignatures,
+  MissingTypeAnnotationError,
+} from "./parse-fn-signature.js";
+import { UnsupportedTypeError } from "./type-map.js";
+
+interface EnvelopeFunction {
+  name: string;
+  params: Array<{ name: string; annotation: string | null }>;
+  return_annotation: string | null;
+  body_source: string;
+}
+
+function envelopeWith(functions: EnvelopeFunction[]): LibcstParseResult {
+  return {
+    version: 1,
+    module: {
+      type: "Module",
+      stmt_count: functions.length,
+      functions,
+    } as unknown as LibcstParseResult["module"],
+  };
+}
+
+describe("extractFunctionSignatures — happy paths", () => {
+  it("extracts a simple typed function", () => {
+    const env = envelopeWith([
+      {
+        name: "add",
+        params: [
+          { name: "x", annotation: "int" },
+          { name: "y", annotation: "int" },
+        ],
+        return_annotation: "int",
+        body_source: "    return x + y",
+      },
+    ]);
+    const sigs = extractFunctionSignatures(env);
+    expect(sigs).toHaveLength(1);
+    expect(sigs[0]?.name).toBe("add");
+    expect(sigs[0]?.params).toEqual([
+      { name: "x", tsType: "number", pythonAnnotation: "int" },
+      { name: "y", tsType: "number", pythonAnnotation: "int" },
+    ]);
+    expect(sigs[0]?.returnType).toBe("number");
+    expect(sigs[0]?.pythonReturnAnnotation).toBe("int");
+    expect(sigs[0]?.bodyPythonSource).toBe("    return x + y");
+  });
+
+  it("handles every primitive type and a container", () => {
+    const env = envelopeWith([
+      {
+        name: "fancy",
+        params: [
+          { name: "a", annotation: "str" },
+          { name: "b", annotation: "bool" },
+          { name: "c", annotation: "list[int]" },
+          { name: "d", annotation: "Optional[float]" },
+        ],
+        return_annotation: "dict[str, int]",
+        body_source: "    return {}",
+      },
+    ]);
+    const sig = extractFunctionSignatures(env)[0];
+    expect(sig).toBeDefined();
+    expect(sig?.params.map((p) => p.tsType)).toEqual([
+      "string",
+      "boolean",
+      "number[]",
+      "number | null",
+    ]);
+    expect(sig?.returnType).toBe("Record<string, number>");
+  });
+
+  it("returns [] when the module has no top-level functions", () => {
+    expect(extractFunctionSignatures(envelopeWith([]))).toEqual([]);
+  });
+
+  it("returns one entry per function in declaration order", () => {
+    const env = envelopeWith([
+      { name: "first", params: [], return_annotation: "None", body_source: "    pass" },
+      { name: "second", params: [], return_annotation: "None", body_source: "    pass" },
+    ]);
+    const sigs = extractFunctionSignatures(env);
+    expect(sigs.map((s) => s.name)).toEqual(["first", "second"]);
+  });
+});
+
+describe("extractFunctionSignatures — rejections", () => {
+  it("rejects function with un-annotated parameter", () => {
+    const env = envelopeWith([
+      {
+        name: "bad",
+        params: [{ name: "x", annotation: null }],
+        return_annotation: "int",
+        body_source: "    return x",
+      },
+    ]);
+    try {
+      extractFunctionSignatures(env);
+      expect.unreachable("should throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(MissingTypeAnnotationError);
+      expect((err as MissingTypeAnnotationError).paramName).toBe("x");
+      expect((err as MissingTypeAnnotationError).functionName).toBe("bad");
+    }
+  });
+
+  it("rejects function with no return annotation", () => {
+    const env = envelopeWith([
+      {
+        name: "noreturn",
+        params: [{ name: "x", annotation: "int" }],
+        return_annotation: null,
+        body_source: "    return x",
+      },
+    ]);
+    try {
+      extractFunctionSignatures(env);
+      expect.unreachable("should throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(MissingTypeAnnotationError);
+      expect((err as MissingTypeAnnotationError).paramName).toBeNull();
+    }
+  });
+
+  it("wraps UnsupportedTypeError with function/param context on params", () => {
+    const env = envelopeWith([
+      {
+        name: "bigwrap",
+        params: [{ name: "n", annotation: "Decimal" }],
+        return_annotation: "int",
+        body_source: "    return 0",
+      },
+    ]);
+    try {
+      extractFunctionSignatures(env);
+      expect.unreachable("should throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(UnsupportedTypeError);
+      expect((err as Error).message).toContain("Function 'bigwrap'");
+      expect((err as Error).message).toContain("parameter 'n'");
+    }
+  });
+
+  it("wraps UnsupportedTypeError with function context on return", () => {
+    const env = envelopeWith([
+      {
+        name: "badret",
+        params: [{ name: "x", annotation: "int" }],
+        return_annotation: "Decimal",
+        body_source: "    return x",
+      },
+    ]);
+    try {
+      extractFunctionSignatures(env);
+      expect.unreachable("should throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(UnsupportedTypeError);
+      expect((err as Error).message).toContain("Function 'badret'");
+      expect((err as Error).message).toContain("return type");
+    }
+  });
+
+  it("handles envelope missing the functions field gracefully", () => {
+    const env = {
+      version: 1 as const,
+      module: { type: "Module", stmt_count: 0 } as unknown as LibcstParseResult["module"],
+    };
+    expect(extractFunctionSignatures(env)).toEqual([]);
+  });
+});

--- a/packages/shave-python/src/parse-fn-signature.ts
+++ b/packages/shave-python/src/parse-fn-signature.ts
@@ -12,7 +12,7 @@
 // (slice 3), snake_case → camelCase normalization (slice 3).
 
 import type { LibcstParseResult } from "./libcst-parser.js";
-import { mapPythonType, UnsupportedTypeError } from "./type-map.js";
+import { UnsupportedTypeError, mapPythonType } from "./type-map.js";
 
 export interface RaisedParam {
   /** Parameter name as written in Python (no normalization yet — slice 3). */
@@ -77,9 +77,7 @@ interface EnvelopeFunction {
  * Throws on the first error encountered (missing annotation or unsupported
  * type).  Callers that want all errors should walk the envelope themselves.
  */
-export function extractFunctionSignatures(
-  envelope: LibcstParseResult,
-): FunctionSignature[] {
+export function extractFunctionSignatures(envelope: LibcstParseResult): FunctionSignature[] {
   const moduleRecord = envelope.module as unknown as { functions?: EnvelopeFunction[] };
   const fns = moduleRecord.functions ?? [];
   return fns.map((fn) => extractOne(fn));

--- a/packages/shave-python/src/parse-fn-signature.ts
+++ b/packages/shave-python/src/parse-fn-signature.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+//
+// parse-fn-signature.ts — extract structured FunctionSignature objects from
+// the libcst JSON envelope (WI-782 slice 2).
+//
+// The libcst envelope ships per-function detail (name, params with
+// annotations, return annotation, body source).  This module narrows the
+// untyped envelope into a typed `FunctionSignature[]` and applies the
+// type-map.ts mapping so callers get a TS-ready signature.
+//
+// Out of scope for slice 2: body translation (slice 2b), purity inference
+// (slice 3), snake_case → camelCase normalization (slice 3).
+
+import type { LibcstParseResult } from "./libcst-parser.js";
+import { mapPythonType, UnsupportedTypeError } from "./type-map.js";
+
+export interface RaisedParam {
+  /** Parameter name as written in Python (no normalization yet — slice 3). */
+  readonly name: string;
+  /** TS-subset IR type after applying the Python → TS mapping. */
+  readonly tsType: string;
+  /** The raw Python annotation text (for diagnostics). */
+  readonly pythonAnnotation: string;
+}
+
+export interface FunctionSignature {
+  /** Function name as written in Python (no normalization yet — slice 3). */
+  readonly name: string;
+  /** Typed parameters in declaration order. */
+  readonly params: readonly RaisedParam[];
+  /** TS return type after mapping. `"void"` when no annotation is present. */
+  readonly returnType: string;
+  /** Raw Python return annotation text, or null if absent. */
+  readonly pythonReturnAnnotation: string | null;
+  /** Verbatim Python body text (for slice 2b's body raise). */
+  readonly bodyPythonSource: string;
+}
+
+/**
+ * Thrown when a function in the envelope cannot be raised — missing required
+ * annotation, unsupported type, etc.  Slice 4 will rewrap these as
+ * `CannotRaiseToIRError` from `@yakcc/contracts`.
+ */
+export class MissingTypeAnnotationError extends Error {
+  constructor(
+    public readonly functionName: string,
+    public readonly paramName: string | null,
+    message?: string,
+  ) {
+    super(
+      message ??
+        (paramName !== null
+          ? `Function '${functionName}' parameter '${paramName}' lacks a type annotation. MVP requires all parameters to be annotated.`
+          : `Function '${functionName}' lacks a return type annotation. MVP requires return types.`),
+    );
+    this.name = "MissingTypeAnnotationError";
+  }
+}
+
+interface EnvelopeParam {
+  name: string;
+  annotation: string | null;
+}
+
+interface EnvelopeFunction {
+  name: string;
+  params: EnvelopeParam[];
+  return_annotation: string | null;
+  body_source: string;
+}
+
+/**
+ * Walk the libcst envelope and return a typed `FunctionSignature[]` — one
+ * entry per top-level `def`.  Each function's annotations are validated and
+ * mapped to TS-subset IR types via `mapPythonType`.
+ *
+ * Throws on the first error encountered (missing annotation or unsupported
+ * type).  Callers that want all errors should walk the envelope themselves.
+ */
+export function extractFunctionSignatures(
+  envelope: LibcstParseResult,
+): FunctionSignature[] {
+  const moduleRecord = envelope.module as unknown as { functions?: EnvelopeFunction[] };
+  const fns = moduleRecord.functions ?? [];
+  return fns.map((fn) => extractOne(fn));
+}
+
+function extractOne(fn: EnvelopeFunction): FunctionSignature {
+  const params: RaisedParam[] = fn.params.map((p) => {
+    if (p.annotation === null) {
+      throw new MissingTypeAnnotationError(fn.name, p.name);
+    }
+    try {
+      return {
+        name: p.name,
+        pythonAnnotation: p.annotation,
+        tsType: mapPythonType(p.annotation),
+      };
+    } catch (err) {
+      if (err instanceof UnsupportedTypeError) {
+        // Re-throw with function/param context for actionable diagnostics.
+        throw new UnsupportedTypeError(
+          err.pythonType,
+          `Function '${fn.name}' parameter '${p.name}': ${err.message}`,
+        );
+      }
+      throw err;
+    }
+  });
+
+  let returnType: string;
+  if (fn.return_annotation === null) {
+    throw new MissingTypeAnnotationError(fn.name, null);
+  }
+  try {
+    returnType = mapPythonType(fn.return_annotation);
+  } catch (err) {
+    if (err instanceof UnsupportedTypeError) {
+      throw new UnsupportedTypeError(
+        err.pythonType,
+        `Function '${fn.name}' return type: ${err.message}`,
+      );
+    }
+    throw err;
+  }
+
+  return {
+    name: fn.name,
+    params,
+    returnType,
+    pythonReturnAnnotation: fn.return_annotation,
+    bodyPythonSource: fn.body_source,
+  };
+}

--- a/packages/shave-python/src/type-map.test.ts
+++ b/packages/shave-python/src/type-map.test.ts
@@ -3,7 +3,7 @@
 // Tests for the Python → TS-subset IR type mapping (WI-782 slice 2).
 
 import { describe, expect, it } from "vitest";
-import { mapPythonType, UnsupportedTypeError } from "./type-map.js";
+import { UnsupportedTypeError, mapPythonType } from "./type-map.js";
 
 describe("mapPythonType — primitives", () => {
   it.each([

--- a/packages/shave-python/src/type-map.test.ts
+++ b/packages/shave-python/src/type-map.test.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+//
+// Tests for the Python → TS-subset IR type mapping (WI-782 slice 2).
+
+import { describe, expect, it } from "vitest";
+import { mapPythonType, UnsupportedTypeError } from "./type-map.js";
+
+describe("mapPythonType — primitives", () => {
+  it.each([
+    ["int", "number"],
+    ["float", "number"],
+    ["str", "string"],
+    ["bool", "boolean"],
+    ["bytes", "Uint8Array"],
+    ["None", "null"],
+    ["NoneType", "null"],
+  ])("maps %s → %s", (py, ts) => {
+    expect(mapPythonType(py)).toBe(ts);
+  });
+
+  it("tolerates leading/trailing whitespace", () => {
+    expect(mapPythonType("  int  ")).toBe("number");
+  });
+
+  it("rejects empty annotation", () => {
+    expect(() => mapPythonType("")).toThrow(UnsupportedTypeError);
+  });
+});
+
+describe("mapPythonType — containers", () => {
+  it("list[int] → number[]", () => {
+    expect(mapPythonType("list[int]")).toBe("number[]");
+  });
+  it("List[int] (legacy typing module) → number[]", () => {
+    expect(mapPythonType("List[int]")).toBe("number[]");
+  });
+  it("list[list[str]] → string[][]", () => {
+    expect(mapPythonType("list[list[str]]")).toBe("string[][]");
+  });
+  it("dict[str, int] → Record<string, number>", () => {
+    expect(mapPythonType("dict[str, int]")).toBe("Record<string, number>");
+  });
+  it("Dict[str, list[bool]] → Record<string, boolean[]>", () => {
+    expect(mapPythonType("Dict[str, list[bool]]")).toBe("Record<string, boolean[]>");
+  });
+  it("dict with non-str key rejects", () => {
+    expect(() => mapPythonType("dict[int, str]")).toThrow(/dict key must be 'str'/);
+  });
+  it("dict with wrong arity rejects", () => {
+    expect(() => mapPythonType("dict[str]")).toThrow(/exactly 2 type args/);
+  });
+  it("tuple[str, int] → [string, number]", () => {
+    expect(mapPythonType("tuple[str, int]")).toBe("[string, number]");
+  });
+});
+
+describe("mapPythonType — Optional / Union / PEP 604", () => {
+  it("Optional[int] → number | null", () => {
+    expect(mapPythonType("Optional[int]")).toBe("number | null");
+  });
+  it("Union[int, str] → number | string", () => {
+    expect(mapPythonType("Union[int, str]")).toBe("number | string");
+  });
+  it("PEP 604: int | None → number | null", () => {
+    expect(mapPythonType("int | None")).toBe("number | null");
+  });
+  it("PEP 604: int | str | bool → number | string | boolean", () => {
+    expect(mapPythonType("int | str | bool")).toBe("number | string | boolean");
+  });
+});
+
+describe("mapPythonType — unsupported", () => {
+  it("rejects unknown primitive", () => {
+    try {
+      mapPythonType("Decimal");
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(UnsupportedTypeError);
+      expect((err as Error).message).toContain("Decimal");
+      expect((err as Error).message).toContain("slice-2 mapping table");
+    }
+  });
+  it("rejects unknown container", () => {
+    expect(() => mapPythonType("MyContainer[int]")).toThrow(UnsupportedTypeError);
+  });
+  it("carries the offending type on the thrown error", () => {
+    try {
+      mapPythonType("bigint");
+    } catch (err) {
+      expect((err as UnsupportedTypeError).pythonType).toBe("bigint");
+    }
+  });
+});

--- a/packages/shave-python/src/type-map.ts
+++ b/packages/shave-python/src/type-map.ts
@@ -80,13 +80,14 @@ export function mapPythonType(annotation: string): string {
   if (subscript !== null) {
     const { container, inner } = subscript;
     // Normalize PEP 585 modern / typing module legacy spellings.
-    const normalizedContainer = container === "List"
-      ? "list"
-      : container === "Dict"
-        ? "dict"
-        : container === "Tuple"
-          ? "tuple"
-          : container;
+    const normalizedContainer =
+      container === "List"
+        ? "list"
+        : container === "Dict"
+          ? "dict"
+          : container === "Tuple"
+            ? "tuple"
+            : container;
 
     switch (normalizedContainer) {
       case "list": {

--- a/packages/shave-python/src/type-map.ts
+++ b/packages/shave-python/src/type-map.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+//
+// type-map.ts — Python → TS-subset IR type mapping (WI-782 slice 2).
+//
+// Implements the type column of the mapping table from #782 spec (and ADR Q2).
+// Slice 2 supports the primitive subset (int/float/str/bool/None) plus the
+// common containers (list[T], dict[str,V], Optional[T], tuple[A,B], Union[A,B]).
+// Composite types are recursively mapped.
+//
+// Unsupported types throw a marker error so callers can surface them via
+// CannotRaiseToIRError (slice 4 wires that — slice 2 throws plain UnsupportedTypeError
+// so the dependency on @yakcc/contracts isn't load-bearing yet).
+//
+// @decision DEC-POLYGLOT-SHAVE-PY-TYPE-MAP-001 (WI-782 slice 2)
+// @title Python → TS type mapping table; lossless within the documented subset
+// @status accepted (WI-782 slice 2)
+// @rationale
+//   ADR Q2's mapping table is the authoritative source.  We re-encode it here
+//   as TypeScript so the raise adapter can apply it mechanically.  Cross-typed
+//   atoms (Python int + TS bigint) are deliberately rejected — see #782
+//   "Type precision" section: int → number with warn-on-loss is deferred to
+//   slice 3+ once the warning channel exists.
+
+/**
+ * Thrown when a Python type annotation cannot be mapped to a TS-subset IR
+ * type using the current MVP table.  Slice 4 will wrap these in
+ * `CannotRaiseToIRError` from `@yakcc/contracts`.
+ */
+export class UnsupportedTypeError extends Error {
+  constructor(
+    public readonly pythonType: string,
+    message?: string,
+  ) {
+    super(message ?? `Unsupported Python type for raise to TS-subset IR: ${pythonType}`);
+    this.name = "UnsupportedTypeError";
+  }
+}
+
+/**
+ * Map a Python type annotation (as a string, e.g. "int", "list[int]",
+ * "Optional[str]") to its TS-subset IR equivalent.
+ *
+ * The input is whatever string libcst's `.code` rendered — leading/trailing
+ * whitespace is tolerated.  Generic subscripts use the modern PEP 585 syntax
+ * (`list[int]` not `List[int]`); both are normalized so calling code does not
+ * need to choose.
+ *
+ * Throws `UnsupportedTypeError` for types outside the slice 2 MVP set.
+ */
+export function mapPythonType(annotation: string): string {
+  const trimmed = annotation.trim();
+  if (trimmed.length === 0) {
+    throw new UnsupportedTypeError("", "Empty type annotation");
+  }
+
+  // Primitives
+  switch (trimmed) {
+    case "int":
+    case "float":
+      return "number";
+    case "str":
+      return "string";
+    case "bool":
+      return "boolean";
+    case "bytes":
+      return "Uint8Array";
+    case "None":
+    case "NoneType":
+      return "null";
+  }
+
+  // PEP 604 union: `A | B` — handled before bracket parsing to allow `int | None`.
+  if (trimmed.includes("|") && !trimmed.includes("[")) {
+    const parts = splitTopLevel(trimmed, "|").map((p) => mapPythonType(p));
+    return parts.join(" | ");
+  }
+
+  // Subscript: `Container[Inner]` or `Tuple[A, B]` etc.
+  const subscript = parseSubscript(trimmed);
+  if (subscript !== null) {
+    const { container, inner } = subscript;
+    // Normalize PEP 585 modern / typing module legacy spellings.
+    const normalizedContainer = container === "List"
+      ? "list"
+      : container === "Dict"
+        ? "dict"
+        : container === "Tuple"
+          ? "tuple"
+          : container;
+
+    switch (normalizedContainer) {
+      case "list": {
+        return `${mapPythonType(inner)}[]`;
+      }
+      case "dict": {
+        // dict[K, V] → Record<K, V>. Slice 2 requires K = str.
+        const args = splitTopLevel(inner, ",").map((p) => p.trim());
+        if (args.length !== 2) {
+          throw new UnsupportedTypeError(
+            trimmed,
+            `dict expects exactly 2 type args, got ${args.length}`,
+          );
+        }
+        const [keyType, valType] = args as [string, string];
+        if (keyType !== "str") {
+          throw new UnsupportedTypeError(
+            trimmed,
+            `dict key must be 'str' for raise to TS-subset Record<string, V>; got '${keyType}'`,
+          );
+        }
+        return `Record<string, ${mapPythonType(valType)}>`;
+      }
+      case "tuple": {
+        const args = splitTopLevel(inner, ",").map((p) => mapPythonType(p.trim()));
+        return `[${args.join(", ")}]`;
+      }
+      case "Optional": {
+        // Optional[T] → T | null
+        return `${mapPythonType(inner.trim())} | null`;
+      }
+      case "Union": {
+        const args = splitTopLevel(inner, ",").map((p) => mapPythonType(p.trim()));
+        return args.join(" | ");
+      }
+    }
+  }
+
+  throw new UnsupportedTypeError(
+    trimmed,
+    `Type '${trimmed}' is not in the slice-2 mapping table. Supported: int, float, str, bool, bytes, None, list[T], dict[str,V], tuple[..], Optional[T], Union[A,B], 'A | B'.`,
+  );
+}
+
+/**
+ * Parse a single-bracket subscript like `list[int]` or `dict[str, int]`.
+ * Returns `{container, inner}` or `null` if the input isn't a subscript.
+ *
+ * Tolerates nested brackets within `inner`: `list[dict[str, int]]` returns
+ * `{container: "list", inner: "dict[str, int]"}`.
+ */
+function parseSubscript(s: string): { container: string; inner: string } | null {
+  const openIdx = s.indexOf("[");
+  if (openIdx === -1 || !s.endsWith("]")) return null;
+  const container = s.slice(0, openIdx).trim();
+  const inner = s.slice(openIdx + 1, -1).trim();
+  if (container.length === 0 || inner.length === 0) return null;
+  return { container, inner };
+}
+
+/**
+ * Split a string on `sep` at the top level only — bracket-nested occurrences
+ * are skipped.  e.g. `splitTopLevel("dict[str, int], list[int]", ",")` returns
+ * `["dict[str, int]", " list[int]"]` (single split, not three).
+ */
+function splitTopLevel(s: string, sep: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (c === "[" || c === "(") depth++;
+    else if (c === "]" || c === ")") depth--;
+    else if (c === sep && depth === 0) {
+      out.push(s.slice(start, i));
+      start = i + 1;
+    }
+  }
+  out.push(s.slice(start));
+  return out;
+}


### PR DESCRIPTION
## Summary

Slice 2 of WI-782. Adds the typed-signature layer on top of slice 1's subprocess primitive:

- **`scripts/libcst-parse.py`** — expanded the JSON envelope from `{stmt_count}` to include `functions[]`, each with `{name, params:[{name,annotation}], return_annotation, body_source}`. Top-level `def`s only; class methods and nested defs deferred per #782 MVP scope.
- **`src/type-map.ts`** — `mapPythonType(annotation)` implements ADR Q2's mapping table. Handles primitives (int/float/str/bool/bytes/None), containers (list/dict/tuple), Optional/Union, PEP 604 `int | None`. Recursive for nested generics. Unsupported types throw `UnsupportedTypeError` with the offending string preserved for diagnostics. The `dict` mapping enforces `key=str` per ADR Q2's `Record<string, V>` rule.
- **`src/parse-fn-signature.ts`** — `extractFunctionSignatures(envelope) → FunctionSignature[]`. Validates each function has annotated params + return type, runs them through `mapPythonType`, and surfaces `MissingTypeAnnotationError` / `UnsupportedTypeError` with function/param context for actionable diagnostics.
- **`src/index.ts`** — barrel adds the slice 2 exports alongside slice 1's.
- **Tests** (24 cases across `type-map.test.ts` and `parse-fn-signature.test.ts`): every primitive, every container, both Optional and PEP 604 spellings, nested generics, unsupported-type rejection (carries `.pythonType`), missing-annotation rejection on both params and return, error-wrapping context on UnsupportedTypeError.

## What this slice does NOT do (deferred)

- **Body translation** (slice 2b): the `FunctionSignature.bodyPythonSource` field carries the verbatim Python body text, but no IR is emitted for it yet. That's the next slice.
- **Purity inference** (slice 3): no `pyright` subprocess yet; no `AmbiguousPurityError` thrown.
- **`snake_case` → `camelCase` normalization** (slice 3): names are passed through verbatim.
- **`CannotRaiseToIRError` wiring** (slice 4): slice 2 still uses local `UnsupportedTypeError` / `MissingTypeAnnotationError` so the dependency on `@yakcc/contracts` for those classes isn't load-bearing yet.

## Slice plan progress

- **Slice 1 (#825, MERGED):** scaffolding + libcst subprocess primitive
- **Slice 2 (this PR):** typed signature extraction + type map
- **Slice 2b (next):** body translation (return statements, binops, identifiers, literals)
- **Slice 3 (next):** purity inference + naming normalization
- **Slice 4 (next):** `CannotRaiseToIRError` rewrap + integration test + CI Python provisioning

## Acceptance (slice 2 of #782)

- [x] Python → TS type mapping table implemented per ADR Q2
- [x] `extractFunctionSignatures` surfaces actionable errors with function/param context
- [x] All tests in `pnpm --filter @yakcc/shave-python test` pass without Python (mocked envelopes)
- [x] `pnpm --filter @yakcc/shave-python typecheck` clean
- [x] PR-CI required gates green (lint/typecheck/build/branch hygiene/B6a air-gap)

Tracking: #782 (slice 2 of 4)

---
_FuckGoblin orchestrator_