### PR TITLE
fix(ci): drop pnpm version: input from website-deploy + polyglot-py — defer to packageManager (v4 strict-mode fix)

### DIFF
--- a/.github/workflows/polyglot-py.yml
+++ b/.github/workflows/polyglot-py.yml
@@ -56,8 +56,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: "9.15.0"
 
       - name: Install Node dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -26,8 +26,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
## Why

`pnpm/action-setup@v4` errors out when **both** `with: version:` is set on the action AND `packageManager: pnpm@x.y.z` is set in `package.json`, even when the versions agree. The error blocks CI even on equal-but-double-specified versions:

> Multiple versions of pnpm specified:
>   - version 9 in the GitHub Action config with the key "version"
>   - version pnpm@9.15.0 in the package.json with the key "packageManager"

This was observed on the **website-deploy** workflow when the v0.7.0-alpha.1 release commit `27f1422` triggered it.

## What

Drop the `with: version:` input from two workflows that were missed in the prior migration to the "defer to packageManager" pattern (`DEC-CI-OFFLINE-004`):

- **`.github/workflows/website-deploy.yml`** — `version: 9` → the immediate failure
- **`.github/workflows/polyglot-py.yml`** — `version: "9.15.0"` → latent failure; same conflict, would fire next time it runs

After the change, both workflows match the established pattern in `pr-ci.yml` / `bootstrap-accumulate.yml` / `test.yml` / `nightly.yml`: bare `uses: pnpm/action-setup@v4`, version sourced from `package.json` `packageManager`.

## Test plan

- [ ] Merge → `website-deploy.yml` re-runs against `main` → the pnpm/action-setup step succeeds
- [ ] Next `polyglot-py.yml` trigger (push touching `packages/shave-python/` or `packages/compile-python/`) doesn't hit the same error

Diff is 4 lines deleted across 2 files. No behavior change beyond unblocking the v4 strict-mode check.

---
_Generated by [Claude Code](https://claude.ai/code/session_013noLdtSZPBScNnxK2YLJPP)_