### PR TITLE
chore(release): bump to v0.7.0-alpha.3 — seed yakcc unscoped on npm

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yakcc/cli",
-  "version": "0.7.0-alpha.2",
+  "version": "0.7.0-alpha.3",
   "description": "Yakcc — content-addressed block registry for assembling programs from verified, reusable building blocks.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/yakcc/package.json
+++ b/packages/yakcc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yakcc",
-  "version": "0.7.0-alpha.2",
+  "version": "0.7.0-alpha.3",
   "description": "Content-addressed block registry — yakcc CLI (unscoped alias for @yakcc/cli).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Recovery release. v0.7.0-alpha.2 published `@yakcc/cli` successfully but the unscoped `yakcc` wrapper 404'd — npm rejects OIDC publish for a package that doesn't exist yet AND has no trusted-publisher entry, and npm's trusted-publisher UI is per-package on the package settings page (which doesn't exist for never-published packages).

## Recovery flow

1. **Merge this PR.**
2. Operator generates a one-shot **Granular Access Token** on npm:
   - npmjs.com → avatar → Access Tokens → Generate New Token → Granular
   - Permissions: `Read and write` for package `yakcc`
   - Expiration: 1 day
3. Operator publishes the unscoped wrapper locally once:
   ```bash
   git checkout main && git pull
   pnpm --filter yakcc publish --access public --tag latest \
     --otp <if-2fa> --token <granular-token>
   ```
4. `yakcc@0.7.0-alpha.3` is now on npm. Operator navigates to https://www.npmjs.com/package/yakcc and adds a Trusted Publisher entry mirroring `@yakcc/cli`'s (repo: `cneckar/yakcc`, workflow: `release.yml`, env: `release`).
5. Tag `release-v0.7.0-alpha.3` and push — the release workflow will publish `@yakcc/cli@0.7.0-alpha.3` via OIDC, and the second filter `yakcc` will succeed because trusted-publisher is now configured.

## What this PR changes

- `@yakcc/cli`: `0.7.0-alpha.2` → `0.7.0-alpha.3`
- `yakcc` wrapper: `0.7.0-alpha.2` → `0.7.0-alpha.3` (lockstep, `workspace:*` dep)