### PR TITLE
ci(website): GH Actions deploy pipeline to GitHub Pages (#929)

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -1,0 +1,53 @@
+name: website-deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'bench/**/results-*.json'
+      - 'README.md'
+      - 'website/**'
+      - 'packages/cli/package.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'website-deploy'
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      - name: Build website
+        run: pnpm --filter @yakcc/website build
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Slice 5 of the website rollout: adds `.github/workflows/website-deploy.yml` that builds `@yakcc/website` and deploys it to GitHub Pages.

- Triggers on push to `main` touching `website/`, `docs/`, `bench/**/results-*.json`, `README.md`, or `packages/cli/package.json`
- `workflow_dispatch` for manual force-rebuild
- Post-merge only (no `pull_request` trigger) — failure is non-gating to other CI per issue requirements
- Deploys via `actions/deploy-pages@v4` to the `github-pages` environment

Closes #929

## Test plan

- [x] YAML parses (validated via planner readiness gate)
- [ ] First push to `main` after merge triggers deploy workflow
- [ ] GitHub Pages environment serves built site

🤖 Generated with [Claude Code](https://claude.com/claude-code)