### PR TITLE
feat(cli): #849 add --version / -v / -V / version flag to yakcc

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -18,7 +18,46 @@
 // Uses CollectingLogger — no mocks (Sacred Practice #5, DEC-CLI-LOGGER-001).
 
 import { describe, expect, it } from "vitest";
+import pkg from "../package.json" with { type: "json" };
 import { CollectingLogger, runCli } from "./index.js";
+
+// ---------------------------------------------------------------------------
+// DEC-CLI-VERSION-001: --version / -v / -V / version flags (WI-849)
+// ---------------------------------------------------------------------------
+
+describe("WI-849: version flags (DEC-CLI-VERSION-001)", () => {
+  /**
+   * All four invocations must print exactly pkg.version (single source of truth)
+   * and exit 0. Help header must also contain the version string.
+   * This test exercises the real runCli dispatch path end-to-end.
+   */
+  for (const flag of ["--version", "-v", "-V", "version"] as const) {
+    it(`runCli(['${flag}']) exits 0 and prints package.json version`, async () => {
+      const logger = new CollectingLogger();
+      const code = await runCli([flag], logger);
+      expect(code).toBe(0);
+      expect(logger.logLines).toHaveLength(1);
+      expect(logger.logLines[0]).toBe(pkg.version);
+      expect(logger.errLines).toHaveLength(0);
+    });
+  }
+
+  it("version output is the canonical package.json value (no hard-coded string)", async () => {
+    // Regression guard: if package.json version changes, the CLI must reflect it.
+    const logger = new CollectingLogger();
+    await runCli(["--version"], logger);
+    expect(logger.logLines[0]).toBe(pkg.version);
+  });
+
+  it("printUsage (--help) header contains the version string", async () => {
+    const logger = new CollectingLogger();
+    const code = await runCli(["--help"], logger);
+    expect(code).toBe(0);
+    const firstLine = logger.logLines[0]?.split("\n")[0] ?? "";
+    expect(firstLine).toContain(pkg.version);
+    expect(firstLine).toContain("yakcc");
+  });
+});
 
 describe("T5: compile-self dispatch wiring in runCli — A2 (DEC-CLI-INDEX-001)", () => {
   it("runCli(['compile-self']) no longer returns exit code 2 — A1 stub retired", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -34,6 +34,7 @@
 // RegistryOptions["embeddings"] keeps @yakcc/registry as the one type-level authority.
 
 import type { RegistryOptions } from "@yakcc/registry";
+import pkg from "../package.json" with { type: "json" };
 import { benchB3 } from "./commands/bench-b3.js";
 import { bootstrap } from "./commands/bootstrap.js";
 import { compileSelf } from "./commands/compile-self.js";
@@ -61,6 +62,22 @@ import { uninstall } from "./commands/uninstall.js";
 
 // Re-export ContractId for callers who import from @yakcc/cli.
 export type { ContractId } from "@yakcc/contracts";
+
+// ---------------------------------------------------------------------------
+// CLI version — single source of truth: packages/cli/package.json
+// ---------------------------------------------------------------------------
+
+/**
+ * @decision DEC-CLI-VERSION-001
+ * @title CLI_VERSION is read from package.json via JSON import (single source of truth)
+ * @status accepted
+ * @rationale Closes #849. Rather than duplicating the version string, we import it
+ *   directly from the canonical location (packages/cli/package.json). TypeScript
+ *   5.7+ + resolveJsonModule:true + with { type: "json" } is the supported form
+ *   under NodeNext/verbatimModuleSyntax. This means version flags (--version, -v,
+ *   -V, version) and the help header both reference the same constant — no drift.
+ */
+const CLI_VERSION: string = pkg.version;
 
 // ---------------------------------------------------------------------------
 // CliOptions interface
@@ -129,7 +146,7 @@ export class CollectingLogger implements Logger {
 // ---------------------------------------------------------------------------
 
 function printUsage(logger: Logger): void {
-  logger.log(`yakcc — content-addressed basic-block registry
+  logger.log(`yakcc ${CLI_VERSION} — content-addressed basic-block registry
 
 USAGE
   yakcc <command> [options]
@@ -426,6 +443,14 @@ export async function runCli(
       // `yakcc telemetry [--path] [--tail <n>]` -- inspect local telemetry (WI-760).
       const telemetryArgv = subcommand !== undefined ? [subcommand, ...rest] : rest;
       return telemetry(telemetryArgv, logger);
+    }
+
+    case "--version":
+    case "-v":
+    case "-V":
+    case "version": {
+      logger.log(CLI_VERSION);
+      return 0;
     }
 
     case undefined:

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       "@yakcc/registry": resolve(__dirname, "../registry/src/index.ts"),
       "@yakcc/ir": resolve(__dirname, "../ir/src/index.ts"),
       "@yakcc/compile": resolve(__dirname, "../compile/src/index.ts"),
+      "@yakcc/compile-python": resolve(__dirname, "../compile-python/src/index.ts"),
       "@yakcc/seeds": resolve(__dirname, "../seeds/src/index.ts"),
       "@yakcc/shave": resolve(__dirname, "../shave/src/index.ts"),
       "@yakcc/federation": resolve(__dirname, "../federation/src/index.ts"),


### PR DESCRIPTION
## Summary

Closes #849. Adds CLI version flags. All four invocations print the version string and exit 0:

```
yakcc --version
yakcc -v
yakcc -V
yakcc version
```

Version source is `packages/cli/package.json` via TypeScript JSON import (NodeNext + `resolveJsonModule` + `with { type: "json" }`). Single source of truth (`@decision DEC-CLI-VERSION-001`). Help header also includes version.

## Test plan

- [x] vitest 19/19 (6 new for version flag invariants)
- [x] `pnpm --filter '@yakcc/cli...' build` clean
- [x] Single-source-of-truth invariant: version output === `pkg.version` (no hard-coded string)
- [ ] CI on PR

## Bonus fix

`packages/cli/vitest.config.ts` was missing the `@yakcc/compile-python` alias (sibling package added in #826/#846). One-line additive fix; required for the test file to run alongside existing tests.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>