### PR TITLE
feat(mcp-registry): #1029 — high-confidence auto_accept override (top > 0.92 waives gap)

### DIFF
--- a/docs/system-prompts/yakcc-discovery.md
+++ b/docs/system-prompts/yakcc-discovery.md
@@ -107,8 +107,11 @@ Build the `query` field as:
 - score < 0.50 (poor):     `result.status` = "no_match". You MUST zoom in and query
                             sub-intents. NEVER write the code directly on a no_match.
 
-Auto-accept rule: if `combinedScore` > 0.85 AND the gap to the second-best candidate is
-> 0.05, the tool returns `confidence_tier: "auto_accept"`. See **Compile and stop** below.
+Auto-accept rule: the tool returns `confidence_tier: "auto_accept"` when either:
+- `combinedScore > 0.92` (high-confidence override — gap requirement waived), OR
+- `combinedScore > 0.85` AND the gap to the second-best candidate `> 0.05`
+
+See **Compile and stop** below.
 
 ## Compile and stop
 

--- a/packages/mcp-registry/src/tools/resolve.test.ts
+++ b/packages/mcp-registry/src/tools/resolve.test.ts
@@ -403,9 +403,45 @@ describe("yakcc_resolve handler — confidence band mapping", () => {
     }
   });
 
-  it("auto_accept tier: matched status + score>0.92 AND gap>0.15 → auto_accept", async () => {
-    // Single candidate, score 0.95. No second candidate → gap is effectively 1.0 > 0.15.
+  it("auto_accept tier: matched status + score>0.85 AND gap>0.05 → auto_accept", async () => {
+    // Single candidate, score 0.95. No second candidate → gap is effectively 1.0 > 0.05.
     vi.mocked(yakccResolve).mockResolvedValue(makeAutoAcceptResult());
+    const http = makeHttp();
+    const result = await tool.handler({ intent: { title: "hash string" } }, http);
+    const parsed = JSON.parse(result[0]!.text) as { confidence_tier: string };
+    expect(parsed.confidence_tier).toBe("auto_accept");
+  });
+
+  // @mock-exempt: mirrors the established mock pattern in this describe block
+  // (yakccResolve is replaced via vi.mock("@yakcc/hooks-base") at the top so
+  // every tier test can drive the unit-under-test deterministically).
+  it("auto_accept tier: #1029 high-confidence override — top>0.92 auto-accepts regardless of gap", async () => {
+    // Top 0.95 with a 2nd candidate at 0.93 -> gap is 0.02 (< 0.05 threshold).
+    // Without the override this would be candidate_list and the model would
+    // hedge; with override it correctly auto-accepts.
+    vi.mocked(yakccResolve).mockResolvedValue({
+      status: "matched",
+      candidates: [
+        {
+          address: "aaaabbbb",
+          behavior: "perfect match",
+          signature: "(x: string) => number",
+          score: 0.95,
+          guarantees: [],
+          tests: { count: 2 },
+          usage: null,
+        },
+        {
+          address: "ccccdddd",
+          behavior: "very close runner-up",
+          signature: "(x: string) => number",
+          score: 0.93,
+          guarantees: [],
+          tests: { count: 2 },
+          usage: null,
+        },
+      ],
+    });
     const http = makeHttp();
     const result = await tool.handler({ intent: { title: "hash string" } }, http);
     const parsed = JSON.parse(result[0]!.text) as { confidence_tier: string };

--- a/packages/mcp-registry/src/tools/resolve.ts
+++ b/packages/mcp-registry/src/tools/resolve.ts
@@ -119,6 +119,18 @@ const HYBRID_AUTO_ACCEPT_THRESHOLD = 0.85;
  */
 const AUTO_ACCEPT_GAP_THRESHOLD = 0.05;
 
+/**
+ * High-confidence auto-accept override: when top score exceeds this, gap rule
+ * is waived. Per #1029 (B4-v5 rerun): real corpora cluster semantic neighbors
+ * tightly, so a 0.95 top-1 correct match can land in candidate_list when the
+ * 2nd-best is within 0.05. The flow rule "drop the gap requirement when top
+ * is very strong" exists precisely for this case.
+ *
+ * Source: #1029 issue body recommendation.
+ * Cross-reference: DEC-1029-HIGH-CONF-OVERRIDE-001.
+ */
+const HIGH_CONFIDENCE_THRESHOLD = 0.92;
+
 // ---------------------------------------------------------------------------
 // Public IntentCard input shape (minimal subset for MCP surface)
 // ---------------------------------------------------------------------------
@@ -150,13 +162,19 @@ type ConfidenceTier = "auto_accept" | "candidate_list" | "no_candidates";
 /**
  * Map a ResolveResult's candidates to one of three D4 ADR Q5 confidence tiers.
  *
- * auto_accept:    top score > HYBRID_AUTO_ACCEPT_THRESHOLD (0.85)
- *                 AND gap to second candidate > AUTO_ACCEPT_GAP_THRESHOLD (0.05)
+ * auto_accept:    top score > HIGH_CONFIDENCE_THRESHOLD (0.92), gap waived
+ *                 OR top score > HYBRID_AUTO_ACCEPT_THRESHOLD (0.85)
+ *                    AND gap to second candidate > AUTO_ACCEPT_GAP_THRESHOLD (0.05)
  * candidate_list: has candidates but not auto_accept
  * no_candidates:  no candidates after full merge
  *
  * This logic is the MCP adapter's responsibility (D4 ADR Q5 "hybrid" mode).
  * yakccResolve returns the raw status + candidates; the adapter maps to tiers.
+ *
+ * #1029: high-confidence override added. Real corpora cluster semantic neighbors
+ * tightly (gap < 0.05 common even for clearly-correct top-1), so strong matches
+ * were getting suppressed into candidate_list and the compile-and-stop flow never
+ * fired. The override lets very high top-1 scores commit unconditionally.
  */
 function deriveConfidenceTier(candidates: readonly EvidenceProjection[]): ConfidenceTier {
   if (candidates.length === 0) {
@@ -168,6 +186,11 @@ function deriveConfidenceTier(candidates: readonly EvidenceProjection[]): Confid
   const topScore = top.score;
   const secondScore = candidates[1]?.score ?? 0;
   const gap = topScore - secondScore;
+
+  // #1029: high-confidence override — drop the gap requirement when top is very strong.
+  if (topScore > HIGH_CONFIDENCE_THRESHOLD) {
+    return "auto_accept";
+  }
 
   if (topScore > HYBRID_AUTO_ACCEPT_THRESHOLD && gap > AUTO_ACCEPT_GAP_THRESHOLD) {
     return "auto_accept";


### PR DESCRIPTION
Per #1029 (B4-v5 rerun empirical evidence): #1009's threshold retune (0.92→0.85, 0.15→0.05) helped a lot, but a 0.95 top-1 correct match with a 2nd candidate at 0.93 (gap 0.02 < 0.05 threshold) still landed in candidate_list. Models then hedged instead of substituting — compile-and-stop flow never fired. Harness experiment relaxing to top > 0.90 flipped all 6 hooked cells to substitute, output tokens ~halved.

## Fix — option 1 from the #1029 issue body

Add high-confidence override path:
- **top > 0.92** → auto_accept regardless of gap (overwhelming match)
- **top > 0.85 + gap > 0.05** → auto_accept (good match cleanly separated)
- else → candidate_list

Real corpora cluster semantic neighbors tightly; a strong top-1 should not be suppressed because a slightly weaker neighbor is also semantically related.

## Files

- packages/mcp-registry/src/tools/resolve.ts — HIGH_CONFIDENCE_THRESHOLD = 0.92 added; deriveConfidenceTier checks it before the gap rule.
- packages/mcp-registry/src/tools/resolve.test.ts — new test exercises the override path (top 0.95, 2nd 0.93, gap 0.02 → auto_accept).
- docs/system-prompts/yakcc-discovery.md — auto-accept rule documents both cases.

@decision DEC-1029-HIGH-CONF-OVERRIDE-001 layered on DEC-1009-THRESHOLD-RETUNE-001.

## Verification

```
pnpm --filter @yakcc/mcp-registry test
 Test Files  14 passed (14)
      Tests  171 passed (171)
```

Closes #1029