### PR TITLE
chore(bootstrap): #1013 — re-embed shipped registry with bge-small-en-v1.5

### DIFF
--- a/packages/registry/src/discovery-eval-full-corpus.test.ts
+++ b/packages/registry/src/discovery-eval-full-corpus.test.ts
@@ -772,6 +772,18 @@ beforeAll(async () => {
   const seedRoots = buildSeedRootMap(rawEntries);
   resolvedEntries = resolveExpectedAtoms(rawEntries, seedRoots);
 
+  // #1013: the shipped bootstrap registry is now semantically embedded with
+  // Xenova/bge-small-en-v1.5. openRegistry's cross-provider gate will reject
+  // any mismatched provider — including createOfflineEmbeddingProvider used
+  // when USE_LOCAL_PROVIDER is false. All meaningful tests in this file are
+  // already gated on USE_LOCAL_PROVIDER (the offline-stub path produces
+  // degenerate KNN regardless), so just skip the registry open when the test
+  // is running with the stub provider. The previously-empty branch existed
+  // when bootstrap stored zero-vector embeddings and the gate didn't fire.
+  if (!USE_LOCAL_PROVIDER) {
+    return;
+  }
+
   // Open the bootstrap registry (read-write so we can re-embed and add seed atoms)
   registry = await openRegistry(BOOTSTRAP_REGISTRY_PATH, { embeddings: embeddingProvider });
 
@@ -928,9 +940,15 @@ describe("discovery-eval-full-corpus — seed root resolution", () => {
 // ---------------------------------------------------------------------------
 
 describe("discovery-eval-full-corpus — full registry benchmark", () => {
-  it.skipIf(!BOOTSTRAP_REGISTRY_EXISTS)("bootstrap registry opens successfully", async () => {
-    expect(registry).not.toBeNull();
-  });
+  // #1013: registry is only opened when USE_LOCAL_PROVIDER because the
+  // shipped bootstrap registry is bge-small-embedded and openRegistry's
+  // cross-provider gate rejects the offline stub used by default tests.
+  it.skipIf(!BOOTSTRAP_REGISTRY_EXISTS || !USE_LOCAL_PROVIDER)(
+    "bootstrap registry opens successfully",
+    async () => {
+      expect(registry).not.toBeNull();
+    },
+  );
 
   it.skipIf(!BOOTSTRAP_REGISTRY_EXISTS)(
     "runBenchmarkEntries returns one result per corpus entry",


### PR DESCRIPTION
## Summary

Follow-up to #1006 (PR #1012). The query side embeds queries with the semantic provider (`Xenova/bge-small-en-v1.5`), but the shipped `bootstrap/yakcc.registry.sqlite` stored **zero-vector embeddings** (per `BOOTSTRAP_EMBEDDING_OPTS` using a null provider). Query(semantic) vs stored(zero) → no real recall in a default install. This blocks the real-IDE benefit of #1006.

## Fix

Re-ran:
```bash
yakcc registry rebuild --path bootstrap/yakcc.registry.sqlite --embedding-provider local
```

All **4904 blocks** re-embedded with `Xenova/bge-small-en-v1.5` (dim=384). Sqlite binary diff ~25MB (all rows updated).

## Test impact

`openRegistry`'s cross-provider gate (`storage.ts:823`) now correctly rejects providers that don't match the registry's recorded model. `discovery-eval-full-corpus.test.ts`'s `beforeAll` was opening the registry with the offline stub when `USE_LOCAL_PROVIDER=false` — exactly the mismatch the gate catches.

Updated the test:
- Skip `openRegistry` call when `!USE_LOCAL_PROVIDER` (all meaningful tests already `USE_LOCAL_PROVIDER`-gated; the stub path produces degenerate KNN regardless of registry contents).
- Skip the "bootstrap registry opens successfully" assertion when `!USE_LOCAL_PROVIDER` for the same reason.

Verification: **345/345 `@yakcc/registry` tests pass** (was failing on the import-time cross-provider check before the test update).

## Closes

#1013

## Test plan

- [x] `pnpm --filter @yakcc/registry test` — 345 pass / 14 skipped
- [x] `yakcc registry rebuild` re-embeds all 4904 blocks at `Xenova/bge-small-en-v1.5` (dim=384)
- [x] Cross-provider gate fires when stub is used against bge-embedded registry (proves the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)