### PR TITLE
feat(shave-go): #1001 — BranchStmt (break/continue) support

### DIFF
--- a/packages/shave-go/src/go-ast-parser.ts
+++ b/packages/shave-go/src/go-ast-parser.ts
@@ -272,6 +272,26 @@ export interface GoAstIncDecStmt extends GoAstLocation {
   readonly op: "++" | "--";
 }
 
+/**
+ * Branch statement: `break` or `continue` (#1001).
+ * Go's *ast.BranchStmt covers four tokens: break, continue, goto, fallthrough.
+ * Only break and continue are raised to this wire node; goto and fallthrough
+ * are emitted as UnsupportedStmt by go-ast-parse.go so raise-body.ts throws
+ * GoUnsupportedConstructError with a clear token-specific message.
+ *
+ * `label` is null for unlabeled break/continue (the common case).  Labeled
+ * break/continue (e.g. `break outer`) carry the label name as a string; the
+ * raiser emits `break outer;` / `continue outer;` verbatim, which is valid
+ * TS syntax for labeled loops.
+ */
+export interface GoAstBranchStmt extends GoAstLocation {
+  readonly type: "BranchStmt";
+  /** "break" or "continue" */
+  readonly tok: "break" | "continue";
+  /** Label name for labeled break/continue, null for unlabeled. */
+  readonly label: string | null;
+}
+
 /** Statement not in the slice-2 supported set. */
 export interface GoAstUnsupportedStmt extends GoAstLocation {
   readonly type: "UnsupportedStmt";
@@ -367,6 +387,7 @@ export type GoAstStmt =
   | GoAstRangeStmt
   | GoAstSwitchStmt
   | GoAstIncDecStmt
+  | GoAstBranchStmt
   | GoAstUnsupportedStmt;
 
 /** Variable spec declaration (from a DeclStmt). */

--- a/packages/shave-go/src/raise-body.test.ts
+++ b/packages/shave-go/src/raise-body.test.ts
@@ -30,6 +30,7 @@ import {
 } from "./errors.js";
 import type {
   GoAstBodyNode,
+  GoAstBranchStmt,
   GoAstCaseClause,
   GoAstExpr,
   GoAstForStmt,
@@ -1287,6 +1288,265 @@ describe("renderExpr — MapLit (#986)", () => {
 // ---------------------------------------------------------------------------
 // #986: CompositeLit compound round-trips through renderBody
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// #1001: BranchStmt (break, continue)
+// ---------------------------------------------------------------------------
+
+describe("renderStmt — BranchStmt (#1001)", () => {
+  it("renders unlabeled break as break;", () => {
+    const stmt: GoAstBranchStmt = {
+      type: "BranchStmt",
+      line: 1,
+      col: 1,
+      tok: "break",
+      label: null,
+    };
+    expect(renderStmt(stmt)).toBe("  break;");
+  });
+
+  it("renders unlabeled continue as continue;", () => {
+    const stmt: GoAstBranchStmt = {
+      type: "BranchStmt",
+      line: 2,
+      col: 3,
+      tok: "continue",
+      label: null,
+    };
+    expect(renderStmt(stmt)).toBe("  continue;");
+  });
+
+  it("renders labeled break as break label;", () => {
+    const stmt: GoAstBranchStmt = {
+      type: "BranchStmt",
+      line: 3,
+      col: 5,
+      tok: "break",
+      label: "outer",
+    };
+    expect(renderStmt(stmt)).toBe("  break outer;");
+  });
+
+  it("renders labeled continue as continue label;", () => {
+    const stmt: GoAstBranchStmt = {
+      type: "BranchStmt",
+      line: 4,
+      col: 7,
+      tok: "continue",
+      label: "loop",
+    };
+    expect(renderStmt(stmt)).toBe("  continue loop;");
+  });
+
+  it("respects custom indent", () => {
+    const stmt: GoAstBranchStmt = {
+      type: "BranchStmt",
+      line: 1,
+      col: 1,
+      tok: "break",
+      label: null,
+    };
+    expect(renderStmt(stmt, "    ")).toBe("    break;");
+  });
+
+  it("BranchStmt is pure (passes checkBodyPurity)", () => {
+    const b = body([
+      { type: "BranchStmt", line: 1, col: 1, tok: "break", label: null } satisfies GoAstBranchStmt,
+    ]);
+    expect(() => checkBodyPurity(b)).not.toThrow();
+  });
+
+  it("continue BranchStmt is pure (passes checkBodyPurity)", () => {
+    const b = body([
+      {
+        type: "BranchStmt",
+        line: 1,
+        col: 1,
+        tok: "continue",
+        label: null,
+      } satisfies GoAstBranchStmt,
+    ]);
+    expect(() => checkBodyPurity(b)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1001: goto and fallthrough rejected as UnsupportedStmt (from Go parser)
+// ---------------------------------------------------------------------------
+
+describe("renderStmt — goto/fallthrough rejected via UnsupportedStmt (#1001)", () => {
+  it("goto emits GoUnsupportedConstructError (via UnsupportedStmt wire node)", () => {
+    // go-ast-parse.go emits UnsupportedStmt for goto/fallthrough; raise-body.ts
+    // must throw GoUnsupportedConstructError when it encounters this node.
+    const stmt: GoAstStmt = {
+      type: "UnsupportedStmt",
+      line: 5,
+      col: 2,
+      reason: "BranchStmt(goto)",
+    };
+    expect(() => renderStmt(stmt)).toThrow(GoUnsupportedConstructError);
+    try {
+      renderStmt(stmt);
+    } catch (err) {
+      expect(err).toBeInstanceOf(CannotRaiseToIRError);
+      expect((err as CannotRaiseToIRError).construct).toBe("BranchStmt(goto)");
+    }
+  });
+
+  it("fallthrough emits GoUnsupportedConstructError (via UnsupportedStmt wire node)", () => {
+    const stmt: GoAstStmt = {
+      type: "UnsupportedStmt",
+      line: 6,
+      col: 4,
+      reason: "BranchStmt(fallthrough)",
+    };
+    expect(() => renderStmt(stmt)).toThrow(GoUnsupportedConstructError);
+    try {
+      renderStmt(stmt);
+    } catch (err) {
+      expect(err).toBeInstanceOf(CannotRaiseToIRError);
+      expect((err as CannotRaiseToIRError).construct).toBe("BranchStmt(fallthrough)");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1001: compound end-to-end — break/continue inside for loops
+// ---------------------------------------------------------------------------
+
+describe("renderBody — BranchStmt compound round-trips (#1001)", () => {
+  it("for loop with break: Go for { if cond { break } } -> TS", () => {
+    // Simulates: func FindFirst(xs []int, pred func(int) bool) int {
+    //   for i := 0; i < len(xs); i++ {
+    //     if pred(xs[i]) { break }
+    //   }
+    //   return -1
+    // }
+    const b: GoAstBodyNode = {
+      stmts: [
+        {
+          type: "ForStmt",
+          line: 1,
+          col: 2,
+          init: {
+            type: "AssignStmt",
+            line: 1,
+            col: 6,
+            lhs: [ident("i")],
+            rhs: [intLit("0")],
+            tok: ":=",
+          },
+          cond: binExpr("<", ident("i"), ident("n")),
+          post: {
+            type: "IncDecStmt",
+            line: 1,
+            col: 20,
+            target: "i",
+            op: "++",
+          } satisfies GoAstIncDecStmt,
+          body: {
+            stmts: [
+              {
+                type: "IfStmt",
+                line: 2,
+                col: 4,
+                init: null,
+                cond: binExpr(">", ident("i"), intLit("5")),
+                body: {
+                  stmts: [
+                    {
+                      type: "BranchStmt",
+                      line: 3,
+                      col: 6,
+                      tok: "break",
+                      label: null,
+                    } satisfies GoAstBranchStmt,
+                  ],
+                },
+                orelse: null,
+              },
+            ],
+          },
+        } satisfies GoAstForStmt,
+        returnStmt([intLit("-1")]),
+      ],
+    };
+    const result = renderBody(b);
+    expect(result).toContain("for (let i = 0;");
+    expect(result).toContain("if ((i > 5)) {");
+    expect(result).toContain("break;");
+    expect(result).toContain("return -1;");
+  });
+
+  it("range loop with continue: skips elements, returns accumulator", () => {
+    // Simulates: func SumPositive(xs []int) int {
+    //   acc := 0
+    //   for _, v := range xs {
+    //     if v <= 0 { continue }
+    //     acc += v
+    //   }
+    //   return acc
+    // }
+    const b: GoAstBodyNode = {
+      stmts: [
+        {
+          type: "AssignStmt",
+          line: 1,
+          col: 2,
+          lhs: [ident("acc")],
+          rhs: [intLit("0")],
+          tok: ":=",
+        },
+        {
+          type: "RangeStmt",
+          line: 2,
+          col: 2,
+          key: null,
+          value: "v",
+          tok: ":=",
+          x: ident("xs"),
+          body: {
+            stmts: [
+              {
+                type: "IfStmt",
+                line: 3,
+                col: 4,
+                init: null,
+                cond: binExpr("<=", ident("v"), intLit("0")),
+                body: {
+                  stmts: [
+                    {
+                      type: "BranchStmt",
+                      line: 4,
+                      col: 6,
+                      tok: "continue",
+                      label: null,
+                    } satisfies GoAstBranchStmt,
+                  ],
+                },
+                orelse: null,
+              },
+              {
+                type: "AssignStmt",
+                line: 5,
+                col: 4,
+                lhs: [ident("acc")],
+                rhs: [binExpr("+", ident("acc"), ident("v"))],
+                tok: "=",
+              },
+            ],
+          },
+        } satisfies GoAstRangeStmt,
+        returnStmt([ident("acc")]),
+      ],
+    };
+    const result = renderBody(b);
+    expect(result).toContain("const acc = 0;");
+    expect(result).toContain("continue;");
+    expect(result).toContain("acc = (acc + v);");
+    expect(result).toContain("return acc;");
+  });
+});
 
 describe("renderBody — CompositeLit compound round-trips (#986)", () => {
   it("slice literal in return: []int{1,2,3} -> [1, 2, 3]", () => {

--- a/packages/shave-go/src/raise-body.ts
+++ b/packages/shave-go/src/raise-body.ts
@@ -69,6 +69,7 @@ import {
 } from "./errors.js";
 import type {
   GoAstBodyNode,
+  GoAstBranchStmt,
   GoAstCaseClause,
   GoAstDecl,
   GoAstElseBody,
@@ -239,6 +240,10 @@ function checkStmtPurity(stmt: GoAstStmt): void {
     // #982: IncDecStmt (i++, i--) is a pure mutation of a local numeric variable.
     // No channel ops, goroutines, or side effects outside the local scope.
     case "IncDecStmt":
+      return;
+
+    // #1001: BranchStmt (break/continue) — no operands, always pure.
+    case "BranchStmt":
       return;
 
     case "UnsupportedStmt":
@@ -544,6 +549,12 @@ export function renderStmt(stmt: GoAstStmt, indent = "  ", file = "stdin.go"): s
     case "IncDecStmt":
       return `${indent}${stmt.target}${stmt.op};`;
 
+    // #1001: BranchStmt — break/continue map directly to TS break/continue.
+    // Labeled break/continue (e.g. `break outer`) are also valid TS syntax for
+    // labeled loops; the label is emitted verbatim after the keyword.
+    case "BranchStmt":
+      return renderBranchStmt(stmt, indent);
+
     case "UnsupportedStmt":
       throw new GoUnsupportedConstructError(stmt.reason, { file, line: stmt.line, col: stmt.col });
   }
@@ -818,6 +829,25 @@ function renderCaseClause(
   lines.push(bodyLines);
   lines.push(`${bodyIndent}break;`);
   return lines.join("\n");
+}
+
+/**
+ * Render a BranchStmt (break or continue) to TS.
+ *
+ * Go:   break          TS:   break;
+ * Go:   continue       TS:   continue;
+ * Go:   break outer    TS:   break outer;
+ * Go:   continue loop  TS:   continue loop;
+ *
+ * Labeled break/continue are valid TS for labeled loops; the label is emitted
+ * verbatim.  goto and fallthrough are rejected at the Go parser level
+ * (emitted as UnsupportedStmt) so they never reach this renderer.
+ */
+function renderBranchStmt(stmt: GoAstBranchStmt, indent: string): string {
+  if (stmt.label !== null) {
+    return `${indent}${stmt.tok} ${stmt.label};`;
+  }
+  return `${indent}${stmt.tok};`;
 }
 
 /**

--- a/scripts/go-ast-parse.go
+++ b/scripts/go-ast-parse.go
@@ -313,6 +313,35 @@ func marshalStmt(fset *token.FileSet, stmt ast.Stmt) json.RawMessage {
 			"op":     op,
 		})
 
+	case *ast.BranchStmt:
+		// #1001: BranchStmt covers break, continue, goto, and fallthrough.
+		// break and continue have direct TS equivalents and are raised as
+		// BranchStmt wire nodes. goto and fallthrough have no TS equivalent;
+		// emit UnsupportedStmt so raise-body.ts can throw
+		// GoUnsupportedConstructError with a clear message rather than a
+		// generic "unsupported" catch.
+		tok := s.Tok.String() // "break", "continue", "goto", "fallthrough"
+		if tok == "break" || tok == "continue" {
+			var label interface{}
+			if s.Label != nil {
+				label = s.Label.Name
+			}
+			return marshal(map[string]interface{}{
+				"type":  "BranchStmt",
+				"line":  line,
+				"col":   col,
+				"tok":   tok,
+				"label": label,
+			})
+		}
+		// goto and fallthrough: not raiseable to TS subset.
+		return marshal(map[string]interface{}{
+			"type":   "UnsupportedStmt",
+			"line":   line,
+			"col":    col,
+			"reason": fmt.Sprintf("BranchStmt(%s)", tok),
+		})
+
 	default:
 		return marshal(map[string]interface{}{
 			"type":   "UnsupportedStmt",


### PR DESCRIPTION
## Summary

Adds Go `*ast.BranchStmt` support to the shave-go pipeline.

- `scripts/go-ast-parse.go`: emit `Branch` wire node for `break`/`continue` (with optional label); reject `goto`/`fallthrough` via `UnsupportedStmt` so they fail loudly via `GoUnsupportedConstructError`
- `packages/shave-go/src/go-ast-parser.ts`: add `GoAstBranchStmt` to wire union
- `packages/shave-go/src/raise-body.ts`: render `Branch` to TS `break;`/`continue;`
- `packages/shave-go/src/raise-body.test.ts`: 6 unit tests + 2 compound round-trip tests (for/range loops)

Unblocks ~6 samber/lo functions that use `break`/`continue` inside loops.

Closes #1001

## Test plan

- [x] `pnpm --filter @yakcc/shave-go test` — 294 tests pass
- [x] `pnpm --filter @yakcc/shave-go exec tsc --noEmit -p .` — clean
- [x] `pnpm --filter @yakcc/shave-go lint` — clean
- [x] `pnpm -r build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)