### PR TITLE
fix(compile-go): #984 — lower TS FunctionType to Go func(...) instead of interface{}

### DIFF
--- a/packages/compile-go/src/lower.test.ts
+++ b/packages/compile-go/src/lower.test.ts
@@ -550,6 +550,101 @@ describe("compileToGo — range round-trip (#975)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// #984 — FunctionType lowering (iteratee params: no interface{} fallthrough)
+// ---------------------------------------------------------------------------
+
+describe("lowerTypeNode — FunctionType (#984)", () => {
+  function makeTypeCtx(typeParams: string[] = []) {
+    return { warnings: [], typeParams, fnName: undefined, importRefs: new Set<string>() };
+  }
+
+  function parseTypeNode(tsType: string) {
+    const project = new Project({
+      useInMemoryFileSystem: true,
+      compilerOptions: { strict: true, target: 99, module: 99, skipLibCheck: true },
+    });
+    const sf = project.createSourceFile("t.ts", `type _T = ${tsType};`);
+    const ta = sf.getStatements()[0];
+    if (!ta) throw new Error("no statement");
+    const typeAlias = ta.asKindOrThrow(SyntaxKind.TypeAliasDeclaration);
+    const tn = typeAlias.getTypeNode();
+    if (!tn) throw new Error("no type node");
+    return tn;
+  }
+
+  it("#984: (a: T) => boolean -> func(T) bool", () => {
+    const ctx = makeTypeCtx(["T"]);
+    expect(lowerTypeNode(parseTypeNode("(a: T) => boolean"), ctx)).toBe("func(T) bool");
+  });
+
+  it("#984: (a: T, b: number) => R -> func(T, int) R", () => {
+    const ctx = makeTypeCtx(["T", "R"]);
+    expect(lowerTypeNode(parseTypeNode("(a: T, b: number) => R"), ctx)).toBe("func(T, int) R");
+  });
+
+  it("#984: () => void -> func() (no return suffix)", () => {
+    const ctx = makeTypeCtx([]);
+    expect(lowerTypeNode(parseTypeNode("() => void"), ctx)).toBe("func()");
+  });
+
+  it("#984: (a: T) => void -> func(T) (no return suffix)", () => {
+    const ctx = makeTypeCtx(["T"]);
+    expect(lowerTypeNode(parseTypeNode("(a: T) => void"), ctx)).toBe("func(T)");
+  });
+
+  it("#984: nested (cb: (x: T) => boolean) => T[] -> func(func(T) bool) []T", () => {
+    const ctx = makeTypeCtx(["T"]);
+    expect(lowerTypeNode(parseTypeNode("(cb: (x: T) => boolean) => T[]"), ctx)).toBe(
+      "func(func(T) bool) []T",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #984 — End-to-end: samber/lo iteratee params no longer collapse to interface{}
+// ---------------------------------------------------------------------------
+
+describe("compileToGo — iteratee FunctionType round-trip (#984)", () => {
+  it("#984: Filter predicate (a0: T, a1: number) => boolean -> func(T, int) bool (not interface{})", () => {
+    // This is the exact IR shave-go emits for samber/lo Filter after #981
+    const src = `export function filter<T, Slice extends GoConstraint_Tilde_SliceOf_T>(
+  collection: Slice,
+  predicate: (a0: T, a1: number) => boolean
+): Slice {
+  return collection;
+}`;
+    const out = compile(src);
+    expect(out).toContain("predicate func(T, int) bool");
+    expect(out).not.toContain("predicate interface{}");
+  });
+
+  it("#984: Reduce accumulator (a0: R, a1: T, a2: number) => R -> func(R, T, int) R", () => {
+    const src = `export function reduce<T, R>(
+  collection: T[],
+  iteratee: (a0: R, a1: T, a2: number) => R,
+  initial: R
+): R {
+  return initial;
+}`;
+    const out = compile(src);
+    expect(out).toContain("iteratee func(R, T, int) R");
+    expect(out).not.toContain("iteratee interface{}");
+  });
+
+  it("#984: Map iteratee (a0: T, a1: number) => R -> func(T, int) R", () => {
+    const src = `export function mapFn<T, R>(
+  collection: T[],
+  iteratee: (a0: T, a1: number) => R
+): R[] {
+  return [];
+}`;
+    const out = compile(src);
+    expect(out).toContain("iteratee func(T, int) R");
+    expect(out).not.toContain("iteratee interface{}");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // #976 — Generic constraint round-trip fidelity
 // ---------------------------------------------------------------------------
 

--- a/packages/compile-go/src/lower.ts
+++ b/packages/compile-go/src/lower.ts
@@ -88,6 +88,7 @@ import { CannotLowerToGoError } from "@yakcc/contracts";
 import {
   type ForOfStatement,
   type FunctionDeclaration,
+  type FunctionTypeNode,
   Node,
   Project,
   SyntaxKind,
@@ -1153,6 +1154,31 @@ export function lowerTypeNode(typeNode: TypeNode, ctx: Ctx): string {
     }
 
     return name;
+  }
+
+  // @decision DEC-WI984-001
+  // @title FunctionType lowering: TS (a0: T, a1: number) => boolean -> Go func(T, int) bool
+  // @status accepted (WI-984)
+  // @rationale
+  //   shave-go #981 made iteratee params structurally typed as TS FunctionType nodes
+  //   (e.g. `(a0: T, a1: number) => boolean`). Without this case, lowerTypeNode fell
+  //   through to the `interface{}` fallback, producing uncompilable Go (predicate
+  //   interface{} instead of func(T, int) bool). Go func-type literals omit param
+  //   names — only types are emitted. The void return is handled by checking lowerTypeNode
+  //   for the return node: "" (void) -> no return suffix; anything else -> " ReturnType".
+  if (k === SyntaxKind.FunctionType) {
+    const fnType = typeNode.asKindOrThrow(SyntaxKind.FunctionType) as FunctionTypeNode;
+    const paramStrs = fnType.getParameters().map((p) => {
+      const pTypeNode = p.getTypeNode();
+      // Go func types don't include param names; emit type only.
+      return pTypeNode ? lowerTypeNode(pTypeNode, ctx) : "interface{}";
+    });
+    const retNode = fnType.getReturnTypeNode();
+    const ret = retNode ? lowerTypeNode(retNode, ctx) : "";
+    // void lowers to "" — no return suffix for void functions
+    return ret && ret !== ""
+      ? `func(${paramStrs.join(", ")}) ${ret}`
+      : `func(${paramStrs.join(", ")})`;
   }
 
   // Fallback: emit the raw TS text as a Go comment-style placeholder


### PR DESCRIPTION
## Summary

- **Bug:** shave-go #981 made iteratees structurally typed as TS `FunctionType` nodes (e.g. `(a0: T, a1: number) => boolean`). compile-go had no `SyntaxKind.FunctionType` case in `lowerTypeNode`, so iteratee params fell through to `interface{}` — producing uncompilable Go for samber/lo `Filter`/`Reduce`/`Map`.
- **Fix:** Added `FunctionType` case to `lowerTypeNode` that strips TS param names (Go func types don't include names) and lowers each param type + return type. `void` → no return suffix.
- **Result:** `predicate func(T, int) bool` instead of `predicate interface{}`. Nested function types compose: `(cb: (x: T) => boolean) => T[]` → `func(func(T) bool) []T`.

## Files

- `packages/compile-go/src/lower.ts` — +26 (FunctionType case + DEC-WI984-001 annotation)
- `packages/compile-go/src/lower.test.ts` — +95 (5 unit + 3 e2e tests for #984)

## Test plan

- [x] `pnpm --filter @yakcc/compile-go test` — 102/102 pass (94 → 102, +8 new)
- [x] `pnpm --filter @yakcc/compile-go build` clean
- [x] `pnpm --filter @yakcc/compile-go typecheck` clean
- [x] `pnpm --filter @yakcc/compile-go lint` clean
- [x] Reviewer verdict: `ready_for_guardian` (no blockers, no major, no minor)

Closes #984