### PR TITLE
fix(website): unify nav across landing / benchmarks / docs (closes nav gap)

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -38,6 +38,7 @@ const { title = 'yakcc' } = Astro.props;
     <nav>
       <a href="/" class="logo">yakcc</a>
       <a href="/benchmarks">benchmarks</a>
+      <a href="/docs">docs</a>
     </nav>
     <main>
       <slot />

--- a/website/src/layouts/DocLayout.astro
+++ b/website/src/layouts/DocLayout.astro
@@ -102,7 +102,8 @@ const { title, description } = Astro.props;
     <header class="site-header">
       <a href="/">yakcc</a>
       <nav>
-        <a href="/docs/">Docs</a>
+        <a href="/benchmarks">benchmarks</a>
+        <a href="/docs/">docs</a>
       </nav>
     </header>
     <div class="layout">

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -36,6 +36,13 @@ import "../styles/global.css";
   </head>
   <body>
 
+    <!-- ===================== NAV ===================== -->
+    <nav class="site-nav">
+      <a href="/" class="logo">yakcc</a>
+      <a href="/benchmarks">benchmarks</a>
+      <a href="/docs">docs</a>
+    </nav>
+
     <!-- ===================== HERO ===================== -->
     <section class="hero">
       <h1>yakcc</h1>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -27,6 +27,29 @@
   padding: 0;
 }
 
+/* Site nav — shared with all pages.
+ * Landing inlines this; benchmarks/docs use the layout-provided nav with the same shape. */
+.site-nav {
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  padding: 0.75rem 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  font-family: var(--font-mono);
+}
+.site-nav a {
+  color: var(--color-text-muted);
+  text-decoration: none;
+  font-size: 0.85rem;
+}
+.site-nav a:hover { color: var(--color-text); }
+.site-nav .logo {
+  color: var(--color-text);
+  font-weight: 700;
+  font-size: 1rem;
+}
+
 html {
   background: var(--color-bg);
   color: var(--color-text);


### PR DESCRIPTION
## Summary

Three pages on yakcc.com (`/`, `/benchmarks`, `/docs`) shipped from three different slices, each adding nav for their own scope and never unifying. Result: the landing page had **no nav at all** (it inlined its own `<doctype html>` instead of using `BaseLayout`), and the two layouts that did exist each linked to only one of the other sections. Visitors lands on `/`, sees the full hero + install + status content, and has nothing to click — looks like "a single minimal page" even though 6 other pages are deployed.

## What changed

| File | Change |
|---|---|
| `website/src/layouts/BaseLayout.astro` | Add `/docs` link to nav (was `[yakcc \| benchmarks]`, now `[yakcc \| benchmarks \| docs]`) |
| `website/src/layouts/DocLayout.astro` | Add `/benchmarks` link to nav |
| `website/src/pages/index.astro` | Add inline `<nav class="site-nav">` with all three links, right after `<body>` opens |
| `website/src/styles/global.css` | Add reusable `.site-nav` class matching landing palette tokens |

Surgical: preserves each layout's existing visual design (they use different palettes — `#020617` vs `#0d1117` — that's a separate concern outside this fix).

## Test plan

- [x] `pnpm --filter @yakcc/website build` is green
- [x] All 7 pages still generate (landing, benchmarks, docs index, 4 doc subpages)
- [x] Verified via `grep` that all three of (`index.html`, `benchmarks/index.html`, `docs/index.html`) emit nav HTML with all three links

## Out of scope

- **Unifying the three layouts into one.** BaseLayout (`#020617` deep blue) and DocLayout (`#0d1117` GitHub-style) use distinct palettes. Unifying them is a separate visual-design pass — not required to make nav work.
- **Mobile responsive nav.** The current nav is desktop-first per `DEC-WEBSITE-001` Q8.
- **Active-page highlighting.** The current nav doesn't indicate which page you're on. Polish follow-up if you want it.

---
_Generated by [Claude Code](https://claude.ai/code/session_018RFmeHWE8TTDvzT8PeotLq)_