### PR TITLE
feat(website): #1019 — palette unification + mobile nav + active-page

### DIFF
--- a/website/src/components/SiteNav.astro
+++ b/website/src/components/SiteNav.astro
@@ -1,0 +1,34 @@
+---
+/**
+ * SiteNav.astro — shared navigation component for all yakcc.com pages.
+ *
+ * @decision DEC-WEBSITE-NAV-001
+ * Title: Shared SiteNav component with aria-current page detection
+ * Status: accepted
+ * Rationale: All three layouts (index, BaseLayout, DocLayout) previously
+ * inlined their own nav markup. Centralising into this component means:
+ *   1. One place to add/remove links.
+ *   2. Active-page highlighting (aria-current) is computed once at build
+ *      time via Astro.url.pathname — zero JS required.
+ *   3. Mobile-responsive behaviour comes from the global .site-nav rules
+ *      in global.css; no per-layout media queries needed.
+ * Introduced by WI-1019-website-polish.
+ */
+
+const path = Astro.url.pathname;
+
+const navItems = [
+  { href: "/", label: "yakcc", isLogo: true },
+  { href: "/benchmarks", label: "benchmarks" },
+  { href: "/docs", label: "docs" },
+];
+---
+<nav class="site-nav">
+  {navItems.map(({ href, label, isLogo }) => (
+    <a
+      href={href}
+      class={isLogo ? "logo" : ""}
+      aria-current={path === href || (href !== "/" && path.startsWith(href)) ? "page" : undefined}
+    >{label}</a>
+  ))}
+</nav>

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -1,6 +1,20 @@
 ---
 // BaseLayout.astro — shell for all yakcc website pages
+//
+// @decision DEC-WEBSITE-LAYOUT-001
+// Title: BaseLayout consumes global.css palette variables (no inlined styles)
+// Status: accepted
+// Rationale: Previously this layout hard-coded its own colour scheme (#020617
+// deep-blue). WI-1019 unifies all three layouts onto the landing's GitHub-dark
+// token set from global.css. Dropping the inline <style> block here means one
+// canonical source for palette tokens (global.css :root variables) and
+// consistent appearance across /, /benchmarks, and /docs/*.
+//
 // Zero client JS: no framework scripts shipped.
+
+import "../styles/global.css";
+import SiteNav from "../components/SiteNav.astro";
+
 const { title = 'yakcc' } = Astro.props;
 ---
 <!doctype html>
@@ -9,39 +23,20 @@ const { title = 'yakcc' } = Astro.props;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{title}</title>
-    <style>
-      *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-      body {
-        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-        background: #020617;
-        color: #f1f5f9;
-        min-height: 100vh;
-      }
-      nav {
-        border-bottom: 1px solid #1e293b;
-        padding: 0.75rem 2rem;
-        display: flex;
-        gap: 1.5rem;
-        align-items: center;
-      }
-      nav a {
-        color: #94a3b8;
-        text-decoration: none;
-        font-size: 0.85rem;
-      }
-      nav a:hover { color: #f1f5f9; }
-      nav .logo { color: #f1f5f9; font-weight: 700; font-size: 1rem; }
-      main { max-width: 1200px; margin: 0 auto; padding: 2rem; }
-    </style>
   </head>
   <body>
-    <nav>
-      <a href="/" class="logo">yakcc</a>
-      <a href="/benchmarks">benchmarks</a>
-      <a href="/docs">docs</a>
-    </nav>
-    <main>
+    <SiteNav />
+    <main class="base-main">
       <slot />
     </main>
   </body>
 </html>
+
+<style>
+  /* Layout-specific rules only — palette comes from global.css :root variables. */
+  .base-main {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+  }
+</style>

--- a/website/src/layouts/DocLayout.astro
+++ b/website/src/layouts/DocLayout.astro
@@ -6,8 +6,20 @@
 // Status: accepted
 // Rationale: Issue #928 requires zero runtime JS. This layout emits pure HTML.
 // All syntax highlighting is done at build time by Astro/shiki — no PrismJS
-// or highlight.js scripts are emitted. The <style> block is inlined at build
-// time and does not require a JS runtime.
+// or highlight.js scripts are emitted.
+//
+// @decision DEC-WEBSITE-LAYOUT-002
+// Title: DocLayout palette sourced from global.css variables (no scoped :root override)
+// Status: accepted
+// Rationale: WI-1019 unifies all three layouts onto the landing's GitHub-dark token
+// set. The previous inline <style> block re-declared :root variables with slightly
+// different values (e.g. --color-text: #c9d1d9 vs landing's #e6edf3, --color-code-bg:
+// #1f2937 vs landing's #1c2128). Removing the scoped override means global.css :root
+// is the single palette authority. Doc-specific styles (headings, code blocks,
+// blockquotes, tables) are preserved below but now reference the shared variables.
+
+import "../styles/global.css";
+import SiteNav from "../components/SiteNav.astro";
 
 interface Props {
   title: string;
@@ -23,91 +35,93 @@ const { title, description } = Astro.props;
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{title} — yakcc docs</title>
     {description && <meta name="description" content={description} />}
-    <style>
-      /* Minimal doc styles — build-time only, no runtime JS */
-      :root {
-        --color-bg: #0d1117;
-        --color-surface: #161b22;
-        --color-border: #30363d;
-        --color-text: #c9d1d9;
-        --color-text-muted: #8b949e;
-        --color-heading: #f0f6fc;
-        --color-link: #58a6ff;
-        --color-code-bg: #1f2937;
-        --font-mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
-        --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
-      }
-      * { box-sizing: border-box; }
-      body {
-        margin: 0;
-        background: var(--color-bg);
-        color: var(--color-text);
-        font-family: var(--font-sans);
-        font-size: 16px;
-        line-height: 1.6;
-      }
-      .site-header {
-        background: var(--color-surface);
-        border-bottom: 1px solid var(--color-border);
-        padding: 0.75rem 1.5rem;
-        display: flex;
-        align-items: center;
-        gap: 1.5rem;
-      }
-      .site-header a { color: var(--color-heading); text-decoration: none; font-weight: 600; }
-      .site-header nav a { color: var(--color-link); text-decoration: none; font-size: 0.9rem; }
-      .site-header nav a:hover { text-decoration: underline; }
-      .layout { max-width: 900px; margin: 0 auto; padding: 2rem 1.5rem; }
-      h1, h2, h3, h4, h5, h6 { color: var(--color-heading); line-height: 1.3; }
-      h1 { font-size: 2rem; border-bottom: 1px solid var(--color-border); padding-bottom: 0.5rem; }
-      h2 { font-size: 1.5rem; margin-top: 2.5rem; border-bottom: 1px solid var(--color-border); padding-bottom: 0.3rem; }
-      h3 { font-size: 1.2rem; margin-top: 1.5rem; }
-      a { color: var(--color-link); }
-      code {
-        font-family: var(--font-mono);
-        font-size: 0.875em;
-        background: var(--color-code-bg);
-        padding: 0.15em 0.4em;
-        border-radius: 4px;
-      }
-      pre {
-        background: var(--color-code-bg) !important;
-        border: 1px solid var(--color-border);
-        border-radius: 6px;
-        padding: 1rem 1.25rem;
-        overflow-x: auto;
-        font-size: 0.875rem;
-        line-height: 1.5;
-      }
-      pre code {
-        background: none;
-        padding: 0;
-        font-size: inherit;
-      }
-      blockquote {
-        border-left: 4px solid var(--color-border);
-        margin: 1rem 0;
-        padding: 0.5rem 1rem;
-        color: var(--color-text-muted);
-      }
-      table { border-collapse: collapse; width: 100%; }
-      th, td { border: 1px solid var(--color-border); padding: 0.5rem 0.75rem; text-align: left; }
-      th { background: var(--color-surface); color: var(--color-heading); }
-      hr { border: none; border-top: 1px solid var(--color-border); margin: 2rem 0; }
-      .breadcrumb { font-size: 0.85rem; color: var(--color-text-muted); margin-bottom: 1.5rem; }
-      .breadcrumb a { color: var(--color-link); text-decoration: none; }
-    </style>
   </head>
   <body>
-    <header class="site-header">
-      <a href="/">yakcc</a>
-      <nav>
-        <a href="/benchmarks">benchmarks</a>
-        <a href="/docs/">docs</a>
-      </nav>
-    </header>
-    <div class="layout">
+    <SiteNav />
+    <div class="doc-layout">
       <slot />
     </div>
   </body>
 </html>
+
+<style>
+  /* Doc-specific layout and typography — palette variables come from global.css :root.
+   * Only structural/typographic overrides live here; no colour hard-coding. */
+
+  .doc-layout {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    color: var(--color-text);
+    line-height: 1.3;
+  }
+
+  h1 {
+    font-size: 2rem;
+    border-bottom: 1px solid var(--color-border);
+    padding-bottom: 0.5rem;
+  }
+
+  h2 {
+    font-size: 1.5rem;
+    margin-top: 2.5rem;
+    border-bottom: 1px solid var(--color-border);
+    padding-bottom: 0.3rem;
+  }
+
+  h3 { font-size: 1.2rem; margin-top: 1.5rem; }
+
+  a { color: var(--color-accent); }
+
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.875em;
+    background: var(--color-code-bg);
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+  }
+
+  pre {
+    background: var(--color-code-bg) !important;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    padding: 1rem 1.25rem;
+    overflow-x: auto;
+    font-size: 0.875rem;
+    line-height: 1.5;
+  }
+
+  pre code {
+    background: none;
+    padding: 0;
+    font-size: inherit;
+  }
+
+  blockquote {
+    border-left: 4px solid var(--color-border);
+    margin: 1rem 0;
+    padding: 0.5rem 1rem;
+    color: var(--color-text-muted);
+  }
+
+  table { border-collapse: collapse; width: 100%; }
+
+  th, td {
+    border: 1px solid var(--color-border);
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+  }
+
+  th {
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+
+  hr { border: none; border-top: 1px solid var(--color-border); margin: 2rem 0; }
+
+  .breadcrumb { font-size: 0.85rem; color: var(--color-text-muted); margin-bottom: 1.5rem; }
+  .breadcrumb a { color: var(--color-accent); text-decoration: none; }
+</style>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -23,6 +23,7 @@
  * Rationale: Zero JS by default, TypeScript-native, markdown-friendly.
  */
 import "../styles/global.css";
+import SiteNav from "../components/SiteNav.astro";
 ---
 
 <!doctype html>
@@ -37,11 +38,7 @@ import "../styles/global.css";
   <body>
 
     <!-- ===================== NAV ===================== -->
-    <nav class="site-nav">
-      <a href="/" class="logo">yakcc</a>
-      <a href="/benchmarks">benchmarks</a>
-      <a href="/docs">docs</a>
-    </nav>
+    <SiteNav />
 
     <!-- ===================== HERO ===================== -->
     <section class="hero">

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -44,6 +44,10 @@
   font-size: 0.85rem;
 }
 .site-nav a:hover { color: var(--color-text); }
+.site-nav a[aria-current="page"] {
+  color: var(--color-text);
+  font-weight: 600;
+}
 .site-nav .logo {
   color: var(--color-text);
   font-weight: 700;
@@ -298,5 +302,12 @@ li {
   }
   .hero {
     padding: 2.5rem 0 1.5rem;
+  }
+  /* Mobile nav: stack links vertically. Three links fit cleanly without a
+     hamburger (DEC-WEBSITE-001 Q8 — minimal, no unnecessary JS toggles). */
+  .site-nav {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.6rem;
   }
 }


### PR DESCRIPTION
## Summary

Three cosmetic gaps from PR #1018 (FuckGoblin → Serenity reassign), bundled into one PR.

### 1. Palette unification

Before: 3 different color schemes across the site.
- Landing (`index.astro` + `global.css`): GitHub-dark (`#0d1117`, `#161b22`, `#58a6ff`)
- `BaseLayout.astro` (powers `/benchmarks`): inlined `#020617` deep blue + slate
- `DocLayout.astro` (powers `/docs/*`): scoped override (`#c9d1d9`, `#1f2937`)

After: all three layouts consume `global.css` CSS variables (the GitHub-dark token set). Doc-specific styles (heading hierarchy, code blocks, blockquotes, tables) preserved but reference variables instead of hard-coded hexes.

### 2. Mobile responsive nav

`@media (max-width: 600px) { .site-nav { flex-direction: column } }` — single rule in `global.css` applies everywhere (because nav is now shared).

### 3. Active-page highlighting

- New `website/src/components/SiteNav.astro` extracted from the inline nav markup duplicated across three files.
- Uses `Astro.url.pathname` to compute `aria-current="page"` on the matching link.
- CSS: `.site-nav a[aria-current="page"] { color: var(--color-text); font-weight: 600; }`
- All three layouts now import `SiteNav.astro` — no more duplicated nav markup.

## Files

```
NEW       website/src/components/SiteNav.astro
MODIFIED  website/src/layouts/BaseLayout.astro
MODIFIED  website/src/layouts/DocLayout.astro
MODIFIED  website/src/pages/index.astro
MODIFIED  website/src/styles/global.css
```

## Verification

- [x] `astro build` clean (7 pages, single `:root` in output CSS)
- [x] `aria-current="page"` present in static HTML for `/`, `/benchmarks`, `/docs`
- [x] **Dogfood gate preserved**: `/atoms/clipboard-copy-text.js` still loads on landing
- [x] **No new runtime JS** (DEC-WEBSITE-DOGFOOD-001 honored)

Closes #1019

🤖 Generated with [Claude Code](https://claude.com/claude-code)