### PR TITLE
feat(shave-go+compile-go): #986 — CompositeLit (slice/map literals) round-trip

### DIFF
--- a/packages/compile-go/src/lower.test.ts
+++ b/packages/compile-go/src/lower.test.ts
@@ -737,3 +737,168 @@ describe("compileToGo — constraint round-trip (#976)", () => {
     expect(out).toContain('"golang.org/x/exp/constraints"');
   });
 });
+
+// ---------------------------------------------------------------------------
+// #986 — CompositeLit lowering: TS array/object literal -> Go []T{} / map[K]V{}
+//
+// @decision DEC-COMPOSITELIT-LOWER-001 (#986)
+// @title Array/object literals use goTypeHint from surrounding declaration; fall back to interface{}
+// @status accepted (#986)
+// @rationale
+//   The Go element/key/value types cannot be inferred from TS literal elements alone.
+//   The surrounding variable declaration type node is the correct authority.
+//   lowerVarStatement propagates lowerTypeNode(typeNode) into ctx.goTypeHint before
+//   lowerExpr runs on the initializer.  lowerArrayLiteral / lowerObjectLiteral consume
+//   this hint to emit the correct Go type prefix.
+// ---------------------------------------------------------------------------
+
+describe("lowerSource — array literal (#986)", () => {
+  it("typed []int with explicit type annotation: const xs: number[] = [1, 2, 3]", () => {
+    const src = `export function nums(): number[] {
+  const xs: number[] = [1, 2, 3];
+  return xs;
+}`;
+    const out = compile(src);
+    expect(out).toContain("xs := []int{1, 2, 3}");
+  });
+
+  it('typed []string: const ss: string[] = ["a", "b"]', () => {
+    const src = `export function strs(): string[] {
+  const ss: string[] = ["a", "b"];
+  return ss;
+}`;
+    const out = compile(src);
+    expect(out).toContain(`ss := []string{"a", "b"}`);
+  });
+
+  it("empty slice with type annotation: const xs: number[] = []", () => {
+    const src = `export function empty(): number[] {
+  const xs: number[] = [];
+  return xs;
+}`;
+    const out = compile(src);
+    expect(out).toContain("xs := []int{}");
+  });
+
+  it("array literal with expression elements", () => {
+    const src = `export function computed(a: number, b: number): number[] {
+  const xs: number[] = [a + b, a - b];
+  return xs;
+}`;
+    const out = compile(src);
+    expect(out).toContain("xs := []int{a + b, a - b}");
+  });
+
+  it("array literal in return position without type hint falls back to []interface{}", () => {
+    // Return-position type propagation is deferred (DEC-COMPOSITELIT-LOWER-001).
+    // Without a type hint, the literal uses interface{} element type.
+    const src = `export function fallback(): any {
+  return [1, 2, 3];
+}`;
+    const out = compile(src);
+    expect(out).toContain("[]interface{}{1, 2, 3}");
+  });
+});
+
+describe("lowerSource — object literal / map (#986)", () => {
+  it('typed Record<string,int> map literal: const m: Record<string,number> = {"a": 1}', () => {
+    const src = `export function scores(): Record<string, number> {
+  const m: Record<string, number> = {"a": 1, "b": 2};
+  return m;
+}`;
+    const out = compile(src);
+    expect(out).toContain(`m := map[string]int{"a": 1, "b": 2}`);
+  });
+
+  it("empty map literal: const m: Record<string,number> = {}", () => {
+    const src = `export function emptyMap(): Record<string, number> {
+  const m: Record<string, number> = {};
+  return m;
+}`;
+    const out = compile(src);
+    expect(out).toContain("m := map[string]int{}");
+  });
+
+  it("identifier property keys become Go string literals", () => {
+    // TS `{foo: 1}` bare identifier key -> `"foo": 1` in Go map literal.
+    const src = `export function bareKey(): Record<string, number> {
+  const m: Record<string, number> = {foo: 1, bar: 2};
+  return m;
+}`;
+    const out = compile(src);
+    expect(out).toContain('"foo": 1');
+    expect(out).toContain('"bar": 2');
+    expect(out).toContain("map[string]int{");
+  });
+
+  it("object literal in return position without type hint uses map[string]interface{}", () => {
+    // Deferred return-position propagation: default key/value types used.
+    const src = `export function fallback(): any {
+  return {"key": 42};
+}`;
+    const out = compile(src);
+    expect(out).toContain('map[string]interface{}{"key": 42}');
+  });
+
+  it("shorthand or spread properties throw CannotLowerToGoError", () => {
+    // Spread / shorthand are not in the CompositeLit MVP scope.
+    const src = `export function spread(m: Record<string, number>): any {
+  return {...m};
+}`;
+    expect(() => compile(src)).toThrow(CannotLowerToGoError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #986 — Compound end-to-end: shave-go IR -> compile-go CompositeLit round-trip
+//
+// Simulates what happens when a Go function using composite literals is shaved
+// (shave-go emits SliceLit/MapLit wire nodes, raise-body renders them as TS
+// array/object literals) and then compiled back to Go (compile-go lowers the
+// TS literals back to []T{} / map[K]V{} using the variable declaration type hint).
+// ---------------------------------------------------------------------------
+
+describe("compileToGo — CompositeLit round-trip compound (#986)", () => {
+  it("#986 compound: slice init + assignment + return: []int{1,2,3} round-trips", () => {
+    // IR as shave-go would emit for:
+    //   func Nums() []int { xs := []int{1, 2, 3}; return xs }
+    // After raise-body renders: const xs: number[] = [1, 2, 3]; return xs;
+    const src = `export function nums(): number[] {
+  const xs: number[] = [1, 2, 3];
+  return xs;
+}`;
+    const out = compile(src);
+    expect(out).toContain("func Nums() []int {");
+    expect(out).toContain("xs := []int{1, 2, 3}");
+    expect(out).toContain("return xs");
+  });
+
+  it("#986 compound: map[string]int{...} round-trips via Record<string,number>", () => {
+    // IR as shave-go would emit for:
+    //   func Scores() map[string]int { m := map[string]int{"a": 1}; return m }
+    // After raise-body renders: const m: Record<string, number> = {"a": 1}; return m;
+    const src = `export function scores(): Record<string, number> {
+  const m: Record<string, number> = {"a": 1, "b": 2};
+  return m;
+}`;
+    const out = compile(src);
+    expect(out).toContain("func Scores() map[string]int {");
+    expect(out).toContain(`m := map[string]int{"a": 1, "b": 2}`);
+    expect(out).toContain("return m");
+  });
+
+  it("#986 compound: slice + for-range over it: []string{...} + key-only range", () => {
+    // Simulates a function that initializes a slice and iterates over it.
+    const src = `export function process(): string {
+  const items: string[] = ["x", "y", "z"];
+  for (const i in items) {
+    return items[i];
+  }
+  return "";
+}`;
+    const out = compile(src);
+    expect(out).toContain(`items := []string{"x", "y", "z"}`);
+    expect(out).toContain("for i := range items {");
+    expect(out).toContain("return items[i]");
+  });
+});

--- a/packages/compile-go/src/lower.ts
+++ b/packages/compile-go/src/lower.ts
@@ -226,6 +226,17 @@ interface Ctx {
    * the import block (WI-977, DEC-WI977-001).
    */
   importRefs: Set<string>;
+  /**
+   * Go type hint propagated from the surrounding variable declaration.
+   * Set by lowerVarStatement when a TypeNode is present (e.g. `const x: number[] = [1, 2]`
+   * or inferred from the declared type in `const x: Record<string, number> = {}`).
+   * Consumed by lowerArrayLiteral and lowerObjectLiteral (#986) to emit the correct
+   * Go element/key/value types instead of falling back to `interface{}`.
+   *
+   * This field is transient: it is set immediately before lowering the initializer
+   * expression and cleared after.  It MUST NOT be used outside expression lowering.
+   */
+  goTypeHint?: string | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -488,7 +499,16 @@ function lowerVarStatement(node: Node, ctx: Ctx, depth: number): string[] {
     const varName = toGoLocalName(vd.getName());
     const init = vd.getInitializer();
     if (init) {
-      lines.push(`${ind}${varName} := ${lowerExpr(init, ctx)}`);
+      // #986: propagate the declared Go type as a hint for array/object literal lowering.
+      // e.g. `const xs: number[] = []` -> hint="[]int" -> lowerArrayLiteral emits `[]int{}`
+      // The hint is cleared after lowering the initializer (transient, see Ctx.goTypeHint).
+      const typeNode = vd.getTypeNode();
+      if (typeNode) {
+        ctx.goTypeHint = lowerTypeNode(typeNode, ctx);
+      }
+      const initStr = lowerExpr(init, ctx);
+      ctx.goTypeHint = undefined;
+      lines.push(`${ind}${varName} := ${initStr}`);
     } else {
       // uninitialized var: emit var x T (requires type annotation)
       const typeNode = vd.getTypeNode();
@@ -932,14 +952,135 @@ function lowerExpr(node: Node, ctx: Ctx): string {
   }
 
   if (k === SyntaxKind.ArrayLiteralExpression) {
-    const al = node.asKindOrThrow(SyntaxKind.ArrayLiteralExpression);
-    const elems = al.getElements().map((e) => lowerExpr(e, ctx));
-    return `[]interface{}{${elems.join(", ")}}`;
+    return lowerArrayLiteral(node, ctx);
+  }
+
+  // #986: ObjectLiteralExpression -> map[K]V{k: v, ...}
+  // shave-go emits map[K]V{} as TS `{}` or `{k: v}` object literals.
+  // compile-go resolves the Go map type from variable-declaration context
+  // via the Ctx.goTypeHint set by lowerVarStatement, or defaults to
+  // map[string]interface{}{} when no hint is available.
+  if (k === SyntaxKind.ObjectLiteralExpression) {
+    return lowerObjectLiteral(node, ctx);
   }
 
   // Loud failure: unhandled expression kind (DEC-WI973-003)
   const snippet = node.getText().slice(0, 60).replace(/\n/g, " ");
   throw new CannotLowerToGoError(SyntaxKind[k], nodeLocation(node), snippet, ctx.fnName);
+}
+
+// ---------------------------------------------------------------------------
+// #986: Array and Object literal lowering
+//
+// @decision DEC-COMPOSITELIT-LOWER-001 (#986)
+// @title Array/object literals use goTypeHint from surrounding declaration; fall back to interface{}
+// @status accepted (#986)
+// @rationale
+//   The Go element/key/value types for composite literals cannot be inferred from
+//   the TS literal elements alone (e.g. `[1, 2, 3]` could be []int, []int64, or []float64).
+//   The surrounding variable declaration type node (e.g. `number[]` -> `[]int`) is the
+//   correct authority.  lowerVarStatement sets ctx.goTypeHint before calling lowerExpr on
+//   the initializer.  lowerArrayLiteral / lowerObjectLiteral read the hint to emit the
+//   correct Go element/key/value type.
+//   When no hint is available (e.g. literal in return position or argument position),
+//   fall back to `interface{}` to avoid silent type corruption — the Go compiler will
+//   flag the mismatch if the inferred type is wrong.
+//   Return-position type propagation (reading the enclosing function's return type) is
+//   deferred to a later work item; it requires threading the return TypeNode through Ctx.
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a Go slice type string (e.g. "[]int", "[]string") and return just the
+ * element type ("int", "string"). Returns "interface{}" for unrecognized shapes.
+ */
+function sliceElementType(goSliceType: string): string {
+  if (goSliceType.startsWith("[]")) {
+    return goSliceType.slice(2);
+  }
+  return "interface{}";
+}
+
+/**
+ * Parse a Go map type string (e.g. "map[string]int") and return [keyType, valueType].
+ * Returns ["string", "interface{}"] for unrecognized shapes.
+ */
+function mapKeyValueTypes(goMapType: string): [string, string] {
+  // map[K]V — find the ] that closes the key bracket
+  if (!goMapType.startsWith("map[")) return ["string", "interface{}"];
+  let depth = 0;
+  let closeIdx = -1;
+  for (let i = 4; i < goMapType.length; i++) {
+    const ch = goMapType[i];
+    if (ch === "[") depth++;
+    else if (ch === "]") {
+      if (depth === 0) {
+        closeIdx = i;
+        break;
+      }
+      depth--;
+    }
+  }
+  if (closeIdx < 0) return ["string", "interface{}"];
+  const keyType = goMapType.slice(4, closeIdx);
+  const valueType = goMapType.slice(closeIdx + 1);
+  return [keyType || "string", valueType || "interface{}"];
+}
+
+/**
+ * Lower a TS array literal `[a, b, c]` to Go `[]T{a, b, c}`.
+ * Uses ctx.goTypeHint (set by lowerVarStatement) to determine T.
+ */
+function lowerArrayLiteral(node: Node, ctx: Ctx): string {
+  const al = node.asKindOrThrow(SyntaxKind.ArrayLiteralExpression);
+  const elems = al.getElements().map((e) => lowerExpr(e, ctx));
+  const elemType = ctx.goTypeHint ? sliceElementType(ctx.goTypeHint) : "interface{}";
+  return `[]${elemType}{${elems.join(", ")}}`;
+}
+
+/**
+ * Lower a TS object literal `{k: v}` to Go `map[K]V{k: v}`.
+ * Uses ctx.goTypeHint to determine K and V.
+ * String property keys are emitted as Go string literals (double-quoted).
+ * Numeric (computed) property keys are emitted as-is.
+ */
+function lowerObjectLiteral(node: Node, ctx: Ctx): string {
+  const ol = node.asKindOrThrow(SyntaxKind.ObjectLiteralExpression);
+  const [keyType, valueType] = ctx.goTypeHint
+    ? mapKeyValueTypes(ctx.goTypeHint)
+    : ["string", "interface{}"];
+
+  const entries = ol.getProperties().map((prop) => {
+    if (prop.getKind() === SyntaxKind.PropertyAssignment) {
+      const pa = prop.asKindOrThrow(SyntaxKind.PropertyAssignment);
+      const nameNode = pa.getNameNode();
+      const valExpr = lowerExpr(pa.getInitializer() ?? pa, ctx);
+
+      // Key rendering: string identifier keys become Go string literals.
+      // Numeric literal keys pass through verbatim.
+      let keyStr: string;
+      if (nameNode.getKind() === SyntaxKind.Identifier) {
+        // Bare identifier property key: emit as Go string literal.
+        keyStr = `"${nameNode.getText()}"`;
+      } else if (nameNode.getKind() === SyntaxKind.StringLiteral) {
+        // Already a string literal: use as-is (TS double-quoted matches Go).
+        keyStr = nameNode.getText();
+      } else {
+        // Computed / numeric: lower as expression.
+        keyStr = lowerExpr(nameNode, ctx);
+      }
+      return `${keyStr}: ${valExpr}`;
+    }
+    // Shorthand, spread, method: not in scope for #986 MVP.
+    const snippet = prop.getText().slice(0, 40);
+    throw new CannotLowerToGoError(
+      SyntaxKind[prop.getKind()],
+      nodeLocation(prop),
+      snippet,
+      ctx.fnName,
+    );
+  });
+
+  return `map[${keyType}]${valueType}{${entries.join(", ")}}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/shave-go/src/go-ast-parser.ts
+++ b/packages/shave-go/src/go-ast-parser.ts
@@ -146,6 +146,38 @@ export interface GoAstChanRecvExpr extends GoAstLocation {
   readonly type: "ChanRecv";
 }
 
+/**
+ * Slice literal expression: `[]T{a, b, c}` (#986).
+ * Type field captures the element type as a Go source string (e.g. "int", "string").
+ * elements is the ordered list of element expressions.
+ */
+export interface GoAstSliceLitExpr extends GoAstLocation {
+  readonly type: "SliceLit";
+  /** Go element type string, e.g. "int", "string", "T". */
+  readonly elementType: string;
+  readonly elements: readonly GoAstExpr[];
+}
+
+/**
+ * Map literal expression: `map[K]V{k: v, ...}` (#986).
+ * keyType and valueType capture the Go source strings.
+ * entries is the ordered list of key/value pairs.
+ */
+export interface GoAstMapLitExpr extends GoAstLocation {
+  readonly type: "MapLit";
+  /** Go key type string, e.g. "string", "int". */
+  readonly keyType: string;
+  /** Go value type string, e.g. "int", "bool". */
+  readonly valueType: string;
+  readonly entries: readonly GoAstMapEntry[];
+}
+
+/** One key/value pair in a MapLit expression (#986). */
+export interface GoAstMapEntry {
+  readonly key: GoAstExpr;
+  readonly value: GoAstExpr;
+}
+
 /** Expression not in the slice-2 supported set. */
 export interface GoAstUnsupportedExpr extends GoAstLocation {
   readonly type: "UnsupportedExpr";
@@ -163,6 +195,8 @@ export type GoAstExpr =
   | GoAstSelectorExpr
   | GoAstIndexExpr
   | GoAstChanRecvExpr
+  | GoAstSliceLitExpr
+  | GoAstMapLitExpr
   | GoAstUnsupportedExpr;
 
 /** Return statement: `return expr1, expr2, ...` */

--- a/packages/shave-go/src/raise-body.test.ts
+++ b/packages/shave-go/src/raise-body.test.ts
@@ -35,7 +35,10 @@ import type {
   GoAstForStmt,
   GoAstIfStmt,
   GoAstIncDecStmt,
+  GoAstMapEntry,
+  GoAstMapLitExpr,
   GoAstRangeStmt,
+  GoAstSliceLitExpr,
   GoAstStmt,
   GoAstSwitchStmt,
 } from "./go-ast-parser.js";
@@ -1114,5 +1117,260 @@ describe("renderBody — compound round-trips for #982 IncDecStmt", () => {
     };
     const result = renderBody(b);
     expect(result).toBe("  i--;\n  return i;");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #986: SliceLit and MapLit expression rendering
+// ---------------------------------------------------------------------------
+
+describe("renderExpr — SliceLit (#986)", () => {
+  it("renders empty slice literal as []", () => {
+    const expr: GoAstSliceLitExpr = {
+      type: "SliceLit",
+      line: 1,
+      col: 1,
+      elementType: "int",
+      elements: [],
+    };
+    expect(renderExpr(expr)).toBe("[]");
+  });
+
+  it("renders single-element []int{42}", () => {
+    const expr: GoAstSliceLitExpr = {
+      type: "SliceLit",
+      line: 1,
+      col: 1,
+      elementType: "int",
+      elements: [intLit("42")],
+    };
+    expect(renderExpr(expr)).toBe("[42]");
+  });
+
+  it('renders multi-element []string{"a","b"} as array literal', () => {
+    const expr: GoAstSliceLitExpr = {
+      type: "SliceLit",
+      line: 1,
+      col: 1,
+      elementType: "string",
+      elements: [strLit('"a"'), strLit('"b"'), strLit('"c"')],
+    };
+    expect(renderExpr(expr)).toBe('["a", "b", "c"]');
+  });
+
+  it("renders nested expressions inside slice", () => {
+    const expr: GoAstSliceLitExpr = {
+      type: "SliceLit",
+      line: 1,
+      col: 1,
+      elementType: "int",
+      elements: [binExpr("+", ident("a"), intLit("1")), binExpr("*", ident("b"), intLit("2"))],
+    };
+    expect(renderExpr(expr)).toBe("[(a + 1), (b * 2)]");
+  });
+
+  it("SliceLit purity: passes checkBodyPurity for pure elements", () => {
+    const b: GoAstBodyNode = {
+      stmts: [
+        returnStmt([
+          {
+            type: "SliceLit",
+            line: 1,
+            col: 3,
+            elementType: "int",
+            elements: [intLit("1"), intLit("2")],
+          } satisfies GoAstSliceLitExpr,
+        ]),
+      ],
+    };
+    expect(() => checkBodyPurity(b)).not.toThrow();
+  });
+
+  it("SliceLit purity: rejects ChanRecv inside elements", () => {
+    const b: GoAstBodyNode = {
+      stmts: [
+        returnStmt([
+          {
+            type: "SliceLit",
+            line: 1,
+            col: 1,
+            elementType: "int",
+            elements: [{ type: "ChanRecv", line: 1, col: 5 }],
+          } satisfies GoAstSliceLitExpr,
+        ]),
+      ],
+    };
+    expect(() => checkBodyPurity(b)).toThrow(GoChanRecvError);
+  });
+});
+
+describe("renderExpr — MapLit (#986)", () => {
+  it("renders empty map literal as {}", () => {
+    const expr: GoAstMapLitExpr = {
+      type: "MapLit",
+      line: 1,
+      col: 1,
+      keyType: "string",
+      valueType: "int",
+      entries: [],
+    };
+    expect(renderExpr(expr)).toBe("{}");
+  });
+
+  it("renders string-key map literal", () => {
+    const entries: GoAstMapEntry[] = [
+      { key: strLit('"foo"'), value: intLit("1") },
+      { key: strLit('"bar"'), value: intLit("2") },
+    ];
+    const expr: GoAstMapLitExpr = {
+      type: "MapLit",
+      line: 1,
+      col: 1,
+      keyType: "string",
+      valueType: "int",
+      entries,
+    };
+    expect(renderExpr(expr)).toBe('{"foo": 1, "bar": 2}');
+  });
+
+  it("renders numeric key map literal using computed property syntax", () => {
+    const entries: GoAstMapEntry[] = [{ key: intLit("0"), value: strLit('"zero"') }];
+    const expr: GoAstMapLitExpr = {
+      type: "MapLit",
+      line: 1,
+      col: 1,
+      keyType: "int",
+      valueType: "string",
+      entries,
+    };
+    // Non-string keys use computed property [key]: value
+    expect(renderExpr(expr)).toBe('{[0]: "zero"}');
+  });
+
+  it("MapLit purity: passes checkBodyPurity for pure entries", () => {
+    const b: GoAstBodyNode = {
+      stmts: [
+        returnStmt([
+          {
+            type: "MapLit",
+            line: 1,
+            col: 1,
+            keyType: "string",
+            valueType: "int",
+            entries: [{ key: strLit('"k"'), value: intLit("1") }],
+          } satisfies GoAstMapLitExpr,
+        ]),
+      ],
+    };
+    expect(() => checkBodyPurity(b)).not.toThrow();
+  });
+
+  it("MapLit purity: rejects ChanRecv in entry value", () => {
+    const b: GoAstBodyNode = {
+      stmts: [
+        returnStmt([
+          {
+            type: "MapLit",
+            line: 1,
+            col: 1,
+            keyType: "string",
+            valueType: "int",
+            entries: [{ key: strLit('"k"'), value: { type: "ChanRecv", line: 1, col: 10 } }],
+          } satisfies GoAstMapLitExpr,
+        ]),
+      ],
+    };
+    expect(() => checkBodyPurity(b)).toThrow(GoChanRecvError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #986: CompositeLit compound round-trips through renderBody
+// ---------------------------------------------------------------------------
+
+describe("renderBody — CompositeLit compound round-trips (#986)", () => {
+  it("slice literal in return: []int{1,2,3} -> [1, 2, 3]", () => {
+    // Simulates: func Nums() []int { return []int{1, 2, 3} }
+    const b: GoAstBodyNode = {
+      stmts: [
+        {
+          type: "ReturnStmt",
+          line: 1,
+          col: 2,
+          results: [
+            {
+              type: "SliceLit",
+              line: 1,
+              col: 9,
+              elementType: "int",
+              elements: [intLit("1"), intLit("2"), intLit("3")],
+            } satisfies GoAstSliceLitExpr,
+          ],
+        },
+      ],
+    };
+    expect(renderBody(b)).toBe("  return [1, 2, 3];");
+  });
+
+  it('map literal in assignment: map[string]int{"a":1} -> {"a":1}', () => {
+    // Simulates: func Scores() map[string]int { m := map[string]int{"a": 1}; return m }
+    const b: GoAstBodyNode = {
+      stmts: [
+        {
+          type: "AssignStmt",
+          line: 1,
+          col: 2,
+          lhs: [ident("m")],
+          rhs: [
+            {
+              type: "MapLit",
+              line: 1,
+              col: 7,
+              keyType: "string",
+              valueType: "int",
+              entries: [{ key: strLit('"a"'), value: intLit("1") }],
+            } satisfies GoAstMapLitExpr,
+          ],
+          tok: ":=",
+        },
+        returnStmt([ident("m")]),
+      ],
+    };
+    expect(renderBody(b)).toBe('  const m = {"a": 1};\n  return m;');
+  });
+
+  it("slice literal with identifier elements: []string{s, t}", () => {
+    const b: GoAstBodyNode = {
+      stmts: [
+        returnStmt([
+          {
+            type: "SliceLit",
+            line: 1,
+            col: 9,
+            elementType: "string",
+            elements: [ident("s"), ident("t")],
+          } satisfies GoAstSliceLitExpr,
+        ]),
+      ],
+    };
+    expect(renderBody(b)).toBe("  return [s, t];");
+  });
+
+  it('map literal with binary-expr value: map[string]int{"x": a+b}', () => {
+    const b: GoAstBodyNode = {
+      stmts: [
+        returnStmt([
+          {
+            type: "MapLit",
+            line: 1,
+            col: 9,
+            keyType: "string",
+            valueType: "int",
+            entries: [{ key: strLit('"x"'), value: binExpr("+", ident("a"), ident("b")) }],
+          } satisfies GoAstMapLitExpr,
+        ]),
+      ],
+    };
+    expect(renderBody(b)).toBe('  return {"x": (a + b)};');
   });
 });

--- a/packages/shave-go/src/raise-body.ts
+++ b/packages/shave-go/src/raise-body.ts
@@ -76,6 +76,7 @@ import type {
   GoAstForStmt,
   GoAstIfStmt,
   GoAstIncDecStmt,
+  GoAstMapEntry,
   GoAstRangeStmt,
   GoAstStmt,
   GoAstSwitchStmt,
@@ -143,6 +144,21 @@ function checkExprPurity(expr: GoAstExpr): void {
 
     case "ChanRecv":
       throw new GoChanRecvError(loc(expr));
+
+    // #986: SliceLit — walk element expressions for purity.
+    case "SliceLit":
+      for (const el of expr.elements) {
+        checkExprPurity(el);
+      }
+      return;
+
+    // #986: MapLit — walk key and value expressions for purity.
+    case "MapLit":
+      for (const entry of expr.entries) {
+        checkExprPurity(entry.key);
+        checkExprPurity(entry.value);
+      }
+      return;
 
     case "UnsupportedExpr":
       // Unsupported expressions are not banned purity boundaries per se.
@@ -394,6 +410,47 @@ export function renderExpr(expr: GoAstExpr, file = "stdin.go"): string {
 
     case "ChanRecv":
       throw new GoChanRecvError({ file, line: expr.line, col: expr.col });
+
+    // #986: SliceLit — Go []T{a, b, c} -> TS array literal [a, b, c].
+    //
+    // @decision DEC-COMPOSITELIT-RAISE-001 (#986)
+    // @title Slice literals lower to plain TS array literals; map literals to object literals
+    // @status accepted (#986)
+    // @rationale
+    //   []T{a, b, c} -> [a, b, c] is the natural TS representation and round-trips
+    //   back correctly through compile-go's ArrayLiteralExpression handler (which
+    //   uses variable-declaration type context to reconstruct the Go element type).
+    //   map[K]V{k: v} -> {k: v} as an object literal matches the Record<K,V> type
+    //   used for Go maps throughout the IR, and round-trips via ObjectLiteralExpression
+    //   handling in compile-go.  Type annotation comments are NOT emitted here because
+    //   the variable declaration that receives the literal already carries the Go type
+    //   via shave-go's type-map pass; compile-go reads it from the assignment context.
+    case "SliceLit": {
+      const elems = expr.elements.map((e) => renderExpr(e, file)).join(", ");
+      return `[${elems}]`;
+    }
+
+    // #986: MapLit — Go map[K]V{k: v} -> TS object literal {k: v}.
+    // Non-string keys are rendered via renderExpr (numeric keys become computed
+    // property notation via bracket syntax in the object literal).
+    case "MapLit": {
+      const entries = expr.entries
+        .map((entry: GoAstMapEntry) => {
+          const keyStr = renderExpr(entry.key, file);
+          const valStr = renderExpr(entry.value, file);
+          // String literal keys: use bare key (strip quotes for property name).
+          // Non-string keys: use computed property [key]: value.
+          if (entry.key.type === "BasicLit" && entry.key.kind === "STRING") {
+            // Strip Go string delimiters to get the bare property name.
+            // e.g. `"foo"` -> `"foo": val` (keep quoted for TS object literal).
+            return `${keyStr}: ${valStr}`;
+          }
+          // Numeric or identifier key: computed property.
+          return `[${keyStr}]: ${valStr}`;
+        })
+        .join(", ");
+      return `{${entries}}`;
+    }
 
     case "UnsupportedExpr":
       throw new GoUnsupportedConstructError(expr.reason, { file, line: expr.line, col: expr.col });

--- a/scripts/go-ast-parse.go
+++ b/scripts/go-ast-parse.go
@@ -411,6 +411,13 @@ func marshalExpr(fset *token.FileSet, expr ast.Expr) json.RawMessage {
 			"col":  col,
 		})
 
+	case *ast.CompositeLit:
+		// #986: CompositeLit covers slice/map/struct literals.
+		// Slice:  []T{a, b, c}  — Type is *ast.ArrayType
+		// Map:    map[K]V{k: v} — Type is *ast.MapType
+		// Struct: Foo{X: 1}     — deferred; emit UnsupportedExpr for MVP.
+		return marshalCompositeLit(fset, e, line, col)
+
 	default:
 		return marshal(map[string]interface{}{
 			"type":   "UnsupportedExpr",
@@ -462,6 +469,97 @@ func typeExprToString(fset *token.FileSet, expr ast.Expr) string {
 		return fmt.Sprintf("%v", expr)
 	}
 	return buf.String()
+}
+
+// ---------------------------------------------------------------------------
+// #986: CompositeLit marshaling (slice and map literals)
+// ---------------------------------------------------------------------------
+
+// marshalCompositeLit emits SliceLit or MapLit wire nodes for []T{...} and
+// map[K]V{...} expressions.  Struct literals (Ident or SelectorExpr type) are
+// deferred for MVP and emitted as UnsupportedExpr so raise-body.ts can throw
+// GoUnsupportedConstructError without re-parsing raw source text.
+//
+// @decision DEC-COMPOSITELIT-WIRE-001 (#986)
+// @title Emit distinct SliceLit/MapLit wire nodes; defer StructLit to UnsupportedExpr
+// @status accepted (#986)
+// @rationale
+//   Conflating slice/map/struct literals into a single "CompositeLit" node would
+//   force raise-body.ts to re-parse the Go type string to distinguish variants --
+//   defeating the structured wire design.  Emitting named variants with decoded
+//   type fields keeps raise-body.ts as a pure TS consumer with no Go syntax
+//   knowledge.  Struct literals require type resolution to handle field names and
+//   are deferred to a later work item.
+func marshalCompositeLit(fset *token.FileSet, e *ast.CompositeLit, line, col int) json.RawMessage {
+	if e.Type == nil {
+		// Untyped composite literal (e.g. struct field shorthand or implicit type).
+		// Not in scope for #986 MVP.
+		return marshal(map[string]interface{}{
+			"type":   "UnsupportedExpr",
+			"line":   line,
+			"col":    col,
+			"reason": "*ast.CompositeLit(untyped)",
+		})
+	}
+
+	switch t := e.Type.(type) {
+	case *ast.ArrayType:
+		// []T{a, b, c} -- slice literal (ArrayType with nil Len means slice, not array).
+		// Fixed-size arrays (e.g. [3]int{1,2,3}) also match ArrayType; treat as slice
+		// for MVP since the pure-function subset rarely uses fixed arrays.
+		elementTypeStr := typeExprToString(fset, t.Elt)
+		elements := make([]json.RawMessage, len(e.Elts))
+		for i, elt := range e.Elts {
+			elements[i] = marshalExpr(fset, elt)
+		}
+		return marshal(map[string]interface{}{
+			"type":        "SliceLit",
+			"line":        line,
+			"col":         col,
+			"elementType": elementTypeStr,
+			"elements":    elements,
+		})
+
+	case *ast.MapType:
+		// map[K]V{k: v, ...} -- map literal.
+		keyTypeStr := typeExprToString(fset, t.Key)
+		valueTypeStr := typeExprToString(fset, t.Value)
+		entries := make([]json.RawMessage, 0, len(e.Elts))
+		for _, elt := range e.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				// Non-KV element in map literal: should not occur in valid Go.
+				return marshal(map[string]interface{}{
+					"type":   "UnsupportedExpr",
+					"line":   line,
+					"col":    col,
+					"reason": "*ast.CompositeLit(map-non-kv)",
+				})
+			}
+			entry := marshal(map[string]interface{}{
+				"key":   marshalExpr(fset, kv.Key),
+				"value": marshalExpr(fset, kv.Value),
+			})
+			entries = append(entries, entry)
+		}
+		return marshal(map[string]interface{}{
+			"type":      "MapLit",
+			"line":      line,
+			"col":       col,
+			"keyType":   keyTypeStr,
+			"valueType": valueTypeStr,
+			"entries":   entries,
+		})
+
+	default:
+		// Struct literal or unknown: deferred for MVP.
+		return marshal(map[string]interface{}{
+			"type":   "UnsupportedExpr",
+			"line":   line,
+			"col":    col,
+			"reason": fmt.Sprintf("*ast.CompositeLit(%T)", e.Type),
+		})
+	}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds Go composite literal support both directions:
- **shave-go**: `*ast.CompositeLit` → `SliceLit`/`MapLit` wire nodes; `raise-body` emits TS array literal and object literal forms
- **compile-go**: TS array literal → `[]T{}` via `ctx.goTypeHint` from variable declaration type; TS object literal → `map[K]V{}` with identifier keys becoming Go string literals

Struct literals are deferred (would require type resolution).

## Test plan

- [x] shave-go: 268 → 283 tests
- [x] compile-go: 102 → 115 tests
- [x] `pnpm -r build` clean
- [x] typecheck + lint clean

Closes #986

🤖 Generated with [Claude Code](https://claude.com/claude-code)