### PR TITLE
feat(mcp-registry): WI-953 yakcc_resolve — LLM intent-time discovery tool

### DIFF
--- a/packages/mcp-registry/package.json
+++ b/packages/mcp-registry/package.json
@@ -21,7 +21,10 @@
     "lint": "echo \"no lint yet\""
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0"
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@yakcc/contracts": "workspace:*",
+    "@yakcc/hooks-base": "workspace:*",
+    "@yakcc/registry": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/mcp-registry/src/.wi-953-anchor.md
+++ b/packages/mcp-registry/src/.wi-953-anchor.md
@@ -1,1 +1,0 @@
-# wi-953 anchor — yakcc_resolve wiring

--- a/packages/mcp-registry/src/.wi-953-anchor.md
+++ b/packages/mcp-registry/src/.wi-953-anchor.md
@@ -1,0 +1,1 @@
+# wi-953 anchor — yakcc_resolve wiring

--- a/packages/mcp-registry/src/__tests__/integration.test.ts
+++ b/packages/mcp-registry/src/__tests__/integration.test.ts
@@ -155,13 +155,14 @@ describe("stdio MCP server integration", () => {
   // tools/list
   // -------------------------------------------------------------------------
 
-  it("tools/list returns exactly 8 tool definitions including yakcc_search_atoms", async () => {
+  it("tools/list returns exactly 9 tool definitions including yakcc_resolve (wi-953)", async () => {
     const result = await client.listTools();
-    expect(result.tools).toHaveLength(8);
+    expect(result.tools).toHaveLength(9);
     const names = result.tools.map((t) => t.name);
     expect(names).toContain("yakcc_search_atoms");
     // Spot-check the full expected set
     const expected = [
+      "yakcc_resolve",
       "yakcc_search_atoms",
       "yakcc_get_atom",
       "yakcc_list_specs",
@@ -285,7 +286,7 @@ describe("stdio MCP server integration", () => {
     // a full round-trip without errors, which is only possible if stdout is clean.
     mock.setNextResponse({ blocks: [], nextCursor: null });
     const result = await client.listTools();
-    expect(result.tools).toHaveLength(8);
+    expect(result.tools).toHaveLength(9);
     // Also do a tool call to confirm wire integrity for request/response cycle
     const callResult = await client.callTool({
       name: "yakcc_search_atoms",

--- a/packages/mcp-registry/src/tools/index.ts
+++ b/packages/mcp-registry/src/tools/index.ts
@@ -20,6 +20,7 @@ import { getShaveStatus } from "./get-shave-status.js";
 import { getSpec } from "./get-spec.js";
 import { listSpecs } from "./list-specs.js";
 import { requestShave } from "./request-shave.js";
+import { resolveTool } from "./resolve.js";
 import { searchAtoms } from "./search-atoms.js";
 import { submitAtom } from "./submit-atom.js";
 import type { ToolModule } from "./types.js";
@@ -30,15 +31,18 @@ export { getShaveStatus } from "./get-shave-status.js";
 export { getSpec } from "./get-spec.js";
 export { listSpecs } from "./list-specs.js";
 export { requestShave } from "./request-shave.js";
+export { resolveTool } from "./resolve.js";
 export { searchAtoms } from "./search-atoms.js";
 export { submitAtom } from "./submit-atom.js";
 export type { ToolModule } from "./types.js";
 
 /**
- * Ordered registry of all 8 tool modules.
+ * Ordered registry of all 9 tool modules.
  * The bite-3 stdio server iterates this array to register with the MCP SDK.
+ * resolveTool added per wi-953 (DEC-HOOK-PROACTIVE-A-001).
  */
 export const TOOLS: ToolModule[] = [
+  resolveTool,
   searchAtoms,
   getAtom,
   listSpecs,

--- a/packages/mcp-registry/src/tools/resolve.test.ts
+++ b/packages/mcp-registry/src/tools/resolve.test.ts
@@ -1,0 +1,549 @@
+// @mock-exempt: yakccResolve wraps SQLite (local DB boundary); openRegistry opens SQLite; createOfflineEmbeddingProvider is a native embedding layer. All are external boundaries relative to the MCP tool under test.
+/**
+ * Tests for yakcc_resolve tool.
+ *
+ * @decision DEC-HOOK-PROACTIVE-A-001 (MASTER_PLAN.md)
+ * @title yakcc_resolve — intent-time discovery surface via MCP
+ * @status decided (wi-953, bite 1)
+ * @rationale
+ *   These tests verify all four resolution paths:
+ *   1. Local auto-accept short-circuit (no http calls when high-confidence local match)
+ *   2. Local empty + global merge (http.get called when local yields no candidates)
+ *   3. Air-gap short-circuit (YAKCC_AIRGAPPED=1 prevents http.get entirely)
+ *   4. Network error in global (http.get throws → degrade to local_only content)
+ *   Plus confidence band mapping, input validation, and error-as-content discipline.
+ *
+ * Mock strategy:
+ *   - yakccResolve from @yakcc/hooks-base is vi.mock()'d at the module boundary.
+ *     This means no real Registry or SQLite is needed in tests.
+ *   - HttpClient is injected as a stub (same pattern as search-atoms.test.ts).
+ *
+ * @mock-exempt HttpClient and yakccResolve are injected/mocked — no real network or DB.
+ *
+ * Implements: yakcc#953
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type HttpClient, HttpError } from "../http-client.js";
+
+// ---------------------------------------------------------------------------
+// Module mock: yakccResolve from @yakcc/hooks-base
+// ---------------------------------------------------------------------------
+// We mock the entire @yakcc/hooks-base module so we never open a real SQLite DB.
+// The tool is created with a mock registry factory that returns a stub registry.
+// yakccResolve is the sole local-query authority (Sacred Practice #12).
+
+vi.mock("@yakcc/hooks-base", () => ({
+  yakccResolve: vi.fn(),
+}));
+
+// We also mock @yakcc/registry's openRegistry so the lazy open doesn't hit disk.
+vi.mock("@yakcc/registry", () => ({
+  openRegistry: vi.fn(),
+}));
+
+// We mock @yakcc/contracts' createOfflineEmbeddingProvider.
+vi.mock("@yakcc/contracts", () => ({
+  createOfflineEmbeddingProvider: vi.fn().mockReturnValue({}),
+}));
+
+import type { ResolveResult } from "@yakcc/hooks-base";
+import { yakccResolve } from "@yakcc/hooks-base";
+import { openRegistry } from "@yakcc/registry";
+import { createResolveTool, resolveTool } from "./resolve.js";
+
+// ---------------------------------------------------------------------------
+// Helper factories
+// ---------------------------------------------------------------------------
+
+function makeHttp(
+  overrides: Partial<{
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+  }> = {},
+): HttpClient {
+  return {
+    get: overrides.get ?? vi.fn(),
+    post: overrides.post ?? vi.fn(),
+  } as unknown as HttpClient;
+}
+
+/** A stub registry object — the content doesn't matter since yakccResolve is mocked. */
+const STUB_REGISTRY = {} as unknown as import("@yakcc/registry").Registry;
+
+/** Produce a tool instance with a registry factory that immediately returns STUB_REGISTRY. */
+function makeToolWithStubRegistry(): ReturnType<typeof createResolveTool> {
+  return createResolveTool({
+    openRegistry: async () => STUB_REGISTRY,
+  });
+}
+
+/** A minimal "matched" ResolveResult with one auto-accept-tier candidate (score 0.95). */
+function makeAutoAcceptResult(): ResolveResult {
+  return {
+    status: "matched",
+    candidates: [
+      {
+        address: "abcd1234",
+        behavior: "computes deterministic hash of a UTF-8 string",
+        signature: "(input: string) => string",
+        score: 0.95,
+        guarantees: ["deterministic", "pure"],
+        tests: { count: 5 },
+        usage: null,
+      },
+    ],
+  };
+}
+
+/** A ResolveResult with no candidates (empty / no_match from local). */
+function makeEmptyResult(): ResolveResult {
+  return { status: "no_match", candidates: [] };
+}
+
+/** A ResolveResult with one weak candidate (score 0.55 — candidate_list tier). */
+function makeWeakResult(): ResolveResult {
+  return {
+    status: "weak_only",
+    candidates: [
+      {
+        address: "deadbeef",
+        behavior: "weak match description",
+        signature: "(x: number) => number",
+        score: 0.55,
+        guarantees: [],
+        tests: { count: 1 },
+        usage: null,
+      },
+    ],
+  };
+}
+
+/** Minimal blocks-page response from the global catalog endpoint. */
+const GLOBAL_BLOCKS_RESPONSE = {
+  roots: [`aabbccdd${"0".repeat(56)}`, `11223344${"0".repeat(56)}`],
+  nextCursor: null,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("yakcc_resolve tool shape", () => {
+  it("has correct name", () => {
+    expect(resolveTool.name).toBe("yakcc_resolve");
+  });
+
+  it("has a non-empty description", () => {
+    expect(resolveTool.description.length).toBeGreaterThan(100);
+  });
+
+  it("inputSchema has type=object, required=[intent], properties for intent and limit", () => {
+    expect(resolveTool.inputSchema.type).toBe("object");
+    expect(resolveTool.inputSchema.required).toContain("intent");
+    expect(resolveTool.inputSchema.properties).toHaveProperty("intent");
+    expect(resolveTool.inputSchema.properties).toHaveProperty("limit");
+  });
+});
+
+describe("yakcc_resolve handler — local auto-accept short-circuit", () => {
+  let tool: ReturnType<typeof createResolveTool>;
+
+  beforeEach(() => {
+    vi.mocked(yakccResolve).mockResolvedValue(makeAutoAcceptResult());
+    tool = makeToolWithStubRegistry();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns confidence_tier=auto_accept for a high-score local match", async () => {
+    const http = makeHttp();
+    const result = await tool.handler(
+      { intent: { title: "compute deterministic hash of string" } },
+      http,
+    );
+    expect(result).toHaveLength(1);
+    const parsed = JSON.parse(result[0]!.text) as {
+      confidence_tier: string;
+      source: string;
+      candidates: unknown[];
+      airgapped: boolean;
+    };
+    expect(parsed.confidence_tier).toBe("auto_accept");
+    expect(parsed.source).toBe("local_only");
+    expect(parsed.airgapped).toBe(false);
+    expect(parsed.candidates).toHaveLength(1);
+  });
+
+  it("does NOT call http.get when local yields auto_accept-tier result", async () => {
+    const getFn = vi.fn();
+    const http = makeHttp({ get: getFn });
+    await tool.handler({ intent: { title: "compute hash" } }, http);
+    expect(getFn).not.toHaveBeenCalled();
+  });
+
+  it("yakccResolve is called with the correct intent card", async () => {
+    const http = makeHttp();
+    await tool.handler(
+      {
+        intent: {
+          title: "my function title",
+          description: "detailed rationale",
+          signature: "(a: string) => boolean",
+        },
+        limit: 5,
+      },
+      http,
+    );
+    expect(vi.mocked(yakccResolve)).toHaveBeenCalledOnce();
+    const callArgs = vi.mocked(yakccResolve).mock.calls[0];
+    // First arg is registry, second is the QueryIntentCard built from intent.
+    // title + description are merged into the behavior field.
+    const query = callArgs?.[1];
+    expect(query).toMatchObject({ behavior: "my function title detailed rationale", topK: 5 });
+  });
+});
+
+describe("yakcc_resolve handler — local empty + global merge", () => {
+  let tool: ReturnType<typeof createResolveTool>;
+  const savedAirgap = process.env.YAKCC_AIRGAPPED;
+
+  beforeEach(() => {
+    vi.mocked(yakccResolve).mockResolvedValue(makeEmptyResult());
+    tool = makeToolWithStubRegistry();
+    // Ensure airgap is OFF
+    process.env.YAKCC_AIRGAPPED = undefined;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    if (savedAirgap !== undefined) {
+      process.env.YAKCC_AIRGAPPED = savedAirgap;
+    } else {
+      process.env.YAKCC_AIRGAPPED = undefined;
+    }
+  });
+
+  it("calls http.get when local yields no candidates and YAKCC_AIRGAPPED is not set", async () => {
+    const getFn = vi.fn().mockResolvedValueOnce(GLOBAL_BLOCKS_RESPONSE);
+    const http = makeHttp({ get: getFn });
+    await tool.handler({ intent: { title: "novel function no local match" } }, http);
+    expect(getFn).toHaveBeenCalled();
+  });
+
+  it("returns confidence_tier=candidate_list with source=local+global when global returns blocks", async () => {
+    const getFn = vi.fn().mockResolvedValueOnce(GLOBAL_BLOCKS_RESPONSE);
+    const http = makeHttp({ get: getFn });
+    const result = await tool.handler({ intent: { title: "no local match" } }, http);
+    expect(result).toHaveLength(1);
+    const parsed = JSON.parse(result[0]!.text) as {
+      confidence_tier: string;
+      source: string;
+      candidates: unknown[];
+      airgapped: boolean;
+    };
+    expect(parsed.confidence_tier).toBe("candidate_list");
+    expect(parsed.source).toBe("local+global");
+    expect(parsed.airgapped).toBe(false);
+    expect(Array.isArray(parsed.candidates)).toBe(true);
+    expect(parsed.candidates.length).toBeGreaterThan(0);
+  });
+
+  it("returns confidence_tier=no_candidates when both local and global are empty", async () => {
+    const getFn = vi.fn().mockResolvedValueOnce({ roots: [], nextCursor: null });
+    const http = makeHttp({ get: getFn });
+    const result = await tool.handler({ intent: { title: "truly novel" } }, http);
+    const parsed = JSON.parse(result[0]!.text) as { confidence_tier: string };
+    expect(parsed.confidence_tier).toBe("no_candidates");
+  });
+
+  it("deduplicates candidates that appear in both local and global results", async () => {
+    // Local has one weak candidate with a known address prefix
+    vi.mocked(yakccResolve).mockResolvedValue(makeWeakResult());
+    // Global returns the same root as what the weak local result maps to,
+    // plus one genuinely new root.
+    // "deadbeef" from makeWeakResult maps to address "deadbeef" (first 8 chars).
+    const dedupedRoot = `deadbeef${"0".repeat(56)}`;
+    const freshRoot = `cafebabe${"0".repeat(56)}`;
+    const getFn = vi
+      .fn()
+      .mockResolvedValueOnce({ roots: [dedupedRoot, freshRoot], nextCursor: null });
+    const http = makeHttp({ get: getFn });
+    const result = await tool.handler({ intent: { title: "partial local match" } }, http);
+    const parsed = JSON.parse(result[0]!.text) as {
+      candidates: Array<{ source: string; atom_id: string }>;
+    };
+    // "deadbeef" should only appear once (deduped)
+    const deadbeefCandidates = parsed.candidates.filter((c) => c.atom_id.startsWith("deadbeef"));
+    expect(deadbeefCandidates).toHaveLength(1);
+  });
+});
+
+describe("yakcc_resolve handler — air-gap short-circuit", () => {
+  let tool: ReturnType<typeof createResolveTool>;
+  const savedAirgap = process.env.YAKCC_AIRGAPPED;
+
+  beforeEach(() => {
+    vi.mocked(yakccResolve).mockResolvedValue(makeEmptyResult());
+    tool = makeToolWithStubRegistry();
+    process.env.YAKCC_AIRGAPPED = "1";
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    if (savedAirgap !== undefined) {
+      process.env.YAKCC_AIRGAPPED = savedAirgap;
+    } else {
+      process.env.YAKCC_AIRGAPPED = undefined;
+    }
+  });
+
+  it("does NOT call http.get when YAKCC_AIRGAPPED=1, even when local is empty", async () => {
+    const getFn = vi.fn();
+    const http = makeHttp({ get: getFn });
+    await tool.handler({ intent: { title: "any intent" } }, http);
+    expect(getFn).not.toHaveBeenCalled();
+  });
+
+  it("returns airgapped=true and source=local_only when airgapped", async () => {
+    const getFn = vi.fn();
+    const http = makeHttp({ get: getFn });
+    const result = await tool.handler({ intent: { title: "any intent" } }, http);
+    const parsed = JSON.parse(result[0]!.text) as {
+      airgapped: boolean;
+      source: string;
+    };
+    expect(parsed.airgapped).toBe(true);
+    expect(parsed.source).toBe("local_only");
+  });
+
+  it("returns confidence_tier=no_candidates when airgapped and local is empty", async () => {
+    const getFn = vi.fn();
+    const http = makeHttp({ get: getFn });
+    const result = await tool.handler({ intent: { title: "any intent" } }, http);
+    const parsed = JSON.parse(result[0]!.text) as { confidence_tier: string };
+    expect(parsed.confidence_tier).toBe("no_candidates");
+  });
+});
+
+describe("yakcc_resolve handler — network error degradation", () => {
+  let tool: ReturnType<typeof createResolveTool>;
+  const savedAirgap = process.env.YAKCC_AIRGAPPED;
+
+  beforeEach(() => {
+    vi.mocked(yakccResolve).mockResolvedValue(makeEmptyResult());
+    tool = makeToolWithStubRegistry();
+    process.env.YAKCC_AIRGAPPED = undefined;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    if (savedAirgap !== undefined) {
+      process.env.YAKCC_AIRGAPPED = savedAirgap;
+    } else {
+      process.env.YAKCC_AIRGAPPED = undefined;
+    }
+  });
+
+  it("catches HttpError from http.get and returns source=local_only without throwing", async () => {
+    const getFn = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new HttpError({ status: 503, code: "service_unavailable", message: "Down" }),
+      );
+    const http = makeHttp({ get: getFn });
+    // Must NOT throw
+    const result = await tool.handler({ intent: { title: "intent" } }, http);
+    expect(result).toHaveLength(1);
+    const parsed = JSON.parse(result[0]!.text) as { source: string };
+    expect(parsed.source).toBe("local_only");
+  });
+
+  it("catches generic Error from http.get and returns source=local_only without throwing", async () => {
+    const getFn = vi.fn().mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    const http = makeHttp({ get: getFn });
+    const result = await tool.handler({ intent: { title: "intent" } }, http);
+    const parsed = JSON.parse(result[0]!.text) as { source: string };
+    expect(parsed.source).toBe("local_only");
+  });
+
+  it("never throws from the handler even when local registry open fails", async () => {
+    const failingTool = createResolveTool({
+      openRegistry: async () => {
+        throw new Error("SQLite open failed — no registry at path");
+      },
+    });
+    const http = makeHttp({ get: vi.fn() });
+    // Must NOT throw — DEC-MCP-ERROR-AS-CONTENT-004
+    const result = await failingTool.handler({ intent: { title: "intent" } }, http);
+    expect(result).toHaveLength(1);
+    const parsed = JSON.parse(result[0]!.text) as { error?: string };
+    expect(typeof parsed.error).toBe("string");
+  });
+});
+
+describe("yakcc_resolve handler — confidence band mapping", () => {
+  let tool: ReturnType<typeof createResolveTool>;
+  const savedAirgap = process.env.YAKCC_AIRGAPPED;
+
+  beforeEach(() => {
+    tool = makeToolWithStubRegistry();
+    // Force airgap so global path never fires and we test local-only bands purely
+    process.env.YAKCC_AIRGAPPED = "1";
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    if (savedAirgap !== undefined) {
+      process.env.YAKCC_AIRGAPPED = savedAirgap;
+    } else {
+      process.env.YAKCC_AIRGAPPED = undefined;
+    }
+  });
+
+  it("auto_accept tier: matched status + score>0.92 AND gap>0.15 → auto_accept", async () => {
+    // Single candidate, score 0.95. No second candidate → gap is effectively 1.0 > 0.15.
+    vi.mocked(yakccResolve).mockResolvedValue(makeAutoAcceptResult());
+    const http = makeHttp();
+    const result = await tool.handler({ intent: { title: "hash string" } }, http);
+    const parsed = JSON.parse(result[0]!.text) as { confidence_tier: string };
+    expect(parsed.confidence_tier).toBe("auto_accept");
+  });
+
+  it("candidate_list tier: matched status with score ≥0.70 but not auto_accept → candidate_list", async () => {
+    // Score 0.75 — confident band but NOT auto_accept (0.75 < 0.92)
+    vi.mocked(yakccResolve).mockResolvedValue({
+      status: "matched",
+      candidates: [
+        {
+          address: "aaaabbbb",
+          behavior: "confident match",
+          signature: "(x: number) => number",
+          score: 0.75,
+          guarantees: [],
+          tests: { count: 2 },
+          usage: null,
+        },
+      ],
+    });
+    const http = makeHttp();
+    const result = await tool.handler({ intent: { title: "confident match" } }, http);
+    const parsed = JSON.parse(result[0]!.text) as { confidence_tier: string };
+    expect(parsed.confidence_tier).toBe("candidate_list");
+  });
+
+  it("candidate_list tier: weak_only status → candidate_list", async () => {
+    vi.mocked(yakccResolve).mockResolvedValue(makeWeakResult());
+    const http = makeHttp();
+    const result = await tool.handler({ intent: { title: "weak match" } }, http);
+    const parsed = JSON.parse(result[0]!.text) as { confidence_tier: string };
+    expect(parsed.confidence_tier).toBe("candidate_list");
+  });
+
+  it("no_candidates tier: no_match status → no_candidates", async () => {
+    vi.mocked(yakccResolve).mockResolvedValue(makeEmptyResult());
+    const http = makeHttp();
+    const result = await tool.handler({ intent: { title: "unknown" } }, http);
+    const parsed = JSON.parse(result[0]!.text) as { confidence_tier: string };
+    expect(parsed.confidence_tier).toBe("no_candidates");
+  });
+});
+
+describe("yakcc_resolve handler — input validation", () => {
+  let tool: ReturnType<typeof createResolveTool>;
+
+  beforeEach(() => {
+    vi.mocked(yakccResolve).mockResolvedValue(makeEmptyResult());
+    tool = makeToolWithStubRegistry();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("missing intent → returns error content, does not throw", async () => {
+    const http = makeHttp();
+    const result = await tool.handler({}, http);
+    expect(result).toHaveLength(1);
+    const parsed = JSON.parse(result[0]!.text) as { error: string; message: string };
+    expect(parsed.error).toBe("invalid_input");
+    expect(typeof parsed.message).toBe("string");
+  });
+
+  it("intent is not an object → returns error content, does not throw", async () => {
+    const http = makeHttp();
+    const result = await tool.handler({ intent: "bare string not allowed" }, http);
+    const parsed = JSON.parse(result[0]!.text) as { error: string };
+    expect(parsed.error).toBe("invalid_input");
+  });
+
+  it("intent.title is missing → returns error content, does not throw", async () => {
+    const http = makeHttp();
+    const result = await tool.handler({ intent: { description: "no title" } }, http);
+    const parsed = JSON.parse(result[0]!.text) as { error: string };
+    expect(parsed.error).toBe("invalid_input");
+  });
+
+  it("intent.title is empty string → returns error content, does not throw", async () => {
+    const http = makeHttp();
+    const result = await tool.handler({ intent: { title: "" } }, http);
+    const parsed = JSON.parse(result[0]!.text) as { error: string };
+    expect(parsed.error).toBe("invalid_input");
+  });
+
+  it("args is null → returns error content, does not throw", async () => {
+    const http = makeHttp();
+    const result = await tool.handler(null, http);
+    const parsed = JSON.parse(result[0]!.text) as { error: string };
+    expect(parsed.error).toBe("invalid_input");
+  });
+
+  it("limit out of range → returns error content, does not throw", async () => {
+    const http = makeHttp();
+    const result = await tool.handler({ intent: { title: "valid title" }, limit: 0 }, http);
+    const parsed = JSON.parse(result[0]!.text) as { error: string };
+    expect(parsed.error).toBe("invalid_input");
+  });
+
+  it("limit too large → returns error content, does not throw", async () => {
+    const http = makeHttp();
+    const result = await tool.handler({ intent: { title: "valid title" }, limit: 9999 }, http);
+    const parsed = JSON.parse(result[0]!.text) as { error: string };
+    expect(parsed.error).toBe("invalid_input");
+  });
+});
+
+describe("yakcc_resolve handler — openRegistry lazy call", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls the injected openRegistry factory exactly once even on multiple handler calls", async () => {
+    vi.mocked(yakccResolve).mockResolvedValue(makeAutoAcceptResult());
+    const openFn = vi.fn().mockResolvedValue(STUB_REGISTRY);
+    const tool = createResolveTool({ openRegistry: openFn });
+    const http = makeHttp();
+    await tool.handler({ intent: { title: "first call" } }, http);
+    await tool.handler({ intent: { title: "second call" } }, http);
+    // Registry opened once and cached
+    expect(openFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("openRegistry mock integration — createResolveTool uses injected factory", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("the default tool instance (resolveTool) still exports correct name", () => {
+    expect(resolveTool.name).toBe("yakcc_resolve");
+  });
+
+  it("openRegistry from @yakcc/registry mock is callable from createResolveTool default path", () => {
+    // This just verifies the mock is wired — we don't want to actually call openRegistry
+    // in unit tests (it would try to open SQLite). The mock ensures it's a no-op.
+    expect(vi.mocked(openRegistry)).toBeDefined();
+  });
+});

--- a/packages/mcp-registry/src/tools/resolve.ts
+++ b/packages/mcp-registry/src/tools/resolve.ts
@@ -1,0 +1,574 @@
+/**
+ * Tool: yakcc_resolve
+ *
+ * @decision DEC-HOOK-PROACTIVE-A-001
+ * @title yakcc_resolve — LLM's intent-time discovery surface (Gap A, #953)
+ * @status decided (wi-953-yakcc-resolve-wiring, bite 1)
+ * @rationale
+ *   Per DEC-HOOK-PROACTIVE-PRIMARY-001 (MASTER_PLAN.md) this is the canonical
+ *   path: LLM emits an IntentCard before writing code, this tool returns
+ *   candidates structured by D4 ADR Q5 confidence bands.
+ *
+ *   Architecture:
+ *   (1) LOCAL-FIRST (D-HOOK-6, Cornerstone B6):
+ *       yakccResolve() from @yakcc/hooks-base is the sole local-query authority
+ *       (Sacred Practice #12 — no parallel implementation). The tool calls it
+ *       directly (embedded-library-call discipline, no IPC/RPC/sidecar).
+ *       The local registry is opened lazily from YAKCC_REGISTRY_PATH or the
+ *       workspace default (.yakcc/registry.sqlite). Lazy open is cached for
+ *       the tool instance lifetime.
+ *
+ *   (2) GLOBAL CASCADE (DEC-MCP-FETCH-ONE-CLIENT-006):
+ *       When local yields no auto_accept tier result AND YAKCC_AIRGAPPED !== "1",
+ *       the tool falls through to GET /v1/blocks via the injected HttpClient
+ *       (the single fetch authority — never calls fetch() directly). In v1 the
+ *       global endpoint is a catalog walk; semantic server-side search is a
+ *       future WI. Global roots are surfaced as additional candidates.
+ *
+ *   (3) DEGRADE GRACEFULLY (DEC-MCP-ERROR-AS-CONTENT-004):
+ *       Air-gap (YAKCC_AIRGAPPED=1) → skip global, return local_only.
+ *       Network error from http.get → catch, return local_only.
+ *       Registry open failure → catch, return structured error content.
+ *       No path throws from the handler.
+ *
+ *   (4) CONFIDENCE TIERS (D4 ADR Q5 hybrid mode):
+ *       "auto_accept"    — top local score > 0.92 AND gap-to-2nd > 0.15
+ *       "candidate_list" — has candidates but not auto_accept
+ *       "no_candidates"  — empty after local + global merge
+ *
+ *   (5) FACTORY PATTERN:
+ *       createResolveTool(opts?) returns a ToolModule with a configurable
+ *       openRegistry factory. The default export `resolveTool` uses the
+ *       production factory. Tests inject a stub via the factory parameter.
+ *
+ *   Cross-references:
+ *     DEC-HOOK-PROACTIVE-PRIMARY-001 — initiative umbrella
+ *     DEC-MCP-FETCH-ONE-CLIENT-006   — HttpClient as single fetch authority
+ *     DEC-MCP-ERROR-AS-CONTENT-004   — errors as content, never throw
+ *     DEC-MCP-STDERR-LOGGING-005     — no stdout output (no console.log)
+ *     DEC-HOOK-PHASE-3-L3-MCP-001    — yakccResolve D4 envelope + thresholds
+ *     D4 ADR Q5 (hybrid mode, auto-accept threshold 0.92, gap 0.15)
+ *     Cornerstone B6 (air-gap: local stays offline; global gated)
+ *     Sacred Practice #12 (single source of truth — yakccResolve is the authority)
+ *     DEC-COMMONS-NO-AUTH-001 (no identity in global payload — IntentCard only)
+ *
+ * Implements: yakcc#953
+ */
+
+import { yakccResolve } from "@yakcc/hooks-base";
+import type { EvidenceProjection, ResolveResult } from "@yakcc/hooks-base";
+import type { Registry } from "@yakcc/registry";
+import type { HttpClient } from "../http-client.js";
+import type { MCPContent, ToolModule } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// D4 ADR Q5 hybrid-mode thresholds (local copy)
+// ---------------------------------------------------------------------------
+
+/**
+ * Hybrid auto-accept threshold: top score must exceed 0.92 for auto-accept.
+ * Mirrors HYBRID_AUTO_ACCEPT_THRESHOLD from @yakcc/hooks-base.
+ * Kept local so the MCP adapter doesn't fail when vi.mock() replaces
+ * @yakcc/hooks-base in tests (constants are not functions — they don't need
+ * to be mocked, but module mocking would drop them).
+ *
+ * Source: docs/archive/developer/adr/discovery-llm-interaction.md §Q5.
+ * Cross-reference: DEC-HOOK-PHASE-3-L3-MCP-001, DEC-HOOK-PROACTIVE-A-001.
+ */
+const HYBRID_AUTO_ACCEPT_THRESHOLD = 0.92;
+
+/**
+ * Auto-accept gap threshold: gap between top-1 and top-2 score must exceed 0.15.
+ * Mirrors AUTO_ACCEPT_GAP_THRESHOLD from @yakcc/hooks-base.
+ *
+ * Source: docs/archive/developer/adr/discovery-query-language.md §Q3.
+ */
+const AUTO_ACCEPT_GAP_THRESHOLD = 0.15;
+
+// ---------------------------------------------------------------------------
+// Public IntentCard input shape (minimal subset for MCP surface)
+// ---------------------------------------------------------------------------
+
+/**
+ * The LLM-facing intent card. This is a minimal subset of @yakcc/contracts
+ * QueryIntentCard sufficient for MCP tool input. Keeping a local redeclaration
+ * per dispatch spec: "redeclare the minimal subset the MCP tool needs" — avoids
+ * pulling the full contracts dep chain into the inputSchema definition.
+ *
+ * The handler maps this to yakccResolve's input format.
+ */
+export interface ResolveInput {
+  readonly intent: {
+    readonly title: string; // 1-line task description (required)
+    readonly description?: string; // longer rationale
+    readonly signature?: string; // proposed function signature
+    readonly examples?: string[]; // example usages
+  };
+  readonly limit?: number; // candidates returned (default 10)
+}
+
+// ---------------------------------------------------------------------------
+// Confidence tier derivation (D4 ADR Q5 hybrid mode)
+// ---------------------------------------------------------------------------
+
+type ConfidenceTier = "auto_accept" | "candidate_list" | "no_candidates";
+
+/**
+ * Map a ResolveResult's candidates to one of three D4 ADR Q5 confidence tiers.
+ *
+ * auto_accept:    top score > HYBRID_AUTO_ACCEPT_THRESHOLD (0.92)
+ *                 AND gap to second candidate > AUTO_ACCEPT_GAP_THRESHOLD (0.15)
+ * candidate_list: has candidates but not auto_accept
+ * no_candidates:  no candidates after full merge
+ *
+ * This logic is the MCP adapter's responsibility (D4 ADR Q5 "hybrid" mode).
+ * yakccResolve returns the raw status + candidates; the adapter maps to tiers.
+ */
+function deriveConfidenceTier(candidates: readonly EvidenceProjection[]): ConfidenceTier {
+  if (candidates.length === 0) {
+    return "no_candidates";
+  }
+  const top = candidates[0];
+  if (top === undefined) return "no_candidates";
+
+  const topScore = top.score;
+  const secondScore = candidates[1]?.score ?? 0;
+  const gap = topScore - secondScore;
+
+  if (topScore > HYBRID_AUTO_ACCEPT_THRESHOLD && gap > AUTO_ACCEPT_GAP_THRESHOLD) {
+    return "auto_accept";
+  }
+
+  return "candidate_list";
+}
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+type ParsedInput = { ok: true; value: ResolveInput } | { ok: false; message: string };
+
+function parseArgs(args: unknown): ParsedInput {
+  if (args === null || typeof args !== "object" || Array.isArray(args)) {
+    return { ok: false, message: "args must be a non-null object" };
+  }
+  const obj = args as Record<string, unknown>;
+
+  // Validate intent
+  const rawIntent = obj.intent;
+  if (rawIntent === null || typeof rawIntent !== "object" || Array.isArray(rawIntent)) {
+    return { ok: false, message: "intent must be a non-null object" };
+  }
+  const intentObj = rawIntent as Record<string, unknown>;
+  if (typeof intentObj.title !== "string" || intentObj.title.length === 0) {
+    return { ok: false, message: "intent.title must be a non-empty string" };
+  }
+
+  // Validate optional fields
+  if (intentObj.description !== undefined && typeof intentObj.description !== "string") {
+    return { ok: false, message: "intent.description must be a string if provided" };
+  }
+  if (intentObj.signature !== undefined && typeof intentObj.signature !== "string") {
+    return { ok: false, message: "intent.signature must be a string if provided" };
+  }
+  if (intentObj.examples !== undefined) {
+    if (
+      !Array.isArray(intentObj.examples) ||
+      (intentObj.examples as unknown[]).some((e) => typeof e !== "string")
+    ) {
+      return { ok: false, message: "intent.examples must be an array of strings if provided" };
+    }
+  }
+
+  // Validate limit
+  if (obj.limit !== undefined) {
+    const lim = obj.limit;
+    if (typeof lim !== "number" || !Number.isInteger(lim) || lim < 1 || lim > 100) {
+      return { ok: false, message: "limit must be an integer between 1 and 100" };
+    }
+  }
+
+  const intent: ResolveInput["intent"] = {
+    title: intentObj.title as string,
+    ...(typeof intentObj.description === "string" ? { description: intentObj.description } : {}),
+    ...(typeof intentObj.signature === "string" ? { signature: intentObj.signature } : {}),
+    ...(Array.isArray(intentObj.examples) ? { examples: intentObj.examples as string[] } : {}),
+  };
+
+  const value: ResolveInput = {
+    intent,
+    ...(typeof obj.limit === "number" ? { limit: obj.limit } : {}),
+  };
+
+  return { ok: true, value };
+}
+
+// ---------------------------------------------------------------------------
+// Candidate shaping for global roots
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape a global root hash (64-char hex) as a minimal candidate.
+ * In v1 the global endpoint is a catalog walk (no spec metadata available).
+ * We surface the address as the only field. Semantic enrichment is a future WI.
+ */
+function globalRootToCandidate(root: string): {
+  atom_id: string;
+  score: number;
+  summary: string;
+  source: "global";
+} {
+  return {
+    atom_id: root,
+    score: 0,
+    summary: `global atom ${root.slice(0, 8)} (no local spec metadata)`,
+    source: "global",
+  };
+}
+
+/**
+ * Shape a local EvidenceProjection as a candidate for the response envelope.
+ */
+function localCandidateToResponse(p: EvidenceProjection): {
+  atom_id: string;
+  score: number;
+  summary: string;
+  source: "local";
+  evidence: EvidenceProjection;
+} {
+  return {
+    atom_id: p.address,
+    score: p.score,
+    summary: p.behavior,
+    source: "local",
+    evidence: p,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory options
+// ---------------------------------------------------------------------------
+
+/**
+ * Options accepted by createResolveTool().
+ *
+ * Tests inject openRegistry to avoid real SQLite access.
+ * Production uses the default factory (lazy open via openRegistry from @yakcc/registry).
+ */
+export interface CreateResolveToolOptions {
+  /**
+   * Factory for the local registry. Called lazily on the first handler invocation
+   * and cached for the tool instance lifetime. Defaults to openRegistry() from
+   * @yakcc/registry with createOfflineEmbeddingProvider() from @yakcc/contracts.
+   */
+  readonly openRegistry?: (() => Promise<Registry>) | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Tool factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a yakcc_resolve ToolModule with an optionally injected registry factory.
+ *
+ * The returned ToolModule has the same ToolModule interface as all other tools
+ * (name, description, inputSchema, handler). The handler is a closure over the
+ * registry promise, which is initialized lazily on the first call.
+ *
+ * @param opts - Optional registry factory override (for tests).
+ */
+export function createResolveTool(opts?: CreateResolveToolOptions): ToolModule {
+  // Lazy-cached registry promise (opened at most once per tool instance).
+  let registryPromise: Promise<Registry> | null = null;
+
+  function getRegistry(): Promise<Registry> {
+    if (registryPromise !== null) return registryPromise;
+    const factory = opts?.openRegistry ?? defaultOpenRegistry;
+    registryPromise = factory();
+    return registryPromise;
+  }
+
+  return {
+    name: "yakcc_resolve",
+
+    description: [
+      "Discover yakcc atoms that match the agent's intent BEFORE emitting code.",
+      "Build an IntentCard from your plan and call this tool. It queries the local",
+      "yakcc registry first; if no high-confidence match is found and the environment",
+      "is not air-gapped, it falls through to the global commons at registry.yakcc.com.",
+      "",
+      "When to call:",
+      "- BEFORE Edit/Write/MultiEdit when you have a clear intent (a function or",
+      "  cohesive snippet whose contract you can describe).",
+      "- The returned `confidence_tier` tells you what to do next:",
+      "  - 'auto_accept' → emit `yakcc compile <atom_id>` and skip writing the code.",
+      "  - 'candidate_list' → review the candidates; pick one and `yakcc compile <id>`,",
+      "    OR emit a fully-formed atom triplet (spec + impl + property tests) for a",
+      "    novel atom.",
+      "  - 'no_candidates' → emit a fully-formed atom triplet for a novel atom.",
+      "",
+      "If you don't call this tool before emitting code, the PreToolUse fallback",
+      "(yakcc#950) will still capture your emission via post-hoc atomize — but the",
+      "atom you contribute will have machine-generated property tests instead of",
+      "your higher-quality ones.",
+    ].join("\n"),
+
+    inputSchema: {
+      type: "object",
+      required: ["intent"],
+      properties: {
+        intent: {
+          type: "object",
+          required: ["title"],
+          properties: {
+            title: {
+              type: "string",
+              minLength: 1,
+              description: "One-line task description (the verb-phrase).",
+            },
+            description: {
+              type: "string",
+              description: "Longer rationale; what problem the code solves.",
+            },
+            signature: {
+              type: "string",
+              description: "Proposed TS-strict-subset function signature.",
+            },
+            examples: {
+              type: "array",
+              items: { type: "string" },
+              description: "Example usages if any.",
+            },
+          },
+        },
+        limit: {
+          type: "number",
+          minimum: 1,
+          maximum: 100,
+          default: 10,
+          description: "Maximum number of candidates to return (1–100, default 10).",
+        },
+      },
+    },
+
+    async handler(args: unknown, http: HttpClient): Promise<MCPContent[]> {
+      // --- Input validation ---
+      const parsed = parseArgs(args);
+      if (!parsed.ok) {
+        return [
+          {
+            type: "text",
+            text: JSON.stringify({ error: "invalid_input", message: parsed.message }),
+          },
+        ];
+      }
+
+      const { intent, limit = 10 } = parsed.value;
+      const airgapped = process.env.YAKCC_AIRGAPPED === "1";
+
+      // --- Open the local registry (lazy, cached) ---
+      let registry: Registry;
+      try {
+        registry = await getRegistry();
+      } catch (err) {
+        // Registry open failure (DEC-MCP-ERROR-AS-CONTENT-004): return structured error content.
+        // This happens when the workspace has no local yakcc registry yet.
+        return [
+          {
+            type: "text",
+            text: JSON.stringify({
+              error: "registry_unavailable",
+              message: `Could not open local registry: ${err instanceof Error ? err.message : String(err)}`,
+              confidence_tier: "no_candidates",
+              source: "local_only",
+              candidates: [],
+              airgapped,
+            }),
+          },
+        ];
+      }
+
+      // --- Local query via yakccResolve (D-HOOK-6, Sacred Practice #12) ---
+      // Map the MCP IntentCard to a yakccResolve QueryIntentCard.
+      //
+      // Mapping rationale:
+      // - intent.title → behavior (primary semantic field, always present)
+      // - intent.description → appended to behavior for richer semantic signal
+      // - intent.signature → NOT mapped: QueryIntentCard.signature is a structured
+      //   {inputs, outputs} type, incompatible with our text-format string. The text
+      //   form can be added to behavior if desired but is not currently mapped.
+      // - intent.examples → NOT mapped: QueryIntentCard has no examples dimension.
+      // - topK: limit → governs max candidates returned by the pipeline.
+      //
+      // yakccResolve accepts string | QueryIntentCard | HashLookup.
+      // We pass a QueryIntentCard directly so the registry pipeline uses
+      // all available dimensions (not just behavior).
+      const behaviorText =
+        intent.description !== undefined ? `${intent.title} ${intent.description}` : intent.title;
+      const intentCard = { behavior: behaviorText, topK: limit };
+
+      let resolveResult: ResolveResult;
+      try {
+        resolveResult = await yakccResolve(registry, intentCard, { confidenceMode: "hybrid" });
+      } catch (err) {
+        // yakccResolve failure (defensive; the library should not throw but we guard it).
+        resolveResult = { status: "no_match", candidates: [] };
+        void err; // Swallow; degrade to no_match
+      }
+
+      const localCandidates = [...resolveResult.candidates].slice(0, limit);
+
+      // --- Auto-accept short-circuit: no global call needed ---
+      const localTier = deriveConfidenceTier(localCandidates);
+      if (localTier === "auto_accept") {
+        return [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                confidence_tier: "auto_accept",
+                source: "local_only",
+                candidates: localCandidates.map(localCandidateToResponse),
+                airgapped,
+              },
+              null,
+              2,
+            ),
+          },
+        ];
+      }
+
+      // --- Air-gap check: skip global pass entirely ---
+      if (airgapped) {
+        return [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                confidence_tier: localCandidates.length > 0 ? "candidate_list" : "no_candidates",
+                source: "local_only",
+                candidates: localCandidates.map(localCandidateToResponse),
+                airgapped: true,
+              },
+              null,
+              2,
+            ),
+          },
+        ];
+      }
+
+      // --- Global cascade via HttpClient (DEC-MCP-FETCH-ONE-CLIENT-006) ---
+      // The global endpoint is GET /v1/blocks — a catalog walk.
+      // Real semantic search server-side is a follow-up (registry.yakcc.com doesn't
+      // yet expose embedding-adjacency over HTTP). In v1, surface top-N global atoms
+      // as additional candidates with score=0 and source="global".
+      // Global query payload is the content-derived IntentCard only (DEC-COMMONS-NO-AUTH-001).
+      let globalRoots: string[] = [];
+      let globalFailed = false;
+
+      try {
+        const globalPage = await http.get<{ roots?: string[]; nextCursor?: string | null }>(
+          `v1/blocks?limit=${limit}`,
+        );
+        globalRoots = Array.isArray(globalPage.roots) ? globalPage.roots : [];
+      } catch {
+        // Network error: degrade to local_only (DEC-MCP-ERROR-AS-CONTENT-004).
+        // Never throw from the handler.
+        globalFailed = true;
+      }
+
+      if (globalFailed) {
+        return [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                confidence_tier: localCandidates.length > 0 ? "candidate_list" : "no_candidates",
+                source: "local_only",
+                candidates: localCandidates.map(localCandidateToResponse),
+                airgapped: false,
+              },
+              null,
+              2,
+            ),
+          },
+        ];
+      }
+
+      // --- Merge + dedup by address prefix ---
+      // Local candidates keyed by first-8-char address prefix (already short-form).
+      const localAddresses = new Set(localCandidates.map((c) => c.address));
+
+      // Global roots whose first-8-char prefix is NOT already in local candidates.
+      const freshGlobalCandidates = globalRoots
+        .filter((root) => !localAddresses.has(root.slice(0, 8)))
+        .slice(0, Math.max(0, limit - localCandidates.length))
+        .map(globalRootToCandidate);
+
+      const merged = [...localCandidates.map(localCandidateToResponse), ...freshGlobalCandidates];
+
+      const mergedTier = deriveConfidenceTier(localCandidates);
+      const finalTier: ConfidenceTier =
+        merged.length === 0
+          ? "no_candidates"
+          : mergedTier === "auto_accept"
+            ? "auto_accept"
+            : "candidate_list";
+
+      return [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              confidence_tier: finalTier,
+              source: "local+global",
+              candidates: merged,
+              airgapped: false,
+            },
+            null,
+            2,
+          ),
+        },
+      ];
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Default production registry opener
+// ---------------------------------------------------------------------------
+
+/**
+ * Default registry opener for production use.
+ *
+ * Resolves the registry path from YAKCC_REGISTRY_PATH env var or falls back
+ * to ".yakcc/registry.sqlite" relative to process.cwd().
+ * Uses createOfflineEmbeddingProvider for deterministic, low-latency embeddings.
+ *
+ * Cross-reference: DEC-HOOK-PHASE-3-L3-MCP-001-C (registry path resolution),
+ * DEC-HOOK-PHASE-3-L3-MCP-001-A (embedded-library-call discipline).
+ */
+async function defaultOpenRegistry(): Promise<Registry> {
+  const { resolve } = await import("node:path");
+  const { openRegistry } = await import("@yakcc/registry");
+  const { createOfflineEmbeddingProvider } = await import("@yakcc/contracts");
+
+  const DEFAULT_REGISTRY_PATH = ".yakcc/registry.sqlite";
+  const registryPath =
+    process.env.YAKCC_REGISTRY_PATH ?? resolve(process.cwd(), DEFAULT_REGISTRY_PATH);
+
+  const provider = createOfflineEmbeddingProvider();
+  return openRegistry(registryPath, { embeddings: provider });
+}
+
+// ---------------------------------------------------------------------------
+// Default export — the production tool instance
+// ---------------------------------------------------------------------------
+
+/**
+ * The default yakcc_resolve tool module, registered in the TOOLS array.
+ * Uses the production registry factory (lazy open, cached per process).
+ *
+ * Tests use createResolveTool({ openRegistry: mockFn }) instead.
+ */
+export const resolveTool: ToolModule = createResolveTool();

--- a/packages/mcp-registry/tsconfig.json
+++ b/packages/mcp-registry/tsconfig.json
@@ -6,5 +6,10 @@
     "rootDir": "src",
     "types": ["node"]
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [
+    { "path": "../contracts" },
+    { "path": "../hooks-base" },
+    { "path": "../registry" }
+  ]
 }

--- a/packages/mcp-registry/tsconfig.typecheck.json
+++ b/packages/mcp-registry/tsconfig.typecheck.json
@@ -5,5 +5,10 @@
     "noEmit": true,
     "rootDir": "."
   },
-  "include": ["src", "vitest.config.ts"]
+  "include": ["src", "vitest.config.ts"],
+  "references": [
+    { "path": "../contracts" },
+    { "path": "../hooks-base" },
+    { "path": "../registry" }
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -558,6 +558,15 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
         version: 1.29.0(zod@4.4.3)
+      '@yakcc/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+      '@yakcc/hooks-base':
+        specifier: workspace:*
+        version: link:../hooks-base
+      '@yakcc/registry':
+        specifier: workspace:*
+        version: link:../registry
     devDependencies:
       '@types/node':
         specifier: ^22.0.0


### PR DESCRIPTION
## What

Adds the **`yakcc_resolve`** MCP tool — the LLM's primary, intent-time discovery surface (sub-#950, DEC-HOOK-PROACTIVE-A-001).

## How

- Builds an `IntentCard` from the request, then runs a **local→global cascade**:
  - queries the **local registry first** via `yakccResolve` (Sacred Practice #12, single authority)
  - falls through to the **global commons** over the single `HttpClient` unless air-gapped (Cornerstone B6)
- Maps results to **D4 ADR Q5 confidence tiers**: `auto_accept` / `candidate_list` / `no_candidates`, exposed as MCP content so the LLM decides, not the substrate.
- Errors are returned **as content**; the handler never throws (DEC-MCP-ERROR-AS-CONTENT-004).
- Registered in `TOOLS` (**8 → 9**); the tool description carries the discovery prompt.

## Tests

- `resolve.test.ts`: tiers, cascade, air-gap, error degradation, input validation, lazy registry open
- `integration.test.ts`: `tools/list` count 8 → 9
- **147 tests passing** (12 files), typecheck clean, on the post-merge tree.

## Scope

This is **bite 1 of #953** (MCP tool + cascade + tiers). Remaining bites stay open on #953:
- `yakcc init` project-instruction-file delivery
- telemetry acceptance check

Refs #953

🤖 Generated with [Claude Code](https://claude.com/claude-code)