### PR TITLE
fix(compile-python): #960 — lower TS 'typeof X' to Python 'type[X]'

### DIFF
--- a/packages/compile-python/src/index.test.ts
+++ b/packages/compile-python/src/index.test.ts
@@ -659,3 +659,71 @@ export function EntitySubstitution_substituteXml(cls: typeof EntitySubstitution,
     expect(source).not.toContain("def EntitySubstitution.substitute_xml(");
   });
 });
+
+// ---------------------------------------------------------------------------
+// #960: typeof X type annotation → type[X] (Python class-type annotation)
+// ---------------------------------------------------------------------------
+// TS `typeof EntitySubstitution` in type position means "the class itself".
+// Python's idiomatic annotation is `type[EntitySubstitution]`.
+// The old code fell through to the string-literal fallback, emitting
+// `"typeof EntitySubstitution"` (a forward-reference string) which is not
+// valid Python type syntax.
+// ---------------------------------------------------------------------------
+
+describe("#960: typeof X type annotation → type[X]", () => {
+  it("lowers typeof SimpleClass → type[SimpleClass] as parameter annotation", () => {
+    const src = `
+export function factory(cls: typeof Foo): Foo {
+  return new Foo();
+}`;
+    const { source } = compileToPython(makeRow(src));
+    expect(source).toContain("cls: type[Foo]");
+    // Must NOT emit the raw string fallback (the bug)
+    expect(source).not.toContain('"typeof Foo"');
+    expect(source).not.toContain("typeof Foo");
+  });
+
+  it("lowers typeof with combined params — bs4 EntitySubstitution case (#960)", () => {
+    // Production sequence: shave-python emits cls: typeof EntitySubstitution;
+    // compile-python must lower it to type[EntitySubstitution].
+    const src = `
+export function EntitySubstitution_substituteXml(cls: typeof EntitySubstitution, value: string, makeUniversalSubstitutions: boolean): string {
+  return value;
+}`;
+    const { source } = compileToPython(makeRow(src));
+    expect(source).toContain("cls: type[EntitySubstitution]");
+    expect(source).toContain("value: str");
+    expect(source).toContain("make_universal_substitutions: bool");
+    // No string-literal leak
+    expect(source).not.toContain('"typeof');
+  });
+
+  it("lowers typeof with dotted qualifier — typeof Module.Foo → type[Module.Foo]", () => {
+    // typeof on a qualified name: translate the full dotted path verbatim.
+    const src = `
+export function make(cls: typeof bs4.Tag): bs4.Tag {
+  return new bs4.Tag();
+}`;
+    const { source } = compileToPython(makeRow(src));
+    expect(source).toContain("cls: type[bs4.Tag]");
+    expect(source).not.toContain('"typeof');
+  });
+
+  it("compound interaction: typeof cls annotation + correct def name (end-to-end #960 + #946)", () => {
+    // Production sequence: shave emits ClassName_methodName with typeof param →
+    // compile emits def with underscore name AND type[X] annotation.
+    // This is the exact bs4 EntitySubstitution.substitute_xml round-trip.
+    const src = `
+export function EntitySubstitution_substituteXml(cls: typeof EntitySubstitution, value: string): string {
+  return value;
+}`;
+    const { source } = compileToPython(makeRow(src));
+    // def name uses underscore form (not dotted — SyntaxError guard from #946)
+    expect(source).toContain("def entity_substitution_substitute_xml(");
+    // cls annotation must be type[...] not "typeof ..."
+    expect(source).toContain("cls: type[EntitySubstitution]");
+    expect(source).not.toContain('"typeof');
+    // return annotation: string lowers to str
+    expect(source).toContain("-> str:");
+  });
+});

--- a/packages/compile-python/src/lower.ts
+++ b/packages/compile-python/src/lower.ts
@@ -977,6 +977,27 @@ export function lowerTypeNode(typeNode: TypeNode, ctx: Ctx): string {
     return first ? lowerTypeNode(first, ctx) : "Any";
   }
 
+  // #960 — typeof X (TypeQuery) → type[X]
+  //
+  // @decision DEC-960-001
+  // @title TypeQuery (typeof X) in type position lowers to Python type[X]
+  // @status accepted (#960)
+  // @rationale In TS, `typeof ClassName` used as a type annotation means "the
+  //   class object itself, not an instance." Python's idiomatic equivalent is
+  //   `type[ClassName]` (PEP 585 / typing.Type). Emitting the raw TS text as a
+  //   forward-reference string literal ("typeof EntitySubstitution") is not
+  //   valid Python — typing.get_type_hints() would fail to resolve it.
+  //   We extract the exprText from the TypeQuery node and wrap it in type[...],
+  //   preserving dotted qualifiers (e.g. typeof bs4.Tag → type[bs4.Tag]) verbatim
+  //   since qualified names are valid in Python type annotations.
+  //   NOTE: this handles TypeQuery only in type-annotation position (TypeNode).
+  //   The expression-position typeof (runtime typeof operator) is handled
+  //   separately in lowerExpr under SyntaxKind.TypeOfExpression.
+  if (k === SyntaxKind.TypeQuery) {
+    const exprText = typeNode.asKindOrThrow(SyntaxKind.TypeQuery).getExprName().getText();
+    return `type[${exprText}]`;
+  }
+
   return `"${typeNode.getText()}"`;
 }
 


### PR DESCRIPTION
## Summary

- Adds `SyntaxKind.TypeQuery` case to `lowerTypeNode` in `packages/compile-python/src/lower.ts`, emitting `type[X]` (PEP 585 / typing.Type) instead of the fall-through string-literal default (`"typeof EntitySubstitution"`).
- Handles dotted qualifiers verbatim (`typeof bs4.Tag` → `type[bs4.Tag]`).
- Adds 4 unit tests in `packages/compile-python/src/index.test.ts` covering the new lowering path.

Before: bs4's `EntitySubstitution.substitute_xml` emitted `cls: "typeof EntitySubstitution"` — a forward-ref string that `typing.get_type_hints()` cannot resolve.
After: emits `cls: type[EntitySubstitution]` — the canonical Python annotation for class-object references.

Closes #960

## Test plan

- [x] `pnpm --filter @yakcc/compile-python test` — 100/100 pass (+4 new)
- [x] Build + typecheck + lint clean on rebased HEAD (`58dcaa5`)
- [x] Scope-compliant: only `packages/compile-python/src/{lower,index.test}.ts` touched
- [x] @decision DEC-960-001 annotation captures rationale at point of implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>