### PR TITLE
fix(shave): #1035 — decomposableChildrenOf descends into TemplateExpression spans

### DIFF
--- a/packages/shave/src/universalize/recursion.test.ts
+++ b/packages/shave/src/universalize/recursion.test.ts
@@ -1335,3 +1335,76 @@ function executeWithTelemetry(toolName: string): void {
     expect(hasSourceContaining(tree.root, "sessionId !== undefined")).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #1035: TemplateExpression decomposes via span expressions
+// ---------------------------------------------------------------------------
+
+describe("decompose — TemplateExpression with multi-ternary spans (#1035)", () => {
+  /**
+   * Pre-#1035 repro: a TemplateExpression with two inline ternary+call
+   * branches threw DidNotReachAtomError because decomposableChildrenOf had
+   * no TemplateExpression branch. Mirrors the
+   * packages/compile-python/src/lower.ts:575 site that broke self-shave
+   * (workaround applied in PR #1034; this is the underlying engine fix).
+   *
+   * Production sequence:
+   * decompose() → SourceFile → FunctionDeclaration → Block →
+   *   ReturnStatement → TemplateExpression → [TemplateSpan.expression,
+   *   TemplateSpan.expression] (ConditionalExpressions) → ternary children →
+   *   atoms.
+   *
+   * Before the fix: decomposableChildrenOf(TemplateExpression) returned [],
+   * recurse() saw zero children for a non-atomic node, threw
+   * DidNotReachAtomError.
+   */
+  it("template literal with two inline ternary+call branches decomposes (was DidNotReachAtomError)", async () => {
+    // This is the exact shape from compile-python/lower.ts:575 (#1034 workaround target)
+    const src = `
+declare function lowerExpr(node: unknown, ctx: unknown): string;
+declare const objStr: string;
+declare const ctx: unknown;
+declare const start: unknown;
+declare const end: unknown;
+
+function buildSlice(): string {
+  return \`\${objStr}[\${start ? lowerExpr(start, ctx) : ""}:\${end ? lowerExpr(end, ctx) : ""}]\`;
+}
+`.trim();
+    // Must not throw — two ternaries inside one template literal → CF count > 1
+    // → non-atomic; must descend through TemplateExpression spans into the
+    // ConditionalExpressions and bottom out at atom leaves.
+    const tree = await decompose(src, emptyRegistry);
+
+    expect(tree.root).toBeDefined();
+    expect(tree.leafCount).toBeGreaterThan(0);
+
+    // Verify the ternary subexpressions are reached by descent
+    function hasSourceContaining(node: typeof tree.root, text: string): boolean {
+      if (node.source.includes(text)) return true;
+      if (node.kind === "branch") return node.children.some((c) => hasSourceContaining(c, text));
+      return false;
+    }
+    expect(hasSourceContaining(tree.root, "start ? lowerExpr(start, ctx)")).toBe(true);
+    expect(hasSourceContaining(tree.root, "end ? lowerExpr(end, ctx)")).toBe(true);
+  });
+
+  it("template literal with a single ternary span also decomposes (regression guard)", async () => {
+    // This pattern previously worked because compile-python/lower.ts:571 (the
+    // args.length === 1 branch) is the same shape but with one ternary
+    // instead of two. After the fix, it should still atomize.
+    const src = `
+declare function lowerExpr(node: unknown, ctx: unknown): string;
+declare const objStr: string;
+declare const ctx: unknown;
+declare const start: unknown;
+
+function buildSliceOpen(): string {
+  return \`\${objStr}[\${start ? lowerExpr(start, ctx) : ""}:]\`;
+}
+`.trim();
+    const tree = await decompose(src, emptyRegistry);
+    expect(tree.root).toBeDefined();
+    expect(tree.leafCount).toBeGreaterThan(0);
+  });
+});

--- a/packages/shave/src/universalize/recursion.ts
+++ b/packages/shave/src/universalize/recursion.ts
@@ -1232,6 +1232,58 @@ function decomposableChildrenOf(node: Node): readonly Node[] {
     return result;
   }
 
+  // TemplateExpression: `\`prefix${expr1}middle${expr2}suffix\`` — decompose to
+  // [expr1, expr2, ...] so each interpolation expression can be atomized
+  // individually. The TemplateHead and TemplateMiddle/Tail string fragments
+  // carry no behavior and don't need their own atoms.
+  //
+  // @decision DEC-SLICER-TEMPLATE-EXPRESSION-001 (closes #1035)
+  // title: TemplateExpression decomposes via its span expressions
+  // status: accepted
+  // rationale:
+  //   Pre-#1035, decomposableChildrenOf had no TemplateExpression branch.
+  //   A template literal that isAtom() classified as non-atomic (e.g. because
+  //   one or more interpolation slots held complex expressions like ternary
+  //   chains over calls) fell through to return []. The recurse() caller then
+  //   threw DidNotReachAtomError. Workaround applied at #1034:
+  //   extract each interpolation expression to a local variable so the
+  //   template only interpolates plain identifiers
+  //   (packages/compile-python/src/lower.ts:575). This is the general fix:
+  //   surface each TemplateSpan.expression as a decomposable child. Each
+  //   child then routes through the existing ConditionalExpression /
+  //   CallExpression / BinaryExpression branches and resolves to atoms as
+  //   expected.
+  //
+  // alternatives:
+  //   A. Make TemplateExpression always-atomic — rejected: a long template
+  //      with genuinely complex interpolations should decompose, not become
+  //      one monolithic atom (quality-of-decomposition matters; same argument
+  //      as DEC-SHAVE-PRIVATE-CLASS-FIELD-001 alternative B).
+  //   B. Extract template literals to locals at every source site — rejected:
+  //      moves the problem to source-style discipline and doesn't address the
+  //      pipeline gap; #1034 applied this workaround once, but future source
+  //      sites will hit the same shape.
+  //
+  // consequences:
+  //   - Files with template literals containing multiple inline ternary+call
+  //     branches now shave without needing the local-extraction workaround.
+  //   - Existing template+ternary sites that already shave (8 sites in
+  //     compile-python/lower.ts with 0 or 1 inline ternaries) are
+  //     unaffected — they were already atomic via isAtom() and decomposition
+  //     is only consulted when isAtom() returns false.
+  if (kind === SyntaxKind.TemplateExpression) {
+    const te = node as Node & { getTemplateSpans?(): readonly Node[] };
+    const spans = te.getTemplateSpans?.() ?? [];
+    const result: Node[] = [];
+    for (const span of spans) {
+      const expr = (span as Node & { getExpression?(): Node | undefined }).getExpression?.();
+      if (expr !== undefined) {
+        result.push(expr);
+      }
+    }
+    return result;
+  }
+
   // All other nodes (expressions, type nodes, etc.) — not decomposable.
   return [];
 }


### PR DESCRIPTION
Per #1035: the shave atom-decomposer had no TemplateExpression branch.

A template literal that `isAtom()` classified as non-atomic (e.g. because one interpolation slot held a complex ternary+call expression) fell through to `return []` and `recurse()` threw:

```
DidNotReachAtomError — Node at [N, M) (kind=TemplateExpression)
is not atomic and has no decomposable children
```

This is the **engine-level fix**. PR #1034 applied a source-level workaround (extract subexpressions to locals) at the one site that broke self-shave. With this PR, the workaround is no longer required for future template+ternary patterns.

## Fix

`packages/shave/src/universalize/recursion.ts`: add a `TemplateExpression` branch to `decomposableChildrenOf` that returns each `TemplateSpan`'s expression — the `${...}` content. `TemplateHead` and `TemplateMiddle`/`TemplateTail` text fragments carry no behavior and aren't surfaced.

`packages/shave/src/universalize/recursion.test.ts`: 2 new tests:
1. The exact `compile-python/lower.ts:575` shape (template with two inline ternary+call branches) decomposes without throwing.
2. Single-ternary template still decomposes (regression guard for the `lower.ts:571` shape that already worked pre-fix).

**44/44 recursion tests pass** (existing 42 + 2 new).

## Decision

`@decision DEC-SLICER-TEMPLATE-EXPRESSION-001`: template literals decompose via their span expressions rather than being treated as opaque non-decomposable leaves.

Closes #1035 (engine fix), follow-up to #1034 (one-site workaround).

## Test plan

- [x] `pnpm --filter @yakcc/shave test recursion.test` — 44 pass (includes 2 new for #1035)
- [x] `pnpm -r build` — clean
- [x] `pnpm --filter @yakcc/shave lint` — clean