### PR TITLE
fix(release): touch bootstrap sqlite in publish job to bypass mtime freshness check (#850 followup to #852)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,4 +88,7 @@ jobs:
 
       - run: pnpm -r build
 
+      - name: Touch bootstrap sqlite (bypass mtime freshness check)
+        run: touch bootstrap/yakcc.registry.sqlite
+
       - run: pnpm --filter @yakcc/cli publish --provenance --access public --no-git-checks


### PR DESCRIPTION
## Summary

Followup to #852. That PR committed the 24MB `bootstrap/yakcc.registry.sqlite` so CI doesn't need to regenerate it. But on a fresh CI runner, `git checkout` + `pnpm install` left source files with mtimes slightly newer than the sqlite, so `ensure-bootstrap-corpus.mjs`'s freshness check (`sqliteMtime >= newestSrc`) returned false. CI then triggered the bootstrap regen path — which failed with a model-mismatch error.

## Fix

Add one workflow step in the publish job, before the publish command:

```yaml
      - name: Touch bootstrap sqlite (bypass mtime freshness check)
        run: touch bootstrap/yakcc.registry.sqlite
```

After touch, the sqlite's mtime is "now" → guaranteed `>= newestSrc` → freshness check passes → `yakcc bootstrap` regen never runs → publish proceeds.

The model-mismatch error only fires INSIDE `yakcc bootstrap`. Downstream scripts (`copy-seed-blocks.mjs`, `sync-publish-assets.mjs`) only copy the sqlite, never open it.

## Layered with #852

- #852: committed prebuilt sqlite to repo
- #850b (this PR): make CI freshness-check accept it

Both together: publish workflow completes in seconds instead of timing out at 30 min.

## Test plan

- [x] YAML parses; touch step is step 6, publish is step 7 (touch BEFORE publish)
- [x] Step inserted in publish job ONLY (version job unchanged)
- [ ] CI on PR
- [ ] Operator re-tags \`release-v0.6.0-alpha.0\` after merge; publish completes in <5 min, \`@yakcc/cli@0.6.0-alpha.0\` lands on npm with provenance

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>