### PR TITLE
feat(shave-go): #981 + #982 — iteratee func params + IncDecStmt

### DIFF
--- a/packages/shave-go/src/go-ast-parser.ts
+++ b/packages/shave-go/src/go-ast-parser.ts
@@ -224,6 +224,20 @@ export interface GoAstSendStmt extends GoAstLocation {
   readonly type: "SendStmt";
 }
 
+/**
+ * Increment/decrement statement: `i++` or `i--` (#982).
+ * Go's *ast.IncDecStmt is a first-class statement node (not an expression
+ * statement wrapping a unary operator).  TS supports postfix `i++` / `i--`
+ * natively; the wire shape records just the target name and operator.
+ */
+export interface GoAstIncDecStmt extends GoAstLocation {
+  readonly type: "IncDecStmt";
+  /** Name of the target identifier (e.g. "i"). */
+  readonly target: string;
+  /** "++" or "--" */
+  readonly op: "++" | "--";
+}
+
 /** Statement not in the slice-2 supported set. */
 export interface GoAstUnsupportedStmt extends GoAstLocation {
   readonly type: "UnsupportedStmt";
@@ -318,6 +332,7 @@ export type GoAstStmt =
   | GoAstForStmt
   | GoAstRangeStmt
   | GoAstSwitchStmt
+  | GoAstIncDecStmt
   | GoAstUnsupportedStmt;
 
 /** Variable spec declaration (from a DeclStmt). */

--- a/packages/shave-go/src/parse-fn-signature.test.ts
+++ b/packages/shave-go/src/parse-fn-signature.test.ts
@@ -321,6 +321,123 @@ describe("extractFunctionSignatures -- WI-963 generic type parameter passthrough
   });
 });
 
+describe("extractFunctionSignatures -- #981 iteratee/predicate with named func params", () => {
+  it("raises Map[T, R any](collection []T, iteratee func(item T, index int) R) []R", () => {
+    const env = envelopeWith([
+      {
+        name: "Map",
+        receiver: null,
+        typeParams: [
+          { name: "T", constraint: "any" },
+          { name: "R", constraint: "any" },
+        ],
+        params: [
+          { name: "collection", goType: "[]T" },
+          { name: "iteratee", goType: "func(item T, index int) R" },
+        ],
+        results: [{ name: "", goType: "[]R" }],
+        bodySource: "// body",
+        body: null,
+      },
+    ]);
+    const sig = extractFunctionSignatures(env)[0];
+    expect(sig?.params[0]?.tsType).toBe("T[]");
+    expect(sig?.params[1]?.tsType).toBe("(a0: T, a1: number) => R");
+    expect(sig?.returnTypes).toEqual(["R[]"]);
+  });
+
+  it("raises Filter[T any](collection []T, predicate func(item T, index int) bool) []T", () => {
+    const env = envelopeWith([
+      {
+        name: "Filter",
+        receiver: null,
+        typeParams: [{ name: "T", constraint: "any" }],
+        params: [
+          { name: "collection", goType: "[]T" },
+          { name: "predicate", goType: "func(item T, index int) bool" },
+        ],
+        results: [{ name: "", goType: "[]T" }],
+        bodySource: "// body",
+        body: null,
+      },
+    ]);
+    const sig = extractFunctionSignatures(env)[0];
+    expect(sig?.params[1]?.tsType).toBe("(a0: T, a1: number) => boolean");
+    expect(sig?.returnTypes).toEqual(["T[]"]);
+  });
+
+  it("raises Reduce[T, R any](collection []T, accumulator func(agg R, item T, index int) R, initial R) R", () => {
+    const env = envelopeWith([
+      {
+        name: "Reduce",
+        receiver: null,
+        typeParams: [
+          { name: "T", constraint: "any" },
+          { name: "R", constraint: "any" },
+        ],
+        params: [
+          { name: "collection", goType: "[]T" },
+          { name: "accumulator", goType: "func(agg R, item T, index int) R" },
+          { name: "initial", goType: "R" },
+        ],
+        results: [{ name: "", goType: "R" }],
+        bodySource: "// body",
+        body: null,
+      },
+    ]);
+    const sig = extractFunctionSignatures(env)[0];
+    expect(sig?.params[0]?.tsType).toBe("T[]");
+    expect(sig?.params[1]?.tsType).toBe("(a0: R, a1: T, a2: number) => R");
+    expect(sig?.params[2]?.tsType).toBe("R");
+    expect(sig?.returnTypes).toEqual(["R"]);
+  });
+
+  it("compound: full production sequence for samber/lo-style Map + Filter", () => {
+    // This exercises the complete production path across parse-fn-signature +
+    // type-map + name-normalize, with named func-typed params (#981 target).
+    const env = envelopeWith([
+      {
+        name: "Map",
+        receiver: null,
+        typeParams: [
+          { name: "T", constraint: "any" },
+          { name: "R", constraint: "any" },
+        ],
+        params: [
+          { name: "collection", goType: "[]T" },
+          { name: "iteratee", goType: "func(item T, index int) R" },
+        ],
+        results: [{ name: "", goType: "[]R" }],
+        bodySource: null,
+        body: null,
+      },
+      {
+        name: "Filter",
+        receiver: null,
+        typeParams: [{ name: "T", constraint: "any" }],
+        params: [
+          { name: "collection", goType: "[]T" },
+          { name: "predicate", goType: "func(item T, index int) bool" },
+        ],
+        results: [{ name: "", goType: "[]T" }],
+        bodySource: null,
+        body: null,
+      },
+    ]);
+
+    const [mapSig, filterSig] = extractFunctionSignatures(env);
+
+    expect(mapSig?.name).toBe("Map");
+    expect(mapSig?.params[0]?.tsType).toBe("T[]");
+    expect(mapSig?.params[1]?.tsType).toBe("(a0: T, a1: number) => R");
+    expect(mapSig?.returnTypes).toEqual(["R[]"]);
+
+    expect(filterSig?.name).toBe("Filter");
+    expect(filterSig?.params[1]?.tsType).toBe("(a0: T, a1: number) => boolean");
+    expect(filterSig?.returnTypes).toEqual(["T[]"]);
+  });
+});
+
 describe("extractFunctionSignatures -- compound production sequence", () => {
   it("exercises the full production path: envelope -> signatures -> types -> names", () => {
     // This test mirrors the real production sequence: the go/ast subprocess

--- a/packages/shave-go/src/raise-body.test.ts
+++ b/packages/shave-go/src/raise-body.test.ts
@@ -34,6 +34,7 @@ import type {
   GoAstExpr,
   GoAstForStmt,
   GoAstIfStmt,
+  GoAstIncDecStmt,
   GoAstRangeStmt,
   GoAstStmt,
   GoAstSwitchStmt,
@@ -1001,5 +1002,117 @@ describe("renderBody — compound round-trips (WI-964)", () => {
     };
     const result = renderBody(b);
     expect(result).toBe("  for (const [i, v] of Object.entries(xs)) {\n    return v;\n  }");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #982: IncDecStmt (i++, i--)
+// ---------------------------------------------------------------------------
+
+describe("renderStmt — IncDecStmt (#982)", () => {
+  it("renders i++ as i++", () => {
+    const stmt: GoAstIncDecStmt = {
+      type: "IncDecStmt",
+      line: 1,
+      col: 1,
+      target: "i",
+      op: "++",
+    };
+    expect(renderStmt(stmt)).toBe("  i++;");
+  });
+
+  it("renders i-- as i--", () => {
+    const stmt: GoAstIncDecStmt = {
+      type: "IncDecStmt",
+      line: 1,
+      col: 1,
+      target: "i",
+      op: "--",
+    };
+    expect(renderStmt(stmt)).toBe("  i--;");
+  });
+
+  it("renders j++ (arbitrary variable name)", () => {
+    const stmt: GoAstIncDecStmt = {
+      type: "IncDecStmt",
+      line: 2,
+      col: 4,
+      target: "j",
+      op: "++",
+    };
+    expect(renderStmt(stmt)).toBe("  j++;");
+  });
+
+  it("renders IncDecStmt with custom indent", () => {
+    const stmt: GoAstIncDecStmt = {
+      type: "IncDecStmt",
+      line: 1,
+      col: 1,
+      target: "n",
+      op: "--",
+    };
+    expect(renderStmt(stmt, "    ")).toBe("    n--;");
+  });
+
+  it("IncDecStmt is pure (passes checkBodyPurity)", () => {
+    const b = body([
+      { type: "IncDecStmt", line: 1, col: 1, target: "i", op: "++" } satisfies GoAstIncDecStmt,
+    ]);
+    expect(() => checkBodyPurity(b)).not.toThrow();
+  });
+});
+
+describe("renderBody — compound round-trips for #982 IncDecStmt", () => {
+  it("for-loop with IncDecStmt post (i++) renders correctly", () => {
+    // Simulates: for i := 0; i < n; i++ { ... }
+    // The post statement is an IncDecStmt, which must render without trailing ;
+    // inside the for(...) header.
+    const b: GoAstBodyNode = {
+      stmts: [
+        {
+          type: "ForStmt",
+          line: 1,
+          col: 2,
+          init: {
+            type: "AssignStmt",
+            line: 1,
+            col: 6,
+            lhs: [ident("i")],
+            rhs: [intLit("0")],
+            tok: ":=",
+          },
+          cond: binExpr("<", ident("i"), ident("n")),
+          post: {
+            type: "IncDecStmt",
+            line: 1,
+            col: 20,
+            target: "i",
+            op: "++",
+          } satisfies GoAstIncDecStmt,
+          body: {
+            stmts: [returnStmt([ident("i")])],
+          },
+        } satisfies GoAstForStmt,
+      ],
+    };
+    const result = renderBody(b);
+    expect(result).toBe("  for (let i = 0; (i < n); i++) {\n    return i;\n  }");
+  });
+
+  it("standalone i-- statement (not in for-post) renders with semicolon", () => {
+    const b: GoAstBodyNode = {
+      stmts: [
+        {
+          type: "IncDecStmt",
+          line: 1,
+          col: 1,
+          target: "i",
+          op: "--",
+        } satisfies GoAstIncDecStmt,
+        returnStmt([ident("i")]),
+      ],
+    };
+    const result = renderBody(b);
+    expect(result).toBe("  i--;\n  return i;");
   });
 });

--- a/packages/shave-go/src/raise-body.ts
+++ b/packages/shave-go/src/raise-body.ts
@@ -75,6 +75,7 @@ import type {
   GoAstExpr,
   GoAstForStmt,
   GoAstIfStmt,
+  GoAstIncDecStmt,
   GoAstRangeStmt,
   GoAstStmt,
   GoAstSwitchStmt,
@@ -217,6 +218,11 @@ function checkStmtPurity(stmt: GoAstStmt): void {
         for (const e of c.list) checkExprPurity(e);
         checkBodyNodePurity(c.body);
       }
+      return;
+
+    // #982: IncDecStmt (i++, i--) is a pure mutation of a local numeric variable.
+    // No channel ops, goroutines, or side effects outside the local scope.
+    case "IncDecStmt":
       return;
 
     case "UnsupportedStmt":
@@ -475,6 +481,11 @@ export function renderStmt(stmt: GoAstStmt, indent = "  ", file = "stdin.go"): s
 
     case "SwitchStmt":
       return renderSwitchStmt(stmt, indent, file);
+
+    // #982: IncDecStmt — Go i++/i-- map directly to TS postfix i++/i--.
+    // TS supports postfix increment/decrement natively; round-trip is lossless.
+    case "IncDecStmt":
+      return `${indent}${stmt.target}${stmt.op};`;
 
     case "UnsupportedStmt":
       throw new GoUnsupportedConstructError(stmt.reason, { file, line: stmt.line, col: stmt.col });

--- a/packages/shave-go/src/type-map.test.ts
+++ b/packages/shave-go/src/type-map.test.ts
@@ -186,3 +186,74 @@ describe("mapGoType -- generic type parameter passthrough (WI-963)", () => {
     expect(mapGoType("[]bool")).toBe("boolean[]");
   });
 });
+
+// ---------------------------------------------------------------------------
+// #981: named parameters inside func literal types
+// ---------------------------------------------------------------------------
+
+describe("mapGoType -- #981 named parameters in func literal types", () => {
+  it("strips param name from 'func(item T) R' with typeParams {T, R}", () => {
+    const typeParams = new Set(["T", "R"]);
+    const result = mapGoType("func(item T) R", { typeParams });
+    expect(result.tsType).toBe("(a0: T) => R");
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("strips param name from 'func(item T, idx int) bool' (Map/Filter iteratee shape)", () => {
+    const typeParams = new Set(["T"]);
+    const result = mapGoType("func(item T, idx int) bool", { typeParams });
+    expect(result.tsType).toBe("(a0: T, a1: number) => boolean");
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("handles samber/lo Map iteratee: func(item T, index int) R", () => {
+    const typeParams = new Set(["T", "R"]);
+    const result = mapGoType("func(item T, index int) R", { typeParams });
+    expect(result.tsType).toBe("(a0: T, a1: number) => R");
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("handles Reduce accumulator: func(agg R, item T, index int) R", () => {
+    const typeParams = new Set(["T", "R"]);
+    const result = mapGoType("func(agg R, item T, index int) R", { typeParams });
+    expect(result.tsType).toBe("(a0: R, a1: T, a2: number) => R");
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("handles Filter predicate: func(item T, index int) bool", () => {
+    const typeParams = new Set(["T"]);
+    const result = mapGoType("func(item T, index int) bool", { typeParams });
+    expect(result.tsType).toBe("(a0: T, a1: number) => boolean");
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("handles named params with slice type: func(collection []T, item T) bool", () => {
+    const typeParams = new Set(["T"]);
+    const result = mapGoType("func(collection []T, item T) bool", { typeParams });
+    expect(result.tsType).toBe("(a0: T[], a1: T) => boolean");
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("handles nested func type in param position: []func(T) R with named outer params", () => {
+    const typeParams = new Set(["T", "R"]);
+    // outer func has a param of type []func(T) R
+    const result = mapGoType("[]func(T) R", { typeParams });
+    expect(result.tsType).toBe("((a0: T) => R)[]");
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("handles unnamed params (no change from current behavior)", () => {
+    const typeParams = new Set(["T", "R"]);
+    const result = mapGoType("func(T) R", { typeParams });
+    expect(result.tsType).toBe("(a0: T) => R");
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("handles variadic func type: func(items ...T) T", () => {
+    const typeParams = new Set(["T"]);
+    // ...T is a variadic — go/ast printer emits "...T" as type string
+    const result = mapGoType("func(items ...T) T", { typeParams });
+    expect(result.tsType).toBe("(a0: T) => T");
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/packages/shave-go/src/type-map.ts
+++ b/packages/shave-go/src/type-map.ts
@@ -12,6 +12,15 @@
 // supplied, identifiers that appear in that set are emitted verbatim as TS
 // generic type parameters rather than looked up in the mapping table.
 //
+// WI-981 extends parseFuncLitType to handle named parameters inside Go func
+// literal types (e.g. `func(item T) R` as the goType of an iteratee/predicate
+// parameter).  Before WI-981, only anonymous-parameter func types worked
+// (func(T) R); named ones like `func(item T, index int) R` (used by samber/lo
+// Map, Filter, Reduce, etc.) threw UnsupportedTypeError on the "item T" token.
+// The fix: strip the leading Go identifier from each comma-split parameter token
+// when it is followed by a type-starting token.  Variadic `...T` forms are also
+// handled.
+//
 // Composite types are recursively mapped.  Types outside the supported set
 // throw UnsupportedTypeError so callers can surface them via CannotRaiseToIRError
 // (slice 4 wires that -- slice 1 throws plain UnsupportedTypeError so the
@@ -38,6 +47,22 @@
 //   no opts still receive a plain string so no existing call sites require changes.
 //   func literal types (func(T) R) are parsed and emitted as TS arrow types so
 //   higher-order generic functions (samber/lo Map, Filter, etc.) raise correctly.
+//
+// @decision DEC-POLYGLOT-GO-NAMED-FUNC-PARAMS-001 (WI-981)
+// @title Strip Go parameter names from func-literal-type parameter tokens
+// @status accepted (WI-981)
+// @rationale
+//   In Go, `func(item T) R` is a valid function-typed parameter where "item" is
+//   the parameter name and "T" is the type.  The type-mapper only needs the type
+//   token for conversion; the name is discarded (TS arrow types use synthesized
+//   names a0, a1, ...).  Detection rule: if a comma-split token starts with a Go
+//   identifier (matches /^[A-Za-z_]\w*/) followed by a space followed by a
+//   type-starting character (not itself an identifier start — so the second token
+//   must start with *, [, f (for func), or be a known primitive), strip the first
+//   token.  Variadic ...T strips the "..." prefix before type-mapping and treats
+//   the result as a plain T (TS doesn't model variadic parameter types in arrow
+//   signatures at slice-1).  This handles the full samber/lo iteratee/predicate
+//   surface.
 
 /**
  * Thrown when a Go type cannot be mapped to a TS-subset IR type using the
@@ -153,9 +178,13 @@ function mapGoTypeInner(
   }
 
   // Slice types: []T -> T[]
+  // Arrow types (from func literals) need parentheses to avoid precedence
+  // ambiguity: []func(T) R must become ((a0: T) => R)[] not (a0: T) => R[].
   if (t.startsWith("[]")) {
     const inner = mapGoTypeInner(t.slice(2), opts);
-    return { tsType: `${inner.tsType}[]`, warnings: inner.warnings };
+    const needsParens = inner.tsType.includes("=>");
+    const elemType = needsParens ? `(${inner.tsType})` : inner.tsType;
+    return { tsType: `${elemType}[]`, warnings: inner.warnings };
   }
 
   // Map types: map[K]V -> Record<K, V>.  Slice 1 requires K = string.
@@ -229,8 +258,14 @@ function mapGoTypeInner(
  * into a TS arrow type `(a0: T) => R`.
  *
  * Supports void (no return) func types: `func(T)` -> `(a0: T) => void`.
- * Parameter names are synthesized as `a0`, `a1`, ... since Go func literals
- * in type position have no parameter names.
+ * Parameter names are synthesized as `a0`, `a1`, ... since TS arrow types
+ * in type position do not use Go parameter names.
+ *
+ * WI-981: Also handles named Go parameters like `func(item T, index int) R` —
+ * go/ast's printer.Fprint preserves the parameter name when it is present in
+ * the source.  The name token is detected and stripped before type-mapping.
+ * Variadic `...T` (or `items ...T`) strips the `...` prefix and maps the base
+ * type (TS does not model variadic arrow parameter types at slice-1).
  *
  * Throws `UnsupportedTypeError` on malformed input or types outside the
  * supported set.
@@ -265,9 +300,10 @@ function parseFuncLitType(
   const warnings: LowerWarning[] = [];
 
   // Parse param types (comma-separated, respecting nested brackets/parens).
-  const paramTypes = paramStr.length === 0 ? [] : splitTypeList(paramStr);
-  const tsParams = paramTypes.map((pType, idx) => {
-    const mapped = mapGoTypeInner(pType, opts);
+  const paramTokens = paramStr.length === 0 ? [] : splitTypeList(paramStr);
+  const tsParams = paramTokens.map((pToken, idx) => {
+    const typeStr = stripGoParamName(pToken);
+    const mapped = mapGoTypeInner(typeStr, opts);
     warnings.push(...mapped.warnings);
     return `a${idx}: ${mapped.tsType}`;
   });
@@ -282,6 +318,61 @@ function parseFuncLitType(
 
   const tsType = `(${tsParams.join(", ")}) => ${tsReturn}`;
   return { tsType, warnings };
+}
+
+/**
+ * Strip a Go parameter name from a func-literal parameter token.
+ *
+ * In Go, a parameter inside a func-literal type can appear in two forms:
+ *   - Anonymous: just the type, e.g. `T`, `int`, `[]T`, `func(T) R`
+ *   - Named: identifier + type, e.g. `item T`, `index int`, `items ...T`
+ *
+ * go/ast's printer.Fprint preserves the name when present.  We detect the
+ * named form by checking whether the token starts with a bare Go identifier
+ * (matches `[A-Za-z_]\w*`) followed by a space.  If yes, we strip the
+ * identifier prefix to get the pure type token.
+ *
+ * Variadic parameters `...T` (or `items ...T`) have their `...` prefix
+ * stripped because TS arrow types do not model variadic parameter types
+ * at slice-1; the base element type is used instead.
+ *
+ * WI-981: This is the key fix for samber/lo iteratee/predicate shapes.
+ */
+function stripGoParamName(token: string): string {
+  const t = token.trim();
+
+  // Check for named parameter: starts with a Go identifier followed by a space.
+  // A Go identifier is /^[A-Za-z_]\w*/; type-starting characters are not plain
+  // identifiers before a space (they start with *, [, f(unc), or are keywords
+  // we already handle).  We split on the first space and check that the prefix
+  // is a pure identifier (no brackets, dots, etc.).
+  const spaceIdx = t.indexOf(" ");
+  if (spaceIdx > 0) {
+    const prefix = t.slice(0, spaceIdx);
+    const rest = t.slice(spaceIdx + 1).trim();
+    // prefix is a plain Go identifier if it matches [A-Za-z_]\w* with no special
+    // characters.  This distinguishes `item T` (name + type) from a type that
+    // could never have a space in it (all Go types that contain spaces are not
+    // valid in this position).
+    if (/^[A-Za-z_]\w*$/.test(prefix)) {
+      // Named parameter detected; rest is the type (possibly "...T" variadic).
+      return stripVariadic(rest);
+    }
+  }
+
+  // No name prefix — strip variadic `...` if present (unnamed variadic param).
+  return stripVariadic(t);
+}
+
+/**
+ * Strip a leading `...` variadic prefix from a Go type token.
+ * `...T` -> `T`, `...[]int` -> `[]int`, `T` -> `T` (no-op).
+ */
+function stripVariadic(t: string): string {
+  if (t.startsWith("...")) {
+    return t.slice(3);
+  }
+  return t;
 }
 
 /**

--- a/scripts/go-ast-parse.go
+++ b/scripts/go-ast-parse.go
@@ -285,6 +285,34 @@ func marshalStmt(fset *token.FileSet, stmt ast.Stmt) json.RawMessage {
 		// WI-964: emit structured SwitchStmt node.
 		return marshalSwitchStmt(fset, s, line, col)
 
+	case *ast.IncDecStmt:
+		// #982: emit IncDecStmt wire node for i++/i-- statements.
+		// Only identifier targets are supported in the pure-function subset;
+		// non-identifier targets (e.g. arr[i]++ or a.b++) fall through to
+		// UnsupportedStmt since they imply mutation of complex lvalue paths.
+		target := ""
+		if id, ok := s.X.(*ast.Ident); ok {
+			target = id.Name
+		} else {
+			return marshal(map[string]interface{}{
+				"type":   "UnsupportedStmt",
+				"line":   line,
+				"col":    col,
+				"reason": fmt.Sprintf("IncDecStmt(non-ident target: %T)", s.X),
+			})
+		}
+		op := "++"
+		if s.Tok == token.DEC {
+			op = "--"
+		}
+		return marshal(map[string]interface{}{
+			"type":   "IncDecStmt",
+			"line":   line,
+			"col":    col,
+			"target": target,
+			"op":     op,
+		})
+
 	default:
 		return marshal(map[string]interface{}{
 			"type":   "UnsupportedStmt",


### PR DESCRIPTION
## Summary

- **#981 — iteratee func params**: `parseFuncLitType` now strips Go named params (`item T`, `agg R`, `idx int`) so iteratees like `func(item T) R` map correctly. Variadic handling for `...T`. Arrow-types as slice elements get parenthesized correctly. `Map`/`Filter`/`Reduce` raise with proper `(a0: T, a1: number) => R` signatures. Unlocks ~120 higher-order `samber/lo` functions.
- **#982 — IncDecStmt**: `*ast.IncDecStmt` (`i++`, `i--`) is wire-emitted and raised to TS `i++`/`i--`. Renders without trailing semicolon in for-loop post position.

## Impact

- shave-go: 248 → 268 tests, all green
- Build + typecheck + lint clean across workspace
- Live subprocess verified: Map/Filter/Reduce + for-loop with `i++` all raise correctly
- Expected `samber/lo` `fnFullyRaised` climbs from 35 toward 150+

## Test plan

- [x] `pnpm -r build` clean
- [x] `pnpm -r test` 268/268 in shave-go
- [x] `pnpm -r typecheck` clean
- [x] `pnpm -r lint` clean
- [x] Live subprocess verification of Map/Filter/Reduce + i++ raise

Closes #981
Closes #982

🤖 Generated with [Claude Code](https://claude.com/claude-code)