### PR TITLE
feat(cli): #1008 — yakcc init injects discovery prompt into LLM context via CLAUDE.md

### DIFF
--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1549,3 +1549,148 @@ describe("init — .mcp.json MCP server registration (#1005)", () => {
     expect(existsSync(join(tmpDir, ".mcp.json"))).toBe(false);
   });
 });
+
+// Suite 26: CLAUDE.md discovery context injection (WI-1008)
+//
+// DEC-1008-CLAUDE-MD-CONTEXT-INJECT-001: `yakcc init --ide claude-code` must
+// write a CLAUDE.md containing the @-import directive so the 299-line
+// discovery prompt body reaches the LLM context on every session start.
+//
+// Production sequence exercised:
+//   init(--ide claude-code) → hooksClaudeCodeInstall → writeCLaudeMdDiscovery
+//   → CLAUDE.md with sentinel-delimited section containing:
+//       @docs/system-prompts/yakcc-discovery.md
+//
+// Tests:
+//   T1 — fresh init creates CLAUDE.md with managed section + @-import
+//   T2 — existing CLAUDE.md (with user content) is preserved; section appended
+//   T3 — re-running init is idempotent (no duplicate sections)
+//   T4 — compound: CLAUDE.md + settings.json + .yakccrc.json all written in one init
+// ---------------------------------------------------------------------------
+
+describe("init — CLAUDE.md discovery context injection (WI-1008)", () => {
+  function readCLaudeMd(dir: string): string | null {
+    const p = join(dir, "CLAUDE.md");
+    if (!existsSync(p)) return null;
+    return readFileSync(p, "utf-8");
+  }
+
+  // T1: fresh init creates CLAUDE.md with managed section + @-import directive
+  it("fresh init (--ide claude-code) creates CLAUDE.md with @-import for discovery prompt", async () => {
+    const fakeHome = join(tmpDir, "fakehome-claude-md-fresh");
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+
+    const code = await init(
+      ["--target", tmpDir, "--ide", "claude-code", "--no-seed"],
+      new CollectingLogger(),
+      { overrideHome: fakeHome, runFederation: noOpMirror },
+    );
+
+    expect(code).toBe(0);
+    const content = readCLaudeMd(tmpDir);
+    expect(content, "CLAUDE.md must be created by yakcc init").not.toBeNull();
+    // Must contain the sentinel markers that delimit the managed section
+    expect(content).toContain("<!-- yakcc-discovery:start -->");
+    expect(content).toContain("<!-- yakcc-discovery:end -->");
+    // Must contain the @-import directive pointing at the canonical prompt
+    expect(content).toContain("@docs/system-prompts/yakcc-discovery.md");
+  });
+
+  // T2: existing CLAUDE.md with user content is preserved; managed section is appended
+  it("existing CLAUDE.md with user content is preserved when managed section is appended", async () => {
+    const fakeHome = join(tmpDir, "fakehome-claude-md-existing");
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+
+    // Write a CLAUDE.md with existing user-owned content
+    const existingContent = "# My Project\n\nSome project-specific instructions.\n";
+    writeFileSyncForPolyglot(join(tmpDir, "CLAUDE.md"), existingContent, "utf-8");
+
+    const code = await init(
+      ["--target", tmpDir, "--ide", "claude-code", "--no-seed"],
+      new CollectingLogger(),
+      { overrideHome: fakeHome, runFederation: noOpMirror },
+    );
+
+    expect(code).toBe(0);
+    const content = readCLaudeMd(tmpDir);
+    expect(content, "CLAUDE.md must still exist").not.toBeNull();
+    // User's original content must be preserved verbatim
+    expect(content).toContain("# My Project");
+    expect(content).toContain("Some project-specific instructions.");
+    // Managed section must be appended
+    expect(content).toContain("<!-- yakcc-discovery:start -->");
+    expect(content).toContain("@docs/system-prompts/yakcc-discovery.md");
+  });
+
+  // T3: re-running init is idempotent — no duplicate sections
+  it("re-running init is idempotent: no duplicate managed sections in CLAUDE.md", async () => {
+    const fakeHome = join(tmpDir, "fakehome-claude-md-idempotent");
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+
+    const opts = { overrideHome: fakeHome, runFederation: noOpMirror };
+
+    // Run init twice
+    await init(
+      ["--target", tmpDir, "--ide", "claude-code", "--no-seed"],
+      new CollectingLogger(),
+      opts,
+    );
+    await init(
+      ["--target", tmpDir, "--ide", "claude-code", "--no-seed"],
+      new CollectingLogger(),
+      opts,
+    );
+
+    const content = readCLaudeMd(tmpDir);
+    expect(content, "CLAUDE.md must exist after two runs").not.toBeNull();
+
+    // Count sentinel occurrences — must be exactly 1 each
+    const startCount = (content?.match(/<!-- yakcc-discovery:start -->/g) ?? []).length;
+    const endCount = (content?.match(/<!-- yakcc-discovery:end -->/g) ?? []).length;
+    expect(startCount).toBe(1);
+    expect(endCount).toBe(1);
+
+    // @-import must appear exactly once
+    const importCount = (content?.match(/@docs\/system-prompts\/yakcc-discovery\.md/g) ?? [])
+      .length;
+    expect(importCount).toBe(1);
+  });
+
+  // T4 (compound): single init call writes CLAUDE.md + settings.json + .yakccrc.json atomically
+  // This exercises the real production sequence: all three surfaces must be consistent.
+  it("compound: CLAUDE.md + settings.json + .yakccrc.json all written in a single init", async () => {
+    const fakeHome = join(tmpDir, "fakehome-claude-md-compound");
+    mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+
+    const logger = new CollectingLogger();
+    const code = await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], logger, {
+      overrideHome: fakeHome,
+      runFederation: noOpMirror,
+    });
+
+    expect(code).toBe(0);
+
+    // Surface 1: CLAUDE.md with @-import directive (context loading)
+    const claudeMd = readCLaudeMd(tmpDir);
+    expect(claudeMd).not.toBeNull();
+    expect(claudeMd).toContain("@docs/system-prompts/yakcc-discovery.md");
+
+    // Surface 2: .claude/settings.json with PreToolUse hook + discovery snippet (hook wiring)
+    const settings = readSettings(tmpDir);
+    expect(settings).not.toBeNull();
+    const hooks = settings?.hooks as Record<string, unknown[]> | undefined;
+    expect(Array.isArray(hooks?.PreToolUse)).toBe(true);
+    const snippet = settings?.["yakcc-discovery"] as Record<string, unknown> | undefined;
+    expect(snippet?._marker).toBe("yakcc-discovery-v1");
+    expect(snippet?.promptRef).toBe("docs/system-prompts/yakcc-discovery.md");
+
+    // Surface 3: .yakccrc.json with mode + installedHooks (registry config)
+    const rc = readRc(tmpDir);
+    expect(rc?.version).toBe(1);
+    expect((rc?.installedHooks as string[]).includes("claude-code")).toBe(true);
+
+    // All three surfaces are written atomically in a single init call —
+    // this is the compound-interaction proof that the real production sequence works.
+    expect(logger.logLines.join("\n")).toContain("Installed in");
+  });
+});

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -105,6 +105,7 @@ import { join } from "node:path";
 import { parseArgs } from "node:util";
 import { type Registry, openRegistry } from "@yakcc/registry";
 import type { Logger } from "../index.js";
+import { writeCLaudeMdDiscovery } from "../lib/claude-md-config.js";
 import { type IdeName, KNOWN_IDE_NAMES, detectInstalledIdes } from "../lib/ide-detect.js";
 import { writeMcpJsonEntry } from "../lib/mcp-config.js";
 import {
@@ -554,6 +555,14 @@ export async function init(
         // not the 12.5 KB body.  DEC-953B-SURFACE-SETTINGS-001: for claude-code this
         // extends .claude/settings.json (no CLAUDE.md resurrection).
         writeDiscoverySnippet(ide, targetDir);
+        // Inject the discovery guidance into CLAUDE.md so the LLM context receives
+        // the full 299-line prompt body (score bands, self-check, compile-and-stop)
+        // on every session start.  DEC-1008-CLAUDE-MD-CONTEXT-INJECT-001: this is
+        // the context-loading surface; the hook wiring lives in settings.json (above).
+        // Only claude-code uses CLAUDE.md; other IDEs are future follow-ups.
+        if (ide === "claude-code") {
+          writeCLaudeMdDiscovery(targetDir);
+        }
       } catch (err) {
         logger.error(`warning: ${String(err)} — continuing`);
         // Non-fatal: the registry is initialized; other hooks may still succeed.

--- a/packages/cli/src/lib/claude-md-config.ts
+++ b/packages/cli/src/lib/claude-md-config.ts
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: MIT
+//
+// claude-md-config.ts — idempotent CLAUDE.md context-injection writer
+//
+// @decision DEC-1008-CLAUDE-MD-CONTEXT-INJECT-001
+// title: CLAUDE.md @-import is the load-bearing mechanism for injecting
+//        yakcc-discovery guidance into the LLM context — distinct from hook wiring
+// status: accepted (WI-1008-discovery-inject)
+// rationale:
+//   PROBLEM:
+//     docs/system-prompts/yakcc-discovery.md (score bands, self-check,
+//     descent-and-compose, compile-and-stop, triplet format) never reaches the
+//     LLM context.  discovery-snippet.ts only writes a promptRef reference inside
+//     .claude/settings.json; nothing causes Claude Code to load the body into the
+//     model's working context.  B4-v5 trace evidence: Sonnet hedged and Haiku
+//     tried to re-fetch the body — behaviors the full guidance would address.
+//
+//   MECHANISM CHOICE — @-import in CLAUDE.md:
+//     Claude Code auto-loads every CLAUDE.md in the project hierarchy into model
+//     context on session start (confirmed: ~/.claude/CLAUDE.md uses "@RTK.md" to
+//     import RTK.md).  A project-root CLAUDE.md line of the form
+//       @docs/system-prompts/yakcc-discovery.md
+//     causes Claude Code to splice the file contents inline at load time.  The LLM
+//     receives the full 299-line guidance without the CLI needing to inline the body.
+//
+//   RELATION TO DEC-CLI-HOOKS-INSTALL-002 / DEC-953B-SURFACE-SETTINGS-001:
+//     Those decisions retired the v0 CLAUDE.md *hook-wiring* facade (which wrote
+//     a settings.json hook entry via CLAUDE.md instructions — a wrong layer).
+//     This write is for *instruction-context loading* — a different concern.
+//     The hook wiring still lives in .claude/settings.json (unchanged).
+//     The discovery body injection lives in CLAUDE.md (new, additive).
+//     Two concerns, two surfaces, one authority each.  No parallel mechanisms.
+//
+//   SINGLE-AUTHORITY:
+//     The canonical 299-line body is still docs/system-prompts/yakcc-discovery.md
+//     governed by DEC-V3-DISCOVERY-D4-001.  This file never copies or re-states
+//     the body; it only writes the @-import directive that causes Claude Code to
+//     load it.  The body remains the single authority; this file is an adapter.
+//
+//   IDEMPOTENCY:
+//     The managed section is delimited by sentinels so re-running `yakcc init`
+//     never duplicates content or stomps user customizations outside the section.
+//     Existing CLAUDE.md content (project-specific instructions) is preserved.
+//
+//   ROLLBACK:
+//     Revert the WI-1008 slice PR; the managed section is additive and guarded by
+//     sentinels so existing CLAUDE.md content is never lost even if this file is
+//     removed.  Any CLAUDE.md written by this helper can be safely deleted by the
+//     user without affecting the registry or hook wiring.
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Relative path (from the project root) to the canonical discovery prompt body.
+ * Governed by DEC-V3-DISCOVERY-D4-001.
+ */
+const CANONICAL_PROMPT_PATH = "docs/system-prompts/yakcc-discovery.md";
+
+/**
+ * Sentinel markers that delimit the yakcc-managed section in CLAUDE.md.
+ * The section content is idempotently updated in-place; text outside the
+ * sentinel range is never touched.
+ */
+const SECTION_START = "<!-- yakcc-discovery:start -->";
+const SECTION_END = "<!-- yakcc-discovery:end -->";
+
+/**
+ * The managed section body.
+ *
+ * Uses the Claude Code @-import directive so the 299-line discovery prompt
+ * body is spliced into the model context at session load time without being
+ * duplicated in this file (DEC-1008-CLAUDE-MD-CONTEXT-INJECT-001).
+ */
+const MANAGED_SECTION = `${SECTION_START}
+## yakcc discovery
+
+@${CANONICAL_PROMPT_PATH}
+${SECTION_END}`;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Result returned by writeCLaudeMdDiscovery.
+ */
+export interface WriteCLaudeMdResult {
+  /** True when the section was already present and up-to-date (no write). */
+  alreadyInstalled: boolean;
+  /** True when CLAUDE.md did not exist and was freshly created. */
+  created: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Read CLAUDE.md content from the given path.
+ * Returns empty string when the file does not exist.
+ */
+function readCLaudeMd(claudeMdPath: string): string {
+  if (!existsSync(claudeMdPath)) return "";
+  return readFileSync(claudeMdPath, "utf-8");
+}
+
+/**
+ * Return true when the managed section is already present verbatim in
+ * the given CLAUDE.md content.
+ *
+ * We check for the start sentinel to detect presence (the body may change
+ * across yakcc versions; presence of the start marker is sufficient for
+ * the idempotency check; the section is replaced in-place if the body
+ * has drifted from the current MANAGED_SECTION).
+ */
+export function hasManagedSection(content: string): boolean {
+  return content.includes(SECTION_START);
+}
+
+/**
+ * Replace an existing managed section in `content` with the current
+ * MANAGED_SECTION body, or append it if no section is present.
+ *
+ * Preserves all text outside the sentinel range unchanged.
+ */
+function upsertManagedSection(content: string): string {
+  if (content.includes(SECTION_START)) {
+    // Replace the existing section (start through end, inclusive).
+    // Use a regex so we replace the full block regardless of trailing newlines.
+    const replaced = content.replace(
+      new RegExp(`${escapeRegex(SECTION_START)}[\\s\\S]*?${escapeRegex(SECTION_END)}`),
+      MANAGED_SECTION,
+    );
+    return replaced;
+  }
+
+  // Append: ensure a clean newline separation before the section.
+  const separator =
+    content.length > 0 && !content.endsWith("\n") ? "\n\n" : content.length > 0 ? "\n" : "";
+  return `${content}${separator}${MANAGED_SECTION}\n`;
+}
+
+/** Escape special regex metacharacters in a literal string. */
+function escapeRegex(s: string): string {
+  return s.replace(/[$()*+.?[\\\]^{|}]/g, "\\$&");
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Idempotently write (or update) the yakcc-discovery managed section into
+ * the project-root CLAUDE.md so Claude Code auto-loads the discovery guidance
+ * into the LLM context on every session start.
+ *
+ * Called from `yakcc init` after the claude-code hook installer completes
+ * (DEC-1008-CLAUDE-MD-CONTEXT-INJECT-001).
+ *
+ * Behavior:
+ *  - If CLAUDE.md does not exist: creates it with only the managed section.
+ *  - If CLAUDE.md exists and contains the section start sentinel: replaces
+ *    the existing section (safe for body-drift between yakcc versions) — all
+ *    text outside the sentinel range is preserved.
+ *  - If CLAUDE.md exists without the section: appends the section, separated
+ *    by a blank line from the last line of existing content.
+ *
+ * Re-entrant: calling this function N times produces the same result as once.
+ *
+ * @param targetDir - Project root (same as the `--target` flag to `yakcc init`).
+ * @returns WriteCLaudeMdResult with alreadyInstalled and created flags.
+ */
+export function writeCLaudeMdDiscovery(targetDir: string): WriteCLaudeMdResult {
+  const claudeMdPath = join(targetDir, "CLAUDE.md");
+  const existing = readCLaudeMd(claudeMdPath);
+  const created = !existsSync(claudeMdPath);
+
+  if (hasManagedSection(existing)) {
+    // Check whether the existing section body is up-to-date.
+    const startIdx = existing.indexOf(SECTION_START);
+    const endIdx = existing.indexOf(SECTION_END, startIdx);
+    if (endIdx !== -1) {
+      const currentBody = existing.slice(startIdx, endIdx + SECTION_END.length);
+      if (currentBody === MANAGED_SECTION) {
+        // Verbatim match — genuinely idempotent, no write needed.
+        return { alreadyInstalled: true, created: false };
+      }
+    }
+  }
+
+  const updated = upsertManagedSection(existing);
+  writeFileSync(claudeMdPath, updated, "utf-8");
+  return { alreadyInstalled: false, created };
+}


### PR DESCRIPTION
## Summary

**Severity: HIGH** — without this, models receive only the ~20-line `yakcc_resolve` tool description. The canonical 299-line discovery prompt at `docs/system-prompts/yakcc-discovery.md` (score bands, self-check, descent-and-compose, compile-and-stop, triplet format) was never reaching the LLM.

Per #1008: `yakcc init` wrote only a `promptRef` (path) into `.claude/settings.json`. Nothing loaded the body into the model's context.

## Fix

`yakcc init --ide claude-code` now writes a managed section to project-root `CLAUDE.md` using Claude Code's `@`-import directive:

```markdown
<!-- yakcc-discovery:start -->
## yakcc discovery

@docs/system-prompts/yakcc-discovery.md
<!-- yakcc-discovery:end -->
```

Claude Code auto-loads `CLAUDE.md` into context and resolves `@path` imports, so the full discovery prompt body now reaches the model — **without duplicating the source** (DEC-V3-DISCOVERY-D4-001 remains the single ADR-governed authority).

### Files

- `packages/cli/src/lib/claude-md-config.ts` (new) — sentinel-delimited read-modify-write helper. Idempotent for re-runs; preserves any user content outside the managed section.
- `packages/cli/src/commands/init.ts` — claude-code case writes the managed section after the hooks install.
- `packages/cli/src/commands/init.test.ts` — fresh init, merge-with-existing, idempotent rerun, and compound (CLAUDE.md + settings.json + .yakccrc.json) coverage.

### Trace evidence (from B4-v5)

With only the tool description, Sonnet hedged (re-authored despite a match) and Haiku tried to re-fetch the body — behaviors the full prompt's `compile-and-stop` + score-band guidance would address. Once this PR lands, the model receives the actual guidance.

### Decision tension

`DEC-CLI-HOOKS-INSTALL-002` and `DEC-953B-SURFACE-SETTINGS-001` retired CLAUDE.md for **hook-wiring** purposes (one hook-instruction surface per IDE). This new write is for **instruction-context loading** — a different concern with its own authority surface, demarcated by sentinel markers to prevent confusion.

Closes #1008

## Test plan

- [x] `pnpm --filter @yakcc/cli build` — clean
- [x] `pnpm --filter @yakcc/cli exec tsc --noEmit -p .` — clean
- [x] `pnpm --filter @yakcc/cli lint` — clean
- [x] New CLAUDE.md tests pass (4 cases: fresh, merge, idempotent, compound)
- ⚠ 6 pre-existing init.test.ts failures persist on `main` (polyglot hint output + seed corpus). Unrelated to this PR — same failures on `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)