### PR TITLE
feat(shave-python): #931 + #932 — Attribute access + Comparison In/NotIn

### DIFF
--- a/packages/shave-python/scripts/libcst-parse.py
+++ b/packages/shave-python/scripts/libcst-parse.py
@@ -70,8 +70,19 @@
 # a message mentioning "nested function definition (closure) — not supported in
 # MVP, refactor to module-level". Cross-reference: #905.
 #
-# Wire shape (cumulative through WI-913):
-#   functions[].body:
+# WI-931: bare Attribute access (obj.attr as expression value) — _expr() now emits
+# {"type":"Attribute","value":<Expr>,"attr":"<str>"} for libcst.Attribute nodes that
+# appear outside of a Call callee.  Previously, Attribute was silently swallowed by
+# _callee_name and only worked inside Call.  Adding a first-class Attribute wire node
+# makes bare access (`cls.CONSTANT`, `obj.attr` as return value, argument, etc.) render
+# correctly in raise-body.ts.  Cross-reference: #931.
+#
+# WI-932: Comparison In / NotIn membership operators — COMPARE_OP_MAP now includes
+# libcst.In → "in" and libcst.NotIn → "not_in".  The TS renderer maps these to
+# right.includes(left) and !right.includes(left) respectively, covering the common
+# string/array membership case.  Cross-reference: #932.
+#
+# Wire shape (cumulative through WI-932):
 #     [ Statement, ... ]
 #   Statement:
 #     {"type": "Return", "value": <Expr> | null}
@@ -114,6 +125,7 @@
 #              "iter": <Expr>, "param": "<str>", "elt": <Expr>,
 #              "cond": <Expr>?,
 #              "target_kind"?: "tuple", "target_names"?: [<str>,...]}   [WI-909]
+#     {"type": "Attribute", "value": <Expr>, "attr": "<str>"}           [WI-931]
 #     {"type": "Subscript", "value": <Expr>, "slice": <Expr>}           [WI-911]
 #     {"type": "Tuple", "elements": [<Expr>, ...]}                      [WI-913]
 #     {"type": "Unsupported", "reason": "<str>"}
@@ -170,6 +182,8 @@ COMPARE_OP_MAP = {
     "GreaterThanEqual": ">=",
     "Is": "is",  # WI-912: `x is y` — TS: === (None→null, else strict-eq)
     "IsNot": "is_not",  # WI-912: `x is not y` — TS: !== (None→null, else strict-neq)
+    "In": "in",  # WI-932: `x in y` — TS: y.includes(x)
+    "NotIn": "not_in",  # WI-932: `x not in y` — TS: !y.includes(x)
 }
 
 # Slice 4: unary op map (libcst class name → TS op string)
@@ -540,6 +554,30 @@ def _expr(node):  # type: ignore[no-untyped-def]
                 "elt": _expr(node.elt),
             }
         return {"type": "Unsupported", "reason": "SetComp with multiple if-clauses"}
+
+    # WI-931: bare Attribute access — obj.attr as an expression value.
+    # Attribute IS already handled implicitly inside _callee_name() (for Call
+    # callees such as `module.fn(...)`), but that path only extracts a dotted
+    # string and never returns a wire node.  When Attribute appears as a
+    # *value* — return value, argument, RHS of an assignment, etc. — we must
+    # emit a proper Attribute wire node so raise-body.ts can render it.
+    #
+    # Wire shape: {"type": "Attribute", "value": <Expr>, "attr": "<str>"}
+    # where "value" is the object expression and "attr" is the identifier name.
+    # Chained access (a.b.c) is handled naturally via recursion: the inner
+    # a.b is itself an Attribute node emitted by the recursive _expr(node.value)
+    # call, producing nested Attribute wire nodes that render as a.b.c.
+    #
+    # Note: libcst.Attribute.attr is a libcst.Name; we read .value for the str.
+    if isinstance(node, libcst.Attribute):
+        attr_name = node.attr.value if isinstance(node.attr, libcst.Name) else None
+        if attr_name is None:
+            return {"type": "Unsupported", "reason": "Attribute with non-Name attr"}
+        return {
+            "type": "Attribute",
+            "value": _expr(node.value),
+            "attr": attr_name,
+        }
 
     # WI-911: obj[key] — libcst.Subscript.
     # .value is the object expr; .slice is a tuple of SubscriptElement.

--- a/packages/shave-python/src/raise-body.test.ts
+++ b/packages/shave-python/src/raise-body.test.ts
@@ -1402,3 +1402,214 @@ describe("WI-911+912+913: compound interaction — bs4 production sequence", () 
     expect(renderExpr(expr)).toBe('[obj["name"], obj["val"]]');
   });
 });
+
+// ---------------------------------------------------------------------------
+// WI-931: Attribute wire node → TS obj.attr
+// ---------------------------------------------------------------------------
+
+describe("WI-931: renderExpr — Attribute", () => {
+  it("renders simple obj.attr", () => {
+    const expr: WireExpr = {
+      type: "Attribute",
+      value: { type: "Name", name: "obj" },
+      attr: "attr",
+    };
+    expect(renderExpr(expr)).toBe("obj.attr");
+  });
+
+  it("renders chained a.b.c (nested Attribute)", () => {
+    const expr: WireExpr = {
+      type: "Attribute",
+      value: {
+        type: "Attribute",
+        value: { type: "Name", name: "a" },
+        attr: "b",
+      },
+      attr: "c",
+    };
+    expect(renderExpr(expr)).toBe("a.b.c");
+  });
+
+  it("renders Attribute used as call argument — f(obj.attr)", () => {
+    const expr: WireExpr = {
+      type: "Call",
+      func: "f",
+      args: [
+        {
+          type: "Attribute",
+          value: { type: "Name", name: "obj" },
+          attr: "method",
+        },
+      ],
+    };
+    expect(renderExpr(expr)).toBe("f(obj.method)");
+  });
+
+  it("renders Attribute as return value (Return stmt)", () => {
+    const stmt: WireStmt = {
+      type: "Return",
+      value: {
+        type: "Attribute",
+        value: { type: "Name", name: "cls" },
+        attr: "CONSTANT",
+      },
+    };
+    expect(renderStmt(stmt)).toBe("  return cls.CONSTANT;");
+  });
+
+  it("renders Attribute on the right of a Call — cls.PATTERN.sub(...)", () => {
+    // cls.AMPERSAND_OR_BRACKET.sub(cls._sub_character_safe, value)
+    // → Call("cls.AMPERSAND_OR_BRACKET.sub", [Attribute(cls, _sub_character_safe), Name(value)])
+    // But the real wire shape from #931 is:
+    //   Call func="cls.AMPERSAND_OR_BRACKET.sub", args=[Attribute(cls,_sub_character_safe), Name(value)]
+    // Here we test that an Attribute appears correctly as a call arg.
+    const expr: WireExpr = {
+      type: "Call",
+      func: "cls.AMPERSAND_OR_BRACKET.sub",
+      args: [
+        {
+          type: "Attribute",
+          value: { type: "Name", name: "cls" },
+          attr: "_sub_character_safe",
+        },
+        { type: "Name", name: "value" },
+      ],
+    };
+    expect(renderExpr(expr)).toBe("cls.AMPERSAND_OR_BRACKET.sub(cls._sub_character_safe, value)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WI-931+932: compound interaction — Attribute in membership check
+// Production sequence: Attribute as left operand of "in" comparison.
+// ---------------------------------------------------------------------------
+
+describe("WI-931+932: compound interaction — Attribute + In/NotIn", () => {
+  it("renders cls.ATTR in collection → collection.includes(cls.ATTR)", () => {
+    const expr: WireExpr = {
+      type: "BinaryOp",
+      op: "in",
+      left: {
+        type: "Attribute",
+        value: { type: "Name", name: "cls" },
+        attr: "QUOTE_CHAR",
+      },
+      right: { type: "Name", name: "value" },
+    };
+    expect(renderExpr(expr)).toBe("value.includes(cls.QUOTE_CHAR)");
+  });
+
+  it('renders quoted_attribute_value pattern: if \'"\' in value → value.includes("\\"")', () => {
+    // Python: if '"' in value: return f"'{value}'"
+    // Wire: BinaryOp(in, String('"'), Name(value))
+    const stmts: WireStmt[] = [
+      {
+        type: "If",
+        test: {
+          type: "BinaryOp",
+          op: "in",
+          left: { type: "String", value: '"' },
+          right: { type: "Name", name: "value" },
+        },
+        body: [{ type: "Return", value: { type: "String", value: "'" } }],
+        orelse: [{ type: "Return", value: { type: "String", value: '"' } }],
+      },
+    ];
+    const out = renderBody(stmts);
+    expect(out).toContain('value.includes("\\""');
+    expect(out).toContain('return "\'";');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WI-932: Comparison In / NotIn → .includes()
+// ---------------------------------------------------------------------------
+
+describe("WI-932: renderExpr — BinaryOp in / not_in", () => {
+  it("renders x in y → y.includes(x)", () => {
+    const expr: WireExpr = {
+      type: "BinaryOp",
+      op: "in",
+      left: { type: "Name", name: "x" },
+      right: { type: "Name", name: "y" },
+    };
+    expect(renderExpr(expr)).toBe("y.includes(x)");
+  });
+
+  it("renders x not in y → !y.includes(x)", () => {
+    const expr: WireExpr = {
+      type: "BinaryOp",
+      op: "not_in",
+      left: { type: "Name", name: "x" },
+      right: { type: "Name", name: "y" },
+    };
+    expect(renderExpr(expr)).toBe("!y.includes(x)");
+  });
+
+  it('renders string in string literal — \'"\' in value → value.includes("\\"")', () => {
+    const expr: WireExpr = {
+      type: "BinaryOp",
+      op: "in",
+      left: { type: "String", value: '"' },
+      right: { type: "Name", name: "value" },
+    };
+    expect(renderExpr(expr)).toBe('value.includes("\\"")');
+  });
+
+  it("renders element not in list literal — x not in [1,2,3]", () => {
+    const expr: WireExpr = {
+      type: "BinaryOp",
+      op: "not_in",
+      left: { type: "Name", name: "x" },
+      right: {
+        type: "ListComp",
+        kind: "map",
+        iter: { type: "Name", name: "ys" },
+        param: "y",
+        elt: { type: "Name", name: "y" },
+      },
+    };
+    // right.includes(left) where right is a comprehension expression
+    expect(renderExpr(expr)).toContain(".includes(x)");
+    expect(renderExpr(expr)).toMatch(/^!/);
+  });
+
+  it("in / not_in do not throw UnsupportedAstError (in ALLOWED_BINARY_OPS)", () => {
+    expect(() =>
+      renderExpr({
+        type: "BinaryOp",
+        op: "in",
+        left: { type: "Name", name: "x" },
+        right: { type: "Name", name: "y" },
+      }),
+    ).not.toThrow();
+    expect(() =>
+      renderExpr({
+        type: "BinaryOp",
+        op: "not_in",
+        left: { type: "Name", name: "x" },
+        right: { type: "Name", name: "y" },
+      }),
+    ).not.toThrow();
+  });
+
+  it("renders BoolOp containing an 'in' check — x in arr and y > 0", () => {
+    const expr: WireExpr = {
+      type: "BoolOp",
+      op: "and",
+      left: {
+        type: "BinaryOp",
+        op: "in",
+        left: { type: "Name", name: "x" },
+        right: { type: "Name", name: "arr" },
+      },
+      right: {
+        type: "BinaryOp",
+        op: ">",
+        left: { type: "Name", name: "y" },
+        right: { type: "Integer", value: "0" },
+      },
+    };
+    expect(renderExpr(expr)).toBe("(arr.includes(x) && (y > 0))");
+  });
+});

--- a/packages/shave-python/src/raise-body.ts
+++ b/packages/shave-python/src/raise-body.ts
@@ -11,6 +11,13 @@
 // WI-911 additions to the wire AST:
 //   Expr: Subscript — `obj[key]` → `obj[key]`
 //
+// WI-931 additions to the wire AST:
+//   Expr: Attribute — `obj.attr` → `obj.attr` (bare attribute access as expression value)
+//
+// WI-932 additions to the wire AST:
+//   Expr: BinaryOp op="in"/"not_in" — `x in y` → `y.includes(x)`;
+//         `x not in y` → `!y.includes(x)`
+//
 // WI-912 additions to the wire AST:
 //   Expr: BinaryOp op="is"/"is_not" — `x is None` → `x === null`;
 //         `x is y` (non-None) → `x === y` with identity-approximated warning comment
@@ -225,6 +232,9 @@ export type WireExpr =
       readonly target_kind?: "tuple";
       readonly target_names?: readonly string[];
     }
+  // WI-931: Attribute — `obj.attr` as a bare expression value → `obj.attr`
+  // Chained access (a.b.c) is represented as nested Attribute nodes and renders naturally.
+  | { readonly type: "Attribute"; readonly value: WireExpr; readonly attr: string }
   // WI-911: Subscript — `obj[key]` → `obj[key]`
   | { readonly type: "Subscript"; readonly value: WireExpr; readonly slice: WireExpr }
   // WI-913: Tuple value — `(a, b)` → `[a, b]` (JS array literal)
@@ -283,6 +293,9 @@ const ALLOWED_BINARY_OPS = new Set<string>([
   // WI-912: identity comparison ops — rendered specially (None→null, else strict-eq)
   "is",
   "is_not",
+  // WI-932: membership ops — rendered as .includes() / !.includes()
+  "in",
+  "not_in",
 ]);
 
 const ALLOWED_UNARY_OPS = new Set<string>(["-", "+", "!", "~"]);
@@ -322,6 +335,15 @@ export function renderExpr(expr: WireExpr): string {
         const right = expr.right.type === "None" ? "null" : renderExpr(expr.right);
         const left = renderExpr(expr.left);
         return `(${left} ${tsOp} ${right})`;
+      }
+      // WI-932: membership operators `x in y` → `y.includes(x)`, `x not in y` → `!y.includes(x)`
+      // MVP: .includes() covers string and array membership which are the common cases.
+      // Dict-key membership is rare; callers should audit non-array/string `in` if needed.
+      if (expr.op === "in") {
+        return `${renderExpr(expr.right)}.includes(${renderExpr(expr.left)})`;
+      }
+      if (expr.op === "not_in") {
+        return `!${renderExpr(expr.right)}.includes(${renderExpr(expr.left)})`;
       }
       // Always parenthesize to avoid precedence surprises across the Python → TS boundary.
       return `(${renderExpr(expr.left)} ${expr.op} ${renderExpr(expr.right)})`;
@@ -414,6 +436,11 @@ export function renderExpr(expr: WireExpr): string {
         `.map(${scParam} => ${renderExpr(expr.elt)}))`
       );
     }
+    case "Attribute":
+      // WI-931: `obj.attr` → `obj.attr` — bare attribute access as an expression value.
+      // value is fully recursive so chained access a.b.c renders naturally:
+      // Attribute(Attribute(a, b), c) → renderExpr(Attribute(a,b)) + ".c" → "a.b.c".
+      return `${renderExpr(expr.value)}.${expr.attr}`;
     case "Subscript":
       // WI-911: `obj[key]` → `obj[key]`
       // Both value and slice are fully recursive — handles nested subscripts,


### PR DESCRIPTION
## Summary

- **#931**: `libcst.Attribute` now emitted as a wire node even when not inside a `Call`. `raise-body.ts` renders `obj.attr` access with chaining support (e.g. `a.b.c`).
- **#932**: `'in'` / `'not in'` membership operators lowered to `.includes()` / `!.includes()`.

After this lands, 7 more bs4 classmethods become raisable (`EntitySubstitution.substitute_*`, `quoted_attribute_value`, `numeric_character_reference`).

## Numbers

- Tests: 377 → **390 pass** (+13 new tests covering Attribute + In/NotIn shapes)
- Typecheck: clean
- Lint: clean

## Scope

- `packages/shave-python/scripts/libcst-parse.py` (+40/-2)
- `packages/shave-python/src/raise-body.ts` (+27)
- `packages/shave-python/src/raise-body.test.ts` (+211)

Closes #931
Closes #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)