### PR TITLE
fix(shave-python): #899 + #900 + #901 — bs4 e2e regression bundle

### DIFF
--- a/packages/shave-python/src/parse-fn-signature.test.ts
+++ b/packages/shave-python/src/parse-fn-signature.test.ts
@@ -7,7 +7,11 @@
 
 import { describe, expect, it } from "vitest";
 import type { LibcstParseResult } from "./libcst-parser.js";
-import { MissingTypeAnnotationError, extractFunctionSignatures } from "./parse-fn-signature.js";
+import {
+  MissingTypeAnnotationError,
+  extractFunctionSignatures,
+  extractFunctionSignaturesAll,
+} from "./parse-fn-signature.js";
 import { UnsupportedTypeError } from "./type-map.js";
 
 interface EnvelopeFunction {
@@ -92,8 +96,11 @@ describe("extractFunctionSignatures — happy paths", () => {
   });
 });
 
-describe("extractFunctionSignatures — rejections", () => {
-  it("rejects function with un-annotated parameter", () => {
+describe("extractFunctionSignatures — rejections (via extractFunctionSignaturesAll)", () => {
+  // Since #899, extractFunctionSignatures no longer throws — it silently skips failures.
+  // Use extractFunctionSignaturesAll to observe per-function failure details.
+
+  it("records failure for function with un-annotated parameter", () => {
     const env = envelopeWith([
       {
         name: "bad",
@@ -102,17 +109,17 @@ describe("extractFunctionSignatures — rejections", () => {
         body_source: "    return x",
       },
     ]);
-    try {
-      extractFunctionSignatures(env);
-      expect.unreachable("should throw");
-    } catch (err) {
-      expect(err).toBeInstanceOf(MissingTypeAnnotationError);
-      expect((err as MissingTypeAnnotationError).paramName).toBe("x");
-      expect((err as MissingTypeAnnotationError).functionName).toBe("bad");
-    }
+    const result = extractFunctionSignaturesAll(env);
+    expect(result.ok).toHaveLength(0);
+    expect(result.failed).toHaveLength(1);
+    const failure = result.failed[0];
+    expect(failure?.name).toBe("bad");
+    expect(failure?.error).toBeInstanceOf(MissingTypeAnnotationError);
+    expect((failure?.error as MissingTypeAnnotationError).paramName).toBe("x");
+    expect((failure?.error as MissingTypeAnnotationError).functionName).toBe("bad");
   });
 
-  it("rejects function with no return annotation", () => {
+  it("records failure for function with no return annotation", () => {
     const env = envelopeWith([
       {
         name: "noreturn",
@@ -121,51 +128,54 @@ describe("extractFunctionSignatures — rejections", () => {
         body_source: "    return x",
       },
     ]);
-    try {
-      extractFunctionSignatures(env);
-      expect.unreachable("should throw");
-    } catch (err) {
-      expect(err).toBeInstanceOf(MissingTypeAnnotationError);
-      expect((err as MissingTypeAnnotationError).paramName).toBeNull();
-    }
+    const result = extractFunctionSignaturesAll(env);
+    expect(result.ok).toHaveLength(0);
+    expect(result.failed).toHaveLength(1);
+    const failure = result.failed[0];
+    expect(failure?.name).toBe("noreturn");
+    expect(failure?.error).toBeInstanceOf(MissingTypeAnnotationError);
+    expect((failure?.error as MissingTypeAnnotationError).paramName).toBeNull();
   });
 
-  it("wraps UnsupportedTypeError with function/param context on params", () => {
+  it("records failure with wrapped UnsupportedTypeError context on params", () => {
+    // Note: with #901, plain identifiers like 'Decimal' now pass through with a warning.
+    // Use 'Set[int]' (a subscript form) which still throws as an unsupported container.
     const env = envelopeWith([
       {
         name: "bigwrap",
-        params: [{ name: "n", annotation: "Decimal" }],
+        params: [{ name: "n", annotation: "Set[int]" }],
         return_annotation: "int",
         body_source: "    return 0",
       },
     ]);
-    try {
-      extractFunctionSignatures(env);
-      expect.unreachable("should throw");
-    } catch (err) {
-      expect(err).toBeInstanceOf(UnsupportedTypeError);
-      expect((err as Error).message).toContain("Function 'bigwrap'");
-      expect((err as Error).message).toContain("parameter 'n'");
-    }
+    const result = extractFunctionSignaturesAll(env);
+    expect(result.ok).toHaveLength(0);
+    expect(result.failed).toHaveLength(1);
+    const failure = result.failed[0];
+    expect(failure?.name).toBe("bigwrap");
+    expect(failure?.error).toBeInstanceOf(UnsupportedTypeError);
+    expect(failure?.error.message).toContain("Function 'bigwrap'");
+    expect(failure?.error.message).toContain("parameter 'n'");
   });
 
-  it("wraps UnsupportedTypeError with function context on return", () => {
+  it("records failure with wrapped UnsupportedTypeError context on return", () => {
+    // Use 'Set[int]' for the same reason — subscript form still throws.
     const env = envelopeWith([
       {
         name: "badret",
         params: [{ name: "x", annotation: "int" }],
-        return_annotation: "Decimal",
+        return_annotation: "Set[int]",
         body_source: "    return x",
       },
     ]);
-    try {
-      extractFunctionSignatures(env);
-      expect.unreachable("should throw");
-    } catch (err) {
-      expect(err).toBeInstanceOf(UnsupportedTypeError);
-      expect((err as Error).message).toContain("Function 'badret'");
-      expect((err as Error).message).toContain("return type");
-    }
+    const result = extractFunctionSignaturesAll(env);
+    expect(result.ok).toHaveLength(0);
+    expect(result.failed).toHaveLength(1);
+    const failure = result.failed[0];
+    expect(failure?.name).toBe("badret");
+    expect(failure?.error).toBeInstanceOf(UnsupportedTypeError);
+    expect(failure?.error.message).toContain("Function 'badret'");
+    expect(failure?.error.message).toContain("return type");
   });
 
   it("handles envelope missing the functions field gracefully", () => {
@@ -284,5 +294,165 @@ describe("extractFunctionSignatures — WI-889 warning threading", () => {
     expect(sigs[0]?.returnType).toBe("(...args: unknown[]) => unknown");
     expect(sigs[0]?.returnWarnings).toHaveLength(1);
     expect(sigs[0]?.returnWarnings?.[0]?.code).toBe("callable-widened");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #899: per-function extraction continuation
+// ---------------------------------------------------------------------------
+// Before #899, extractFunctionSignatures used .map() which threw on the first
+// failure, aborting extraction of ALL remaining functions in the module.
+// After #899, each function is extracted independently; failures accumulate
+// in failed[] and successes continue to accumulate in ok[].
+//
+// These tests exercise the compound-interaction production sequence:
+//   envelope (N functions) → extractFunctionSignaturesAll → { ok, failed }
+// demonstrating that a single failure mid-module does not abort the rest.
+// ---------------------------------------------------------------------------
+
+describe("#899 — per-function extraction continuation", () => {
+  it("extracts successes even when the first function fails (unannotated param)", () => {
+    // Module with 3 functions: first fails (unannotated param), second and third succeed.
+    // Production scenario: bs4 module where some helpers lack annotations.
+    const env = envelopeWith([
+      {
+        name: "bad_first",
+        params: [{ name: "x", annotation: null }],
+        return_annotation: "int",
+        body_source: "    return x",
+      },
+      {
+        name: "good_second",
+        params: [{ name: "a", annotation: "int" }],
+        return_annotation: "str",
+        body_source: "    return str(a)",
+      },
+      {
+        name: "good_third",
+        params: [],
+        return_annotation: "None",
+        body_source: "    pass",
+      },
+    ]);
+    const result = extractFunctionSignaturesAll(env);
+    expect(result.ok).toHaveLength(2);
+    expect(result.failed).toHaveLength(1);
+    expect(result.ok.map((s) => s.name)).toEqual(["good_second", "good_third"]);
+    expect(result.failed[0]?.name).toBe("bad_first");
+  });
+
+  it("extracts successes even when a middle function fails (missing return annotation)", () => {
+    // Module where only the middle function lacks its return annotation.
+    const env = envelopeWith([
+      {
+        name: "first_ok",
+        params: [{ name: "x", annotation: "int" }],
+        return_annotation: "int",
+        body_source: "    return x",
+      },
+      {
+        name: "middle_bad",
+        params: [{ name: "x", annotation: "int" }],
+        return_annotation: null,
+        body_source: "    return x",
+      },
+      {
+        name: "last_ok",
+        params: [{ name: "s", annotation: "str" }],
+        return_annotation: "bool",
+        body_source: "    return bool(s)",
+      },
+    ]);
+    const result = extractFunctionSignaturesAll(env);
+    expect(result.ok).toHaveLength(2);
+    expect(result.failed).toHaveLength(1);
+    expect(result.ok[0]?.name).toBe("first_ok");
+    expect(result.ok[1]?.name).toBe("last_ok");
+    expect(result.failed[0]?.name).toBe("middle_bad");
+  });
+
+  it("accumulates multiple failures without aborting — all successes still returned", () => {
+    // Module with 5 functions: positions 1, 3, 5 succeed; positions 2, 4 fail.
+    // Demonstrates that failures at non-adjacent positions all accumulate.
+    const env = envelopeWith([
+      { name: "ok1", params: [], return_annotation: "None", body_source: "    pass" },
+      {
+        name: "fail2",
+        params: [{ name: "x", annotation: null }], // missing annotation
+        return_annotation: "int",
+        body_source: "    return x",
+      },
+      { name: "ok3", params: [], return_annotation: "None", body_source: "    pass" },
+      {
+        name: "fail4",
+        params: [{ name: "x", annotation: "int" }],
+        return_annotation: null, // missing return annotation
+        body_source: "    return x",
+      },
+      { name: "ok5", params: [], return_annotation: "None", body_source: "    pass" },
+    ]);
+    const result = extractFunctionSignaturesAll(env);
+    expect(result.ok).toHaveLength(3);
+    expect(result.failed).toHaveLength(2);
+    expect(result.ok.map((s) => s.name)).toEqual(["ok1", "ok3", "ok5"]);
+    expect(result.failed.map((f) => f.name)).toEqual(["fail2", "fail4"]);
+  });
+
+  it("extractFunctionSignatures (permissive) silently skips failures, returning only successes", () => {
+    // Verifies backward-compatible public API: callers not using extractFunctionSignaturesAll
+    // see only the successfully extracted signatures (no throws, no undefined entries).
+    const env = envelopeWith([
+      {
+        name: "bad",
+        params: [{ name: "x", annotation: null }],
+        return_annotation: "int",
+        body_source: "    return x",
+      },
+      {
+        name: "good",
+        params: [{ name: "x", annotation: "int" }],
+        return_annotation: "int",
+        body_source: "    return x",
+      },
+    ]);
+    // Must NOT throw, must return only the succeeded function.
+    const sigs = extractFunctionSignatures(env);
+    expect(sigs).toHaveLength(1);
+    expect(sigs[0]?.name).toBe("good");
+  });
+
+  it("extractFunctionSignaturesAll: unsupported type in middle does not abort — compound production sequence", () => {
+    // End-to-end production sequence: a bs4-style module where one function uses
+    // Set[int] (unsupported subscript container) — a common real-world annotation
+    // that used to abort the whole module before #899.
+    const env = envelopeWith([
+      {
+        name: "count_items",
+        params: [{ name: "n", annotation: "int" }],
+        return_annotation: "str",
+        body_source: "    return str(n)",
+      },
+      {
+        name: "set_fn",
+        params: [{ name: "items", annotation: "Set[int]" }], // unsupported subscript
+        return_annotation: "int",
+        body_source: "    return len(items)",
+      },
+      {
+        name: "stringify",
+        params: [{ name: "val", annotation: "Any" }],
+        return_annotation: "str",
+        body_source: "    return str(val)",
+      },
+    ]);
+    const result = extractFunctionSignaturesAll(env);
+    // count_items and stringify succeed; set_fn fails
+    expect(result.ok).toHaveLength(2);
+    expect(result.failed).toHaveLength(1);
+    expect(result.ok.map((s) => s.name)).toEqual(["count_items", "stringify"]);
+    expect(result.failed[0]?.name).toBe("set_fn");
+    // stringify's Any param should carry the any-widened warning end-to-end
+    const stringifySig = result.ok.find((s) => s.name === "stringify");
+    expect(stringifySig?.params[0]?.warnings?.[0]?.code).toBe("any-widened");
   });
 });

--- a/packages/shave-python/src/parse-fn-signature.ts
+++ b/packages/shave-python/src/parse-fn-signature.ts
@@ -64,6 +64,40 @@ export interface FunctionSignature {
 }
 
 /**
+ * A failed per-function extraction record — returned by `extractFunctionSignaturesAll`
+ * for functions that could not be fully raised.
+ *
+ * @decision DEC-SHAVE-PY-PARSE-SIG-899
+ * @title Per-function extraction failure record
+ * @status accepted (#899)
+ * @rationale
+ *   extractFunctionSignatures used .map() which threw on the first failure,
+ *   aborting extraction of all remaining functions (#899).  The fix wraps each
+ *   extractOne() call in try/catch.  Failed entries are exposed via
+ *   extractFunctionSignaturesAll so callers that want the full picture (e.g.
+ *   exploration scripts, batch tools) can inspect per-function errors.
+ *   extractFunctionSignatures preserves its existing return type (FunctionSignature[])
+ *   for backward compatibility with integration.test.ts and other callers not in scope.
+ */
+export interface ExtractionFailure {
+  /** Python function name from the envelope. */
+  readonly name: string;
+  /** The error that caused extraction to fail for this function. */
+  readonly error: Error;
+}
+
+/**
+ * Return shape of `extractFunctionSignaturesAll` — separates successes from
+ * per-function failures.
+ */
+export interface ExtractionResult {
+  /** Successfully extracted function signatures. */
+  readonly ok: readonly FunctionSignature[];
+  /** Functions that failed extraction, with their errors. */
+  readonly failed: readonly ExtractionFailure[];
+}
+
+/**
  * Thrown when a function in the envelope cannot be raised — missing required
  * annotation, unsupported type, etc.  Slice 4 will rewrap these as
  * `CannotRaiseToIRError` from `@yakcc/contracts`.
@@ -98,16 +132,50 @@ interface EnvelopeFunction {
 
 /**
  * Walk the libcst envelope and return a typed `FunctionSignature[]` — one
- * entry per top-level `def`.  Each function's annotations are validated and
- * mapped to TS-subset IR types via `mapPythonType`.
+ * entry per successfully extracted top-level `def`.
  *
- * Throws on the first error encountered (missing annotation or unsupported
- * type).  Callers that want all errors should walk the envelope themselves.
+ * Unlike the pre-#899 implementation, this function does NOT throw on the
+ * first per-function failure.  Each function is extracted independently; if
+ * one fails (e.g. unsupported type annotation), it is silently skipped and
+ * extraction continues for the remaining functions.
+ *
+ * Callers that need the full picture (successes AND per-function failures)
+ * should use `extractFunctionSignaturesAll` instead.
+ *
+ * Return type is preserved as `FunctionSignature[]` for backward compatibility
+ * with existing callers.
  */
 export function extractFunctionSignatures(envelope: LibcstParseResult): FunctionSignature[] {
+  return extractFunctionSignaturesAll(envelope).ok as FunctionSignature[];
+}
+
+/**
+ * Walk the libcst envelope and return an `ExtractionResult` with both
+ * successfully extracted signatures and per-function failures.
+ *
+ * Each function is extracted independently via try/catch so a single
+ * failure (unsupported annotation, missing annotation, etc.) does not
+ * abort extraction of the remaining functions in the module (#899).
+ */
+export function extractFunctionSignaturesAll(envelope: LibcstParseResult): ExtractionResult {
   const moduleRecord = envelope.module as unknown as { functions?: EnvelopeFunction[] };
   const fns = moduleRecord.functions ?? [];
-  return fns.map((fn) => extractOne(fn));
+
+  const ok: FunctionSignature[] = [];
+  const failed: ExtractionFailure[] = [];
+
+  for (const fn of fns) {
+    try {
+      ok.push(extractOne(fn));
+    } catch (err) {
+      failed.push({
+        name: fn.name,
+        error: err instanceof Error ? err : new Error(String(err)),
+      });
+    }
+  }
+
+  return { ok, failed };
 }
 
 function extractOne(fn: EnvelopeFunction): FunctionSignature {

--- a/packages/shave-python/src/purity-check.test.ts
+++ b/packages/shave-python/src/purity-check.test.ts
@@ -16,7 +16,12 @@
 
 import { describe, expect, it } from "vitest";
 import type { LibcstParseResult, PythonAstNode } from "./libcst-parser.js";
-import { ImpureFunctionError, checkFunctionPurity, checkPurity } from "./purity-check.js";
+import {
+  ImpureFunctionError,
+  checkFunctionPurity,
+  checkModuleImports,
+  checkPurity,
+} from "./purity-check.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -501,6 +506,63 @@ describe("checkFunctionPurity", () => {
     } as unknown as PythonAstNode;
     const module = { type: "Module" } as unknown as PythonAstNode;
     expect(() => checkFunctionPurity(fn, module, "bad")).toThrow(ImpureFunctionError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #900: checkModuleImports defensive null checks
+// ---------------------------------------------------------------------------
+
+describe("#900 — checkModuleImports defensive null checks", () => {
+  it("does not crash when envelope.module has no imports field (undefined imports)", () => {
+    // bs4 _invert: a module with no import statements at all (or only 'from typing import Any'
+    // which libcst may not populate into imports[] on some envelope shapes).
+    const envelope: LibcstParseResult = {
+      version: 1,
+      module: {
+        type: "Module",
+        stmt_count: 1,
+        functions: [{ name: "_invert", params: [], return_annotation: "dict", body_source: "" }],
+        // No 'imports' field at all
+      } as unknown as PythonAstNode,
+    };
+    // Must not throw TypeError; the function should return cleanly (no forbidden imports).
+    expect(() => checkModuleImports(envelope, "_invert")).not.toThrow();
+  });
+
+  it("does not crash when envelope.module.imports is an empty array", () => {
+    const envelope: LibcstParseResult = {
+      version: 1,
+      module: {
+        type: "Module",
+        stmt_count: 1,
+        functions: [],
+        imports: [],
+      } as unknown as PythonAstNode,
+    };
+    expect(() => checkModuleImports(envelope, "some_fn")).not.toThrow();
+  });
+
+  it("does not crash when envelope.module is undefined (extreme defensive case)", () => {
+    // Synthetic worst-case: envelope produced without a module node.
+    const envelope = {
+      version: 1 as const,
+      module: undefined as unknown as PythonAstNode,
+    };
+    expect(() => checkModuleImports(envelope, "some_fn")).not.toThrow();
+  });
+
+  it("still rejects forbidden import when imports field IS present", () => {
+    const envelope: LibcstParseResult = {
+      version: 1,
+      module: {
+        type: "Module",
+        stmt_count: 1,
+        functions: [],
+        imports: [{ kind: "import", module: "os", name: "os" }],
+      } as unknown as PythonAstNode,
+    };
+    expect(() => checkModuleImports(envelope, "_invert")).toThrow(ImpureFunctionError);
   });
 });
 

--- a/packages/shave-python/src/purity-check.ts
+++ b/packages/shave-python/src/purity-check.ts
@@ -421,7 +421,12 @@ export function checkFunctionPurity(
  * Returns void if no forbidden imports are present.
  */
 export function checkModuleImports(envelope: LibcstParseResult, fnName: string): void {
-  const moduleNode = envelope.module as PythonAstNode;
+  // #900: envelope.module can be undefined when the envelope is constructed for a
+  // module with no top-level statements (or a synthetic envelope in tests).
+  // collectImportImpurities already guards against undefined .imports, but it does
+  // NOT guard against moduleNode itself being undefined — pass an empty sentinel
+  // instead so the function returns cleanly rather than crashing.
+  const moduleNode = (envelope.module ?? { type: "Module" }) as PythonAstNode;
   const importViolations = collectImportImpurities(moduleNode);
   const firstImport = importViolations[0];
   if (firstImport !== undefined) {

--- a/packages/shave-python/src/type-map.test.ts
+++ b/packages/shave-python/src/type-map.test.ts
@@ -108,25 +108,23 @@ describe("mapPythonType — Optional / Union / PEP 604", () => {
 // ---------------------------------------------------------------------------
 
 describe("mapPythonType — unsupported", () => {
-  it("rejects unknown primitive", () => {
-    try {
-      mapPythonType("Decimal");
-      expect.unreachable("should have thrown");
-    } catch (err) {
-      expect(err).toBeInstanceOf(UnsupportedTypeError);
-      expect((err as Error).message).toContain("Decimal");
-      expect((err as Error).message).toContain("slice-2 mapping table");
-    }
+  it("plain identifier not in table passes through with user-defined-type-identifier warning (#901)", () => {
+    // Decimal is a plain identifier — no longer throws; passes through verbatim.
+    const result = mapPythonType("Decimal");
+    expect(result.tsType).toBe("Decimal");
+    expectOneWarning(result, "user-defined-type-identifier");
+    expect(result.warnings[0]?.pythonFragment).toBe("Decimal");
   });
-  it("rejects unknown container", () => {
+  it("rejects unknown container (subscript form still throws)", () => {
+    // MyContainer[int] has brackets — not a plain identifier, still throws.
     expect(() => mapPythonType("MyContainer[int]")).toThrow(UnsupportedTypeError);
   });
-  it("carries the offending type on the thrown error", () => {
-    try {
-      mapPythonType("bigint");
-    } catch (err) {
-      expect((err as UnsupportedTypeError).pythonType).toBe("bigint");
-    }
+  it("plain identifier bigint passes through (was throwing — now user-defined-type-identifier)", () => {
+    // bigint is a plain identifier that matches /^[A-Za-z_][A-Za-z0-9_]*$/.
+    // Prior to #901 this threw; now it passes through with a warning.
+    const result = mapPythonType("bigint");
+    expect(result.tsType).toBe("bigint");
+    expectOneWarning(result, "user-defined-type-identifier");
   });
 });
 
@@ -190,26 +188,19 @@ describe("mapPythonType — quoted forward references", () => {
     expect(result.warnings).toHaveLength(0);
   });
 
-  it('double-quoted unsupported type throws with inner name in error: "_IncomingMarkup"', () => {
-    try {
-      mapPythonType('"_IncomingMarkup"');
-      expect.unreachable("should have thrown");
-    } catch (err) {
-      expect(err).toBeInstanceOf(UnsupportedTypeError);
-      // Error message must reference the inner (unquoted) name, not the quoted form.
-      expect((err as Error).message).toContain("_IncomingMarkup");
-      expect((err as Error).message).not.toContain('"_IncomingMarkup"');
-    }
+  it('double-quoted plain identifier "_IncomingMarkup" strips quotes and passes through (#901)', () => {
+    // Prior to #901 this threw UnsupportedTypeError.  Now: quotes strip → _IncomingMarkup
+    // is a plain identifier → passes through verbatim with user-defined-type-identifier warning.
+    const result = mapPythonType('"_IncomingMarkup"');
+    expect(result.tsType).toBe("_IncomingMarkup");
+    expectOneWarning(result, "user-defined-type-identifier");
+    expect(result.warnings[0]?.pythonFragment).toBe("_IncomingMarkup");
   });
 
-  it("single-quoted unsupported type throws with inner name: '_IncomingMarkup'", () => {
-    try {
-      mapPythonType("'_IncomingMarkup'");
-      expect.unreachable("should have thrown");
-    } catch (err) {
-      expect(err).toBeInstanceOf(UnsupportedTypeError);
-      expect((err as Error).message).toContain("_IncomingMarkup");
-    }
+  it("single-quoted plain identifier '_IncomingMarkup' strips quotes and passes through (#901)", () => {
+    const result = mapPythonType("'_IncomingMarkup'");
+    expect(result.tsType).toBe("_IncomingMarkup");
+    expectOneWarning(result, "user-defined-type-identifier");
   });
 
   it('double-quoted Any strips and maps to unknown: "Any"', () => {
@@ -390,30 +381,21 @@ describe("mapPythonType — real bs4 regressions from #889", () => {
     expectOneWarning(result, "callable-widened");
   });
 
-  // bs4 case 3: "_IncomingMarkup" double-quoted forward ref
-  // Quote handling is fixed (no longer throws on the quote form).
-  // The inner symbol _IncomingMarkup is genuinely unsupported — the UnsupportedTypeError
-  // must reference the inner name, not the outer quoted form.
-  it('bs4 #3: "_IncomingMarkup" strips quotes and throws on inner _IncomingMarkup', () => {
-    try {
-      mapPythonType('"_IncomingMarkup"');
-      expect.unreachable("should have thrown");
-    } catch (err) {
-      expect(err).toBeInstanceOf(UnsupportedTypeError);
-      expect((err as Error).message).toContain("_IncomingMarkup");
-      expect((err as Error).message).not.toContain('"_IncomingMarkup"');
-    }
+  // bs4 case 3: "_IncomingMarkup" double-quoted forward ref — #901 fix
+  // Quotes strip → _IncomingMarkup is a plain identifier → passes through verbatim
+  // with user-defined-type-identifier warning (was UnsupportedTypeError before #901).
+  it('bs4 #3: "_IncomingMarkup" strips quotes and passes through verbatim with warning (#901)', () => {
+    const result = mapPythonType('"_IncomingMarkup"');
+    expect(result.tsType).toBe("_IncomingMarkup");
+    expectOneWarning(result, "user-defined-type-identifier");
+    expect(result.warnings[0]?.pythonFragment).toBe("_IncomingMarkup");
   });
 
-  // bs4 case 4: "_IncomingMarkup" again (lxml_trace path) — same as case 3
-  it('bs4 #4 (lxml_trace): "_IncomingMarkup" same as case 3 — error references inner name', () => {
-    try {
-      mapPythonType('"_IncomingMarkup"');
-      expect.unreachable("should have thrown");
-    } catch (err) {
-      expect(err).toBeInstanceOf(UnsupportedTypeError);
-      expect((err as UnsupportedTypeError).pythonType).toBe("_IncomingMarkup");
-    }
+  // bs4 case 4: "_IncomingMarkup" again (lxml_trace path) — same pass-through behavior
+  it('bs4 #4 (lxml_trace): "_IncomingMarkup" same — passes through verbatim with warning (#901)', () => {
+    const result = mapPythonType('"_IncomingMarkup"');
+    expect(result.tsType).toBe("_IncomingMarkup");
+    expectOneWarning(result, "user-defined-type-identifier");
   });
 
   // bs4 case 5: dict[Any, str] — was throwing "dict key must be 'str'"
@@ -435,5 +417,55 @@ describe("mapPythonType — real bs4 regressions from #889", () => {
     const result = mapPythonType("Any");
     expect(result.tsType).toBe("unknown");
     expectOneWarning(result, "any-widened");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #901: User-defined type identifier pass-through
+// ---------------------------------------------------------------------------
+
+describe("mapPythonType — #901 user-defined type identifier pass-through", () => {
+  it("plain identifier _IncomingMarkup passes through verbatim with user-defined-type-identifier warning", () => {
+    const result = mapPythonType("_IncomingMarkup");
+    expect(result.tsType).toBe("_IncomingMarkup");
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]?.code).toBe("user-defined-type-identifier");
+    expect(result.warnings[0]?.pythonFragment).toBe("_IncomingMarkup");
+    expect(result.warnings[0]?.message).toBeTruthy();
+  });
+
+  it("underscore-prefixed plain identifier MyType passes through verbatim", () => {
+    const result = mapPythonType("MyType");
+    expect(result.tsType).toBe("MyType");
+    expectOneWarning(result, "user-defined-type-identifier");
+  });
+
+  it("Set[int] (generic subscript) still throws UnsupportedTypeError — not a plain identifier", () => {
+    // Generic subscript forms are not plain identifiers; they fall into parseSubscript
+    // and must still throw unless they are known containers.
+    expect(() => mapPythonType("Set[int]")).toThrow(UnsupportedTypeError);
+  });
+
+  it("Iterable[str] still throws UnsupportedTypeError — not a plain identifier", () => {
+    expect(() => mapPythonType("Iterable[str]")).toThrow(UnsupportedTypeError);
+  });
+
+  it("dotted name types.Foo still throws UnsupportedTypeError — not a plain identifier", () => {
+    // Dotted names contain '.' which fails /^[A-Za-z_][A-Za-z0-9_]*$/.
+    // Exception: types.ModuleType is caught in the switch above this rule.
+    expect(() => mapPythonType("types.Foo")).toThrow(UnsupportedTypeError);
+  });
+
+  it("user-defined-type-identifier propagates through Optional[_IncomingMarkup]", () => {
+    // Compound types containing user-defined identifiers should propagate warnings.
+    const result = mapPythonType("Optional[_IncomingMarkup]");
+    expect(result.tsType).toBe("_IncomingMarkup | null");
+    expectOneWarning(result, "user-defined-type-identifier");
+  });
+
+  it("user-defined-type-identifier propagates through list[_IncomingMarkup]", () => {
+    const result = mapPythonType("list[_IncomingMarkup]");
+    expect(result.tsType).toBe("_IncomingMarkup[]");
+    expectOneWarning(result, "user-defined-type-identifier");
   });
 });

--- a/packages/shave-python/src/type-map.ts
+++ b/packages/shave-python/src/type-map.ts
@@ -83,7 +83,8 @@ export interface LowerWarning {
     | "any-widened" // typing.Any → unknown
     | "callable-widened" // bare Callable or Callable[..., R]
     | "module-type-widened" // types.ModuleType → unknown
-    | "dict-any-key-widened"; // dict[Any, V] → Record<string, V>
+    | "dict-any-key-widened" // dict[Any, V] → Record<string, V>
+    | "user-defined-type-identifier"; // plain identifier not in mapping table → pass through verbatim (#901)
   /** Human-readable message for diagnostics. */
   readonly message: string;
   /** The original Python annotation fragment that triggered the warning. */
@@ -330,6 +331,43 @@ export function mapPythonType(annotation: string): MapPythonTypeResult {
         return mapCallableSubscript(inner, trimmed);
       }
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // #901: Plain user-defined type identifier pass-through.
+  // A bare Python identifier (no brackets, no operators, no dots) that is not
+  // in the mapping table is likely a user-defined type (TypeAlias, NewType,
+  // class).  Pass it through verbatim as the TS type name + LowerWarning.
+  //
+  // Acceptance rule:
+  //   - PLAIN identifier: [A-Za-z_][A-Za-z0-9_]*  (no brackets or operators)
+  //   - Known-unsupported generics like Set[X], Iterable[X] still throw
+  //     (parseSubscript handled them above; they never reach here)
+  //   - Dotted names like types.MyType also still throw (contain a dot)
+  //
+  // @decision DEC-SHAVE-PY-TYPE-MAP-901
+  // @title Plain identifier fall-through → verbatim TS type + user-defined-type-identifier warning
+  // @status accepted (#901)
+  // @rationale
+  //   Real Python codebases pervasively annotate with user-defined types.
+  //   Throwing on every one makes extraction fail for nearly all annotated
+  //   functions.  Option A from #901 (pass-through with warning) is the MVP:
+  //   least friction, fewest test changes, lets exploration proceed.
+  //   Dotted names (module.Type) and subscript forms still throw — only bare
+  //   identifiers are eligible because only those have an obvious verbatim TS
+  //   representation.
+  // ---------------------------------------------------------------------------
+  if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(trimmed)) {
+    return {
+      tsType: trimmed,
+      warnings: [
+        {
+          code: "user-defined-type-identifier",
+          message: `Python identifier '${trimmed}' is not in the type-map table; passed through verbatim as TS type. Ensure the TypeScript environment defines this type.`,
+          pythonFragment: trimmed,
+        },
+      ],
+    };
   }
 
   throw new UnsupportedTypeError(


### PR DESCRIPTION
## Summary

Three bs4 e2e blockers found during 2026-05-29 re-exploration after #888 / #889 / #898 landed:

- **#899** — `extractFunctionSignatures` aborted on first per-function failure, losing all subsequent functions in the same module. Added new `extractFunctionSignaturesAll` returning `{ ok, failed }` with per-function continuation. Backward-compat `extractFunctionSignatures` returns ok-only.
- **#900** — `checkModuleImports` crashed with `Cannot read properties of undefined (reading 'imports')` when `envelope.module` was undefined. Added defensive sentinel.
- **#901** — type-map rejected user-defined type identifiers (`_IncomingMarkup`, etc.). Added plain-identifier fallthrough with `LowerWarning` code `user-defined-type-identifier`. Subscript / dotted names still rejected as before.

## Test plan

- [x] `pnpm -F @yakcc/shave-python test` — 273/273 pass (up from 257)
- [x] Typecheck clean
- [x] Lint clean
- [ ] CI green
- [ ] bs4 e2e re-run surfaces compile-stage bugs (next slice)

## Context

Follow-up to bs4 e2e exploration. #888 + #889 + #898 already landed. After this lands, bs4 e2e should advance past shave-stage and start surfacing compile-stage bugs.

Closes #899
Closes #900
Closes #901

🤖 Generated with [Claude Code](https://claude.com/claude-code)