### PR TITLE
feat(discovery): #1048 emit reference on strong match — compose-by-reference prompt path (5/6)

### DIFF
--- a/docs/archive/developer/adr/discovery-llm-interaction.md
+++ b/docs/archive/developer/adr/discovery-llm-interaction.md
@@ -545,6 +545,84 @@ type, failure-mode shapes, and D4/D5 boundary are all unchanged. Only the
 
 ---
 
+### Q10: Compose-by-reference emit path on strong match (2026-06-01)
+
+**Decision:** When `.yakcc/manifest.json` is present at the project root
+(indicating the project is wired for `yakcc build`), on `auto_accept` the model
+MUST call `yakcc_reference` (not `yakcc_compile`) and write only the returned
+`import_line` (~10 tokens). The verbatim `yakcc_compile` path from Q9/#1030
+remains valid for projects not wired for compose-by-reference.
+
+**Detection signal:** `.yakcc/manifest.json` presence at project root. This file
+is created when the project adopts compose-by-reference (#1044). Its presence is
+the unambiguous signal that `yakcc build` is wired and will materialize atom
+implementations at build time.
+
+**What changed:**
+
+The Q9 directive (#1030) mandated: `yakcc_resolve → auto_accept →
+yakcc_compile → Write(source verbatim)`. The B4-v5 rerun (#1041) proved this
+path is token-negative: writing `yakcc_compile`'s returned source (~370 tokens)
+equals re-authoring the implementation. The reference-emit path collapses that
+to ~10 tokens (the import line alone).
+
+The revised two-branch directive (as of this WI, issue #1048) adds a detection
+gate before the Q9 sequence:
+
+1. **Reference path** (`.yakcc/manifest.json` present — preferred, token-savings):
+   - Call `yakcc_reference({ atom_id: candidates[0].atom_id })` — NOT `yakcc_compile`.
+   - Write the returned `import_line` verbatim to the target file.
+   - Append the returned `manifest_entry` to the `references` array in
+     `.yakcc/manifest.json`.
+   - Write the returned `dts_ref.dts` to `dts_ref.path` (enables typecheck before build).
+   - You MUST NOT write the atom's implementation body. `yakcc build` materializes it.
+
+2. **Verbatim path** (`.yakcc/manifest.json` absent — fallback, existing Q9 behaviour):
+   - Call `yakcc_compile({ atom_id })` and write the returned `source` verbatim.
+   - The Q9 "protocol violation" framing for re-implementation remains fully in force.
+
+**Token rationale (#1041):**
+- Verbatim path: ~370 output tokens (the full implementation body).
+- Reference path: ~10 output tokens (one import line).
+- Savings: ~360 tokens per `auto_accept` hit on a reference-wired project.
+- This is the empirical motivation documented in #1041 that justifies the
+  reference-emit path as the preferred fork rather than a suggestion.
+
+**Relationship to prior Q-sections:**
+- Branches from Q9/#1030: the verbatim `yakcc_compile` directive is preserved
+  as the fallback; it is NOT deleted or superseded for non-reference projects.
+- Coexists with #1029 (auto_accept tier): the detection gate fires AFTER
+  `auto_accept` is confirmed; the `confidence_tier` semantics and score bands
+  are unchanged.
+- References the `yakcc_reference` MCP tool introduced by #1047
+  (DEC-COMPOSE-BY-REF-REFERENCE-TOOL-001).
+
+**Invariants verified (DEC-COMPOSE-BY-REF-REFERENCE-EMIT-001):**
+- `grep -c "yakcc_reference" docs/system-prompts/yakcc-discovery.md` ≥ 1
+- `grep -c "manifest.json" docs/system-prompts/yakcc-discovery.md` ≥ 1
+- `grep -c "import_line" docs/system-prompts/yakcc-discovery.md` ≥ 1
+- `grep -c "manifest_entry" docs/system-prompts/yakcc-discovery.md` ≥ 1
+- `grep -c "dts_ref" docs/system-prompts/yakcc-discovery.md` ≥ 1
+- `grep -c "You MUST NOT write the atom" docs/system-prompts/yakcc-discovery.md` ≥ 1
+- The Section B verbatim path (yakcc_compile) still exists exactly once.
+- `grep -c "You SHOULD consider\|Try to\|When possible\|Reserve hand-written code"` = 0
+
+**What is NOT changed:** Q1–Q9 substantive decisions remain in force. The
+two-branch detection gate does not alter tool-call shape, evidence rendering
+contract, 4-band protocol, `status` enum, `ConfidenceMode` type, failure-mode
+shapes, or D4/D5 boundary. The Q9 verbatim `yakcc_compile` path is preserved as
+the fallback for all non-reference-wired projects.
+
+**Rollback:** `git revert` the WI-1048 landing commit. The prompt file reverts
+to the Q9/single-path form; Section A is removed; Section B reverts to the flat
+verbatim directive.
+
+**Issue:** https://github.com/cneckar/yakcc/issues/1048
+**Decision ID:** DEC-COMPOSE-BY-REF-REFERENCE-EMIT-001
+**Date:** 2026-06-01
+
+---
+
 ### Q7: Boundary with D5 (quality measurement)
 
 **Decision:** D4 pins **interaction shape** in v1; D5 measures and tunes **calibration knobs**.
@@ -972,6 +1050,10 @@ The fallback path is intentionally NOT retired. Agents in the wild that don't kn
 
 ## References
 
+- Issue #1048 (WI-1048 — Compose-by-reference reference-emit path; D4 ADR revision in Q10)
+- `DEC-COMPOSE-BY-REF-REFERENCE-EMIT-001` — reference-emit preferred path when `.yakcc/manifest.json` present (`docs/system-prompts/yakcc-discovery.md`, Q10 of this ADR)
+- Issue #1047 (`yakcc_reference` MCP tool; `DEC-COMPOSE-BY-REF-REFERENCE-TOOL-001`)
+- Issue #1041 (B4-v5 token-savings analysis; empirical basis for Q10)
 - Issue #1030 (WI-1030 — Forceful substitution directive; D4 ADR revision in Q9)
 - `DEC-BENCH-B4-V5-SUBSTITUTION-DIRECTIVE-001` — B4-v5 rerun empirical validation; forceful compile-and-stop directive (`docs/system-prompts/yakcc-discovery.md`, Q9 of this ADR)
 - Issue #578 (WI-578 — Descent-and-Compose prompt rewrite; D4 ADR revision in Q8)

--- a/docs/system-prompts/yakcc-discovery.md
+++ b/docs/system-prompts/yakcc-discovery.md
@@ -113,7 +113,23 @@ Auto-accept rule: the tool returns `confidence_tier: "auto_accept"` when either:
 
 See **Compile and stop** below.
 
-## Compile and stop
+## Compose by reference (preferred) and compile-and-stop (fallback)
+
+<!-- @decision DEC-COMPOSE-BY-REF-REFERENCE-EMIT-001
+     @title Compose-by-reference emit path on strong/auto_accept match
+     @status accepted
+     @rationale
+       B4-v5 rerun (#1041) proved that writing yakcc_compile's returned source
+       (~370 tokens) is token-negative compared to writing only the import line
+       (~10 tokens) when the project is wired for yakcc build. The yakcc_reference
+       tool (#1047, DEC-COMPOSE-BY-REF-REFERENCE-TOOL-001) returns
+       { manifest_entry, import_line, dts_ref } — the model writes the import line
+       verbatim and does NOT write the implementation body; yakcc build materializes
+       it. This path is preferred when .yakcc/manifest.json is present. The
+       yakcc_compile verbatim path remains valid for projects not wired for
+       compose-by-reference.
+       Issue: https://github.com/cneckar/yakcc/issues/1048
+       Branches from: DEC-BENCH-B4-V5-SUBSTITUTION-DIRECTIVE-001 (#1030) -->
 
 <!-- @decision DEC-BENCH-B4-V5-SUBSTITUTION-DIRECTIVE-001
      @title Forceful substitution directive for yakcc_compile tool path
@@ -130,6 +146,61 @@ See **Compile and stop** below.
        Issue: https://github.com/cneckar/yakcc/issues/1030 -->
 
 When `yakcc_resolve` returns `confidence_tier: "auto_accept"`:
+
+**Detection: is the project wired for compose-by-reference?**
+
+Check whether `.yakcc/manifest.json` exists at the project root.
+
+- If `.yakcc/manifest.json` IS present → use the **reference path** (Section A below).
+- If `.yakcc/manifest.json` is NOT present → use the **verbatim path** (Section B below).
+
+---
+
+### Section A — Reference path (`.yakcc/manifest.json` present)
+
+<!-- @decision DEC-COMPOSE-BY-REF-REFERENCE-EMIT-001 continued -->
+
+The project is wired for compose-by-reference. `yakcc build` (#1045) will
+materialize atom implementations from the manifest. You MUST NOT write the
+atom's implementation body — writing it duplicates work that `yakcc build` does
+and defeats the token-savings purpose of compose-by-reference.
+
+The correct sequence on `auto_accept` when `.yakcc/manifest.json` is present:
+
+```
+yakcc_resolve(intent) → auto_accept
+  → yakcc_reference({ atom_id: candidates[0].atom_id })
+      returns { manifest_entry, import_line, dts_ref: { path, dts } }
+  → Write import_line verbatim to the target file       ← ~10 tokens, end of story
+  → Append manifest_entry to .yakcc/manifest.json references array
+  → Write dts_ref.dts to dts_ref.path                  ← enables typecheck before build
+```
+
+Step by step — you MUST follow all four steps:
+
+1. Call `yakcc_reference({ atom_id: candidates[0].atom_id })`.
+2. Write the returned `import_line` verbatim to the target file. Copy it exactly
+   as returned — do not paraphrase or alter it.
+3. Append the returned `manifest_entry` to the `references` array in
+   `.yakcc/manifest.json`.
+4. Write the returned `dts_ref.dts` to `dts_ref.path` so the import typechecks
+   before `yakcc build` runs.
+
+**You MUST NOT write the atom's implementation body.** `yakcc build` materializes
+the implementation from the manifest. Writing the body yourself creates an
+untested divergent copy and wastes the token budget that compose-by-reference
+was designed to save.
+
+**This is not a suggestion.** Calling `yakcc_compile` and writing the full source
+when `.yakcc/manifest.json` is present is a protocol violation. Use
+`yakcc_reference` and write only the import line.
+
+---
+
+### Section B — Verbatim path (`.yakcc/manifest.json` absent)
+
+The project is NOT wired for compose-by-reference. You MUST use `yakcc_compile`
+and write the returned source verbatim.
 
 1. Call `yakcc_compile({ atom_id: candidates[0].atom_id })` immediately.
 2. The tool returns a `source` field — that IS the final implementation.

--- a/packages/hooks-base/test/system-prompt.test.ts
+++ b/packages/hooks-base/test/system-prompt.test.ts
@@ -232,6 +232,46 @@ describe("no forbidden carve-out keywords as permissive guidance", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Test: compose-by-reference path (#1048 / DEC-COMPOSE-BY-REF-REFERENCE-EMIT-001)
+// ---------------------------------------------------------------------------
+
+describe("compose-by-reference reference-emit path (WI-1048)", () => {
+  it("references the yakcc_reference MCP tool by name", () => {
+    expect(promptText).toMatch(/yakcc_reference/);
+  });
+
+  it("uses .yakcc/manifest.json as the detection signal", () => {
+    expect(promptText).toMatch(/\.yakcc\/manifest\.json/);
+  });
+
+  it("instructs writing import_line verbatim", () => {
+    expect(promptText).toMatch(/import_line/);
+  });
+
+  it("instructs recording manifest_entry", () => {
+    expect(promptText).toMatch(/manifest_entry/);
+  });
+
+  it("instructs writing dts_ref to enable typecheck before build", () => {
+    expect(promptText).toMatch(/dts_ref/);
+  });
+
+  it("forbids writing the atom implementation body on reference path (imperative)", () => {
+    expect(promptText).toMatch(/You MUST NOT write the atom/);
+  });
+
+  it("preserves the verbatim yakcc_compile fallback path for non-reference projects", () => {
+    // Section B must still instruct calling yakcc_compile and writing source verbatim.
+    expect(promptText).toMatch(/yakcc_compile/);
+    expect(promptText).toMatch(/verbatim/i);
+  });
+
+  it("carries the DEC-COMPOSE-BY-REF-REFERENCE-EMIT-001 annotation", () => {
+    expect(promptText).toMatch(/DEC-COMPOSE-BY-REF-REFERENCE-EMIT-001/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Test: structural invariants
 // ---------------------------------------------------------------------------
 

--- a/packages/hooks-claude-code/test/system-prompt.test.ts
+++ b/packages/hooks-claude-code/test/system-prompt.test.ts
@@ -188,6 +188,45 @@ describe("ADR authority line", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Compose-by-reference reference-emit path (#1048 / DEC-COMPOSE-BY-REF-REFERENCE-EMIT-001)
+// ---------------------------------------------------------------------------
+
+describe("compose-by-reference reference-emit path (WI-1048)", () => {
+  it("references the yakcc_reference MCP tool by name", () => {
+    expect(prompt).toMatch(/yakcc_reference/);
+  });
+
+  it("uses .yakcc/manifest.json as the detection signal for reference path", () => {
+    expect(prompt).toMatch(/\.yakcc\/manifest\.json/);
+  });
+
+  it("instructs writing import_line to the target file", () => {
+    expect(prompt).toMatch(/import_line/);
+  });
+
+  it("instructs recording manifest_entry into the manifest", () => {
+    expect(prompt).toMatch(/manifest_entry/);
+  });
+
+  it("instructs writing dts_ref to enable typecheck before build", () => {
+    expect(prompt).toMatch(/dts_ref/);
+  });
+
+  it("forbids writing the atom implementation body on the reference path (imperative)", () => {
+    expect(prompt).toMatch(/You MUST NOT write the atom/);
+  });
+
+  it("preserves the verbatim yakcc_compile fallback path for non-reference projects", () => {
+    expect(prompt).toMatch(/yakcc_compile/);
+    expect(promptLower).toContain("verbatim");
+  });
+
+  it("carries the DEC-COMPOSE-BY-REF-REFERENCE-EMIT-001 annotation", () => {
+    expect(prompt).toMatch(/DEC-COMPOSE-BY-REF-REFERENCE-EMIT-001/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Forceful substitution directive (#1030 / DEC-BENCH-B4-V5-SUBSTITUTION-DIRECTIVE-001)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Part of epic #1043 (compose-by-reference). Depends on #1047. [5/6] — the LLM-facing flow. **Governance: DEC-V3-DISCOVERY-D4-001 revision.**

## What
Revises the discovery system prompt so the model emits a ~10-token **reference** on a strong match instead of writing the atom impl verbatim — the token-savings path the D4 ADR originally intended.

- **`docs/system-prompts/yakcc-discovery.md`** — on `auto_accept`:
  - **Section A (new, preferred):** when `.yakcc/manifest.json` is present (project wired for compose-by-reference), call `yakcc_reference({atom_id})` (#1047), write the returned `import_line` verbatim, append `manifest_entry` to `.yakcc/manifest.json`, write `dts_ref.dts` to `dts_ref.path` — and **MUST NOT** write the implementation body (`yakcc build` materializes it).
  - **Section B (preserved):** the forceful verbatim `yakcc_compile` directive (#1030), now framed as the fallback for non-reference projects. Not weakened or deleted.
- **`docs/archive/developer/adr/discovery-llm-interaction.md`** — new **Q10** (DEC-COMPOSE-BY-REF-REFERENCE-EMIT-001): the decision, the #1041 token rationale (verbatim ~370 tok is token-negative; reference collapses output to ~10), relationships to #1029/#1030, and the detection signal.
- **Both `system-prompt.test.ts` suites** — +8 assertions each pinning the reference-emit content.

## Why it's safe
- Coexists with #1029 (auto_accept tier semantics unchanged — the gate fires *after* auto_accept is confirmed) and #1030 (verbatim path intact).
- **Reviewer verified** the prompt's instructed fields exactly match `yakcc_reference`'s real return shape (`{manifest_entry, import_line, dts_ref:{path,dts}}`) — no model-facing field mismatch.
- Imperative discipline preserved: 7 "You MUST" / 3 "You MUST NOT", **0** forbidden soft-suggestion phrases.
- `docs/system-prompts/yakcc-discovery.md` remains the single canonical source (loader `system-prompt.ts` untouched).

## Verification
**109 prompt tests green** (hooks-base 76+1todo, hooks-claude-code 33). Full-workspace build/lint/typecheck clean. Reviewer: ready_for_guardian (one non-blocking note re: fresh-project manifest timing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)