### PR TITLE
ci(release): #842 split release.yml — version PR on main; publish on `release` tag with environment gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,71 @@
 # @decision DEC-WI834-004
-# title: Release workflow trigger — canonical Changesets PR auto-flow on push to main
-# status: accepted
-# rationale: changesets/action@v1 is no-op-safe when NPM_TOKEN is unset; the Version PR is
-#   still opened. Workflow ships before operator claims @yakcc scope on npm, matching the
-#   "infrastructure exists when the operator is ready" idiom. See PLAN.md for full rationale.
+# title: Release workflow split — version-PR on main; publish on `release` tag with environment gate
+# status: accepted (updated 2026-05-28 for WI-842 — operator added GitHub Environment `release`
+#   with NPM_TOKEN scoped to it, deployment policy = tag pattern `release`, required reviewer
+#   = cneckar)
+# rationale:
+#   - Two jobs because the env's deployment policy gates the secret on tag `release`, but the
+#     Changesets Version-PR auto-flow runs on push to main (no tag, no secret needed).
+#   - `version` job: push to main → opens Version PR via changesets/action@v1, no env, no
+#     NPM_TOKEN needed (action is no-op-safe without it).
+#   - `publish` job: push of tag `release` → declares `environment: release` so the secret
+#     resolves AND the manual approval gate fires. Runs `pnpm release` (= `changeset publish`)
+#     which publishes whatever package.json versions don't yet exist on npm.
+#   - Operator flow: merge to main → Changesets opens Version PR → merge it → bump versions on
+#     main → `git tag -f release && git push -f origin release` → approve in GH UI → publish.
 name: release
 
 on:
   push:
     branches: [main]
+    tags: [release]
 
 concurrency:
   group: release-${{ github.ref }}
 
 jobs:
-  release:
-    name: release (changesets)
+  version:
+    name: open version PR (changesets)
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write
-      id-token: write   # reserved for npm provenance once token is set
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm -r build
+
+      - uses: changesets/action@v1
+        with:
+          version: pnpm version-packages
+          title: "chore(release): version packages"
+          commit: "chore(release): version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: publish to npm (gated on environment:release)
+    if: github.ref == 'refs/tags/release'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: release
+    permissions:
+      contents: read
+      id-token: write   # reserved for npm provenance once enabled
 
     steps:
       - uses: actions/checkout@v4
@@ -40,14 +84,7 @@ jobs:
 
       - run: pnpm -r build
 
-      - id: changesets
-        name: Create Release Pull Request or Publish
-        uses: changesets/action@v1
-        with:
-          publish: pnpm release
-          version: pnpm version-packages
-          title: "chore(release): version packages"
-          commit: "chore(release): version packages"
+      - run: pnpm release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Closes #842. Reconciles `.github/workflows/release.yml` with the operator's GitHub Environment `release` (set up 2026-05-28).

The env config:
- Required reviewer: `cneckar` (manual approval gate)
- Deployment policy: tag pattern `release` (literal)
- `NPM_TOKEN` scoped to this environment

The pre-#842 workflow (landed by #837) triggered only on push to main and referenced `${{ secrets.NPM_TOKEN }}` without declaring the environment. So `NPM_TOKEN` never resolved.

## Changes

Split single job into two:

| Job | Trigger | Environment | Purpose |
|---|---|---|---|
| `version` | push to `main` | none | Opens Changesets Version PR (no NPM_TOKEN needed) |
| `publish` | push of tag `release` | `release` (unlocks NPM_TOKEN + approval gate) | Runs `pnpm release` (= `changeset publish`) |

Auth fix on the publish step: `setup-node`'s `.npmrc` expansion uses `NODE_AUTH_TOKEN`, not `NPM_TOKEN`. The bare-shell `pnpm release` would have 401'd without it. Now both env vars are set on the publish step.

## Operator flow

1. Work merges to main → Changesets bot opens "chore(release): version packages" PR
2. Operator merges Version PR → main carries new versions
3. Operator: `git tag -f release && git push -f origin release`
4. Tag push triggers publish job; GH UI shows pending approval
5. cneckar approves → `pnpm release` publishes whatever package.json versions don't yet exist on npm

## Test plan

- [x] YAML parses cleanly (python3 yaml.safe_load → jobs: version, publish)
- [x] `version` job has no environment, no NPM_TOKEN
- [x] `publish` job has `environment: release`, both `NODE_AUTH_TOKEN` and `NPM_TOKEN` in publish step env
- [x] `if:` guards route correctly (main → version only, tag → publish only)
- [ ] CI run on PR — workflow file change won't actually execute publish until a tag push, so CI just validates YAML

## Out of scope (operator-side adjustments)

- Widening the env's tag pattern from literal `release` to a glob like `release-*` or `v*` — change in GH env settings, not in this workflow file
- Replacing required-reviewer approval with automated — intentional safety gate

Generated with [Claude Code](https://claude.com/claude-code)