### PR TITLE
fix(mcp-registry): #1028 yakcc_compile resolves short ids against the full registry, not just seed roots

### DIFF
--- a/packages/mcp-registry/src/tools/compile.test.ts
+++ b/packages/mcp-registry/src/tools/compile.test.ts
@@ -3,38 +3,48 @@
 /**
  * Tests for yakcc_compile tool.
  *
- * @decision DEC-MCP-COMPILE-EXEC-1007-001
- * @title yakcc_compile — local-registry atom materialization
- * @status decided (wi-1007)
+ * @decision DEC-1028-COMPILE-FULL-ROOTS-001
+ * @title yakcc_compile — full-registry root enumeration for id-resolution and assembly
+ * @status decided (wi-1028)
  * @rationale
- *   Five required cases per dispatch spec:
+ *   WI-1028 fix: short-id resolution now uses the FULL registry block root set
+ *   (enumerateSpecs → selectBlocks) instead of seedRegistry().merkleRoots.
+ *   This makes non-seed atoms (the common case from yakcc_resolve) resolvable.
+ *
+ *   Test cases:
  *   (1) Full 64-char root → correct assembled source/implSource
- *   (2) 8-char short id → the SAME correct source (proves short→full resolution)
+ *   (2) 8-char short id (seed root) → the SAME correct source
+ *   (2c) 8-char short id of a NON-SEED root (present in full registry but NOT
+ *        in seed corpus) → resolves correctly and returns assembled source.
+ *        This is the WI-1028 regression test: MUST FAIL on old logic (seedRegistry
+ *        roots only), MUST PASS with new logic (full enumeration).
  *   (3) Ambiguous short prefix → ambiguous_short_id structured content
  *   (4) Unknown id → not_found structured content
  *   (5) Bad/missing input → structured error, handler does not throw
- *
- *   Plus:
  *   (6) Registry open failure → registry_unavailable structured content, no throw
  *   (7) assemble() failure → assembly_failed structured content, no throw
  *   (8) Lazy registry open: factory called once even across multiple calls
  *
  * Mock strategy:
  *   - seedRegistry from @yakcc/seeds is vi.mock()'d — no real filesystem walk.
+ *     Its return value is now irrelevant (discarded by handler); mock returns void stub.
  *   - assemble from @yakcc/compile is vi.mock()'d — no real assembly.
  *   - openRegistry from @yakcc/registry is vi.mock()'d — no real SQLite.
  *   - createOfflineEmbeddingProvider from @yakcc/contracts is vi.mock()'d.
- *   - The tool is created with a stub openRegistry factory for deterministic control.
- *   - HttpClient is injected (unused by compile handler — compile is local-only).
+ *   - The tool is created with a stub openRegistry factory. The stub Registry has
+ *     enumerateSpecs() and selectBlocks() returning controlled roots — this is the
+ *     full-registry enumeration surface that the new handler calls.
  *
  * Compound-Interaction Test Requirement (CLAUDE.md):
- *   Case (1) + (2) together exercise the full production sequence:
- *   createCompileTool() → handler → getRegistryAndSeed() → seedRegistry() →
- *   resolveAtomId() → assemble() → structured response.
- *   The short-id test (case 2) proves the resolution path is wired to the same
- *   assembled output as the full-root path (case 1).
+ *   Case (2c) exercises the full production sequence for the WI-1028 fix:
+ *   createCompileTool() → handler → getRegistryAndFullRoots() →
+ *   seedRegistry() [idempotent] → enumerateSpecs() → selectBlocks() →
+ *   resolveAtomId(shortId, fullRoots) → assemble(fullRoot, registry, ...) →
+ *   structured source response.
+ *   The non-seed short-id test proves the resolution path crosses the
+ *   enumerateSpecs/selectBlocks boundary correctly end-to-end.
  *
- * Implements: yakcc#1007
+ * Implements: yakcc#1007, yakcc#1028
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -62,31 +72,45 @@ vi.mock("@yakcc/contracts", () => ({
 
 import { assemble } from "@yakcc/compile";
 import type { Artifact } from "@yakcc/compile";
-import type { BlockMerkleRoot } from "@yakcc/contracts";
+import type { BlockMerkleRoot, SpecHash } from "@yakcc/contracts";
 import type { Registry } from "@yakcc/registry";
 import { seedRegistry } from "@yakcc/seeds";
-import type { SeedResult } from "@yakcc/seeds";
 import { compileTool, createCompileTool } from "./compile.js";
 
 // ---------------------------------------------------------------------------
 // Test fixtures
 // ---------------------------------------------------------------------------
 
-/** A realistic-looking 64-char hex BlockMerkleRoot for the "primary" seed atom. */
+/** A realistic-looking 64-char hex BlockMerkleRoot for the "primary" atom (seed-like). */
 const ROOT_A = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2" as BlockMerkleRoot;
 /** Short id for ROOT_A (first 8 chars). */
 const SHORT_A = ROOT_A.slice(0, 8); // "a1b2c3d4"
 
-/** A second root — used to create an ambiguous prefix scenario. Exactly 64 hex chars, shares "a1b2c3d4" prefix with ROOT_A. */
+/**
+ * A NON-SEED root — present in the full registry enumeration but NOT in the
+ * seed corpus (i.e. NOT among seedRegistry().merkleRoots). This is the WI-1028
+ * regression fixture: old code returned not_found; new code must resolve it.
+ */
+const ROOT_NON_SEED = "beef1234cafe5678beef1234cafe5678beef1234cafe5678beef1234cafe5678ab" as BlockMerkleRoot;
+const SHORT_NON_SEED = ROOT_NON_SEED.slice(0, 8); // "beef1234"
+
+/** A second root — used to create an ambiguous prefix scenario. Shares "a1b2c3d4" prefix with ROOT_A. */
 const ROOT_B = ("a1b2c3d4" + "1".repeat(56)) as BlockMerkleRoot;
 
 /** A root whose short id does NOT appear in any known root — for not_found tests. */
 const ROOT_UNKNOWN_SHORT = "deadbeef";
 
+/** Fake SpecHash values (64 hex chars, branded). */
+const SPEC_HASH_A = "aaaa0000000000000000000000000000000000000000000000000000000000000000" as SpecHash;
+const SPEC_HASH_NON_SEED = "bbbb0000000000000000000000000000000000000000000000000000000000000000" as SpecHash;
+const SPEC_HASH_B = "cccc0000000000000000000000000000000000000000000000000000000000000000" as SpecHash;
+
 /** The assembled TS source the mock returns for ROOT_A. */
 const ASSEMBLED_SOURCE = `export function asciiChar(code: number): string { return String.fromCharCode(code); }`;
+/** The assembled TS source the mock returns for ROOT_NON_SEED. */
+const ASSEMBLED_SOURCE_NON_SEED = `export function nonSeedFn(x: number): number { return x * 2; }`;
 
-/** A mock Artifact returned by the mocked assemble(). */
+/** A mock Artifact returned by the mocked assemble() for ROOT_A. */
 function makeArtifact(): Artifact {
   return {
     source: ASSEMBLED_SOURCE,
@@ -94,7 +118,7 @@ function makeArtifact(): Artifact {
       entries: [
         {
           root: ROOT_A,
-          specHash: "spechashhex00000000000000000000000000000000000000000000000000000000" as import("@yakcc/contracts").SpecHash,
+          specHash: SPEC_HASH_A,
           behavior: "converts ASCII code point to character",
           signature: "(code: number) => string",
           guarantees: ["pure", "deterministic"],
@@ -107,17 +131,71 @@ function makeArtifact(): Artifact {
   };
 }
 
-/** A stub Registry object (content irrelevant — assemble is mocked). */
-const STUB_REGISTRY = {} as unknown as Registry;
-
-/** A SeedResult with a single known root: ROOT_A. */
-function makeSeedResultOne(): SeedResult {
-  return { stored: 1, merkleRoots: [ROOT_A] };
+/** A mock Artifact returned by assemble() for ROOT_NON_SEED. */
+function makeNonSeedArtifact(): Artifact {
+  return {
+    source: ASSEMBLED_SOURCE_NON_SEED,
+    manifest: {
+      entries: [
+        {
+          root: ROOT_NON_SEED,
+          specHash: SPEC_HASH_NON_SEED,
+          behavior: "doubles a number",
+          signature: "(x: number) => number",
+          guarantees: ["pure", "deterministic"],
+          sourceOffset: 0,
+          sourceLength: ASSEMBLED_SOURCE_NON_SEED.length,
+        },
+      ],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+  };
 }
 
-/** A SeedResult with two roots that share the same 8-char prefix: ROOT_A and ROOT_B. */
-function makeSeedResultAmbiguous(): SeedResult {
-  return { stored: 2, merkleRoots: [ROOT_A, ROOT_B] };
+/**
+ * Build a stub Registry with controlled enumerateSpecs / selectBlocks responses.
+ *
+ * `specToRoots` maps SpecHash → BlockMerkleRoot[]. The stub's enumerateSpecs()
+ * returns the map's keys; selectBlocks(sh) returns the corresponding roots.
+ *
+ * This replaces the old `STUB_REGISTRY = {}` approach: the new handler calls
+ * enumerateSpecs + selectBlocks to build fullRoots, so the stub must implement them.
+ */
+function makeRegistryStub(specToRoots: ReadonlyMap<SpecHash, BlockMerkleRoot[]>): Registry {
+  return {
+    enumerateSpecs: vi.fn().mockResolvedValue([...specToRoots.keys()]),
+    selectBlocks: vi.fn().mockImplementation(async (sh: SpecHash) => specToRoots.get(sh) ?? []),
+  } as unknown as Registry;
+}
+
+/**
+ * Build a specToRoots map containing only ROOT_A (single, non-ambiguous).
+ * ROOT_A is reachable via SHORT_A. seedRegistry is mocked to return void.
+ */
+function makeSpecMapOne(): ReadonlyMap<SpecHash, BlockMerkleRoot[]> {
+  return new Map([[SPEC_HASH_A, [ROOT_A]]]);
+}
+
+/**
+ * Build a specToRoots map with ROOT_A + ROOT_NON_SEED (two distinct prefixes).
+ * ROOT_NON_SEED is NOT in seedRegistry().merkleRoots — proves the WI-1028 fix.
+ */
+function makeSpecMapWithNonSeed(): ReadonlyMap<SpecHash, BlockMerkleRoot[]> {
+  return new Map([
+    [SPEC_HASH_A, [ROOT_A]],
+    [SPEC_HASH_NON_SEED, [ROOT_NON_SEED]],
+  ]);
+}
+
+/**
+ * Build a specToRoots map with ROOT_A + ROOT_B (both share "a1b2c3d4" prefix).
+ * Used to trigger ambiguous_short_id.
+ */
+function makeSpecMapAmbiguous(): ReadonlyMap<SpecHash, BlockMerkleRoot[]> {
+  return new Map([
+    [SPEC_HASH_A, [ROOT_A]],
+    [SPEC_HASH_B, [ROOT_B]],
+  ]);
 }
 
 /** A minimal stub HttpClient (compile handler never uses it — but the interface requires it). */
@@ -126,11 +204,13 @@ const STUB_HTTP: HttpClient = {
   post: vi.fn(),
 } as unknown as HttpClient;
 
-/** Helper: create a tool instance with mocked seedRegistry + controlled registry. */
-function makeTool(openRegistryFn?: () => Promise<Registry>): ReturnType<typeof createCompileTool> {
-  return createCompileTool({
-    openRegistry: openRegistryFn ?? (async () => STUB_REGISTRY),
-  });
+/**
+ * Helper: create a tool instance backed by a controlled registry stub.
+ * seedRegistry mock is set up to resolve (void — result discarded by handler).
+ */
+function makeTool(registry?: Registry): ReturnType<typeof createCompileTool> {
+  const reg = registry ?? makeRegistryStub(makeSpecMapOne());
+  return createCompileTool({ openRegistry: async () => reg });
 }
 
 // ---------------------------------------------------------------------------
@@ -140,7 +220,7 @@ function makeTool(openRegistryFn?: () => Promise<Registry>): ReturnType<typeof c
 
 describe("yakcc_compile — full root and short id produce identical source (compound)", () => {
   beforeEach(() => {
-    vi.mocked(seedRegistry).mockResolvedValue(makeSeedResultOne());
+    vi.mocked(seedRegistry).mockResolvedValue({ stored: 0, merkleRoots: [] } as any);
     vi.mocked(assemble).mockResolvedValue(makeArtifact());
   });
 
@@ -161,10 +241,10 @@ describe("yakcc_compile — full root and short id produce identical source (com
     expect(parsed.source).toBe(ASSEMBLED_SOURCE);
     expect(parsed.root).toBe(ROOT_A);
     expect(parsed.block_count).toBe(1);
-    // assemble was called with the full root
+    // assemble was called with the full root and fullRoots from registry enumeration
     expect(vi.mocked(assemble)).toHaveBeenCalledWith(
       ROOT_A,
-      STUB_REGISTRY,
+      expect.anything(),
       undefined,
       expect.objectContaining({ knownMerkleRoots: [ROOT_A] }),
     );
@@ -186,7 +266,7 @@ describe("yakcc_compile — full root and short id produce identical source (com
     // assemble was called with the resolved full root (not the short id)
     expect(vi.mocked(assemble)).toHaveBeenCalledWith(
       ROOT_A,
-      STUB_REGISTRY,
+      expect.anything(),
       undefined,
       expect.objectContaining({ knownMerkleRoots: [ROOT_A] }),
     );
@@ -205,14 +285,98 @@ describe("yakcc_compile — full root and short id produce identical source (com
 });
 
 // ---------------------------------------------------------------------------
+// Case (2c): WI-1028 regression — non-seed atom resolves via full registry
+//
+// This is the primary regression test for yakcc#1028.
+// Old code: prefix-matched against seedRegistry().merkleRoots → not_found
+// New code: prefix-matched against fullRoots (enumerateSpecs → selectBlocks) → resolved
+//
+// Setup: registry contains ROOT_NON_SEED (via SPEC_HASH_NON_SEED) but seedRegistry
+// returns merkleRoots=[] (simulating a non-seed atom not in the seed corpus).
+// The handler must still resolve SHORT_NON_SEED to ROOT_NON_SEED and return assembled source.
+// ---------------------------------------------------------------------------
+
+describe("yakcc_compile — WI-1028: non-seed atom resolves via full registry enumeration", () => {
+  beforeEach(() => {
+    // seedRegistry returns an empty merkleRoots list (no seed atoms) to prove
+    // that resolution does NOT rely on seed roots for non-seed atoms.
+    vi.mocked(seedRegistry).mockResolvedValue({ stored: 0, merkleRoots: [] } as any);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("(2c) non-seed short id → full registry enumeration resolves it → real assembled source (regression)", async () => {
+    // Registry contains ONLY the non-seed root. seedRegistry returns empty roots.
+    // Old logic: resolveAtomId(SHORT_NON_SEED, []) → not_found
+    // New logic: resolveAtomId(SHORT_NON_SEED, [ROOT_NON_SEED]) → full root → assemble
+    const registry = makeRegistryStub(
+      new Map([[SPEC_HASH_NON_SEED, [ROOT_NON_SEED]]]),
+    );
+    vi.mocked(assemble).mockResolvedValue(makeNonSeedArtifact());
+
+    const tool = createCompileTool({ openRegistry: async () => registry });
+    const result = await tool.handler({ atom_id: SHORT_NON_SEED }, STUB_HTTP);
+
+    expect(result).toHaveLength(1);
+    const parsed = JSON.parse(result[0]!.text) as {
+      atom_id: string;
+      root: string;
+      source: string;
+      block_count: number;
+      error?: string;
+    };
+
+    // Must NOT be not_found — this was the bug before WI-1028.
+    expect(parsed.error).toBeUndefined();
+    // Must resolve to the non-seed root.
+    expect(parsed.root).toBe(ROOT_NON_SEED);
+    // Must return the assembled source for the non-seed atom.
+    expect(parsed.source).toBe(ASSEMBLED_SOURCE_NON_SEED);
+    expect(parsed.block_count).toBe(1);
+
+    // assemble called with the resolved non-seed root
+    expect(vi.mocked(assemble)).toHaveBeenCalledWith(
+      ROOT_NON_SEED,
+      registry,
+      undefined,
+      expect.objectContaining({ knownMerkleRoots: [ROOT_NON_SEED] }),
+    );
+
+    // enumerateSpecs and selectBlocks must have been called — proves full enumeration
+    expect(vi.mocked(registry.enumerateSpecs as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(registry.selectBlocks as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(SPEC_HASH_NON_SEED);
+  });
+
+  it("(2c-full) non-seed full 64-char root → passes straight through to assemble without enumeration lookup", async () => {
+    // Full 64-char root bypasses prefix matching (straight through).
+    // Even without any roots in the registry, a full root can be assembled.
+    const registry = makeRegistryStub(new Map([[SPEC_HASH_NON_SEED, [ROOT_NON_SEED]]]));
+    vi.mocked(assemble).mockResolvedValue(makeNonSeedArtifact());
+
+    const tool = createCompileTool({ openRegistry: async () => registry });
+    const result = await tool.handler({ atom_id: ROOT_NON_SEED }, STUB_HTTP);
+
+    const parsed = JSON.parse(result[0]!.text) as { root: string; source: string; error?: string };
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.root).toBe(ROOT_NON_SEED);
+    expect(parsed.source).toBe(ASSEMBLED_SOURCE_NON_SEED);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Case (3): Ambiguous short prefix
 // ---------------------------------------------------------------------------
 
 describe("yakcc_compile — ambiguous short id", () => {
   beforeEach(() => {
-    // Two roots share the "a1b2c3d4" prefix
-    vi.mocked(seedRegistry).mockResolvedValue(makeSeedResultAmbiguous());
+    // Both ROOT_A and ROOT_B share "a1b2c3d4" prefix — in full registry
+    const registry = makeRegistryStub(makeSpecMapAmbiguous());
+    vi.mocked(seedRegistry).mockResolvedValue({ stored: 0, merkleRoots: [] } as any);
     vi.mocked(assemble).mockResolvedValue(makeArtifact());
+    // Override tool for this suite via beforeEach closure — tests create their own tools
+    void registry; // used inline in each test
   });
 
   afterEach(() => {
@@ -220,7 +384,8 @@ describe("yakcc_compile — ambiguous short id", () => {
   });
 
   it("(3) ambiguous_short_id → structured content, assemble NOT called", async () => {
-    const tool = makeTool();
+    const registry = makeRegistryStub(makeSpecMapAmbiguous());
+    const tool = createCompileTool({ openRegistry: async () => registry });
     // Both ROOT_A and ROOT_B start with "a1b2c3d4"
     const result = await tool.handler({ atom_id: SHORT_A }, STUB_HTTP);
     expect(result).toHaveLength(1);
@@ -251,7 +416,7 @@ describe("yakcc_compile — ambiguous short id", () => {
 
 describe("yakcc_compile — not_found", () => {
   beforeEach(() => {
-    vi.mocked(seedRegistry).mockResolvedValue(makeSeedResultOne());
+    vi.mocked(seedRegistry).mockResolvedValue({ stored: 0, merkleRoots: [] } as any);
     vi.mocked(assemble).mockResolvedValue(makeArtifact());
   });
 
@@ -260,7 +425,7 @@ describe("yakcc_compile — not_found", () => {
   });
 
   it("(4) short id with no matching prefix → not_found structured content", async () => {
-    const tool = makeTool();
+    const tool = makeTool(); // registry only has ROOT_A
     const result = await tool.handler({ atom_id: ROOT_UNKNOWN_SHORT }, STUB_HTTP);
     expect(result).toHaveLength(1);
     const parsed = JSON.parse(result[0]!.text) as {
@@ -273,16 +438,16 @@ describe("yakcc_compile — not_found", () => {
     expect(vi.mocked(assemble)).not.toHaveBeenCalled();
   });
 
-  it("(4b) full 64-char root not in seed set → assembly_failed (passes straight through to assemble)", async () => {
-    // A full root that is syntactically valid but not in knownRoots.
+  it("(4b) full 64-char root not in registry → assembly_failed (passes straight through to assemble)", async () => {
+    // A full root that is syntactically valid but not in the registry.
     // resolveAtomId accepts full 64-char roots directly (no prefix match needed),
     // so it returns { kind: "full", root } — then assemble() is called.
     // If the registry doesn't have it, assemble() throws → assembly_failed content.
     const unknownFullRoot =
       "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" as BlockMerkleRoot;
-    const tool4b = makeTool();
+    const tool = makeTool();
     vi.mocked(assemble).mockRejectedValueOnce(new Error("block not found in registry"));
-    const result = await tool4b.handler({ atom_id: unknownFullRoot }, STUB_HTTP);
+    const result = await tool.handler({ atom_id: unknownFullRoot }, STUB_HTTP);
     const parsed = JSON.parse(result[0]!.text) as { error: string };
     expect(parsed.error).toBe("assembly_failed");
   });
@@ -294,7 +459,7 @@ describe("yakcc_compile — not_found", () => {
 
 describe("yakcc_compile — input validation (handler never throws)", () => {
   beforeEach(() => {
-    vi.mocked(seedRegistry).mockResolvedValue(makeSeedResultOne());
+    vi.mocked(seedRegistry).mockResolvedValue({ stored: 0, merkleRoots: [] } as any);
     vi.mocked(assemble).mockResolvedValue(makeArtifact());
   });
 
@@ -368,6 +533,18 @@ describe("yakcc_compile — registry open failure", () => {
     const parsed = JSON.parse(result[0]!.text) as { error: string };
     expect(parsed.error).toBe("registry_unavailable");
   });
+
+  it("enumerateSpecs throws → registry_unavailable, no throw", async () => {
+    vi.mocked(seedRegistry).mockResolvedValue({ stored: 0, merkleRoots: [] } as any);
+    const badRegistry = {
+      enumerateSpecs: vi.fn().mockRejectedValue(new Error("DB corrupted")),
+      selectBlocks: vi.fn(),
+    } as unknown as Registry;
+    const tool = createCompileTool({ openRegistry: async () => badRegistry });
+    const result = await tool.handler({ atom_id: SHORT_A }, STUB_HTTP);
+    const parsed = JSON.parse(result[0]!.text) as { error: string };
+    expect(parsed.error).toBe("registry_unavailable");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -376,7 +553,7 @@ describe("yakcc_compile — registry open failure", () => {
 
 describe("yakcc_compile — assembly failure", () => {
   beforeEach(() => {
-    vi.mocked(seedRegistry).mockResolvedValue(makeSeedResultOne());
+    vi.mocked(seedRegistry).mockResolvedValue({ stored: 0, merkleRoots: [] } as any);
   });
 
   afterEach(() => {
@@ -404,10 +581,11 @@ describe("yakcc_compile — lazy registry open (factory called once)", () => {
   });
 
   it("openRegistry factory called exactly once even after multiple handler calls", async () => {
-    vi.mocked(seedRegistry).mockResolvedValue(makeSeedResultOne());
+    vi.mocked(seedRegistry).mockResolvedValue({ stored: 0, merkleRoots: [] } as any);
     vi.mocked(assemble).mockResolvedValue(makeArtifact());
 
-    const openFn = vi.fn().mockResolvedValue(STUB_REGISTRY);
+    const registry = makeRegistryStub(makeSpecMapOne());
+    const openFn = vi.fn().mockResolvedValue(registry);
     const tool = createCompileTool({ openRegistry: openFn });
 
     await tool.handler({ atom_id: ROOT_A }, STUB_HTTP);
@@ -417,6 +595,8 @@ describe("yakcc_compile — lazy registry open (factory called once)", () => {
     expect(openFn).toHaveBeenCalledTimes(1);
     // seedRegistry also called only once (cached alongside registry)
     expect(vi.mocked(seedRegistry)).toHaveBeenCalledTimes(1);
+    // enumerateSpecs called only once (roots cached)
+    expect(vi.mocked(registry.enumerateSpecs as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/mcp-registry/src/tools/compile.ts
+++ b/packages/mcp-registry/src/tools/compile.ts
@@ -1,16 +1,26 @@
 /**
  * Tool: yakcc_compile
  *
- * @decision DEC-MCP-COMPILE-EXEC-1007-001
- * @title yakcc_compile — materialize an atom's impl source from the local registry
- * @status decided (wi-1007)
+ * @decision DEC-1028-COMPILE-FULL-ROOTS-001
+ * @title yakcc_compile — use full registry block roots for id-resolution and assembly
+ * @status decided (wi-1028)
  * @rationale
- *   After yakcc_resolve surfaces a candidate (auto_accept or chosen from
- *   candidate_list), the model used to emit the inert CLI string
- *   `yakcc compile <id>` — which produced nothing inside a Claude Code session.
- *   This tool closes that gap: it resolves the atom in the LOCAL registry,
- *   runs `assemble()` from @yakcc/compile, and returns the write-ready
- *   `artifact.source` so the model can immediately pass it to Edit/Write.
+ *   Prior to WI-1028, short-id prefix matching used seedRegistry().merkleRoots
+ *   (~26 seed blocks). yakcc_resolve returns 8-char prefixes of BlockMerkleRoots
+ *   from the FULL local registry, which can contain many non-seed atoms. Attempting
+ *   to compile a non-seed atom (by short id) always returned not_found/"ghost
+ *   reference" even though the atom was present in the registry.
+ *
+ *   Fix: enumerate the FULL registry block roots via
+ *     for (const sh of await registry.enumerateSpecs())
+ *       for (const root of await registry.selectBlocks(sh)) fullRoots.push(root);
+ *   and use those roots for BOTH prefix matching (resolveAtomId) AND as
+ *   knownMerkleRoots in assemble(). This is the canonical pattern used by
+ *   packages/registry/src/rebuild.ts:104-112.
+ *
+ *   seedRegistry is retained so seed blocks are present in the local DB on first
+ *   use, but its merkleRoots are no longer authoritative for id-resolution. After
+ *   seeding, fullRoots is built from the registry itself — one authority.
  *
  *   Architecture decisions:
  *
@@ -19,37 +29,37 @@
  *       an atom that exists only in the global commons (not in the local DB)
  *       is not in scope for WI-1007 (follow-up WI).
  *
- *   (2) SHORT-ID RESOLUTION (one authority):
+ *   (2) FULL-REGISTRY SHORT-ID RESOLUTION (one authority, WI-1028):
  *       An 8-char (or any non-64-char) atom_id is treated as a prefix against
- *       the full set of BlockMerkleRoots known to the seeded registry
- *       (seedRegistry(registry).merkleRoots — the same set CLI compile.ts:199
- *       uses). Unique prefix → resolve; ambiguous → structured
- *       ambiguous_short_id content; no match → not_found.
- *       Full 64-char root passes straight through (no seedRegistry call needed).
+ *       the FULL set of BlockMerkleRoots enumerated from the registry
+ *       (enumerateSpecs → selectBlocks). Unique prefix → resolve; ambiguous →
+ *       structured ambiguous_short_id content; no match → not_found.
+ *       Full 64-char root passes straight through (no enumeration needed).
  *       One short-id authority; no parallel scheme.
  *
  *   (3) ASSEMBLE PREFERRED:
  *       Uses assemble() from @yakcc/compile (not just registry.getBlock().implSource)
- *       so multi-block composite atoms work correctly. The knownMerkleRoots from
- *       seedRegistry are forwarded as the pre-scan stem index (same as CLI).
+ *       so multi-block composite atoms work correctly. The fullRoots from the
+ *       full-registry enumeration are forwarded as the pre-scan stem index.
  *
  *   (4) ERROR DISCIPLINE (DEC-MCP-ERROR-AS-CONTENT-004):
  *       All errors returned as structured MCP content. The handler NEVER throws.
  *       Structured error codes: invalid_input, registry_unavailable,
  *       not_found, ambiguous_short_id, assembly_failed.
  *
- *   (5) LAZY REGISTRY OPEN:
+ *   (5) LAZY REGISTRY OPEN + FULL-ROOTS CACHE:
  *       Registry opened once per tool instance (same pattern as resolve.ts).
+ *       Full registry roots are enumerated once and cached alongside the registry.
  *       Factory injectable for tests.
  *
  *   Cross-references:
- *     DEC-HOOK-PROACTIVE-PRIMARY-001 — initiative umbrella
- *     DEC-MCP-ERROR-AS-CONTENT-004   — errors as content, never throw
- *     DEC-MCP-STDERR-LOGGING-005     — no stdout (no console.log)
- *     Sacred Practice #12            — single authority for short-id resolution
- *     CLI compile.ts lines 195-257   — reference implementation for assemble flow
+ *     DEC-HOOK-PROACTIVE-PRIMARY-001       — initiative umbrella
+ *     DEC-MCP-ERROR-AS-CONTENT-004         — errors as content, never throw
+ *     DEC-MCP-STDERR-LOGGING-005           — no stdout (no console.log)
+ *     Sacred Practice #12                  — single authority for short-id resolution
+ *     packages/registry/src/rebuild.ts:104 — canonical enumerateSpecs→selectBlocks pattern
  *
- * Implements: yakcc#1007
+ * Implements: yakcc#1007, yakcc#1028
  */
 
 import { assemble } from "@yakcc/compile";
@@ -57,7 +67,6 @@ import type { Artifact } from "@yakcc/compile";
 import type { BlockMerkleRoot } from "@yakcc/contracts";
 import type { Registry } from "@yakcc/registry";
 import { seedRegistry } from "@yakcc/seeds";
-import type { SeedResult } from "@yakcc/seeds";
 import type { HttpClient } from "../http-client.js";
 import type { MCPContent, ToolModule } from "./types.js";
 
@@ -95,14 +104,18 @@ type ResolveIdResult =
  * Resolve a possibly-short atom_id to a unique BlockMerkleRoot.
  *
  * - 64-char hex string → pass straight through as BlockMerkleRoot.
- * - Shorter string → prefix-match against knownRoots (the seeded registry set).
+ * - Shorter string → prefix-match against knownRoots (FULL registry block set).
  *   Unique match → resolve. Multiple matches → ambiguous. Zero → not_found.
  *
  * This is the single short-id resolution authority for the MCP compile tool
- * (Sacred Practice #12). The knownRoots come from seedRegistry().merkleRoots,
- * matching CLI compile.ts line 199.
+ * (Sacred Practice #12, DEC-1028-COMPILE-FULL-ROOTS-001). knownRoots must
+ * come from the full registry enumeration (enumerateSpecs → selectBlocks),
+ * NOT from seedRegistry().merkleRoots, so non-seed atoms resolve correctly.
  */
-function resolveAtomId(atomId: string, knownRoots: ReadonlyArray<BlockMerkleRoot>): ResolveIdResult {
+function resolveAtomId(
+  atomId: string,
+  knownRoots: ReadonlyArray<BlockMerkleRoot>,
+): ResolveIdResult {
   // Full 64-char merkle root: pass through directly.
   if (/^[a-f0-9]{64}$/i.test(atomId)) {
     return { kind: "full", root: atomId.toLowerCase() as BlockMerkleRoot };
@@ -149,23 +162,35 @@ export interface CreateCompileToolOptions {
  * Create a yakcc_compile ToolModule with an optionally injected registry factory.
  *
  * Handler is a closure over the lazy registry promise. The registry is opened
- * once and seeded once per tool instance. The seeded merkle roots are cached
- * alongside the registry so subsequent calls don't re-seed.
+ * once, seeded once, and the FULL block root set is enumerated once per tool
+ * instance (DEC-1028-COMPILE-FULL-ROOTS-001). All three are cached so subsequent
+ * calls pay zero setup cost.
  *
  * @param opts - Optional registry factory override (for tests).
  */
 export function createCompileTool(opts?: CreateCompileToolOptions): ToolModule {
-  // Lazy-cached registry + seed state (opened and seeded at most once per instance).
-  let registryPromise: Promise<{ registry: Registry; seedResult: SeedResult }> | null = null;
+  // Lazy-cached registry + full block roots (opened/enumerated at most once per instance).
+  let registryPromise: Promise<{ registry: Registry; fullRoots: BlockMerkleRoot[] }> | null = null;
 
-  function getRegistryAndSeed(): Promise<{ registry: Registry; seedResult: SeedResult }> {
+  function getRegistryAndFullRoots(): Promise<{ registry: Registry; fullRoots: BlockMerkleRoot[] }> {
     if (registryPromise !== null) return registryPromise;
     const factory = opts?.openRegistry ?? defaultOpenRegistry;
     registryPromise = factory().then(async (registry) => {
-      // seedRegistry is idempotent (INSERT OR IGNORE) — safe to call on an
-      // already-seeded registry. We need its merkleRoots for short-id resolution.
-      const seedResult = await seedRegistry(registry);
-      return { registry, seedResult };
+      // Seed the registry so seed blocks are present for resolution and assembly.
+      // seedRegistry is idempotent (INSERT OR IGNORE) — safe on an already-seeded DB.
+      await seedRegistry(registry);
+
+      // Enumerate the FULL registry block root set (DEC-1028-COMPILE-FULL-ROOTS-001).
+      // This is the canonical pattern from packages/registry/src/rebuild.ts:104-112.
+      // Using seed roots alone misses non-seed atoms returned by yakcc_resolve.
+      const fullRoots: BlockMerkleRoot[] = [];
+      const specHashes = await registry.enumerateSpecs();
+      for (const sh of specHashes) {
+        const roots = await registry.selectBlocks(sh);
+        for (const root of roots) fullRoots.push(root);
+      }
+
+      return { registry, fullRoots };
     });
     return registryPromise;
   }
@@ -219,11 +244,11 @@ export function createCompileTool(opts?: CreateCompileToolOptions): ToolModule {
 
       const { atomId } = parsed;
 
-      // --- Open registry + seed (lazy, cached) ---
+      // --- Open registry + seed + enumerate full roots (lazy, cached) ---
       let registry: Registry;
-      let seedResult: SeedResult;
+      let fullRoots: BlockMerkleRoot[];
       try {
-        ({ registry, seedResult } = await getRegistryAndSeed());
+        ({ registry, fullRoots } = await getRegistryAndFullRoots());
       } catch (err) {
         return [
           {
@@ -236,8 +261,8 @@ export function createCompileTool(opts?: CreateCompileToolOptions): ToolModule {
         ];
       }
 
-      // --- Short-id → full-root resolution ---
-      const resolved = resolveAtomId(atomId, seedResult.merkleRoots);
+      // --- Short-id → full-root resolution (against FULL registry, not seed-only) ---
+      const resolved = resolveAtomId(atomId, fullRoots);
 
       if (resolved.kind === "not_found") {
         return [
@@ -272,7 +297,7 @@ export function createCompileTool(opts?: CreateCompileToolOptions): ToolModule {
       let artifact: Artifact;
       try {
         artifact = await assemble(entryRoot, registry, undefined, {
-          knownMerkleRoots: seedResult.merkleRoots,
+          knownMerkleRoots: fullRoots,
         });
       } catch (err) {
         return [


### PR DESCRIPTION
Fixes the HIGH-severity bug that makes `yakcc_compile` (#1007) non-functional for most real atoms in the IDE.

## Bug
`yakcc_compile` resolved a short `atom_id` by prefix-matching `seedRegistry().merkleRoots` (~26 seed-block roots only), but `yakcc_resolve` returns 8-char candidate ids from the **full** registry. So compile returned `not_found`/"ghost reference" for any resolved atom that wasn't a seed block — the model gets nothing back and falls back to authoring. Trace-confirmed in the B4-v5 rerun (the exact blocker that kept substitution from firing).

## Fix (DEC-1028-COMPILE-FULL-ROOTS-001)
Enumerate **all** block roots from the registry (`enumerateSpecs()` → `selectBlocks(specHash)`) and use that full set for both short-id prefix matching and `assemble()`'s `knownMerkleRoots`, replacing the seed-root set. One short-id authority; compile now consults the same registry `yakcc_resolve` queries.

## Evidence
New regression test `(2c)`: a non-seed atom (in the full block set, NOT in `seedRegistry().merkleRoots`) now resolves via short id to real assembled source — **fails against the old seed-roots logic, passes with the fix**. 173/173 mcp-registry tests pass (incl. the existing 18-case compile suite); full-workspace build/typecheck/lint green. `resolve.ts`/#1006 untouched.

This was the last gap between the proactive flow and real-IDE benefit: with it fixed, the B4-v5 rerun showed all three models compose-by-reference correctly.

Closes #1028
Refs #1007 #950 #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)