### PR TITLE
feat(shave-python): #903 + #904 — If statements + comprehensions

### DIFF
--- a/packages/shave-python/scripts/libcst-parse.py
+++ b/packages/shave-python/scripts/libcst-parse.py
@@ -9,7 +9,16 @@
 # wire nodes emitted by _stmt_inner() when it encounters libcst.Expr nodes.
 # See PLAN.md §3 and DEC-WI888-001..003.
 #
-# Wire shape (cumulative through WI-888):
+# WI-903: If statement support — _stmt_v2() now handles libcst.If compound
+# statements, emitting {"type":"If","test":<Expr>,"body":[...],"orelse":[...]}
+# where orelse is [] (no else), a flat list (else block), or [{type:"If",...}]
+# (elif chain, matching Python AST convention). Cross-reference: #903.
+#
+# WI-904: Comprehension support — _expr() handles GeneratorExp, DictComp,
+# SetComp with single-source single-clause MVP. Multi-clause raises Unsupported.
+# Cross-reference: #904.
+#
+# Wire shape (cumulative through WI-904):
 #   functions[].body:
 #     [ Statement, ... ]
 #   Statement:
@@ -19,6 +28,8 @@
 #     {"type": "Docstring", "value": "<str>"}                           [WI-888]
 #     {"type": "ImpureStatement", "construct": "bare_call"|            [WI-888]
 #              "bare_expression", "detail": "<str>"}
+#     {"type": "If", "test": <Expr>, "body": [<Stmt>...],              [WI-903]
+#              "orelse": [<Stmt>...]}
 #     {"type": "Unsupported", "reason": "<str>"}
 #   Expr:
 #     {"type": "Name",    "name": "<str>"}
@@ -36,6 +47,14 @@
 #              "param": "<str>", "elt": <Expr>}
 #     {"type": "ListComp", "kind": "filter", "iter": <Expr>,            [slice 4]
 #              "param": "<str>", "cond": <Expr>}
+#     {"type": "GeneratorExp", "kind": "map"|"filter_map",              [WI-904]
+#              "iter": <Expr>, "param": "<str>", "elt": <Expr>,
+#              "cond": <Expr>?}
+#     {"type": "DictComp", "iter": <Expr>, "param": "<str>",            [WI-904]
+#              "keyElt": <Expr>, "valElt": <Expr>, "cond": <Expr>|null}
+#     {"type": "SetComp", "kind": "map"|"filter_map",                   [WI-904]
+#              "iter": <Expr>, "param": "<str>", "elt": <Expr>,
+#              "cond": <Expr>?}
 #     {"type": "Unsupported", "reason": "<str>"}
 #
 # Exit codes (unchanged from slice 1):
@@ -226,6 +245,84 @@ def _expr(node):  # type: ignore[no-untyped-def]
             "reason": ("ListComp: complex pattern (multiple ifs or non-identity elt with filter)"),
         }
 
+    # WI-904: generator expression (x for target in iter [if cond])
+    # Lowers identically to ListComp — TS consumer receives an Array.
+    if isinstance(node, libcst.GeneratorExp):
+        gen = node.for_in
+        if gen.inner_for_in is not None:
+            return {"type": "Unsupported", "reason": "GeneratorExp with multiple generators"}
+        if not isinstance(gen.target, libcst.Name):
+            return {"type": "Unsupported", "reason": "GeneratorExp with tuple/complex target"}
+        param = gen.target.value
+        iter_expr = _expr(gen.iter)
+        if len(gen.ifs) == 0:
+            return {
+                "type": "GeneratorExp",
+                "kind": "map",
+                "iter": iter_expr,
+                "param": param,
+                "elt": _expr(node.elt),
+            }
+        if len(gen.ifs) == 1:
+            return {
+                "type": "GeneratorExp",
+                "kind": "filter_map",
+                "iter": iter_expr,
+                "param": param,
+                "cond": _expr(gen.ifs[0].test),
+                "elt": _expr(node.elt),
+            }
+        return {"type": "Unsupported", "reason": "GeneratorExp with multiple if-clauses"}
+
+    # WI-904: dict comprehension {key: val for target in iter [if cond]}
+    if isinstance(node, libcst.DictComp):
+        gen = node.for_in
+        if gen.inner_for_in is not None:
+            return {"type": "Unsupported", "reason": "DictComp with multiple generators"}
+        if not isinstance(gen.target, libcst.Name):
+            return {"type": "Unsupported", "reason": "DictComp with tuple/complex target"}
+        param = gen.target.value
+        iter_expr = _expr(gen.iter)
+        cond_expr = _expr(gen.ifs[0].test) if len(gen.ifs) == 1 else None
+        if len(gen.ifs) > 1:
+            return {"type": "Unsupported", "reason": "DictComp with multiple if-clauses"}
+        return {
+            "type": "DictComp",
+            "iter": iter_expr,
+            "param": param,
+            "keyElt": _expr(node.key),
+            "valElt": _expr(node.value),
+            "cond": cond_expr,
+        }
+
+    # WI-904: set comprehension {elt for target in iter [if cond]}
+    if isinstance(node, libcst.SetComp):
+        gen = node.for_in
+        if gen.inner_for_in is not None:
+            return {"type": "Unsupported", "reason": "SetComp with multiple generators"}
+        if not isinstance(gen.target, libcst.Name):
+            return {"type": "Unsupported", "reason": "SetComp with tuple/complex target"}
+        param = gen.target.value
+        iter_expr = _expr(gen.iter)
+        if len(gen.ifs) == 0:
+            return {
+                "type": "SetComp",
+                "kind": "map",
+                "iter": iter_expr,
+                "param": param,
+                "elt": _expr(node.elt),
+            }
+        if len(gen.ifs) == 1:
+            return {
+                "type": "SetComp",
+                "kind": "filter_map",
+                "iter": iter_expr,
+                "param": param,
+                "cond": _expr(gen.ifs[0].test),
+                "elt": _expr(node.elt),
+            }
+        return {"type": "Unsupported", "reason": "SetComp with multiple if-clauses"}
+
     return {"type": "Unsupported", "reason": type(node).__name__}
 
 
@@ -360,6 +457,21 @@ def _stmt_inner(inner, is_first=False):  # type: ignore[no-untyped-def]
     return {"type": "Unsupported", "reason": f"SmallStatement {type(inner).__name__}"}
 
 
+def _if_stmts(body):  # type: ignore[no-untyped-def]
+    """Translate an IndentedBlock body into a list of wire Statement dicts.
+
+    Used by _stmt_v2 for if/elif/else branches. is_first is always False for
+    nested bodies (docstring detection only applies to top-level function body).
+    """
+    stmts = []
+    try:
+        for stmt in body.body:
+            stmts.append(_stmt_v2(stmt, is_first=False))
+    except AttributeError:
+        pass
+    return stmts
+
+
 def _stmt_v2(node, is_first=False):  # type: ignore[no-untyped-def]
     """Translate a libcst statement node into a wire Statement dict (slice 4).
 
@@ -372,6 +484,34 @@ def _stmt_v2(node, is_first=False):  # type: ignore[no-untyped-def]
         if len(node.body) != 1:
             return {"type": "Unsupported", "reason": "Multi-statement simple line"}
         return _stmt_inner(node.body[0], is_first=is_first)
+
+    # WI-903: if/elif/else compound statement.
+    #
+    # libcst represents:
+    #   if cond: body
+    #   elif cond2: body2  → stored as node.orelse = libcst.If(...)
+    #   else: body3        → stored as node.orelse = libcst.Else(...)
+    #
+    # Wire convention (matches Python AST): orelse is either:
+    #   []                            — no else/elif
+    #   [{type:"If",...}]             — elif chain (single nested If)
+    #   [<stmt>, ...]                 — else block (flat list of stmts)
+    if isinstance(node, libcst.If):
+        orelse: list = []  # type: ignore[type-arg]
+        if node.orelse is not None:
+            if isinstance(node.orelse, libcst.If):
+                # elif: recurse — produces a single If wire node
+                orelse = [_stmt_v2(node.orelse, is_first=False)]
+            elif isinstance(node.orelse, libcst.Else):
+                # else: flat list of stmts in the else body
+                orelse = _if_stmts(node.orelse.body)
+        return {
+            "type": "If",
+            "test": _expr(node.test),
+            "body": _if_stmts(node.body),
+            "orelse": orelse,
+        }
+
     return {"type": "Unsupported", "reason": type(node).__name__}
 
 

--- a/packages/shave-python/src/libcst-parser.test.ts
+++ b/packages/shave-python/src/libcst-parser.test.ts
@@ -305,3 +305,153 @@ describe("WI-888: Docstring + ImpureStatement emission (real Python subprocess)"
     });
   }
 });
+
+// ---------------------------------------------------------------------------
+// WI-903: If statement emission (real Python subprocess)
+// ---------------------------------------------------------------------------
+
+describe("WI-903: If statement emission (real Python subprocess)", () => {
+  const pythonAvailable = (() => {
+    try {
+      execSync("python3 -c 'import libcst'", { stdio: "pipe" });
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
+  if (!pythonAvailable) {
+    it.skip("requires python3 with libcst installed (skipped)", () => {});
+  } else {
+    it("emits If wire node for a simple if-only statement", async () => {
+      const source = "def check(x: int) -> int:\n    if x > 0:\n        return x\n    return 0\n";
+      const result = await parsePythonSource(source);
+      const fn = (result.module.functions as PythonAstNode[])[0] as PythonAstNode;
+      const body = fn.body as PythonAstNode[];
+      // First statement is the if
+      expect(body[0]?.type).toBe("If");
+      const ifStmt = body[0] as PythonAstNode;
+      // test is a BinaryOp (x > 0)
+      expect((ifStmt.test as PythonAstNode).type).toBe("BinaryOp");
+      expect((ifStmt.test as PythonAstNode).op).toBe(">");
+      // body contains a Return
+      expect(Array.isArray(ifStmt.body)).toBe(true);
+      expect((ifStmt.body as PythonAstNode[])[0]?.type).toBe("Return");
+      // orelse is empty
+      expect(Array.isArray(ifStmt.orelse)).toBe(true);
+      expect((ifStmt.orelse as PythonAstNode[]).length).toBe(0);
+    });
+
+    it("emits If with orelse for if/else", async () => {
+      const source =
+        "def sign(x: int) -> int:\n    if x >= 0:\n        return 1\n    else:\n        return -1\n";
+      const result = await parsePythonSource(source);
+      const fn = (result.module.functions as PythonAstNode[])[0] as PythonAstNode;
+      const body = fn.body as PythonAstNode[];
+      expect(body[0]?.type).toBe("If");
+      const ifStmt = body[0] as PythonAstNode;
+      // orelse is a flat list with a Return
+      expect(Array.isArray(ifStmt.orelse)).toBe(true);
+      expect((ifStmt.orelse as PythonAstNode[]).length).toBe(1);
+      expect((ifStmt.orelse as PythonAstNode[])[0]?.type).toBe("Return");
+    });
+
+    it("emits nested If in orelse for if/elif/else (Python AST convention)", async () => {
+      const source =
+        "def classify(x: int) -> int:\n    if x > 0:\n        return 1\n    elif x < 0:\n        return -1\n    else:\n        return 0\n";
+      const result = await parsePythonSource(source);
+      const fn = (result.module.functions as PythonAstNode[])[0] as PythonAstNode;
+      const body = fn.body as PythonAstNode[];
+      const ifStmt = body[0] as PythonAstNode;
+      expect(ifStmt.type).toBe("If");
+      // elif: orelse is a single-element list containing an If node
+      expect((ifStmt.orelse as PythonAstNode[]).length).toBe(1);
+      const elifNode = (ifStmt.orelse as PythonAstNode[])[0] as PythonAstNode;
+      expect(elifNode.type).toBe("If");
+      // The elif's orelse is a flat list (the else block)
+      expect((elifNode.orelse as PythonAstNode[]).length).toBe(1);
+      expect((elifNode.orelse as PythonAstNode[])[0]?.type).toBe("Return");
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// WI-904: Comprehension emission (real Python subprocess)
+// ---------------------------------------------------------------------------
+
+describe("WI-904: Comprehension emission (real Python subprocess)", () => {
+  const pythonAvailable = (() => {
+    try {
+      execSync("python3 -c 'import libcst'", { stdio: "pipe" });
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
+  if (!pythonAvailable) {
+    it.skip("requires python3 with libcst installed (skipped)", () => {});
+  } else {
+    it("emits ListComp map node for [f(x) for x in xs]", async () => {
+      const source = "def double_all(xs: list) -> list:\n    return [x * 2 for x in xs]\n";
+      const result = await parsePythonSource(source);
+      const fn = (result.module.functions as PythonAstNode[])[0] as PythonAstNode;
+      const ret = (fn.body as PythonAstNode[])[0] as PythonAstNode;
+      expect(ret.type).toBe("Return");
+      const comp = ret.value as PythonAstNode;
+      expect(comp.type).toBe("ListComp");
+      expect(comp.kind).toBe("map");
+      expect(comp.param).toBe("x");
+    });
+
+    it("emits ListComp filter node for [x for x in xs if cond]", async () => {
+      const source = "def keep_positive(xs: list) -> list:\n    return [x for x in xs if x > 0]\n";
+      const result = await parsePythonSource(source);
+      const fn = (result.module.functions as PythonAstNode[])[0] as PythonAstNode;
+      const ret = (fn.body as PythonAstNode[])[0] as PythonAstNode;
+      const comp = ret.value as PythonAstNode;
+      expect(comp.type).toBe("ListComp");
+      expect(comp.kind).toBe("filter");
+      expect(comp.param).toBe("x");
+      // cond is a BinaryOp (x > 0)
+      expect((comp.cond as PythonAstNode).type).toBe("BinaryOp");
+    });
+
+    it("emits GeneratorExp map node for (f(x) for x in xs)", async () => {
+      const source = "def gen_doubled(xs: list) -> list:\n    return list(x * 2 for x in xs)\n";
+      const result = await parsePythonSource(source);
+      const fn = (result.module.functions as PythonAstNode[])[0] as PythonAstNode;
+      const ret = (fn.body as PythonAstNode[])[0] as PythonAstNode;
+      // Return value is a Call (list(...))
+      expect(ret.type).toBe("Return");
+      const callNode = ret.value as PythonAstNode;
+      expect(callNode.type).toBe("Call");
+      // The single arg is the GeneratorExp
+      const genArg = (callNode.args as PythonAstNode[])[0] as PythonAstNode;
+      expect(genArg.type).toBe("GeneratorExp");
+      expect(genArg.kind).toBe("map");
+    });
+
+    it("emits DictComp wire node for {k: v for k in keys}", async () => {
+      const source = "def invert(keys: list) -> dict:\n    return {k: 1 for k in keys}\n";
+      const result = await parsePythonSource(source);
+      const fn = (result.module.functions as PythonAstNode[])[0] as PythonAstNode;
+      const ret = (fn.body as PythonAstNode[])[0] as PythonAstNode;
+      const comp = ret.value as PythonAstNode;
+      expect(comp.type).toBe("DictComp");
+      expect(comp.param).toBe("k");
+      expect(comp.cond).toBeNull();
+    });
+
+    it("emits SetComp map node for {f(x) for x in xs}", async () => {
+      const source = "def unique_doubled(xs: list) -> set:\n    return {x * 2 for x in xs}\n";
+      const result = await parsePythonSource(source);
+      const fn = (result.module.functions as PythonAstNode[])[0] as PythonAstNode;
+      const ret = (fn.body as PythonAstNode[])[0] as PythonAstNode;
+      const comp = ret.value as PythonAstNode;
+      expect(comp.type).toBe("SetComp");
+      expect(comp.kind).toBe("map");
+      expect(comp.param).toBe("x");
+    });
+  }
+});

--- a/packages/shave-python/src/raise-body.test.ts
+++ b/packages/shave-python/src/raise-body.test.ts
@@ -442,3 +442,224 @@ describe("WI-875: floor-divide // renders as Math.floor(a / b)", () => {
     expect(() => renderExpr(expr)).not.toThrow();
   });
 });
+
+// ---------------------------------------------------------------------------
+// WI-903: If statement → TS if/else if/else
+// ---------------------------------------------------------------------------
+
+describe("WI-903: renderStmt — If statement", () => {
+  const trueCond: WireExpr = { type: "Name", name: "x" };
+  const retOne: WireStmt = { type: "Return", value: { type: "Integer", value: "1" } };
+  const retTwo: WireStmt = { type: "Return", value: { type: "Integer", value: "2" } };
+  const retThree: WireStmt = { type: "Return", value: { type: "Integer", value: "3" } };
+
+  it("renders if-only (no else)", () => {
+    const stmt: WireStmt = {
+      type: "If",
+      test: trueCond,
+      body: [retOne],
+      orelse: [],
+    };
+    expect(renderStmt(stmt)).toBe("  if (x) {\n    return 1;\n  }");
+  });
+
+  it("renders if/else", () => {
+    const stmt: WireStmt = {
+      type: "If",
+      test: trueCond,
+      body: [retOne],
+      orelse: [retTwo],
+    };
+    expect(renderStmt(stmt)).toBe("  if (x) {\n    return 1;\n  } else {\n    return 2;\n  }");
+  });
+
+  it("renders if/elif/else (chained via nested If in orelse)", () => {
+    const elifCond: WireExpr = { type: "Name", name: "y" };
+    const stmt: WireStmt = {
+      type: "If",
+      test: trueCond,
+      body: [retOne],
+      orelse: [
+        {
+          type: "If",
+          test: elifCond,
+          body: [retTwo],
+          orelse: [retThree],
+        },
+      ],
+    };
+    expect(renderStmt(stmt)).toBe(
+      "  if (x) {\n    return 1;\n  } else if (y) {\n    return 2;\n  } else {\n    return 3;\n  }",
+    );
+  });
+
+  it("renders nested if inside body", () => {
+    // if (x) { if (y) { return 1; } }
+    const inner: WireStmt = {
+      type: "If",
+      test: { type: "Name", name: "y" },
+      body: [retOne],
+      orelse: [],
+    };
+    const outer: WireStmt = {
+      type: "If",
+      test: trueCond,
+      body: [inner],
+      orelse: [],
+    };
+    expect(renderStmt(outer)).toBe("  if (x) {\n    if (y) {\n      return 1;\n    }\n  }");
+  });
+
+  it("renders empty body with void 0 fallback", () => {
+    const stmt: WireStmt = {
+      type: "If",
+      test: trueCond,
+      body: [],
+      orelse: [],
+    };
+    expect(renderStmt(stmt)).toBe("  if (x) {\n    void 0;\n  }");
+  });
+
+  it("honors custom indent at the outer level", () => {
+    const stmt: WireStmt = {
+      type: "If",
+      test: trueCond,
+      body: [retOne],
+      orelse: [],
+    };
+    expect(renderStmt(stmt, "")).toBe("if (x) {\n  return 1;\n}");
+  });
+
+  it("skips Docstring nodes inside if-body (renders empty string, filtered out)", () => {
+    const stmt: WireStmt = {
+      type: "If",
+      test: trueCond,
+      body: [{ type: "Docstring", value: "ignored" }, retOne],
+      orelse: [],
+    };
+    // Docstring renders "" and is filtered, only the Return remains
+    expect(renderStmt(stmt)).toBe("  if (x) {\n    return 1;\n  }");
+  });
+
+  it("renderBody includes If statement correctly in multi-statement body", () => {
+    const stmts: WireStmt[] = [
+      {
+        type: "If",
+        test: {
+          type: "BinaryOp",
+          op: ">",
+          left: { type: "Name", name: "n" },
+          right: { type: "Integer", value: "0" },
+        },
+        body: [{ type: "Return", value: { type: "Name", name: "n" } }],
+        orelse: [],
+      },
+      { type: "Return", value: { type: "Integer", value: "0" } },
+    ];
+    const out = renderBody(stmts);
+    expect(out).toBe("  if ((n > 0)) {\n    return n;\n  }\n  return 0;");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WI-904: GeneratorExp, DictComp, SetComp expression renderers
+// ---------------------------------------------------------------------------
+
+describe("WI-904: renderExpr — GeneratorExp", () => {
+  it("renders map-kind (f(x) for x in xs) → (xs).map((x) => f(x))", () => {
+    const expr: WireExpr = {
+      type: "GeneratorExp",
+      kind: "map",
+      iter: { type: "Name", name: "xs" },
+      param: "x",
+      elt: { type: "Call", func: "f", args: [{ type: "Name", name: "x" }] },
+    };
+    expect(renderExpr(expr)).toBe("(xs).map((x) => f(x))");
+  });
+
+  it("renders filter_map-kind (f(x) for x in xs if p(x)) → filter then map", () => {
+    const expr: WireExpr = {
+      type: "GeneratorExp",
+      kind: "filter_map",
+      iter: { type: "Name", name: "xs" },
+      param: "x",
+      cond: { type: "Call", func: "p", args: [{ type: "Name", name: "x" }] },
+      elt: { type: "Call", func: "f", args: [{ type: "Name", name: "x" }] },
+    };
+    expect(renderExpr(expr)).toBe("(xs).filter((x) => p(x)).map((x) => f(x))");
+  });
+
+  it("renders identity map-kind (x for x in xs) → (xs).map((x) => x)", () => {
+    const expr: WireExpr = {
+      type: "GeneratorExp",
+      kind: "map",
+      iter: { type: "Name", name: "xs" },
+      param: "x",
+      elt: { type: "Name", name: "x" },
+    };
+    expect(renderExpr(expr)).toBe("(xs).map((x) => x)");
+  });
+});
+
+describe("WI-904: renderExpr — DictComp", () => {
+  it("renders {k: v for item in pairs} without condition", () => {
+    const expr: WireExpr = {
+      type: "DictComp",
+      iter: { type: "Name", name: "pairs" },
+      param: "item",
+      keyElt: { type: "Name", name: "item" },
+      valElt: { type: "Integer", value: "1" },
+      cond: null,
+    };
+    expect(renderExpr(expr)).toBe("Object.fromEntries((pairs).map((item) => [item, 1]))");
+  });
+
+  it("renders {k: v for item in pairs if cond} with condition filter", () => {
+    const expr: WireExpr = {
+      type: "DictComp",
+      iter: { type: "Name", name: "d" },
+      param: "k",
+      keyElt: { type: "Name", name: "k" },
+      valElt: { type: "Call", func: "f", args: [{ type: "Name", name: "k" }] },
+      cond: {
+        type: "BinaryOp",
+        op: "!=",
+        left: { type: "Name", name: "k" },
+        right: { type: "String", value: "x" },
+      },
+    };
+    expect(renderExpr(expr)).toBe(
+      'Object.fromEntries((d).filter((k) => (k != "x")).map((k) => [k, f(k)]))',
+    );
+  });
+});
+
+describe("WI-904: renderExpr — SetComp", () => {
+  it("renders {f(x) for x in xs} map-kind → new Set((xs).map(...))", () => {
+    const expr: WireExpr = {
+      type: "SetComp",
+      kind: "map",
+      iter: { type: "Name", name: "xs" },
+      param: "x",
+      elt: { type: "Call", func: "f", args: [{ type: "Name", name: "x" }] },
+    };
+    expect(renderExpr(expr)).toBe("new Set((xs).map((x) => f(x)))");
+  });
+
+  it("renders {f(x) for x in xs if cond} filter_map-kind", () => {
+    const expr: WireExpr = {
+      type: "SetComp",
+      kind: "filter_map",
+      iter: { type: "Name", name: "xs" },
+      param: "x",
+      cond: {
+        type: "BinaryOp",
+        op: ">",
+        left: { type: "Name", name: "x" },
+        right: { type: "Integer", value: "0" },
+      },
+      elt: { type: "Name", name: "x" },
+    };
+    expect(renderExpr(expr)).toBe("new Set((xs).filter((x) => (x > 0)).map((x) => x))");
+  });
+});

--- a/packages/shave-python/src/raise-body.ts
+++ b/packages/shave-python/src/raise-body.ts
@@ -15,6 +15,14 @@
 //   Stmt: Docstring    — silently skipped by renderStmt (returns "")
 //   Stmt: ImpureStatement — throws ImpureFunctionError(kind:"forbidden_construct")
 //
+// WI-903 additions to the wire AST:
+//   Stmt: If — Python if/elif/else → TS if/else if/else blocks
+//
+// WI-904 additions to the wire AST:
+//   Expr: GeneratorExp — Python generator expression → TS .map()/.filter()
+//   Expr: DictComp     — Python dict comprehension → TS Object.fromEntries()
+//   Expr: SetComp      — Python set comprehension → TS new Set(.map())
+//
 // @decision DEC-POLYGLOT-SHAVE-PY-BODY-RAISE-001 (WI-782 slice 2b)
 // @title Body translation pass operates on a structured wire AST, not raw text
 // @status accepted
@@ -42,6 +50,21 @@
 // @rationale Avoids a catch+rewrap layer in raise-function.ts. Existing callers
 //   that don't pass fnName get "<unknown>" as fallback — backward-compatible.
 //   Cross-reference: PLAN.md §4 / #888
+//
+// @decision DEC-WI903-001 — If statement lowering to TS if/else if/else
+// @title Python if/elif/else lowers to nested TS if/else blocks
+// @status accepted
+// @rationale Standard Python → TS structural equivalence. The elif chain is
+//   represented as a nested If in orelse (Python AST convention), which maps
+//   naturally to TS `else if`. Single-pass recursive renderStmt handles arbitrary
+//   depth. Cross-reference: #903
+//
+// @decision DEC-WI904-001 — Comprehension lowering MVP: single-source single-clause
+// @title ListComp/DictComp/SetComp/GeneratorExp lower to .map/.filter/Object.fromEntries
+// @status accepted
+// @rationale MVP scope: single generator, no nested comprehension. Multi-source
+//   comprehensions are rare in the bs4 target set and raise UnsupportedAstError
+//   so they fail loudly rather than silently. Cross-reference: #904
 
 import { CannotRaiseToIRError, type SourceLocation } from "@yakcc/contracts";
 import { ImpureFunctionError } from "./purity-check.js";
@@ -106,6 +129,47 @@ export type WireExpr =
       readonly param: string;
       readonly cond: WireExpr;
     }
+  // WI-904: GeneratorExp — `(f(x) for x in xs [if cond])` → same lowering as ListComp
+  | {
+      readonly type: "GeneratorExp";
+      readonly kind: "map";
+      readonly iter: WireExpr;
+      readonly param: string;
+      readonly elt: WireExpr;
+    }
+  | {
+      readonly type: "GeneratorExp";
+      readonly kind: "filter_map";
+      readonly iter: WireExpr;
+      readonly param: string;
+      readonly cond: WireExpr;
+      readonly elt: WireExpr;
+    }
+  // WI-904: DictComp — `{k: v for target in iter [if cond]}` → Object.fromEntries(iter.map(...))
+  | {
+      readonly type: "DictComp";
+      readonly iter: WireExpr;
+      readonly param: string;
+      readonly keyElt: WireExpr;
+      readonly valElt: WireExpr;
+      readonly cond: WireExpr | null;
+    }
+  // WI-904: SetComp — `{f(x) for x in xs [if cond]}` → new Set(iter.map(...))
+  | {
+      readonly type: "SetComp";
+      readonly kind: "map";
+      readonly iter: WireExpr;
+      readonly param: string;
+      readonly elt: WireExpr;
+    }
+  | {
+      readonly type: "SetComp";
+      readonly kind: "filter_map";
+      readonly iter: WireExpr;
+      readonly param: string;
+      readonly cond: WireExpr;
+      readonly elt: WireExpr;
+    }
   | { readonly type: "Unsupported"; readonly reason: string };
 
 export type WireStmt =
@@ -122,6 +186,14 @@ export type WireStmt =
       readonly type: "ImpureStatement";
       readonly construct: "bare_call" | "bare_expression";
       readonly detail: string;
+    }
+  // WI-903: If statement — Python if/elif/else → TS if/else if/else (DEC-WI903-001)
+  // orelse: [] = no else; [WireStmt...] = else block; [{type:"If",...}] = elif chain.
+  | {
+      readonly type: "If";
+      readonly test: WireExpr;
+      readonly body: readonly WireStmt[];
+      readonly orelse: readonly WireStmt[];
     }
   | { readonly type: "Unsupported"; readonly reason: string };
 
@@ -197,6 +269,36 @@ export function renderExpr(expr: WireExpr): string {
       }
       // `[x for x in xs if p(x)]` → `(xs).filter((x) => p(x))`
       return `(${renderExpr(expr.iter)}).filter((${expr.param}) => ${renderExpr(expr.cond)})`;
+    case "GeneratorExp":
+      // WI-904: generator expressions lower identically to ListComp — the consumer
+      // receives an Array (TS doesn't have lazy generators in this subset).
+      if (expr.kind === "map") {
+        // `(f(x) for x in xs)` → `(xs).map((x) => f(x))`
+        return `(${renderExpr(expr.iter)}).map((${expr.param}) => ${renderExpr(expr.elt)})`;
+      }
+      // `(f(x) for x in xs if cond)` → `(xs).filter((x) => cond).map((x) => f(x))`
+      return (
+        `(${renderExpr(expr.iter)}).filter((${expr.param}) => ${renderExpr(expr.cond)})` +
+        `.map((${expr.param}) => ${renderExpr(expr.elt)})`
+      );
+    case "DictComp": {
+      // WI-904: `{k: v for target in iter [if cond]}`
+      // → `Object.fromEntries(<iter>[.filter(...)].map((target) => [k, v]))`
+      const iterPart =
+        expr.cond !== null
+          ? `(${renderExpr(expr.iter)}).filter((${expr.param}) => ${renderExpr(expr.cond)})`
+          : `(${renderExpr(expr.iter)})`;
+      return `Object.fromEntries(${iterPart}.map((${expr.param}) => [${renderExpr(expr.keyElt)}, ${renderExpr(expr.valElt)}]))`;
+    }
+    case "SetComp":
+      // WI-904: `{f(x) for x in xs [if cond]}` → `new Set(<iter>[.filter(...)].map(...))`
+      if (expr.kind === "map") {
+        return `new Set((${renderExpr(expr.iter)}).map((${expr.param}) => ${renderExpr(expr.elt)}))`;
+      }
+      return (
+        `new Set((${renderExpr(expr.iter)}).filter((${expr.param}) => ${renderExpr(expr.cond)})` +
+        `.map((${expr.param}) => ${renderExpr(expr.elt)}))`
+      );
     case "Unsupported":
       throw new UnsupportedAstError(expr.reason);
   }
@@ -241,6 +343,41 @@ export function renderStmt(stmt: WireStmt, indent = "  ", fnName?: string): stri
       const verb = stmt.construct === "bare_call" ? "calls" : "evaluates";
       const detail = `${verb} bare expression-statement: ${stmt.detail}`;
       throw new ImpureFunctionError(fnName ?? "<unknown>", "forbidden_construct", detail);
+    }
+    case "If": {
+      // WI-903 DEC-WI903-001: Python if/elif/else → TS if/else if/else.
+      //
+      // Python's elif is represented as orelse=[{type:"If",...}] — a single-element
+      // list containing a nested If. We detect that shape and emit `else if` rather
+      // than a nested `else { if (...) { } }` block, matching Python's flat style.
+      //
+      // indent for the inner body uses two extra spaces relative to the current level.
+      const innerIndent = `${indent}  `;
+      const bodyLines = stmt.body
+        .map((s) => renderStmt(s, innerIndent, fnName))
+        .filter((l) => l !== "")
+        .join("\n");
+      const bodyBlock = bodyLines || `${innerIndent}void 0;`;
+      let result = `${indent}if (${renderExpr(stmt.test)}) {\n${bodyBlock}\n${indent}}`;
+      if (stmt.orelse.length > 0) {
+        // elif chain: orelse is a single If node — emit `else if`
+        const firstOrelse = stmt.orelse[0];
+        if (stmt.orelse.length === 1 && firstOrelse?.type === "If") {
+          // Recurse: renderStmt will produce `<indent>if (...) { ... }` — splice after `else `.
+          const elseIfText = renderStmt(firstOrelse, indent, fnName);
+          // elseIfText starts with `${indent}if` — trim the leading indent for the else clause.
+          result += ` else ${elseIfText.trimStart()}`;
+        } else {
+          // Plain else block
+          const elseLines = stmt.orelse
+            .map((s) => renderStmt(s, innerIndent, fnName))
+            .filter((l) => l !== "")
+            .join("\n");
+          const elseBlock = elseLines || `${innerIndent}void 0;`;
+          result += ` else {\n${elseBlock}\n${indent}}`;
+        }
+      }
+      return result;
     }
     case "Unsupported":
       throw new UnsupportedAstError(stmt.reason);

--- a/packages/shave-python/src/raise-function.test.ts
+++ b/packages/shave-python/src/raise-function.test.ts
@@ -352,3 +352,303 @@ describe("WI-888: raiseFunctionWithPurityAndNormalization — e2e compound inter
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// WI-903: If statement — compound-interaction tests through the full pipeline
+// ---------------------------------------------------------------------------
+
+describe("WI-903: raiseFunctionWithPurityAndNormalization — If statement compound interaction", () => {
+  // Production sequence: checkModuleImports → checkFunctionPurity → normalize names →
+  // renderFunctionDeclaration → renderBody → renderStmt(If) → TS output.
+
+  it("lowers if/else to TS if/else in a function body (compound production sequence)", () => {
+    // def clamp(x: int) -> int:
+    //     if x > 100: return 100
+    //     else: return x
+    const envelope = makeEnvelope();
+    const signature: FunctionSignature = {
+      name: "clamp",
+      params: [{ name: "x", tsType: "number", pythonAnnotation: "int" }],
+      returnType: "number",
+      pythonReturnAnnotation: "int",
+      bodyPythonSource: "    if x > 100:\n        return 100\n    else:\n        return x",
+    };
+    const body: WireStmt[] = [
+      {
+        type: "If",
+        test: {
+          type: "BinaryOp",
+          op: ">",
+          left: { type: "Name", name: "x" },
+          right: { type: "Integer", value: "100" },
+        },
+        body: [{ type: "Return", value: { type: "Integer", value: "100" } }],
+        orelse: [{ type: "Return", value: { type: "Name", name: "x" } }],
+      },
+    ];
+    const out = raiseFunctionWithPurityAndNormalization(envelope, signature, body);
+    expect(out).toBe(
+      "export function clamp(x: number): number {\n  if ((x > 100)) {\n    return 100;\n  } else {\n    return x;\n  }\n}",
+    );
+  });
+
+  it("lowers if/elif/else chain (3-way) in the pipeline with snake_case normalization", () => {
+    // def classify_score(raw_score: int) -> int:
+    //     if raw_score > 90: return 3
+    //     elif raw_score > 50: return 2
+    //     else: return 1
+    const envelope = makeEnvelope();
+    const signature: FunctionSignature = {
+      name: "classify_score",
+      params: [{ name: "raw_score", tsType: "number", pythonAnnotation: "int" }],
+      returnType: "number",
+      pythonReturnAnnotation: "int",
+      bodyPythonSource:
+        "    if raw_score > 90:\n        return 3\n    elif raw_score > 50:\n        return 2\n    else:\n        return 1",
+    };
+    const body: WireStmt[] = [
+      {
+        type: "If",
+        test: {
+          type: "BinaryOp",
+          op: ">",
+          left: { type: "Name", name: "raw_score" },
+          right: { type: "Integer", value: "90" },
+        },
+        body: [{ type: "Return", value: { type: "Integer", value: "3" } }],
+        orelse: [
+          {
+            type: "If",
+            test: {
+              type: "BinaryOp",
+              op: ">",
+              left: { type: "Name", name: "raw_score" },
+              right: { type: "Integer", value: "50" },
+            },
+            body: [{ type: "Return", value: { type: "Integer", value: "2" } }],
+            orelse: [{ type: "Return", value: { type: "Integer", value: "1" } }],
+          },
+        ],
+      },
+    ];
+    const out = raiseFunctionWithPurityAndNormalization(envelope, signature, body);
+    // Function name normalized: classify_score → classifyScore
+    // Param name normalized: raw_score → rawScore
+    expect(out).toContain("function classifyScore(rawScore: number)");
+    // elif chain collapses to `else if`
+    expect(out).toContain("} else if (");
+    // All three return paths present
+    expect(out).toContain("return 3;");
+    expect(out).toContain("return 2;");
+    expect(out).toContain("return 1;");
+  });
+
+  it("lowers if-only (no else) to TS if block followed by a bare return", () => {
+    // def early_exit(n: int) -> int:
+    //     if n < 0: return 0
+    //     return n
+    const envelope = makeEnvelope();
+    const signature: FunctionSignature = {
+      name: "early_exit",
+      params: [{ name: "n", tsType: "number", pythonAnnotation: "int" }],
+      returnType: "number",
+      pythonReturnAnnotation: "int",
+      bodyPythonSource: "    if n < 0:\n        return 0\n    return n",
+    };
+    const body: WireStmt[] = [
+      {
+        type: "If",
+        test: {
+          type: "BinaryOp",
+          op: "<",
+          left: { type: "Name", name: "n" },
+          right: { type: "Integer", value: "0" },
+        },
+        body: [{ type: "Return", value: { type: "Integer", value: "0" } }],
+        orelse: [],
+      },
+      { type: "Return", value: { type: "Name", name: "n" } },
+    ];
+    const out = raiseFunctionWithPurityAndNormalization(envelope, signature, body);
+    expect(out).toContain("if ((n < 0))");
+    expect(out).not.toContain("else");
+    expect(out).toContain("return 0;");
+    expect(out).toContain("return n;");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WI-904: Comprehension — compound-interaction tests through the full pipeline
+// ---------------------------------------------------------------------------
+
+describe("WI-904: raiseFunctionWithPurityAndNormalization — comprehension compound interaction", () => {
+  // Production sequence: checkModuleImports → checkFunctionPurity → normalize names →
+  // renderFunctionDeclaration → renderBody → renderStmt / renderExpr → TS output.
+
+  it("lowers ListComp map pattern in a function body (compound production sequence)", () => {
+    // def double_all(items: list) -> list:
+    //     return [x * 2 for x in items]
+    const envelope = makeEnvelope();
+    const signature: FunctionSignature = {
+      name: "double_all",
+      params: [{ name: "items", tsType: "number[]", pythonAnnotation: "list" }],
+      returnType: "number[]",
+      pythonReturnAnnotation: "list",
+      bodyPythonSource: "    return [x * 2 for x in items]",
+    };
+    const body: WireStmt[] = [
+      {
+        type: "Return",
+        value: {
+          type: "ListComp",
+          kind: "map",
+          iter: { type: "Name", name: "items" },
+          param: "x",
+          elt: {
+            type: "BinaryOp",
+            op: "*",
+            left: { type: "Name", name: "x" },
+            right: { type: "Integer", value: "2" },
+          },
+        },
+      },
+    ];
+    const out = raiseFunctionWithPurityAndNormalization(envelope, signature, body);
+    expect(out).toBe(
+      "export function doubleAll(items: number[]): number[] {\n  return (items).map((x) => (x * 2));\n}",
+    );
+  });
+
+  it("lowers ListComp filter pattern to .filter() call in the pipeline", () => {
+    // def keep_positive(xs: list) -> list:
+    //     return [x for x in xs if x > 0]
+    const envelope = makeEnvelope();
+    const signature: FunctionSignature = {
+      name: "keep_positive",
+      params: [{ name: "xs", tsType: "number[]", pythonAnnotation: "list" }],
+      returnType: "number[]",
+      pythonReturnAnnotation: "list",
+      bodyPythonSource: "    return [x for x in xs if x > 0]",
+    };
+    const body: WireStmt[] = [
+      {
+        type: "Return",
+        value: {
+          type: "ListComp",
+          kind: "filter",
+          iter: { type: "Name", name: "xs" },
+          param: "x",
+          cond: {
+            type: "BinaryOp",
+            op: ">",
+            left: { type: "Name", name: "x" },
+            right: { type: "Integer", value: "0" },
+          },
+        },
+      },
+    ];
+    const out = raiseFunctionWithPurityAndNormalization(envelope, signature, body);
+    expect(out).toContain("(xs).filter((x) => (x > 0))");
+  });
+
+  it("lowers DictComp to Object.fromEntries() in a function body with normalization", () => {
+    // def build_map(keys: list) -> dict:
+    //     return {k: 1 for k in keys}
+    const envelope = makeEnvelope();
+    const signature: FunctionSignature = {
+      name: "build_map",
+      params: [{ name: "keys", tsType: "string[]", pythonAnnotation: "list" }],
+      returnType: "Record<string, number>",
+      pythonReturnAnnotation: "dict",
+      bodyPythonSource: "    return {k: 1 for k in keys}",
+    };
+    const body: WireStmt[] = [
+      {
+        type: "Return",
+        value: {
+          type: "DictComp",
+          iter: { type: "Name", name: "keys" },
+          param: "k",
+          keyElt: { type: "Name", name: "k" },
+          valElt: { type: "Integer", value: "1" },
+          cond: null,
+        },
+      },
+    ];
+    const out = raiseFunctionWithPurityAndNormalization(envelope, signature, body);
+    expect(out).toContain("Object.fromEntries(");
+    expect(out).toContain("(keys).map((k) => [k, 1])");
+  });
+
+  it("lowers SetComp map pattern to new Set(.map()) in the pipeline", () => {
+    // def unique_vals(xs: list) -> set:
+    //     return {x * 2 for x in xs}
+    const envelope = makeEnvelope();
+    const signature: FunctionSignature = {
+      name: "unique_vals",
+      params: [{ name: "xs", tsType: "number[]", pythonAnnotation: "list" }],
+      returnType: "Set<number>",
+      pythonReturnAnnotation: "set",
+      bodyPythonSource: "    return {x * 2 for x in xs}",
+    };
+    const body: WireStmt[] = [
+      {
+        type: "Return",
+        value: {
+          type: "SetComp",
+          kind: "map",
+          iter: { type: "Name", name: "xs" },
+          param: "x",
+          elt: {
+            type: "BinaryOp",
+            op: "*",
+            left: { type: "Name", name: "x" },
+            right: { type: "Integer", value: "2" },
+          },
+        },
+      },
+    ];
+    const out = raiseFunctionWithPurityAndNormalization(envelope, signature, body);
+    expect(out).toContain("new Set((xs).map((x) => (x * 2)))");
+  });
+
+  it("lowers GeneratorExp filter_map pattern in the pipeline", () => {
+    // def gen_positives(xs: list) -> list:
+    //     return list(x for x in xs if x > 0)
+    // Wrapped in a list() call that contains the GeneratorExp
+    const envelope = makeEnvelope();
+    const signature: FunctionSignature = {
+      name: "gen_positives",
+      params: [{ name: "xs", tsType: "number[]", pythonAnnotation: "list" }],
+      returnType: "number[]",
+      pythonReturnAnnotation: "list",
+      bodyPythonSource: "    return list(x for x in xs if x > 0)",
+    };
+    const body: WireStmt[] = [
+      {
+        type: "Return",
+        value: {
+          type: "Call",
+          func: "list",
+          args: [
+            {
+              type: "GeneratorExp",
+              kind: "filter_map",
+              iter: { type: "Name", name: "xs" },
+              param: "x",
+              cond: {
+                type: "BinaryOp",
+                op: ">",
+                left: { type: "Name", name: "x" },
+                right: { type: "Integer", value: "0" },
+              },
+              elt: { type: "Name", name: "x" },
+            },
+          ],
+        },
+      },
+    ];
+    const out = raiseFunctionWithPurityAndNormalization(envelope, signature, body);
+    expect(out).toContain("(xs).filter((x) => (x > 0)).map((x) => x)");
+  });
+});


### PR DESCRIPTION
## Summary

Adds two AST lowering capabilities to `raise-body.ts` (and the libcst wire), unblocking real bs4 cases that previously hit `unsupported_ast`.

- **#903 — If statements:** lowers Python `if/elif/else` to TS `if/else if/else`. Wire detection in `libcst-parse.py` handles flat `else` blocks and elif chains (orelse = single nested If). Renderer collapses the nested-If pattern into `else if`.
- **#904 — Comprehensions:** lowers list/dict/set/generator comprehensions to `.map` / `.filter` / `Object.fromEntries` / `new Set`. Single-source single-clause MVP; multi-generator or tuple-target patterns are rejected with a clear `unsupported_ast` message rather than silently miscompiling.

## Impact

- Test suite: **273 → 304 pass** (31 new tests across `raise-body.test.ts`, `libcst-parser.test.ts`, `raise-function.test.ts`).
- Typecheck + lint clean.
- Unblocks the bs4 `unsupported_ast` cohort: `_chardet_dammit`, `__getattr__`, `_invert`, plus partial `_deprecated_function_alias`. (Functions still blocked by nested `FunctionDef` remain pending #905.)

## Test plan

- [x] `pnpm -F shave-python test` — 304/304 pass
- [x] `pnpm -F shave-python typecheck` — clean
- [x] `pnpm -F shave-python lint` — clean
- [ ] CI green on PR
- [ ] Squash-merge after green

Closes #903
Closes #904

🤖 Generated with [Claude Code](https://claude.com/claude-code)