### PR TITLE
fix(release): #850 commit bootstrap sqlite to fix publish workflow timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,8 @@ tmp/
 DECISIONS.md
 DECISIONS.md.tmp.*
 
-# Bootstrap outputs — registry and report are ephemeral; expected-roots.json is committed.
-# (WI-V2-BOOTSTRAP-02: registry + report gitignored; expected-roots.json committed in WI-V2-BOOTSTRAP-03)
-bootstrap/yakcc.registry.sqlite
+# Bootstrap outputs — registry sqlite is now committed (WI-850); WAL/SHM are transient SQLite journals.
+# expected-roots.json is committed separately (WI-V2-BOOTSTRAP-03).
 bootstrap/yakcc.registry.sqlite-wal
 bootstrap/yakcc.registry.sqlite-shm
 bootstrap/report.json


### PR DESCRIPTION
## Summary

Closes #850. Release workflow run [26601240803](https://github.com/cneckar/yakcc/actions/runs/26601240803) for tag `release-v0.6.0-alpha.0` timed out at the 30-min `timeout-minutes` limit. Approval was given on schedule; setup/build all succeeded; the hang was in `ensure-bootstrap-corpus.mjs` running `yakcc bootstrap` to regenerate the 4904-atom W-114 corpus on a fresh CI runner. That operation exceeds 30 min cold.

## Fix

Commit the 24MB `bootstrap/yakcc.registry.sqlite` to the repo. The freshness check in `packages/cli/scripts/ensure-bootstrap-corpus.mjs` (`sqliteMtime >= newestSrc → skip`) holds on `git clone` because all checked-out files share the checkout mtime. CI will see the file present and skip the multi-hour regen.

## Tradeoffs

| Trade | Choice |
|---|---|
| 24MB binary in git history | Acceptable — under GitHub's 100MB limit; content-addressed corpus is reproducible from source |
| .gitignore line removed | Yes (`bootstrap/yakcc.registry.sqlite`); WAL/SHM journal-file ignores kept (those ARE transient) |
| Maintenance burden | Low for now; scheduled action regenerating baseline weekly is a follow-up |

## Test plan

- [x] `.gitignore` no longer lists `bootstrap/yakcc.registry.sqlite` (line removed; WAL/SHM kept)
- [x] `ls -lh bootstrap/yakcc.registry.sqlite` returns 24M in the worktree
- [x] Implementer verified `node packages/cli/scripts/ensure-bootstrap-corpus.mjs` reports already-current/skip against the staged tree
- [ ] CI on PR
- [ ] Operator re-pushes `release-v0.6.0-alpha.0` tag after merge; publish completes in <5 min

## Cross-links

- #850 — root cause investigation
- PR #848 — OIDC workflow that the timeout exposed
- DEC-BOOTSTRAP-MANIFEST-ACCUMULATE-001 — committed manifest is load-bearing (NOT modified here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)