### PR TITLE
fix(ci): #866 delete committed sqlite before self-shave pass-1 bootstrap

### DIFF
--- a/.github/workflows/self-shave.yml
+++ b/.github/workflows/self-shave.yml
@@ -185,6 +185,18 @@ jobs:
       #   (step "Write self-shave verified-marker" below), so a stale false-green cache
       #   cannot arise once the test code is fixed to hard-fail on missing preconditions
       #   (DEC-V2-TWO-PASS-PRECONDITION-001).
+      - name: Prepare clean bootstrap state (delete committed artifacts)
+        if: steps.verified-cache.outputs.cache-hit != 'true'
+        run: |
+          # Self-shave's intent is FRESH bootstrap pass-1, then verify pass-2
+          # produces a byte-identical result. The committed sqlite from PR #852
+          # exists for the release workflow's ensure-bootstrap-corpus.mjs
+          # speed-up — it would conflict with self-shave's pass-1 model
+          # (DEC-V2-BOOTSTRAP-EMBEDDING-001: bootstrap/null-zero). Delete
+          # before pass-1 so `yakcc bootstrap` produces registry A fresh.
+          rm -f bootstrap/yakcc.registry.sqlite bootstrap/report.json
+          ls -la bootstrap/ || true  # confirm only expected-roots.json remains tracked
+
       - name: Bootstrap pass 1 (produce registry A + report A)
         if: steps.verified-cache.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
## Summary

Closes #866. Fixes "two-pass bootstrap equivalence" CI job that's been failing on every push to main since PR #852 landed.

## Root cause

PR #852 committed `bootstrap/yakcc.registry.sqlite` for the release workflow (skip multi-hour `ensure-bootstrap-corpus.mjs` regen). That sqlite was embedded with `yakcc/offline-blake3-stub` (operator's local seed corpus). Self-shave's `yakcc bootstrap` uses `bootstrap/null-zero` per DEC-V2-BOOTSTRAP-EMBEDDING-001 — `openRegistry`'s model-match guard blocks opening the existing sqlite.

```
error: failed to open registry at bootstrap/yakcc.registry.sqlite:
  Registry was embedded with model "yakcc/offline-blake3-stub",
  but the current provider uses "bootstrap/null-zero".
```

Self-shave and release have fundamentally different intents:
- `release.yml`: committed sqlite present + freshness passes -> skip regen -> fast publish
- `self-shave.yml`: committed sqlite ABSENT -> fresh bootstrap from source -> equivalence test valid

## Fix

Add "Prepare clean bootstrap state" step immediately before "Bootstrap pass 1". Deletes `bootstrap/yakcc.registry.sqlite` + `bootstrap/report.json`. Subsequent `yakcc bootstrap` produces fresh artifacts with the matching `bootstrap/null-zero` model.

`bootstrap/expected-roots.json` is NOT deleted — load-bearing monotonic manifest (DEC-BOOTSTRAP-MANIFEST-ACCUMULATE-001).

`release.yml` is untouched — it still reuses the committed sqlite via `ensure-bootstrap-corpus.mjs` + the touch step from #854.

The new step's `if: steps.verified-cache.outputs.cache-hit != 'true'` guard mirrors the existing pass-1 step's guard (cache-miss only). When verified-marker cache hits, the entire bootstrap+test sequence skips, so the delete is a no-op.

## Test plan

- [x] YAML parses; new step appears immediately before "Bootstrap pass 1" (verified post-rebase: verify[8] then verify[9])
- [x] if: guard mirrors existing pass-1 step (cache-miss only)
- [x] release.yml untouched
- [ ] CI on this PR (the self-shave run will exercise the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)