### PR TITLE
chore(release): bump to v0.7.0-alpha.2

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yakcc/cli",
-  "version": "0.7.0-alpha.1",
+  "version": "0.7.0-alpha.2",
   "description": "Yakcc — content-addressed block registry for assembling programs from verified, reusable building blocks.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/yakcc/package.json
+++ b/packages/yakcc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yakcc",
-  "version": "0.7.0-alpha.1",
+  "version": "0.7.0-alpha.2",
   "description": "Content-addressed block registry — yakcc CLI (unscoped alias for @yakcc/cli).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Cuts `v0.7.0-alpha.2` release. 18 commits landed since v0.7.0-alpha.1 was version-bumped in PR #1010 (alpha.1 was never tagged — alpha.2 is the first cut of the 0.7.0 line that actually publishes).

## Bumps

- `@yakcc/cli`: `0.7.0-alpha.1` → `0.7.0-alpha.2`
- `yakcc` wrapper: `0.7.0-alpha.1` → `0.7.0-alpha.2` (lockstep per fixed-group config)

## Notable since v0.7.0-alpha.1

### Discovery / MCP — the proactive substitution flow is now actually usable

- #1005 `yakcc init` registers MCP server in `.mcp.json` (proactive tools reachable from default Claude Code install)
- #1006 `yakcc_resolve` uses semantic embedding offline (was stub)
- #1007 `yakcc_compile` tool — discovered atoms become write-ready code
- #1008 CLAUDE.md @-import injects the 299-line discovery prompt into LLM context
- #1009 flow adherence + coherence: thresholds retuned (0.92→0.85, 0.15→0.05), atom_body inlined on auto_accept, compile-and-stop directive explicit
- #1013 re-embed shipped bootstrap registry with bge-small-en-v1.5 (was zero-vector)
- #1028 `yakcc_compile` resolves short ids against full registry
- #1029 high-confidence auto_accept override (top > 0.92 waives gap rule)
- #1030 forceful write-verbatim substitution directive in discovery prompt

### Website

- #1018, #1019, #1032, #1037, #1039: yakcc.com landing/benchmarks/docs rewritten for an outside audience, palette unified, mobile responsive, active-page highlighting, copy-button still dogfooded

### Engine

- #1011 CI fix
- #1034 compile-python workaround at lower.ts:575
- #1035 shave engine fix: `decomposableChildrenOf` now descends into TemplateExpression spans

## Release process

After merging this PR:
1. `git tag release-v0.7.0-alpha.2`
2. `git push origin release-v0.7.0-alpha.2`
3. Approve deployment in GH Actions UI (`release` environment gate).
4. OIDC trusted publisher publishes both packages with `--provenance`.