### PR TITLE
fix(shave-python): #875 floor-divide // support (3 coordinated fixes)

### DIFF
--- a/packages/shave-python/scripts/libcst-parse.py
+++ b/packages/shave-python/scripts/libcst-parse.py
@@ -60,6 +60,7 @@ BINARY_OP_MAP = {
     "Subtract": "-",
     "Multiply": "*",
     "Divide": "/",
+    "FloorDivide": "//",  # WI-875: Python a//b — TS renders as Math.floor(a/b)
     "Modulo": "%",
     "Equal": "==",
     "NotEqual": "!=",

--- a/packages/shave-python/src/libcst-parser.test.ts
+++ b/packages/shave-python/src/libcst-parser.test.ts
@@ -10,6 +10,7 @@
 // A future slice (likely slice 4) will add an opt-in integration test gated
 // on `process.env.YAKCC_PY` that exercises the real Python interpreter.
 
+import { execSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -204,4 +205,33 @@ describe("parsePythonSource (#782 slice 1)", () => {
     await parsePythonSource("pass", { spawnImpl: spawnFn, scriptPath: "/fake/x.py" });
     expect(capturedCmd).toBe("/custom/python");
   });
+});
+
+// ---------------------------------------------------------------------------
+// WI-875: floor-divide // emission (REGRESSION — real Python subprocess)
+// ---------------------------------------------------------------------------
+
+describe("WI-875: floor-divide // emission (REGRESSION — real Python subprocess)", () => {
+  const pythonAvailable = (() => {
+    try {
+      execSync("python3 -c 'import libcst'", { stdio: "pipe" });
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
+  if (!pythonAvailable) {
+    it.skip("requires python3 with libcst installed (skipped)", () => {});
+  } else {
+    it("emits FloorDivide as a // BinaryOp wire node", async () => {
+      const source = "def divmod_int(a: int, b: int) -> int:\n    return a // b\n";
+      const result = await parsePythonSource(source);
+      const fn = (result.module as any).functions[0];
+      const ret = fn.body[0];
+      expect(ret.type).toBe("Return");
+      expect(ret.value.type).toBe("BinaryOp");
+      expect(ret.value.op).toBe("//");
+    });
+  }
 });

--- a/packages/shave-python/src/libcst-parser.test.ts
+++ b/packages/shave-python/src/libcst-parser.test.ts
@@ -16,6 +16,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   AdapterSubprocessError,
   type LibcstParseOptions,
+  type PythonAstNode,
   type SpawnImpl,
   parsePythonSource,
 } from "./libcst-parser.js";
@@ -227,11 +228,11 @@ describe("WI-875: floor-divide // emission (REGRESSION — real Python subproces
     it("emits FloorDivide as a // BinaryOp wire node", async () => {
       const source = "def divmod_int(a: int, b: int) -> int:\n    return a // b\n";
       const result = await parsePythonSource(source);
-      const fn = (result.module as any).functions[0];
-      const ret = fn.body[0];
+      const fn = (result.module.functions as PythonAstNode[])[0] as PythonAstNode;
+      const ret = (fn.body as PythonAstNode[])[0] as PythonAstNode;
       expect(ret.type).toBe("Return");
-      expect(ret.value.type).toBe("BinaryOp");
-      expect(ret.value.op).toBe("//");
+      expect((ret.value as PythonAstNode).type).toBe("BinaryOp");
+      expect((ret.value as PythonAstNode).op).toBe("//");
     });
   }
 });

--- a/packages/shave-python/src/raise-body.test.ts
+++ b/packages/shave-python/src/raise-body.test.ts
@@ -319,3 +319,29 @@ describe("UnsupportedAstError extends CannotRaiseToIRError (slice 4)", () => {
     expect(err.construct).toBe("async def");
   });
 });
+
+// ---------------------------------------------------------------------------
+// WI-875: floor-divide // operator
+// ---------------------------------------------------------------------------
+
+describe("WI-875: floor-divide // renders as Math.floor(a / b)", () => {
+  it("renders the // binary op as Math.floor(left / right)", () => {
+    const expr: WireExpr = {
+      type: "BinaryOp",
+      op: "//",
+      left: { type: "Name", name: "a" },
+      right: { type: "Name", name: "b" },
+    };
+    expect(renderExpr(expr)).toBe("Math.floor(a / b)");
+  });
+
+  it("accepts // in ALLOWED_BINARY_OPS (does not throw UnsupportedAstError)", () => {
+    const expr: WireExpr = {
+      type: "BinaryOp",
+      op: "//",
+      left: { type: "Name", name: "x" },
+      right: { type: "Name", name: "y" },
+    };
+    expect(() => renderExpr(expr)).not.toThrow();
+  });
+});

--- a/packages/shave-python/src/raise-body.ts
+++ b/packages/shave-python/src/raise-body.ts
@@ -103,6 +103,7 @@ const ALLOWED_BINARY_OPS = new Set<string>([
   "-",
   "*",
   "/",
+  "//", // WI-875: Python floor-divide; rendered as Math.floor(left/right), not a TS operator
   "%",
   "==",
   "!=",
@@ -132,6 +133,11 @@ export function renderExpr(expr: WireExpr): string {
     case "BinaryOp": {
       if (!ALLOWED_BINARY_OPS.has(expr.op)) {
         throw new UnsupportedAstError(`BinaryOp '${expr.op}'`);
+      }
+      // WI-875: TS has no floor-divide operator; emit Math.floor(left / right)
+      // which matches Python semantics for integer division.
+      if (expr.op === "//") {
+        return `Math.floor(${renderExpr(expr.left)} / ${renderExpr(expr.right)})`;
       }
       // Always parenthesize to avoid precedence surprises across the Python → TS boundary.
       return `(${renderExpr(expr.left)} ${expr.op} ${renderExpr(expr.right)})`;


### PR DESCRIPTION
## Summary

Closes #875. Python's `a // b` floor-divide operator did not round-trip. Three coordinated gaps closed:

1. `libcst-parse.py` `BINARY_OP_MAP` — added `"FloorDivide": "//"`
2. `raise-body.ts` `ALLOWED_BINARY_OPS` — added `"//"`
3. `raise-body.ts` `renderExpr` — special-cased `//` → `Math.floor(left / right)` (TS has no floor-divide operator)

## Test plan

- [x] `pnpm --filter @yakcc/shave-python test` — 194/194 pass (3 new WI-875 tests)
- [x] Smoke: `def f(a, b): return a // b` → wire `{op:"//"}` ✓
- [x] Rendered IR: `Math.floor(a / b)` ✓
- [ ] CI on PR

## Discovered during

Python round-trip exploration #872-#877. Most superseded by #864 (slice-4 MVP); this one real.

## Out of scope

- compile-python lowering direction — separate WI

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>