### PR TITLE
feat(release): #856 unscoped `yakcc` wrapper + auto-tag latest on publish

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": ["@changesets/changelog-github", { "repo": "cneckar/yakcc" }],
   "commit": false,
-  "fixed": [],
+  "fixed": [["@yakcc/cli", "yakcc"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 # @decision DEC-WI834-004
 # title: Release workflow — version-PR on main; publish on `release-*` tag via OIDC trusted publisher
-# status: accepted (updated 2026-05-28 for WI-845 — OIDC trusted publisher replaces NPM_TOKEN;
-#   tag pattern updated to `release-*` per operator deployment policy; only @yakcc/cli publishes)
+# status: accepted (updated 2026-05-28 for WI-856 — dual publish: @yakcc/cli + unscoped yakcc wrapper)
 # rationale:
 #   - Two jobs: `version` runs on push to main (opens Changesets Version PR); `publish` runs on
 #     `release-*` tags (e.g. release-0.6.0) per operator env deployment policy change.
@@ -9,12 +8,16 @@
 #   - `publish` job: push of tag matching `release-*` → declares `environment: release` for the
 #     manual approval gate. Uses OIDC via id-token:write; no NPM_TOKEN needed. npm@latest required
 #     because Node 22 ships npm 10.x and OIDC trusted publishing requires npm 11.5.1+.
-#     `pnpm --filter @yakcc/cli publish --provenance` invokes npm directly so --provenance is
-#     passed through; `changeset publish` does not forward this flag (silently dropped).
-#   - Only @yakcc/cli is published; the 7 sub-packages are private:true and in the ignore list.
-#   - Operator flow: merge to main → Changesets opens Version PR → merge it → bump cli version →
-#     `git tag release-X.Y.Z && git push origin release-X.Y.Z` → approve in GH UI → publish.
-#   - References: #834 (initial release flow), #842 (split jobs), #845 (OIDC + cli-only).
+#     `pnpm --filter @yakcc/cli --filter yakcc publish --provenance` invokes npm directly so
+#     --provenance is passed through; `changeset publish` does not forward this flag (silently
+#     dropped). Both packages publish in one step.
+#   - @yakcc/cli: scoped package, --access public required. yakcc: unscoped wrapper, forwards bin.
+#   - The 7 sub-packages are private:true and in the ignore list.
+#   - Operator flow: merge to main → Changesets opens Version PR → merge it → bump cli+yakcc
+#     versions in lockstep (fixed group) → `git tag release-X.Y.Z && git push origin
+#     release-X.Y.Z` → approve in GH UI → publish.
+#   - References: #834 (initial release flow), #842 (split jobs), #845 (OIDC + cli-only),
+#     #856 (dual publish + unscoped yakcc wrapper).
 name: release
 
 on:
@@ -91,4 +94,4 @@ jobs:
       - name: Touch bootstrap sqlite (bypass mtime freshness check)
         run: touch bootstrap/yakcc.registry.sqlite
 
-      - run: pnpm --filter @yakcc/cli publish --provenance --access public --no-git-checks
+      - run: pnpm --filter @yakcc/cli --filter yakcc publish --provenance --access public --no-git-checks

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,8 @@
     "LICENSE-ATOMS"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "latest"
   },
   "scripts": {
     "build": "rm -f tsconfig.tsbuildinfo && tsc -p .",

--- a/packages/yakcc/LICENSE
+++ b/packages/yakcc/LICENSE
@@ -1,0 +1,214 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a
+      fee for, acceptance of support, warranty, indemnity, or other
+      liability obligations and/or rights consistent with this License.
+      However, in accepting such obligations, You may act only on Your
+      own behalf and on Your sole responsibility, not on behalf of any
+      other Contributor, and only if You agree to indemnify, defend,
+      and hold each Contributor harmless for any liability incurred by,
+      or claims asserted against, such Contributor by reason of your
+      accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 The Yakcc Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+----------------------------------------------------------------------
+
+NOTE: This Apache 2.0 license applies to the substrate code in this
+repository (the engine: shave, compile, discovery, registry storage,
+hooks, CLI, tooling, configs, build files).
+
+Atom content — items registered in the atom registry, including everything
+under `packages/seeds/blocks/` and the contents of `bootstrap/` artifacts —
+is dedicated to the public domain under The Unlicense. See LICENSE-ATOMS.
+
+The split reflects the nature of the artifacts: the engine is a software
+tool with conventional copyright; the registry is a content commons.

--- a/packages/yakcc/README.md
+++ b/packages/yakcc/README.md
@@ -1,0 +1,26 @@
+# yakcc
+
+The unscoped alias for [`@yakcc/cli`](https://www.npmjs.com/package/@yakcc/cli) — content-addressed block registry for assembling programs from verified, reusable building blocks.
+
+## Install
+
+```bash
+npm install -g yakcc
+# or
+pnpm add -g yakcc
+```
+
+Functionally identical to installing `@yakcc/cli` directly; provides the `yakcc` command on your PATH.
+
+## Usage
+
+See the [main yakcc docs](https://github.com/cneckar/yakcc) for full command reference.
+
+```bash
+yakcc init
+yakcc help
+```
+
+## License
+
+Apache-2.0 — see [LICENSE](./LICENSE).

--- a/packages/yakcc/bin.js
+++ b/packages/yakcc/bin.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+// Unscoped alias: forward to @yakcc/cli's bin.
+// Using ESM dynamic import preserves stdio, signals, and process.argv handling
+// without a subprocess boundary.
+await import("@yakcc/cli/dist/bin.js");

--- a/packages/yakcc/package.json
+++ b/packages/yakcc/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "yakcc",
+  "version": "0.6.0-alpha.0",
+  "description": "Content-addressed block registry — yakcc CLI (unscoped alias for @yakcc/cli).",
+  "license": "Apache-2.0",
+  "type": "module",
+  "bin": {
+    "yakcc": "./bin.js"
+  },
+  "files": [
+    "bin.js",
+    "README.md",
+    "LICENSE"
+  ],
+  "dependencies": {
+    "@yakcc/cli": "0.6.0-alpha.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "tag": "latest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cneckar/yakcc.git",
+    "directory": "packages/yakcc"
+  },
+  "homepage": "https://github.com/cneckar/yakcc#readme",
+  "bugs": {
+    "url": "https://github.com/cneckar/yakcc/issues"
+  },
+  "keywords": [
+    "yakcc",
+    "code-generation",
+    "content-addressed",
+    "registry",
+    "claude-code",
+    "cursor",
+    "cline",
+    "continue.dev",
+    "windsurf",
+    "aider",
+    "ai-coding"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -653,6 +653,12 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7))
 
+  packages/yakcc:
+    dependencies:
+      '@yakcc/cli':
+        specifier: 0.6.0-alpha.0
+        version: 0.6.0-alpha.0
+
 packages:
 
   '@anthropic-ai/sdk@0.40.1':
@@ -1407,6 +1413,10 @@ packages:
 
   '@xenova/transformers@2.17.2':
     resolution: {integrity: sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ==}
+
+  '@yakcc/cli@0.6.0-alpha.0':
+    resolution: {integrity: sha512-P3Q30eoeebBPQrTebh1WMNvMShD5EwW4RTPvnZ6Wj9mSt9VrzWzika1vKvLbuRHoyoB9U0SKEbIG2172FpcHfg==}
+    hasBin: true
 
   '@yao-pkg/pkg-fetch@3.5.33':
     resolution: {integrity: sha512-j2UoH+eP4VobfovQg1gkWwDoB4O/tv8rlLnEjUEEHuWXJ5eBLNUIrobMSEp773/2pgUJUfqqPUFIhS1pN8OZuQ==}
@@ -3513,6 +3523,20 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
+      - react-native-b4a
+
+  '@yakcc/cli@0.6.0-alpha.0':
+    dependencies:
+      '@anthropic-ai/sdk': 0.40.1
+      '@xenova/transformers': 2.17.2
+      assemblyscript: 0.27.37
+      better-sqlite3: 12.9.0
+      sqlite-vec: 0.1.9
+      ts-morph: 28.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - encoding
       - react-native-b4a
 
   '@yao-pkg/pkg-fetch@3.5.33':


### PR DESCRIPTION
## Summary

Closes #856. Two coordinated operator-direction changes:

1. **Auto-tag latest**: `packages/cli/package.json` gets `publishConfig.tag: "latest"`. Future publishes route to the `latest` dist-tag automatically (no manual `npm dist-tag add` post-publish).

2. **`npm install yakcc` works**: new `packages/yakcc/` is a thin unscoped wrapper package that exact-pin-depends on `@yakcc/cli@0.6.0-alpha.0` and forwards via dynamic ESM import. Both packages release in lockstep (Changesets fixed group).

## Operator flow after merge

```bash
git tag -f release-v0.6.0-alpha.1   # or next version
git push -f origin release-v0.6.0-alpha.1
# approve in GH UI
# both @yakcc/cli@N and yakcc@N publish with --tag latest
```

Result on npm: `npm install -g yakcc` works; both packages tagged `latest`; `@yakcc/cli` and `yakcc` are functionally identical.

## Architecture note

The `yakcc` wrapper does NOT change the bundled-CLI architecture from #845. `@yakcc/cli` still bundles all workspace deps into one tarball; `yakcc` is a 4-file package whose only runtime job is `await import("@yakcc/cli/dist/bin.js")`. Two npm install paths, one actual code path.

## Test plan

- [x] `packages/cli/package.json` has `publishConfig.tag: "latest"`
- [x] `packages/yakcc/{package.json,bin.js,README.md,LICENSE}` present with shape per spec
- [x] `.github/workflows/release.yml` publish step uses `--filter @yakcc/cli --filter yakcc`
- [x] `.changeset/config.json` has fixed group `["@yakcc/cli", "yakcc"]`
- [x] `pnpm install --frozen-lockfile` + `pnpm -r build` clean post-rebase
- [x] Both `pnpm publish --dry-run` succeed with `tag latest` (cli: 36.3MB tarball; yakcc: 13.6kB tarball)
- [ ] CI on PR

Rebased onto `origin/main` at `79ba0b0` (3 commits ahead at push time). New commit: `1d3349e`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)