### PR TITLE
fix(compile-python): extract template-literal ternaries so self-shave can atomize

### DIFF
--- a/packages/compile-python/src/lower.ts
+++ b/packages/compile-python/src/lower.ts
@@ -572,7 +572,13 @@ function lowerCall(node: Node, ctx: Ctx): string {
       }
       const start = args[0];
       const end = args[1];
-      return `${objStr}[${start ? lowerExpr(start, ctx) : ""}:${end ? lowerExpr(end, ctx) : ""}]`;
+      // Extracted to locals so the template literal interpolates plain
+      // identifiers — a single template with two inline ternary+call branches
+      // is the one shape the self-shave atomizer can't decompose (single inline
+      // ternary works at the args.length === 1 branch above).
+      const startStr = start ? lowerExpr(start, ctx) : "";
+      const endStr = end ? lowerExpr(end, ctx) : "";
+      return `${objStr}[${startStr}:${endStr}]`;
     }
 
     // xs.push(v) → xs.append(v)


### PR DESCRIPTION
## Why

Self-shave (two-pass bootstrap equivalence CI) has been red on every run since #826 (compile-python lower MVP) landed. The blocker:

```
packages/compile-python/src/lower.ts:575
  DidNotReachAtomError — Node at [20780, 20864) (kind=TemplateExpression)
  is not atomic and has no decomposable children
```

## What was wrong

```ts
return `${objStr}[${start ? lowerExpr(start, ctx) : ""}:${end ? lowerExpr(end, ctx) : ""}]`;
```

The shave atomizer handles template literals with **one** inline ternary+call branch (line 571 above this works). The compound shape — template with **two** inline ternaries each calling a function and a string literal — has no atomic match and no child small enough to be its own atom.

8 other sites in the same file with 0 or 1 inline ternary all shave fine. Only this one shape fails.

## Fix

Extract both ternaries into named locals; template then interpolates plain identifiers (trivially atomic).

```ts
const startStr = start ? lowerExpr(start, ctx) : "";
const endStr = end ? lowerExpr(end, ctx) : "";
return `${objStr}[${startStr}:${endStr}]`;
```

Behavior identical. 100/100 compile-python tests still pass.

## Verification

```bash
$ pnpm --filter @yakcc/compile-python test
 Test Files  3 passed (3)
      Tests  100 passed (100)

$ node packages/cli/dist/bin.js shave packages/compile-python/src/lower.ts --offline
... (lots of atoms, including the slice fragments) ...
exit: 0
```

Previously: `DidNotReachAtomError` on the same invocation.

## Followups

- **#1031** (new) — separate self-shave breakage from #1017 (re-embedded bootstrap registry vs bootstrap's `null-zero` provider). Both fixes are needed for full self-shave green.
- The underlying shaver gap (template + multi-inline-ternary should decompose) remains — should be filed as its own issue against the shave pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)