### PR TITLE
chore(release): bump to v0.7.0-alpha.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yakcc/cli",
-  "version": "0.7.0-alpha.0",
+  "version": "0.7.0-alpha.1",
   "description": "Yakcc — content-addressed block registry for assembling programs from verified, reusable building blocks.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/yakcc/package.json
+++ b/packages/yakcc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yakcc",
-  "version": "0.6.0-alpha.0",
+  "version": "0.7.0-alpha.1",
   "description": "Content-addressed block registry — yakcc CLI (unscoped alias for @yakcc/cli).",
   "license": "Apache-2.0",
   "type": "module",
@@ -13,7 +13,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@yakcc/cli": "0.6.0-alpha.0"
+    "@yakcc/cli": "workspace:*"
   },
   "publishConfig": {
     "access": "public",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -731,8 +731,8 @@ importers:
   packages/yakcc:
     dependencies:
       '@yakcc/cli':
-        specifier: 0.6.0-alpha.0
-        version: 0.6.0-alpha.0
+        specifier: workspace:*
+        version: link:../cli
 
 packages:
 
@@ -1660,10 +1660,6 @@ packages:
 
   '@xenova/transformers@2.17.2':
     resolution: {integrity: sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ==}
-
-  '@yakcc/cli@0.6.0-alpha.0':
-    resolution: {integrity: sha512-P3Q30eoeebBPQrTebh1WMNvMShD5EwW4RTPvnZ6Wj9mSt9VrzWzika1vKvLbuRHoyoB9U0SKEbIG2172FpcHfg==}
-    hasBin: true
 
   '@yao-pkg/pkg-fetch@3.5.33':
     resolution: {integrity: sha512-j2UoH+eP4VobfovQg1gkWwDoB4O/tv8rlLnEjUEEHuWXJ5eBLNUIrobMSEp773/2pgUJUfqqPUFIhS1pN8OZuQ==}
@@ -4143,20 +4139,6 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
-      - react-native-b4a
-
-  '@yakcc/cli@0.6.0-alpha.0':
-    dependencies:
-      '@anthropic-ai/sdk': 0.40.1
-      '@xenova/transformers': 2.17.2
-      assemblyscript: 0.27.37
-      better-sqlite3: 12.9.0
-      sqlite-vec: 0.1.9
-      ts-morph: 28.0.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - encoding
       - react-native-b4a
 
   '@yao-pkg/pkg-fetch@3.5.33':


### PR DESCRIPTION
## Summary

Cuts `v0.7.0-alpha.1` release of `@yakcc/cli` + `yakcc` wrapper.

Bumps:
- `@yakcc/cli`: `0.7.0-alpha.0` (never published) → `0.7.0-alpha.1`
- `yakcc` wrapper: `0.6.0-alpha.0` → `0.7.0-alpha.1` (lockstep per `.changeset/config.json` fixed group)
- Wrapper's `@yakcc/cli` dep: pinned literal → `workspace:*` (pnpm-standard pattern; `pnpm publish` substitutes the literal at publish time)

## Notable changes since v0.6.0-alpha.0

**Go pipeline** — samber/lo `fully-raised` went **51 → 78 / 436 (+53%)**:
- #1001 BranchStmt (break/continue)
- #999 multi-LHS assign + #1000 SliceExpr
- #985 generic instantiations (`Tuple3[A,B,C]`)
- #986 CompositeLit (slice/map literals)
- #984 FunctionType lowering
- #975/#976 range fidelity + constraint preservation
- #982 IncDecStmt, #981 iteratee param shapes
- #973 IR → Go lowering MVP, #977/#978 import synthesis + SwitchStatement

**Website** — 6 slices, all on yakcc.com via GH Pages:
- #925/#926 scaffold + landing
- #927 12 benchmark SVGs
- #928 docs route
- #929 deploy workflow
- #930 dogfood copy-button atom (every byte of runtime JS originates from `website/atoms/`)

**Python pipeline**:
- #943 `CannotLowerToPythonError` loud-failure tripwire
- #933/#934 classmethod polish
- #905 nested funcdef
- #964 control-flow expansion

**CLI**:
- WI-WPE-C `registry.yakcc.com` default mirror on init
- #764 `yakcc stats` Tier-1 telemetry-metrics
- #760 `yakcc telemetry` path discovery
- WI-953 `yakcc_resolve` MCP tool
- #968 init.test.ts hint formatting

## Release process (post-merge)

1. Merge this PR
2. Tag: `git tag release-v0.7.0-alpha.1`
3. Push: `git push origin release-v0.7.0-alpha.1`
4. Approve deployment in GH Actions UI (per `release` environment gate)
5. OIDC trusted publisher publishes both packages with `--provenance`

## Test plan

- [x] `pnpm install --no-frozen-lockfile` — clean
- [x] `pnpm -r build` — all packages build
- [x] `pnpm --filter @yakcc/cli test` — passes
- [x] Lockfile updated to reflect `workspace:*` resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)