### PR TITLE
fix(shave-python): #905 — nested FunctionDef rejected with clear ImpureFunctionError

### DIFF
--- a/packages/shave-python/scripts/libcst-parse.py
+++ b/packages/shave-python/scripts/libcst-parse.py
@@ -62,6 +62,14 @@
 #   no decorator  → "instance" (self param; tagged impure downstream)
 # Cross-reference: PLAN.md §WI-890 / DEC-WI890-001..010
 #
+# WI-905: Nested FunctionDef rejection — _stmt_v2() detects libcst.FunctionDef
+# as a compound statement inside a function body and emits ImpureStatement with
+# construct "nested_function" instead of the generic Unsupported wire node.
+# This reuses the existing WI-888 ImpureStatement wire shape; no new wire type.
+# TS raise-body.ts throws ImpureFunctionError(kind:'forbidden_construct') with
+# a message mentioning "nested function definition (closure) — not supported in
+# MVP, refactor to module-level". Cross-reference: #905.
+#
 # Wire shape (cumulative through WI-913):
 #   functions[].body:
 #     [ Statement, ... ]
@@ -72,6 +80,8 @@
 #     {"type": "Docstring", "value": "<str>"}                           [WI-888]
 #     {"type": "ImpureStatement", "construct": "bare_call"|            [WI-888]
 #              "bare_expression", "detail": "<str>"}
+#     {"type": "ImpureStatement", "construct": "nested_function",      [WI-905]
+#              "detail": "<str>"}
 #     {"type": "If", "test": <Expr>, "body": [<Stmt>...],              [WI-903]
 #              "orelse": [<Stmt>...]}
 #     {"type": "Assign", "target": "<name>", "value": <Expr>}          [WI-907]
@@ -780,6 +790,34 @@ def _stmt_v2(node, is_first=False):  # type: ignore[no-untyped-def]
             "test": _expr(node.test),
             "body": _if_stmts(node.body),
             "orelse": orelse,
+        }
+
+    # WI-905: nested FunctionDef inside a function body.
+    #
+    # libcst represents a `def inner(): ...` inside an outer function body as a
+    # libcst.FunctionDef compound statement (not a SimpleStatementLine).
+    # We catch it here — before the generic fallback — and emit an ImpureStatement
+    # so that raise-body.ts throws ImpureFunctionError(kind:"forbidden_construct")
+    # with a clear message instead of a generic UnsupportedAstError("FunctionDef").
+    #
+    # @decision DEC-WI905-001 — Nested FunctionDef → ImpureStatement(nested_function)
+    # @title Detect nested def in body; emit ImpureStatement not Unsupported
+    # @status accepted
+    # @rationale Closures are not supported in the MVP shave corpus. Raising as
+    #   ImpureFunctionError (kind:forbidden_construct) gives callers a typed,
+    #   actionable error with a clear "refactor to module-level" message, rather
+    #   than the opaque UnsupportedAstError("FunctionDef") that previously fired.
+    #   Reuses the existing WI-888 ImpureStatement wire shape — no new wire type.
+    #   Cross-reference: PLAN.md §WI-905 / #905.
+    if isinstance(node, libcst.FunctionDef):
+        return {
+            "type": "ImpureStatement",
+            "construct": "nested_function",
+            "detail": (
+                f"nested function '{node.name.value}' — "
+                "nested function definition (closure) — not supported in MVP, "
+                "refactor to module-level"
+            ),
         }
 
     return {"type": "Unsupported", "reason": type(node).__name__}

--- a/packages/shave-python/src/libcst-parser.test.ts
+++ b/packages/shave-python/src/libcst-parser.test.ts
@@ -644,6 +644,74 @@ describe("WI-909: Comprehension tuple-target emission (real Python subprocess)",
 });
 
 // ---------------------------------------------------------------------------
+// WI-905: Nested FunctionDef → ImpureStatement(nested_function) emission
+// (real Python subprocess)
+// ---------------------------------------------------------------------------
+
+describe("WI-905: nested FunctionDef emission (real Python subprocess)", () => {
+  const pythonAvailable = (() => {
+    try {
+      execSync("python3 -c 'import libcst'", { stdio: "pipe" });
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
+  if (!pythonAvailable) {
+    it.skip("requires python3 with libcst installed (skipped)", () => {});
+  } else {
+    it("emits ImpureStatement(nested_function) for a nested def inside a function body", async () => {
+      // def outer(x: int) -> int:
+      //     def inner(y: int) -> int:
+      //         return y + 1
+      //     return inner(x)
+      const source = [
+        "def outer(x: int) -> int:",
+        "    def inner(y: int) -> int:",
+        "        return y + 1",
+        "    return inner(x)",
+        "",
+      ].join("\n");
+      const result = await parsePythonSource(source);
+      const fn = (result.module.functions as PythonAstNode[])[0] as PythonAstNode;
+      const body = fn.body as PythonAstNode[];
+      // First statement is ImpureStatement(nested_function), not Unsupported
+      expect(body.length).toBeGreaterThanOrEqual(1);
+      const stmt = body[0] as PythonAstNode;
+      expect(stmt.type).toBe("ImpureStatement");
+      expect((stmt as { construct?: string }).construct).toBe("nested_function");
+      // detail mentions the inner function name and the clear closure message
+      const detail = (stmt as { detail?: string }).detail ?? "";
+      expect(detail).toContain("inner");
+      expect(detail).toContain("nested function definition (closure)");
+      expect(detail).toContain("refactor to module-level");
+    });
+
+    it("emits ImpureStatement(nested_function) — NOT Unsupported — for nested def", async () => {
+      // Regression: before WI-905 this emitted {"type":"Unsupported","reason":"FunctionDef"}.
+      // After WI-905 it must be ImpureStatement so raise-body throws ImpureFunctionError,
+      // not the opaque UnsupportedAstError.
+      const source = [
+        "def wrapper(n: int) -> int:",
+        "    def helper(x: int) -> int:",
+        "        return x * 2",
+        "    return helper(n)",
+        "",
+      ].join("\n");
+      const result = await parsePythonSource(source);
+      const fn = (result.module.functions as PythonAstNode[])[0] as PythonAstNode;
+      const body = fn.body as PythonAstNode[];
+      const stmt = body[0] as PythonAstNode;
+      // Must not be Unsupported
+      expect(stmt.type).not.toBe("Unsupported");
+      expect(stmt.type).toBe("ImpureStatement");
+      expect((stmt as { construct?: string }).construct).toBe("nested_function");
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
 // WI-890: Class method extraction (real Python subprocess)
 // ---------------------------------------------------------------------------
 

--- a/packages/shave-python/src/raise-body.test.ts
+++ b/packages/shave-python/src/raise-body.test.ts
@@ -418,6 +418,48 @@ describe("WI-888: renderStmt — ImpureStatement throws ImpureFunctionError", ()
 });
 
 // ---------------------------------------------------------------------------
+// WI-905: ImpureStatement(nested_function) — nested FunctionDef in body
+// ---------------------------------------------------------------------------
+
+describe("WI-905: renderStmt — ImpureStatement(nested_function) throws ImpureFunctionError", () => {
+  it("throws ImpureFunctionError for nested_function construct", () => {
+    const stmt: WireStmt = {
+      type: "ImpureStatement",
+      construct: "nested_function",
+      detail:
+        "nested function 'inner' — nested function definition (closure) — not supported in MVP, refactor to module-level",
+    };
+    try {
+      renderStmt(stmt);
+      expect.unreachable("should throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ImpureFunctionError);
+      expect((err as ImpureFunctionError).kind).toBe("forbidden_construct");
+      expect((err as ImpureFunctionError).detail).toContain("nested function");
+      expect((err as ImpureFunctionError).detail).toContain("closure");
+      expect((err as ImpureFunctionError).functionName).toBe("<unknown>");
+    }
+  });
+
+  it("threads fnName through to ImpureFunctionError for nested_function", () => {
+    const stmt: WireStmt = {
+      type: "ImpureStatement",
+      construct: "nested_function",
+      detail:
+        "nested function 'helper' — nested function definition (closure) — not supported in MVP, refactor to module-level",
+    };
+    try {
+      renderStmt(stmt, "  ", "outer_fn");
+      expect.unreachable("should throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ImpureFunctionError);
+      expect((err as ImpureFunctionError).functionName).toBe("outer_fn");
+      expect((err as ImpureFunctionError).detail).toContain("nested function");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // WI-875: floor-divide // operator
 // ---------------------------------------------------------------------------
 

--- a/packages/shave-python/src/raise-body.ts
+++ b/packages/shave-python/src/raise-body.ts
@@ -242,9 +242,10 @@ export type WireStmt =
   // WI-888: ImpureStatement — bare expression statement (call or other expr).
   // renderStmt throws ImpureFunctionError(kind:"forbidden_construct").
   // DEC-WI888-002/003: bare_call = Expr(Call); bare_expression = everything else.
+  // WI-905: nested_function = FunctionDef compound statement inside a body.
   | {
       readonly type: "ImpureStatement";
-      readonly construct: "bare_call" | "bare_expression";
+      readonly construct: "bare_call" | "bare_expression" | "nested_function";
       readonly detail: string;
     }
   // WI-903: If statement — Python if/elif/else → TS if/else if/else (DEC-WI903-001)

--- a/packages/shave-python/src/raise-function.test.ts
+++ b/packages/shave-python/src/raise-function.test.ts
@@ -9,7 +9,7 @@
 import { describe, expect, it } from "vitest";
 import type { LibcstParseResult, PythonAstNode } from "./libcst-parser.js";
 import type { FunctionSignature } from "./parse-fn-signature.js";
-import type { WireStmt } from "./raise-body.js";
+import { UnsupportedAstError, type WireStmt } from "./raise-body.js";
 import {
   ImpureFunctionError,
   raiseFunctionWithPurityAndNormalization,
@@ -829,6 +829,89 @@ describe("WI-909: raiseFunctionWithPurityAndNormalization — tuple-target compr
     expect(out).toContain(".filter(([k, v]) => v)");
     expect(out).toContain(".map(([k, v]) => k)");
     expect(out).toContain("function truthyKeys(");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WI-905: Nested FunctionDef — compound-interaction tests through the full pipeline
+// ---------------------------------------------------------------------------
+
+describe("WI-905: raiseFunctionWithPurityAndNormalization — nested_function throws ImpureFunctionError", () => {
+  // Production sequence: checkModuleImports → checkFunctionPurity → normalize names →
+  // renderFunctionDeclaration → renderBody → renderStmt(ImpureStatement) → ImpureFunctionError.
+  // Verifies that a nested FunctionDef wire node results in a typed, actionable error
+  // rather than the opaque UnsupportedAstError("FunctionDef") that fired before WI-905.
+
+  it("throws ImpureFunctionError(forbidden_construct) for ImpureStatement(nested_function) in body", () => {
+    // def outer(x: int) -> int:
+    //     def inner(y): return y + 1
+    //     return inner(x)
+    //
+    // Wire body: [ImpureStatement(nested_function), Return]
+    // Expected: ImpureFunctionError thrown at render time with kind='forbidden_construct'
+    // and detail mentioning closure/nested function.
+    const envelope = makeEnvelope();
+    const signature: FunctionSignature = {
+      name: "outer",
+      params: [{ name: "x", tsType: "number", pythonAnnotation: "int" }],
+      returnType: "number",
+      pythonReturnAnnotation: "int",
+      bodyPythonSource: "    def inner(y): return y + 1\n    return inner(x)",
+    };
+    const body: WireStmt[] = [
+      {
+        type: "ImpureStatement",
+        construct: "nested_function",
+        detail:
+          "nested function 'inner' — nested function definition (closure) — not supported in MVP, refactor to module-level",
+      },
+      {
+        type: "Return",
+        value: { type: "Call", func: "inner", args: [{ type: "Name", name: "x" }] },
+      },
+    ];
+    try {
+      raiseFunctionWithPurityAndNormalization(envelope, signature, body);
+      expect.unreachable("should throw ImpureFunctionError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ImpureFunctionError);
+      expect((err as ImpureFunctionError).kind).toBe("forbidden_construct");
+      // detail must contain the closure message, not a generic UnsupportedAstError reason
+      expect((err as ImpureFunctionError).detail).toContain("nested function");
+      expect((err as ImpureFunctionError).detail).toContain("closure");
+      // functionName is the normalized outer function name
+      expect((err as ImpureFunctionError).functionName).toBe("outer");
+    }
+  });
+
+  it("throws ImpureFunctionError — not UnsupportedAstError — for nested_function (regression guard)", () => {
+    // Before WI-905 the Python layer emitted Unsupported("FunctionDef"), which caused
+    // UnsupportedAstError at render time. After WI-905 we must get ImpureFunctionError.
+    // UnsupportedAstError is imported statically at the top of this file.
+    const envelope = makeEnvelope();
+    const signature: FunctionSignature = {
+      name: "wrapper",
+      params: [],
+      returnType: "null",
+      pythonReturnAnnotation: "None",
+      bodyPythonSource: "    def helper(): pass",
+    };
+    const body: WireStmt[] = [
+      {
+        type: "ImpureStatement",
+        construct: "nested_function",
+        detail:
+          "nested function 'helper' — nested function definition (closure) — not supported in MVP, refactor to module-level",
+      },
+    ];
+    try {
+      raiseFunctionWithPurityAndNormalization(envelope, signature, body);
+      expect.unreachable("should throw");
+    } catch (err) {
+      // Must be ImpureFunctionError, not UnsupportedAstError
+      expect(err).toBeInstanceOf(ImpureFunctionError);
+      expect(err).not.toBeInstanceOf(UnsupportedAstError);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- `libcst-parse.py` `_stmt_v2` now detects `libcst.FunctionDef` as a body statement and emits `ImpureStatement(construct:"nested_function")` instead of falling through to generic `Unsupported`.
- `raise-body.ts` `ImpureStatement` handler already throws `ImpureFunctionError(kind:"forbidden_construct")` carrying the detail message `"nested function definition (closure) — not supported in MVP, refactor to module-level"`, so the parser signal flows through to a precise user-facing error.
- Tests: 365 → 371 passing. Typecheck + lint clean.

Closes #905

## Test plan

- [x] `pnpm -C packages/shave-python test` — 371/371 pass
- [x] `pnpm -C packages/shave-python typecheck` — clean
- [x] `pnpm -C packages/shave-python lint` — clean
- [ ] CI green on PR

Scope: `packages/shave-python/scripts/libcst-parse.py`, `packages/shave-python/src/raise-body.ts`, plus the four targeted test files. No edits to forbidden surfaces (`libcst-parser.ts`, `raise-function.ts`, `type-map.ts`, `parse-fn-signature.ts`, `normalize-names.ts`, `compile-python/**`, `cli/**`, `bootstrap/**`, `.github/**`, `.claude/**`).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)