### PR TITLE
docs(discovery): #1030 forceful write-verbatim substitution directive (preserves #1029)

### DIFF
--- a/docs/archive/developer/adr/discovery-llm-interaction.md
+++ b/docs/archive/developer/adr/discovery-llm-interaction.md
@@ -485,6 +485,66 @@ file at `docs/system-prompts/yakcc-discovery.md`.
 
 ---
 
+### Q9: Forceful substitution directive — B4-v5 rerun (2026-05-31)
+
+**Decision:** Replace the weak "Compile and stop" section in
+`docs/system-prompts/yakcc-discovery.md` with an imperative substitution directive
+that makes the `yakcc_compile` → verbatim-write path unambiguous and frames
+re-implementation as a protocol violation.
+
+**What changed:**
+
+The pre-1030 "Compile and stop" section (predating the `yakcc_compile` tool→source
+path) gave soft guidance:
+
+- "your final answer for that sub-intent MUST be a single line: `yakcc compile <atom_id>`"
+- "Do NOT also write or restate the implementation."
+
+The B4-v5 benchmark rerun identified the failure mode: models were calling
+`yakcc_compile` (compile=1 in 5/6 hooked cells) but then re-authoring the full
+implementation anyway (`wrote_compiled_source=false` everywhere), producing 3,400–5,100
+output tokens of unnecessary re-implementation. The old directive targeted the pre-tool
+CLI path and did not address the case where the tool returns a `source` field that the
+model should write verbatim.
+
+The revised directive (as of this WI, issue #1030) replaces the weak section with:
+
+1. An explicit 4-step sequence: call `yakcc_compile({ atom_id })` → tool returns
+   `source` → write THAT EXACT `source` verbatim using Write/Edit → STOP.
+2. A "protocol violation" framing for re-implementation: "Re-implementing what
+   `yakcc_compile` already returned is a protocol violation."
+3. A correct-flow diagram (`yakcc_resolve → auto_accept → yakcc_compile → Write(verbatim)`).
+4. An explicit "Do NOT" list covering the four observed failure patterns.
+5. A "stop immediately, delete, substitute" instruction for mid-stream self-correction.
+
+**Empirical evidence:**
+
+With the new directive + `auto_accept` tier firing (the score/confidence band gate) +
+the #1028 compile fix (which corrected `atom_id` → correct field in the tool call),
+all 6 hooked B4-v5 cells flipped from re-authoring to verbatim substitution
+(`wrote_compiled_source=true`). Output token count halved vs the hedge/re-author
+baseline. This is the empirical validation that justifies the wording as production
+copy rather than a further experimental variant.
+
+**Invariants verified (DEC-BENCH-B4-V5-SUBSTITUTION-DIRECTIVE-001):**
+- `grep -c "protocol violation" docs/system-prompts/yakcc-discovery.md` ≥ 1
+- `grep -ci "verbatim" docs/system-prompts/yakcc-discovery.md` ≥ 1
+- `grep -c "DEC-BENCH-B4-V5-SUBSTITUTION-DIRECTIVE-001" docs/system-prompts/yakcc-discovery.md` ≥ 1
+- The `## Compile and stop` section exists exactly once (no duplicate/contradictory section).
+
+**What is NOT changed:** D4 design decisions Q1–Q8 remain in force. The tool call
+shape, evidence rendering contract, 4-band protocol, `status` enum, `ConfidenceMode`
+type, failure-mode shapes, and D4/D5 boundary are all unchanged. Only the
+"Compile and stop" subsection of the system-prompt text is updated.
+
+**Rollback:** `git revert` the WI-1030 landing commit.
+
+**Issue:** https://github.com/cneckar/yakcc/issues/1030
+**Decision ID:** DEC-BENCH-B4-V5-SUBSTITUTION-DIRECTIVE-001
+**Date:** 2026-05-31
+
+---
+
 ### Q7: Boundary with D5 (quality measurement)
 
 **Decision:** D4 pins **interaction shape** in v1; D5 measures and tunes **calibration knobs**.
@@ -912,6 +972,8 @@ The fallback path is intentionally NOT retired. Agents in the wild that don't kn
 
 ## References
 
+- Issue #1030 (WI-1030 — Forceful substitution directive; D4 ADR revision in Q9)
+- `DEC-BENCH-B4-V5-SUBSTITUTION-DIRECTIVE-001` — B4-v5 rerun empirical validation; forceful compile-and-stop directive (`docs/system-prompts/yakcc-discovery.md`, Q9 of this ADR)
 - Issue #578 (WI-578 — Descent-and-Compose prompt rewrite; D4 ADR revision in Q8)
 - Issue #154 (this work item — V3-DISCOVERY-D4)
 - Issue #153 (D3 — V3-DISCOVERY-D3)

--- a/docs/system-prompts/yakcc-discovery.md
+++ b/docs/system-prompts/yakcc-discovery.md
@@ -115,25 +115,53 @@ See **Compile and stop** below.
 
 ## Compile and stop
 
-When `yakcc_resolve` returns `confidence_tier: "auto_accept"`, your final answer
-for that sub-intent MUST be a single line:
+<!-- @decision DEC-BENCH-B4-V5-SUBSTITUTION-DIRECTIVE-001
+     @title Forceful substitution directive for yakcc_compile tool path
+     @status accepted
+     @rationale
+       Minimal rerun showed models now CALL yakcc_compile (compile=1 in 5/6 hooked
+       cells) but wrote_compiled_source=false everywhere — they receive the assembled
+       source from the tool and then re-author the full implementation anyway
+       (~3400–5100 output tokens). This directive makes the substitution path
+       unambiguous: the compiled source IS the answer; writing your own is a failure.
+       With the directive + auto_accept firing + the #1028 compile fix, all 6 hooked
+       B4-v5 cells flipped from re-authoring to verbatim substitution
+       (wrote_compiled_source=true); output token count halved vs the hedge baseline.
+       Issue: https://github.com/cneckar/yakcc/issues/1030 -->
 
+When `yakcc_resolve` returns `confidence_tier: "auto_accept"`:
+
+1. Call `yakcc_compile({ atom_id: candidates[0].atom_id })` immediately.
+2. The tool returns a `source` field — that IS the final implementation.
+3. Write THAT EXACT `source` string to the target file using the Write or Edit
+   tool. Copy it verbatim — do not paraphrase, restructure, or re-implement.
+4. STOP. Do not write any additional code.
+
+**This is not a suggestion. Re-implementing what `yakcc_compile` already returned
+is a protocol violation.** The source returned by `yakcc_compile` is authoritative,
+tested, and registry-stamped. Writing your own version instead creates an untested
+divergent copy and defeats the entire value of yakcc. If you write code when
+`yakcc_compile` returned a `source`, you have failed the flow.
+
+The correct sequence on `auto_accept` is exactly this:
 ```
-yakcc compile <atom_id>
+yakcc_resolve(intent) → auto_accept
+  → yakcc_compile({ atom_id }) → { source: "..." }
+  → Write(target_file, source)   ← verbatim, end of story
 ```
 
-where `<atom_id>` is `candidates[0].block_merkle_root`. **Do NOT also write or
-restate the implementation.** The build substrate inlines the atom body from
-the registry — re-emitting it is wasted tokens and creates a second copy that
-drifts from the canonical version.
+**Do NOT:**
+- Write your own implementation after receiving the compiled source
+- Paraphrase or restate the implementation in your own words
+- Emit the source as a markdown code block and then also write a "cleaner" version
+- Skip `yakcc_compile` and write code based only on the resolve summary
 
-On `auto_accept` the envelope also includes `atom_body` (the inlined function
-source). You already have what you need to verify the fit; you do not need to
-call `yakcc_get_atom` again.
+On `auto_accept` the score met the auto-accept confidence band. Trust it.
+The registry is authoritative; your re-implementation is not.
 
-If you find yourself writing the function body anyway "to be safe" — stop.
-The match is auto-accept precisely because the score and the gap exceeded the
-thresholds. Trust the registry.
+If you find yourself writing a function body "to be safe" after `yakcc_compile`
+returned a source — stop immediately, delete what you wrote, and substitute the
+compiled source instead.
 
 ## Inspecting an atom before committing
 

--- a/packages/hooks-claude-code/test/system-prompt.test.ts
+++ b/packages/hooks-claude-code/test/system-prompt.test.ts
@@ -167,7 +167,9 @@ describe("score bands and auto-accept rule", () => {
   it("documents the auto-accept rule with both conditions", () => {
     expect(prompt).toMatch(/auto.accept|auto accept/i);
     expect(prompt).toMatch(/0\.85/);
-    expect(prompt).toMatch(/0\.15/);
+    // #1029 revised the gap threshold from 0.15 to 0.05 (and added the 0.92 high-confidence
+    // override that waives the gap entirely). Verify the current rule is present.
+    expect(prompt).toMatch(/0\.05|0\.92/);
   });
 });
 
@@ -182,5 +184,28 @@ describe("ADR authority line", () => {
 
   it("references the WI-578 revision decision record", () => {
     expect(prompt).toContain("DEC-WI578");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Forceful substitution directive (#1030 / DEC-BENCH-B4-V5-SUBSTITUTION-DIRECTIVE-001)
+// ---------------------------------------------------------------------------
+
+describe("forceful substitution directive (WI-1030)", () => {
+  it("frames re-implementation as a protocol violation", () => {
+    // The B4-v5 validated wording that flipped all 6 hooked cells.
+    expect(prompt).toContain("protocol violation");
+  });
+
+  it("instructs writing the compiled source verbatim", () => {
+    expect(promptLower).toContain("verbatim");
+  });
+
+  it("carries the DEC-BENCH-B4-V5-SUBSTITUTION-DIRECTIVE-001 annotation", () => {
+    expect(prompt).toContain("DEC-BENCH-B4-V5-SUBSTITUTION-DIRECTIVE-001");
+  });
+
+  it("provides an explicit Do NOT list for the compile path", () => {
+    expect(prompt).toMatch(/Do NOT/);
   });
 });


### PR DESCRIPTION
Re-applied on current main so #1030 and #1029 **compose** instead of conflict (the prior #1038 branch clashed with #1029's auto_accept override). 

Adds the empirically-validated forceful directive to `yakcc-discovery.md` 'Compile and stop': on a strong match, call `yakcc_compile({atom_id})` and **write the returned source verbatim, then STOP — re-implementing is a protocol violation**. Gap-agnostic framing.

**Preserves #1029:** the relaxed auto-accept rule (`combinedScore > 0.92` waives the gap) is left untouched — that override is what makes auto_accept fire, which the B4-v5 rerun showed is required. The two fixes are coherent.

Bundle: prompt + D4 ADR Q9 (DEC-BENCH-B4-V5-SUBSTITUTION-DIRECTIVE-001, coexists with #1029's ADR entry) + test assertions. 44/44 tests, full-workspace green, no `packages/**/src`.

Closes #1030
Refs #1007 #1028 #1029 #950 #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)