### PR TITLE
fix(shave-python): add @yakcc/contracts and @yakcc/ir tsconfig references

### DIFF
--- a/packages/shave-python/tsconfig.json
+++ b/packages/shave-python/tsconfig.json
@@ -6,5 +6,9 @@
     "rootDir": "src",
     "types": ["node"]
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [
+    { "path": "../contracts" },
+    { "path": "../ir" }
+  ]
 }


### PR DESCRIPTION
## Summary

Adds the missing `references` entries to `packages/shave-python/tsconfig.json` so it composes with its workspace deps `@yakcc/contracts` and `@yakcc/ir`. Same drift pattern as #882: package.json declares the workspace deps correctly, but tsconfig was missing the project references, so `tsc -b` failed even though `pnpm --filter @yakcc/shave-python test` was green (vitest aliases were masking the build break).

Unblocks `pnpm --filter @yakcc/shave-python build`, needed for the bs4 e2e exploration.

## Test plan

- [x] `pnpm -r --filter @yakcc/shave-python... build` passes locally
- [x] Existing test suite green (257/257)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)