### PR TITLE
bench(B4-v5): reference-emit paid behavioral experiment (cost-gated harness)

### DIFF
--- a/bench/B4-tokens-v5/reference-emit/PAID-README.md
+++ b/bench/B4-tokens-v5/reference-emit/PAID-README.md
@@ -1,0 +1,107 @@
+# Reference-Emit Paid Experiment
+
+**Purpose:** Behavioral confirmation that a real model emits ~10 output tokens
+under the reference-emit flow vs hundreds under the verbatim-write flow.
+
+`measure.mjs` (#1041) proved the OUTPUT collapse OFFLINE via char/token estimation
+(50x ratio across the B4-v5 corpus). This experiment confirms the same phenomenon
+with real Anthropic API calls: does a model that receives the real discovery system
+prompt and is placed in the correct prompt-path actually write ~10 tokens in
+reference mode?
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `paid-experiment.mjs` | Main experiment script. `--dry` (default) validates wiring keyless. `--real` makes live API calls. |
+| `paid-experiment.test.mjs` | Vitest tests validating experiment construction in `--dry` mode (no API). |
+| `vitest.config.mjs` | Vitest config — includes both `measure.test.mjs` and `paid-experiment.test.mjs`. |
+| `results/paid-experiment.json` | Raw results written after a `--real` run. |
+| `results/paid-experiment.md` | Dossier written after a `--real` run. |
+
+## Design
+
+For each `(atom, model, condition, rep)` cell:
+
+- **system** = `docs/system-prompts/yakcc-discovery.md` (real discovery prompt, prompt-cached via `cache_control: {type: "ephemeral"}`).
+- **user message** simulates the state right before the model writes:
+  - **verbatim** condition: "You called `yakcc_compile` and received this source: `<IMPL>`. Complete the task now." — no mention of `.yakcc/manifest.json`, so the prompt's Section B fires → model should write the full impl body.
+  - **reference** condition: "This project is configured for compose-by-reference (`.yakcc/manifest.json` is present). You called `yakcc_reference` and received: `<JSON artifact>`. Complete the task now." — Section A fires → model should write only the import line (~10 tokens).
+- Reference artifacts are built by the real `@yakcc/compile` builders (`addReference`, `referenceImportLine`, `generateAtomDts`) — same approach as `measure.mjs`.
+
+**Atoms:**
+- Small: `crc32c`, `lru-ttl-cache` (from `tasks.json`)
+- Large: `avl-tree`, `dijkstra-heap` (from `tasks-hard.json`)
+
+**Models:** `claude-haiku-4-5-20251001`, `claude-sonnet-4-6`
+
+**Reps:** 2 per cell (configurable)
+
+## Cost Gate (mandatory)
+
+- `--dry` is the DEFAULT. No API calls, no key needed. Prints the full plan + per-cell messages + cost estimate.
+- `--real` requires `ANTHROPIC_API_KEY` in the environment. Errors out clearly if missing.
+- Hard `--max-usd` cap (default `$5.00`): estimates before running; refuses if estimate exceeds cap; aborts rolling spend if exceeded.
+- The key is read ONLY from `process.env.ANTHROPIC_API_KEY`. No `.env` files, no hardcoded values.
+
+## Running Dry (keyless validation)
+
+```bash
+node bench/B4-tokens-v5/reference-emit/paid-experiment.mjs --dry
+# Or equivalently (--dry is the default):
+node bench/B4-tokens-v5/reference-emit/paid-experiment.mjs
+```
+
+Prints: plan summary, cost estimate (~$0.40 for the default 32-cell matrix), per-cell messages (truncated). Makes zero API calls.
+
+## Running Tests (keyless)
+
+```bash
+cd bench/B4-tokens-v5/reference-emit
+npx vitest run --config vitest.config.mjs
+```
+
+Both `measure.test.mjs` and `paid-experiment.test.mjs` pass with no API key. 75 tests total.
+
+## Running Real (operator-gated)
+
+Once `ANTHROPIC_API_KEY` is available:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+node bench/B4-tokens-v5/reference-emit/paid-experiment.mjs --real
+```
+
+Configurable options:
+
+```bash
+node bench/B4-tokens-v5/reference-emit/paid-experiment.mjs --real \
+  --atoms crc32c,lru-ttl-cache,avl-tree,dijkstra-heap \
+  --models claude-haiku-4-5-20251001,claude-sonnet-4-6 \
+  --reps 2 \
+  --max-usd 5.00
+```
+
+Results are written to:
+- `results/paid-experiment.json` — raw cell data (output_tokens, input_tokens, cache fields, behavioral pass, response text)
+- `results/paid-experiment.md` — formatted dossier with per-(atom, model) averages and ratio
+
+## Expected Headline
+
+Reference condition expected output: ~10–20 tokens (import line + brief affirmation).
+Verbatim condition expected output: 200–600 tokens (full implementation body).
+Expected ratio: 20–60x, confirming the offline measure.mjs prediction.
+
+## Behavioral Correctness Flag
+
+For each reference-condition cell, the experiment records `behavioral_pass`:
+- `true` if the model's response contains the import line AND does not contain a distinctive snippet of the impl body.
+- `false` if the model wrote the impl anyway (protocol violation — Section A not followed).
+
+This is the key behavioral confirmation: if `behavioral_pass=true` across reference cells, the prompt conditioning is working correctly.
+
+## Scope
+
+- Does NOT modify `measure.mjs`, `phase2-v5.mjs`, `PROTOCOL.md`, or any governed harness file.
+- Standalone experiment under `bench/B4-tokens-v5/reference-emit/`.
+- Rollback: delete `paid-experiment.mjs`, `paid-experiment.test.mjs`, `PAID-README.md`, `results/paid-experiment.*`.

--- a/bench/B4-tokens-v5/reference-emit/paid-experiment.mjs
+++ b/bench/B4-tokens-v5/reference-emit/paid-experiment.mjs
@@ -1,0 +1,814 @@
+// SPDX-License-Identifier: MIT
+//
+// bench/B4-tokens-v5/reference-emit/paid-experiment.mjs
+//
+// @decision DEC-BENCH-B4-REFEMIT-PAID-001
+// @title Paid behavioral experiment: verbatim-write vs reference-emit output tokens
+// @status accepted (refemit-paid workflow, wi-rep)
+// @rationale
+//   measure.mjs (#1041) proved the OUTPUT collapse OFFLINE via char/token estimation.
+//   This experiment proves it LIVE: does a real model (Haiku, Sonnet) actually emit
+//   ~10 tokens in reference mode vs hundreds in verbatim mode when driven by the
+//   real discovery system prompt?
+//
+//   Design:
+//   - system  = real docs/system-prompts/yakcc-discovery.md (prompt-cached)
+//   - verbatim condition: simulate state after yakcc_compile (Section B of the prompt)
+//   - reference condition: simulate state after yakcc_reference (Section A of the prompt)
+//   - Reference artifacts built by real @yakcc/compile builders (same as measure.mjs)
+//   - One real Anthropic call per (atom, model, condition, rep)
+//   - Records usage.output_tokens + behavioral correctness flags
+//   - --dry (default): NO API calls; prints plan + per-cell messages + cost estimate
+//   - --real: requires ANTHROPIC_API_KEY; enforces --max-usd cap
+//
+//   Scope: OUTPUT token measurement only. Input amortization, cache economics, and
+//   multi-turn narration are measured by the v5 harness (phase2-v5.mjs).
+//
+// Usage:
+//   node bench/B4-tokens-v5/reference-emit/paid-experiment.mjs [--dry] [--real]
+//        [--atoms crc32c,lru-ttl-cache,avl-tree,dijkstra-heap]
+//        [--models claude-haiku-4-5-20251001,claude-sonnet-4-6]
+//        [--reps 2] [--max-usd 5.00]
+//
+// Exports (for paid-experiment.test.mjs):
+//   buildPlan(opts)              → ExperimentPlan
+//   buildVerbatimMessage(atom)   → string   (the user message for verbatim condition)
+//   buildReferenceMessage(atom)  → string   (the user message for reference condition)
+//   estimatePlanCostUsd(plan)    → { totalUsd, perCell }
+//   EXPERIMENT_DEFAULTS          → object
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BENCH_ROOT = resolve(__dirname, "..");
+const REPO_ROOT = resolve(__dirname, "../../..");
+const RESULTS_DIR = join(__dirname, "results");
+
+// ---------------------------------------------------------------------------
+// @yakcc/compile imports — real production reference-artifact builders
+// Same approach as measure.mjs: dynamic import of the compiled dist.
+// ---------------------------------------------------------------------------
+
+const { addReference, emptyManifest, referenceImportLine, generateAtomDts } =
+  await import(
+    `file://${join(REPO_ROOT, "packages", "compile", "dist", "index.js")}`
+  );
+
+// ---------------------------------------------------------------------------
+// Billing — reuse the billing.mjs authority from bench/B4-tokens-v5/harness/
+// ---------------------------------------------------------------------------
+
+const { PRICING, estimateCostUsd } = await import(
+  `file://${join(BENCH_ROOT, "harness", "billing.mjs")}`
+);
+
+// ---------------------------------------------------------------------------
+// Constants and defaults
+// ---------------------------------------------------------------------------
+
+/**
+ * @decision DEC-BENCH-B4-REFEMIT-PAID-001 continued
+ *
+ * Default experiment parameters. These are exported so tests can assert
+ * against them without re-parsing the CLI.
+ */
+export const EXPERIMENT_DEFAULTS = {
+  atoms: ["crc32c", "lru-ttl-cache", "avl-tree", "dijkstra-heap"],
+  models: ["claude-haiku-4-5-20251001", "claude-sonnet-4-6"],
+  conditions: ["verbatim", "reference"],
+  reps: 2,
+  maxUsd: 5.00,
+  // Assumed output token budget for cost estimation in dry mode.
+  // verbatim: ~400 tokens (conservative estimate for a real implementation body).
+  // reference: ~15 tokens (import line + brief confirmation).
+  estimatedOutputTokens: {
+    verbatim: 400,
+    reference: 15,
+  },
+  // max_tokens to request from Anthropic — caps spending and forces brief output.
+  maxTokensVerbatim: 800,
+  maxTokensReference: 60,
+};
+
+// ---------------------------------------------------------------------------
+// System prompt — real discovery prompt, read once at startup
+// ---------------------------------------------------------------------------
+
+const SYSTEM_PROMPT_PATH = join(REPO_ROOT, "docs", "system-prompts", "yakcc-discovery.md");
+if (!existsSync(SYSTEM_PROMPT_PATH)) {
+  throw new Error(`Discovery system prompt not found: ${SYSTEM_PROMPT_PATH}`);
+}
+export const SYSTEM_PROMPT = readFileSync(SYSTEM_PROMPT_PATH, "utf8");
+
+if (!SYSTEM_PROMPT.includes("yakcc_reference")) {
+  throw new Error(
+    `System prompt at ${SYSTEM_PROMPT_PATH} does not contain 'yakcc_reference' — ` +
+    `file may be wrong or stale`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Task corpus loader — reads from both tasks.json (small) and tasks-hard.json (large)
+// ---------------------------------------------------------------------------
+
+const TASKS_JSON = JSON.parse(readFileSync(join(BENCH_ROOT, "tasks.json"), "utf8"));
+const TASKS_HARD_JSON = JSON.parse(readFileSync(join(BENCH_ROOT, "tasks-hard.json"), "utf8"));
+
+/** Map from atom id → task record (merged from both manifests) */
+const ALL_TASKS_BY_ID = new Map(
+  [...TASKS_JSON.tasks, ...TASKS_HARD_JSON.tasks].map((t) => [t.id, t]),
+);
+
+// ---------------------------------------------------------------------------
+// Helpers shared with measure.mjs (duplicated here to stay self-contained;
+// measure.mjs is governed and must not be modified)
+// ---------------------------------------------------------------------------
+
+function symbolFromExpectedExport(expectedExport) {
+  if (typeof expectedExport === "string" && expectedExport.startsWith("named:")) {
+    return expectedExport.slice("named:".length);
+  }
+  return expectedExport ?? "UnknownSymbol";
+}
+
+function syntheticRoot(implSource) {
+  return createHash("sha256").update(implSource, "utf8").digest("hex");
+}
+
+/**
+ * Load and compute all artifacts for one atom needed by both conditions.
+ *
+ * @param {string} atomId
+ * @returns {AtomArtifacts}
+ */
+function loadAtomArtifacts(atomId) {
+  const task = ALL_TASKS_BY_ID.get(atomId);
+  if (!task) {
+    throw new Error(
+      `Atom '${atomId}' not found in tasks.json or tasks-hard.json. ` +
+      `Available: ${[...ALL_TASKS_BY_ID.keys()].join(", ")}`,
+    );
+  }
+
+  const implPath = join(BENCH_ROOT, task.reference_impl);
+  if (!existsSync(implPath)) {
+    throw new Error(`reference-impl not found: ${implPath}`);
+  }
+
+  const implSource = readFileSync(implPath, "utf8");
+  const symbol = symbolFromExpectedExport(task.expected_export);
+  const root = syntheticRoot(implSource);
+
+  // Build reference artifacts via real @yakcc/compile (same as measure.mjs)
+  const { reference } = addReference(emptyManifest(), { root, symbol });
+  const importLine = referenceImportLine(reference);
+
+  // Minimal synthetic spec for DTS (see measure.mjs notes on class-vs-function)
+  const spec = { name: task.id, inputs: [], outputs: [], preconditions: [], postconditions: [], invariants: [], effects: [], level: 0 };
+  const dtsContent = generateAtomDts(spec, symbol);
+  const dtsPath = reference.alias
+    ? `.yakcc/atoms/${reference.alias}.d.ts`
+    : `.yakcc/atoms/${root.slice(0, 12)}.d.ts`;
+
+  return {
+    atomId,
+    task,
+    implSource,
+    symbol,
+    root,
+    importLine,
+    dtsContent,
+    dtsPath,
+    manifestEntry: reference,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Message builders — the critical wiring that determines which prompt section fires
+//
+// @decision DEC-BENCH-B4-REFEMIT-PAID-001 continued
+//
+// Verbatim condition: omit any mention of .yakcc/manifest.json → Section B fires.
+// Reference condition: explicitly state manifest is present + provide yakcc_reference
+//   tool result JSON → Section A fires.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the user message for the VERBATIM condition.
+ *
+ * Simulates: yakcc_resolve returned auto_accept, yakcc_compile returned source.
+ * The system prompt Section B instructs: write this source verbatim, stop.
+ * Expected model output: the full impl (hundreds of tokens).
+ *
+ * @param {AtomArtifacts} artifacts
+ * @returns {string}
+ */
+export function buildVerbatimMessage(artifacts) {
+  const { task, implSource, symbol } = artifacts;
+  const description = task.description ?? task.id;
+  return (
+    `You called yakcc_resolve for «${description}» and got confidence_tier auto_accept. ` +
+    `You then called yakcc_compile and received this source:\n\n` +
+    `\`\`\`typescript\n${implSource}\n\`\`\`\n\n` +
+    `Complete the task now.`
+  );
+}
+
+/**
+ * Build the user message for the REFERENCE condition.
+ *
+ * Simulates: .yakcc/manifest.json is present + yakcc_reference returned artifacts.
+ * The system prompt Section A instructs: write only the import line, append manifest
+ * entry, write dts — do NOT write the implementation body.
+ * Expected model output: import line + brief notes (~10–15 tokens of real content).
+ *
+ * @param {AtomArtifacts} artifacts
+ * @returns {string}
+ */
+export function buildReferenceMessage(artifacts) {
+  const { task, importLine, dtsContent, dtsPath, manifestEntry } = artifacts;
+  const description = task.description ?? task.id;
+  const referenceToolResult = JSON.stringify({
+    manifest_entry: manifestEntry,
+    import_line: importLine,
+    dts_ref: { path: dtsPath, dts: dtsContent },
+  }, null, 2);
+  return (
+    `This project is configured for compose-by-reference (\`.yakcc/manifest.json\` is present). ` +
+    `You called yakcc_resolve for «${description}» and got confidence_tier auto_accept. ` +
+    `You then called yakcc_reference and received:\n\n` +
+    `${referenceToolResult}\n\n` +
+    `Complete the task now.`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Cost estimation (dry-mode: uses assumed output token budgets)
+// ---------------------------------------------------------------------------
+
+/**
+ * Estimate tokens for a string using the standard heuristic (chars / 4).
+ * Used for input token estimation in dry mode.
+ */
+function estimateInputTokens(text) {
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Estimate cost of one (atom, model, condition, rep) cell.
+ *
+ * In dry mode we don't know actual output tokens, so we use the
+ * EXPERIMENT_DEFAULTS estimated budgets. System prompt tokens are estimated
+ * the same way (one call = one system prompt, but cache_creation on first,
+ * cache_read on subsequent — we conservatively assume full input for simplicity).
+ *
+ * @param {object} opts
+ * @returns {number} USD
+ */
+function estimateCellCostUsd({ model, condition, systemTokens, userTokens }) {
+  const assumedOutputTokens = EXPERIMENT_DEFAULTS.estimatedOutputTokens[condition];
+  // Conservative: no cache credit in estimate (overestimates, safe side)
+  return estimateCostUsd({
+    model_id: model,
+    input_tokens: systemTokens + userTokens,
+    output_tokens: assumedOutputTokens,
+    cache_read_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Plan builder
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} ExperimentCell
+ * @property {string} atomId
+ * @property {string} model
+ * @property {string} condition
+ * @property {number} rep
+ * @property {AtomArtifacts} artifacts
+ * @property {string} userMessage
+ * @property {number} estimatedInputTokens
+ * @property {number} estimatedOutputTokens
+ * @property {number} estimatedCostUsd
+ */
+
+/**
+ * @typedef {object} ExperimentPlan
+ * @property {ExperimentCell[]} cells
+ * @property {string[]} atoms
+ * @property {string[]} models
+ * @property {string[]} conditions
+ * @property {number} reps
+ * @property {number} maxUsd
+ * @property {number} systemPromptTokens
+ * @property {number} totalEstimatedCostUsd
+ * @property {Map<string, AtomArtifacts>} artifactsByAtomId
+ */
+
+/**
+ * Build the full experiment plan. Pure, no API calls.
+ *
+ * This is exported so tests can inspect plan structure without triggering any I/O.
+ *
+ * @param {object} opts
+ * @param {string[]} [opts.atoms]
+ * @param {string[]} [opts.models]
+ * @param {number}   [opts.reps]
+ * @param {number}   [opts.maxUsd]
+ * @returns {ExperimentPlan}
+ */
+export function buildPlan(opts = {}) {
+  const atoms = opts.atoms ?? EXPERIMENT_DEFAULTS.atoms;
+  const models = opts.models ?? EXPERIMENT_DEFAULTS.models;
+  const conditions = EXPERIMENT_DEFAULTS.conditions;
+  const reps = opts.reps ?? EXPERIMENT_DEFAULTS.reps;
+  const maxUsd = opts.maxUsd ?? EXPERIMENT_DEFAULTS.maxUsd;
+
+  const systemPromptTokens = estimateInputTokens(SYSTEM_PROMPT);
+
+  // Load artifacts for all atoms
+  const artifactsByAtomId = new Map();
+  for (const atomId of atoms) {
+    artifactsByAtomId.set(atomId, loadAtomArtifacts(atomId));
+  }
+
+  const cells = [];
+  for (const atomId of atoms) {
+    const artifacts = artifactsByAtomId.get(atomId);
+    for (const model of models) {
+      for (const condition of conditions) {
+        for (let rep = 0; rep < reps; rep++) {
+          const userMessage =
+            condition === "verbatim"
+              ? buildVerbatimMessage(artifacts)
+              : buildReferenceMessage(artifacts);
+          const userTokens = estimateInputTokens(userMessage);
+          const estimatedInputTokens = systemPromptTokens + userTokens;
+          const estimatedOutputTokens = EXPERIMENT_DEFAULTS.estimatedOutputTokens[condition];
+          const estimatedCostUsd = estimateCellCostUsd({
+            model,
+            condition,
+            systemTokens: systemPromptTokens,
+            userTokens,
+          });
+          cells.push({
+            atomId,
+            model,
+            condition,
+            rep,
+            artifacts,
+            userMessage,
+            estimatedInputTokens,
+            estimatedOutputTokens,
+            estimatedCostUsd,
+          });
+        }
+      }
+    }
+  }
+
+  const totalEstimatedCostUsd = cells.reduce((s, c) => s + c.estimatedCostUsd, 0);
+
+  return {
+    cells,
+    atoms,
+    models,
+    conditions,
+    reps,
+    maxUsd,
+    systemPromptTokens,
+    totalEstimatedCostUsd,
+    artifactsByAtomId,
+  };
+}
+
+/**
+ * Estimate the total plan cost. Convenience wrapper used in tests.
+ *
+ * @param {ExperimentPlan} plan
+ * @returns {{ totalUsd: number, perCell: Array<{atomId, model, condition, rep, usd}> }}
+ */
+export function estimatePlanCostUsd(plan) {
+  return {
+    totalUsd: plan.totalEstimatedCostUsd,
+    perCell: plan.cells.map((c) => ({
+      atomId: c.atomId,
+      model: c.model,
+      condition: c.condition,
+      rep: c.rep,
+      usd: c.estimatedCostUsd,
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Dry-mode output
+// ---------------------------------------------------------------------------
+
+function printDryRun(plan) {
+  const { cells, atoms, models, conditions, reps, systemPromptTokens, totalEstimatedCostUsd, maxUsd } = plan;
+
+  console.log("=".repeat(80));
+  console.log("PAID EXPERIMENT DRY RUN — no API calls made");
+  console.log("=".repeat(80));
+  console.log();
+  console.log("Plan summary:");
+  console.log(`  atoms:       ${atoms.join(", ")}`);
+  console.log(`  models:      ${models.join(", ")}`);
+  console.log(`  conditions:  ${conditions.join(", ")}`);
+  console.log(`  reps:        ${reps}`);
+  console.log(`  total cells: ${cells.length}`);
+  console.log(`  system prompt: ${SYSTEM_PROMPT_PATH}`);
+  console.log(`  system prompt tokens (est): ${systemPromptTokens}`);
+  console.log();
+
+  // Cost estimate
+  console.log("Cost estimate (conservative — no cache credit, assumed output tokens):");
+  console.log(`  Assumed output tokens — verbatim: ~${EXPERIMENT_DEFAULTS.estimatedOutputTokens.verbatim}`);
+  console.log(`  Assumed output tokens — reference: ~${EXPERIMENT_DEFAULTS.estimatedOutputTokens.reference}`);
+  console.log();
+
+  // Per-model summary
+  for (const model of models) {
+    const modelCells = cells.filter((c) => c.model === model);
+    const modelTotal = modelCells.reduce((s, c) => s + c.estimatedCostUsd, 0);
+    console.log(`  ${model}: $${modelTotal.toFixed(4)}`);
+  }
+  console.log(`  TOTAL: $${totalEstimatedCostUsd.toFixed(4)}  (cap: $${maxUsd.toFixed(2)})`);
+  console.log();
+
+  if (totalEstimatedCostUsd > maxUsd) {
+    console.log(`  ⚠  WARNING: estimated cost $${totalEstimatedCostUsd.toFixed(4)} EXCEEDS cap $${maxUsd.toFixed(2)}`);
+    console.log(`     Real run would abort. Reduce --atoms or --reps, or raise --max-usd.`);
+  } else {
+    console.log(`  Cost gate: PASS (estimate under cap)`);
+  }
+  console.log();
+
+  // Per-cell messages (truncated for readability)
+  const MAX_MSG_PREVIEW = 300;
+  console.log("-".repeat(80));
+  console.log("Per-cell user messages (truncated to first 300 chars):");
+  console.log("-".repeat(80));
+  for (const cell of cells) {
+    const preview = cell.userMessage.slice(0, MAX_MSG_PREVIEW).replace(/\n/g, "\\n");
+    const ellipsis = cell.userMessage.length > MAX_MSG_PREVIEW ? "..." : "";
+    console.log();
+    console.log(`[${cell.atomId}] model=${cell.model} condition=${cell.condition} rep=${cell.rep}`);
+    console.log(`  est input_tokens=${cell.estimatedInputTokens}  est output_tokens=${cell.estimatedOutputTokens}  est_usd=$${cell.estimatedCostUsd.toFixed(6)}`);
+    console.log(`  user: ${preview}${ellipsis}`);
+  }
+
+  console.log();
+  console.log("=".repeat(80));
+  console.log("To run real experiment (requires ANTHROPIC_API_KEY):");
+  console.log("  ANTHROPIC_API_KEY=sk-ant-... node bench/B4-tokens-v5/reference-emit/paid-experiment.mjs --real");
+  console.log("=".repeat(80));
+}
+
+// ---------------------------------------------------------------------------
+// Real-mode: actual Anthropic API calls
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} CellResult
+ * @property {string} atomId
+ * @property {string} model
+ * @property {string} condition
+ * @property {number} rep
+ * @property {number} output_tokens
+ * @property {number} input_tokens
+ * @property {number} cache_read_input_tokens
+ * @property {number} cache_creation_input_tokens
+ * @property {number} actualCostUsd
+ * @property {boolean} behavioralPass  — reference: contains import line, not impl body
+ * @property {string}  responseText
+ * @property {string}  timestamp
+ */
+
+/**
+ * Run one cell against the real Anthropic API.
+ *
+ * @param {object} opts
+ * @param {object} opts.client        — Anthropic client instance
+ * @param {ExperimentCell} opts.cell
+ * @returns {Promise<CellResult>}
+ */
+async function runCell({ client, cell }) {
+  const { atomId, model, condition, rep, artifacts, userMessage } = cell;
+  const maxTokens = condition === "verbatim"
+    ? EXPERIMENT_DEFAULTS.maxTokensVerbatim
+    : EXPERIMENT_DEFAULTS.maxTokensReference;
+
+  const response = await client.messages.create({
+    model,
+    max_tokens: maxTokens,
+    system: [
+      {
+        type: "text",
+        text: SYSTEM_PROMPT,
+        cache_control: { type: "ephemeral" },
+      },
+    ],
+    messages: [
+      {
+        role: "user",
+        content: userMessage,
+      },
+    ],
+  });
+
+  const usage = response.usage;
+  const outputTokens = usage.output_tokens;
+  const inputTokens = usage.input_tokens;
+  const cacheRead = usage.cache_read_input_tokens ?? 0;
+  const cacheCreation = usage.cache_creation_input_tokens ?? 0;
+
+  const actualCostUsd = estimateCostUsd({
+    model_id: model,
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    cache_read_input_tokens: cacheRead,
+    cache_creation_input_tokens: cacheCreation,
+  });
+
+  const responseText = response.content
+    .filter((b) => b.type === "text")
+    .map((b) => b.text)
+    .join("\n");
+
+  // Behavioral correctness check
+  let behavioralPass = false;
+  if (condition === "reference") {
+    // Reference condition: output MUST contain the import line and MUST NOT
+    // contain a distinctive impl substring (the first 40 chars of the impl body
+    // past the license header, skipping blank lines and comments).
+    const implLines = artifacts.implSource.split("\n").filter(
+      (l) => l.trim() && !l.trim().startsWith("//") && !l.trim().startsWith("/*") && !l.trim().startsWith("*"),
+    );
+    const implDistinctiveSnippet = implLines.slice(0, 3).join(" ").slice(0, 80);
+    const containsImportLine = responseText.includes(artifacts.importLine);
+    const containsImplBody = implDistinctiveSnippet.length > 10
+      ? responseText.includes(implDistinctiveSnippet)
+      : false;
+    behavioralPass = containsImportLine && !containsImplBody;
+  } else {
+    // Verbatim condition: output should contain a substantial impl block.
+    // We just check it is non-trivially long.
+    behavioralPass = outputTokens > 50;
+  }
+
+  return {
+    atomId,
+    model,
+    condition,
+    rep,
+    output_tokens: outputTokens,
+    input_tokens: inputTokens,
+    cache_read_input_tokens: cacheRead,
+    cache_creation_input_tokens: cacheCreation,
+    actualCostUsd,
+    behavioralPass,
+    responseText,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+/**
+ * Run all cells for the plan against the real API.
+ * Enforces rolling spend cap; aborts if exceeded.
+ *
+ * @param {ExperimentPlan} plan
+ * @returns {Promise<CellResult[]>}
+ */
+async function runRealExperiment(plan) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    console.error(
+      "ERROR: ANTHROPIC_API_KEY is not set in the environment.\n" +
+      "       Export it before running --real:\n" +
+      "         export ANTHROPIC_API_KEY=sk-ant-...\n" +
+      "         node ... --real",
+    );
+    process.exit(1);
+  }
+
+  // Cost gate: refuse if estimated cost exceeds cap
+  if (plan.totalEstimatedCostUsd > plan.maxUsd) {
+    console.error(
+      `ERROR: Estimated cost $${plan.totalEstimatedCostUsd.toFixed(4)} exceeds ` +
+      `--max-usd cap $${plan.maxUsd.toFixed(2)}.\n` +
+      `       Reduce --atoms or --reps, or raise --max-usd, then retry.`,
+    );
+    process.exit(1);
+  }
+
+  // Dynamic import of @anthropic-ai/sdk — only in real mode.
+  // The bench/B4-tokens-v5 package.json lists it as a dependency.
+  const { default: Anthropic } = await import("@anthropic-ai/sdk");
+  const client = new Anthropic({ apiKey });
+
+  console.log("=".repeat(80));
+  console.log("PAID EXPERIMENT — REAL MODE");
+  console.log(`  ${plan.cells.length} cells, models: ${plan.models.join(", ")}`);
+  console.log(`  Estimated cost: $${plan.totalEstimatedCostUsd.toFixed(4)} / cap: $${plan.maxUsd.toFixed(2)}`);
+  console.log("=".repeat(80));
+  console.log();
+
+  const results = [];
+  let rollingSpend = 0;
+
+  for (const cell of plan.cells) {
+    const label = `[${cell.atomId}] model=${cell.model} condition=${cell.condition} rep=${cell.rep}`;
+    console.log(`Running ${label} ...`);
+
+    const result = await runCell({ client, cell });
+    results.push(result);
+
+    rollingSpend += result.actualCostUsd;
+    console.log(
+      `  output_tokens=${result.output_tokens}  input_tokens=${result.input_tokens}` +
+      `  cache_read=${result.cache_read_input_tokens}  cache_creation=${result.cache_creation_input_tokens}` +
+      `  actual_usd=$${result.actualCostUsd.toFixed(6)}` +
+      `  behavioral_pass=${result.behavioralPass}` +
+      `  rolling_spend=$${rollingSpend.toFixed(4)}`,
+    );
+
+    // Hard rolling spend check
+    if (rollingSpend > plan.maxUsd) {
+      console.error(
+        `\nABORTED: rolling spend $${rollingSpend.toFixed(4)} exceeded cap $${plan.maxUsd.toFixed(2)}.\n` +
+        `Partial results written.`,
+      );
+      break;
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Results aggregation and reporting
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregate per (atom, model) for headline numbers.
+ */
+function aggregateResults(results) {
+  // Group by atomId + model
+  const groups = new Map();
+  for (const r of results) {
+    const key = `${r.atomId}|${r.model}`;
+    if (!groups.has(key)) {
+      groups.set(key, { verbatim: [], reference: [] });
+    }
+    groups.get(key)[r.condition].push(r);
+  }
+
+  const rows = [];
+  for (const [key, { verbatim, reference }] of groups.entries()) {
+    const [atomId, model] = key.split("|");
+    const avgVerbatimOut = verbatim.length
+      ? verbatim.reduce((s, r) => s + r.output_tokens, 0) / verbatim.length
+      : null;
+    const avgReferenceOut = reference.length
+      ? reference.reduce((s, r) => s + r.output_tokens, 0) / reference.length
+      : null;
+    const ratio = avgVerbatimOut != null && avgReferenceOut != null && avgReferenceOut > 0
+      ? avgVerbatimOut / avgReferenceOut
+      : null;
+    const behavioralPassRate = reference.length
+      ? reference.filter((r) => r.behavioralPass).length / reference.length
+      : null;
+    rows.push({ atomId, model, avgVerbatimOut, avgReferenceOut, ratio, behavioralPassRate });
+  }
+
+  return rows;
+}
+
+function buildResultsMarkdown(results, plan, aggregated) {
+  const lines = [];
+  lines.push("# Reference-Emit Paid Experiment Results");
+  lines.push("");
+  lines.push(`*Run at: ${new Date().toISOString()}*`);
+  lines.push(`*atoms: ${plan.atoms.join(", ")}*`);
+  lines.push(`*models: ${plan.models.join(", ")}*`);
+  lines.push(`*reps: ${plan.reps}*`);
+  lines.push(`*total cells run: ${results.length} / ${plan.cells.length}*`);
+  lines.push("");
+  lines.push("## Headline: avg output_tokens per (atom, model)");
+  lines.push("");
+  lines.push("| atom | model | verbatim_out_tok | reference_out_tok | ratio | ref_behavioral_pass |");
+  lines.push("|------|-------|-----------------|------------------|-------|---------------------|");
+  for (const row of aggregated) {
+    const vStr = row.avgVerbatimOut != null ? row.avgVerbatimOut.toFixed(1) : "n/a";
+    const rStr = row.avgReferenceOut != null ? row.avgReferenceOut.toFixed(1) : "n/a";
+    const ratioStr = row.ratio != null ? `${row.ratio.toFixed(1)}x` : "n/a";
+    const passStr = row.behavioralPassRate != null ? `${(row.behavioralPassRate * 100).toFixed(0)}%` : "n/a";
+    lines.push(`| ${row.atomId} | ${row.model} | ${vStr} | ${rStr} | ${ratioStr} | ${passStr} |`);
+  }
+  lines.push("");
+  lines.push("## Raw cell results");
+  lines.push("");
+  lines.push("| atom | model | condition | rep | output_tok | input_tok | cache_read | cache_create | actual_usd | behavioral_pass |");
+  lines.push("|------|-------|-----------|-----|-----------|----------|-----------|-------------|-----------|-----------------|");
+  for (const r of results) {
+    lines.push(
+      `| ${r.atomId} | ${r.model} | ${r.condition} | ${r.rep} | ${r.output_tokens} | ${r.input_tokens} | ${r.cache_read_input_tokens} | ${r.cache_creation_input_tokens} | $${r.actualCostUsd.toFixed(6)} | ${r.behavioralPass} |`,
+    );
+  }
+  lines.push("");
+  lines.push("## Total spend");
+  const totalSpend = results.reduce((s, r) => s + r.actualCostUsd, 0);
+  lines.push(`$${totalSpend.toFixed(4)} across ${results.length} cells`);
+  return lines.join("\n");
+}
+
+function printRealSummary(results, plan) {
+  const aggregated = aggregateResults(results);
+  console.log();
+  console.log("=".repeat(80));
+  console.log("RESULTS SUMMARY");
+  console.log("=".repeat(80));
+  console.log();
+  console.log("avg output_tokens per (atom, model):");
+  console.log();
+  console.log("  atom                 model                         verbatim  reference  ratio  pass%");
+  console.log("  " + "-".repeat(85));
+  for (const row of aggregated) {
+    const vStr = row.avgVerbatimOut != null ? row.avgVerbatimOut.toFixed(0).padStart(8) : "     n/a";
+    const rStr = row.avgReferenceOut != null ? row.avgReferenceOut.toFixed(0).padStart(9) : "      n/a";
+    const ratioStr = row.ratio != null ? `${row.ratio.toFixed(1)}x`.padStart(6) : "   n/a";
+    const passStr = row.behavioralPassRate != null ? `${(row.behavioralPassRate * 100).toFixed(0)}%`.padStart(5) : "  n/a";
+    console.log(`  ${row.atomId.padEnd(20)} ${row.model.padEnd(30)} ${vStr} ${rStr} ${ratioStr} ${passStr}`);
+  }
+  console.log();
+  const totalSpend = results.reduce((s, r) => s + r.actualCostUsd, 0);
+  console.log(`  Total actual spend: $${totalSpend.toFixed(4)}`);
+
+  // Write results
+  if (!existsSync(RESULTS_DIR)) {
+    mkdirSync(RESULTS_DIR, { recursive: true });
+  }
+  const jsonPath = join(RESULTS_DIR, "paid-experiment.json");
+  const mdPath = join(RESULTS_DIR, "paid-experiment.md");
+  const resultPayload = {
+    experiment: "refemit-paid",
+    runAt: new Date().toISOString(),
+    plan: {
+      atoms: plan.atoms, models: plan.models, reps: plan.reps,
+      cells: plan.cells.length, estimatedCostUsd: plan.totalEstimatedCostUsd,
+    },
+    results,
+    aggregated,
+    totalActualSpendUsd: totalSpend,
+  };
+  writeFileSync(jsonPath, JSON.stringify(resultPayload, null, 2) + "\n");
+  writeFileSync(mdPath, buildResultsMarkdown(results, plan, aggregated) + "\n");
+  console.log();
+  console.log(`Results written to:`);
+  console.log(`  ${jsonPath}`);
+  console.log(`  ${mdPath}`);
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+const { values: flags } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    dry:      { type: "boolean", default: true },
+    real:     { type: "boolean", default: false },
+    atoms:    { type: "string"  },
+    models:   { type: "string"  },
+    reps:     { type: "string"  },
+    "max-usd": { type: "string" },
+  },
+  strict: false,
+});
+
+// --real overrides --dry; --dry is the safe default
+const isDry = !flags.real;
+
+const planOpts = {
+  atoms:  flags.atoms  ? flags.atoms.split(",").map((s) => s.trim())  : undefined,
+  models: flags.models ? flags.models.split(",").map((s) => s.trim()) : undefined,
+  reps:   flags.reps   ? parseInt(flags.reps, 10)                     : undefined,
+  maxUsd: flags["max-usd"] ? parseFloat(flags["max-usd"])             : undefined,
+};
+
+const plan = buildPlan(planOpts);
+
+if (isDry) {
+  printDryRun(plan);
+} else {
+  const results = await runRealExperiment(plan);
+  printRealSummary(results, plan);
+}

--- a/bench/B4-tokens-v5/reference-emit/paid-experiment.test.mjs
+++ b/bench/B4-tokens-v5/reference-emit/paid-experiment.test.mjs
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: MIT
+//
+// bench/B4-tokens-v5/reference-emit/paid-experiment.test.mjs
+//
+// Validates paid-experiment.mjs in --dry mode (no API calls, no ANTHROPIC_API_KEY needed).
+//
+// Test scope:
+//   1. buildPlan() covers all (atom × model × condition × rep) cells correctly
+//   2. verbatim user-message contains the impl source
+//   3. reference user-message contains the real import line and DTS, NOT the full impl
+//   4. system prompt is the real discovery prompt (non-empty, contains "yakcc_reference")
+//   5. cost estimate is computed and > 0
+//   6. plan covers the default atom/model/condition/rep matrix exactly
+//   7. Deterministic: two calls to buildPlan() produce identical messages
+//   8. Compound integration: real @yakcc/compile artifacts are embedded in reference msgs
+//
+// No mocks. No API calls. No ANTHROPIC_API_KEY required.
+//
+// Runner: vitest via bench/B4-tokens-v5/reference-emit/vitest.config.mjs
+
+import { describe, it, expect, beforeAll } from "vitest";
+import {
+  buildPlan,
+  buildVerbatimMessage,
+  buildReferenceMessage,
+  estimatePlanCostUsd,
+  EXPERIMENT_DEFAULTS,
+  SYSTEM_PROMPT,
+} from "./paid-experiment.mjs";
+
+// ---------------------------------------------------------------------------
+// Shared fixture — build the plan once for all tests
+// ---------------------------------------------------------------------------
+
+let plan;
+beforeAll(() => {
+  plan = buildPlan();
+});
+
+// ---------------------------------------------------------------------------
+// Plan structure
+// ---------------------------------------------------------------------------
+
+describe("buildPlan() — plan structure", () => {
+  it("covers all (atom × model × condition × rep) cells", () => {
+    const expectedCells =
+      EXPERIMENT_DEFAULTS.atoms.length *
+      EXPERIMENT_DEFAULTS.models.length *
+      EXPERIMENT_DEFAULTS.conditions.length *
+      EXPERIMENT_DEFAULTS.reps;
+    expect(plan.cells).toHaveLength(expectedCells);
+  });
+
+  it("contains all default atoms", () => {
+    const atomsInPlan = [...new Set(plan.cells.map((c) => c.atomId))];
+    for (const atom of EXPERIMENT_DEFAULTS.atoms) {
+      expect(atomsInPlan).toContain(atom);
+    }
+  });
+
+  it("contains all default models", () => {
+    const modelsInPlan = [...new Set(plan.cells.map((c) => c.model))];
+    for (const model of EXPERIMENT_DEFAULTS.models) {
+      expect(modelsInPlan).toContain(model);
+    }
+  });
+
+  it("contains both conditions: verbatim and reference", () => {
+    const conditionsInPlan = [...new Set(plan.cells.map((c) => c.condition))];
+    expect(conditionsInPlan).toContain("verbatim");
+    expect(conditionsInPlan).toContain("reference");
+  });
+
+  it("contains correct rep count per (atom, model, condition)", () => {
+    for (const atom of EXPERIMENT_DEFAULTS.atoms) {
+      for (const model of EXPERIMENT_DEFAULTS.models) {
+        for (const condition of EXPERIMENT_DEFAULTS.conditions) {
+          const matching = plan.cells.filter(
+            (c) => c.atomId === atom && c.model === model && c.condition === condition,
+          );
+          expect(matching).toHaveLength(EXPERIMENT_DEFAULTS.reps);
+          // Rep indices are 0..reps-1
+          expect(matching.map((c) => c.rep).sort()).toEqual(
+            Array.from({ length: EXPERIMENT_DEFAULTS.reps }, (_, i) => i),
+          );
+        }
+      }
+    }
+  });
+
+  it("carries artifacts for every atom in the plan", () => {
+    for (const atom of EXPERIMENT_DEFAULTS.atoms) {
+      expect(plan.artifactsByAtomId.has(atom)).toBe(true);
+      const artifacts = plan.artifactsByAtomId.get(atom);
+      expect(artifacts.atomId).toBe(atom);
+      expect(typeof artifacts.implSource).toBe("string");
+      expect(artifacts.implSource.length).toBeGreaterThan(100);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// System prompt integrity
+// ---------------------------------------------------------------------------
+
+describe("SYSTEM_PROMPT — real discovery prompt", () => {
+  it("is non-empty", () => {
+    expect(SYSTEM_PROMPT.length).toBeGreaterThan(100);
+  });
+
+  it("contains 'yakcc_reference'", () => {
+    expect(SYSTEM_PROMPT).toContain("yakcc_reference");
+  });
+
+  it("contains Section A (reference path) text", () => {
+    expect(SYSTEM_PROMPT).toContain(".yakcc/manifest.json");
+  });
+
+  it("contains Section B (verbatim path) text", () => {
+    expect(SYSTEM_PROMPT).toContain("yakcc_compile");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verbatim user-message content
+// ---------------------------------------------------------------------------
+
+describe("buildVerbatimMessage() — verbatim condition user message", () => {
+  it("contains the impl source for crc32c", () => {
+    const artifacts = plan.artifactsByAtomId.get("crc32c");
+    const msg = buildVerbatimMessage(artifacts);
+    // Must contain a distinctive snippet from the impl
+    const implSnippet = artifacts.implSource.slice(0, 60);
+    expect(msg).toContain(implSnippet);
+  });
+
+  it("contains the impl source for avl-tree (large atom)", () => {
+    const artifacts = plan.artifactsByAtomId.get("avl-tree");
+    const msg = buildVerbatimMessage(artifacts);
+    expect(msg).toContain(artifacts.implSource.slice(0, 60));
+  });
+
+  it("mentions yakcc_compile and auto_accept", () => {
+    const artifacts = plan.artifactsByAtomId.get("crc32c");
+    const msg = buildVerbatimMessage(artifacts);
+    expect(msg).toContain("yakcc_compile");
+    expect(msg).toContain("auto_accept");
+  });
+
+  it("does NOT mention .yakcc/manifest.json (ensures Section B fires, not Section A)", () => {
+    for (const atom of EXPERIMENT_DEFAULTS.atoms) {
+      const artifacts = plan.artifactsByAtomId.get(atom);
+      const msg = buildVerbatimMessage(artifacts);
+      expect(msg).not.toContain(".yakcc/manifest.json");
+    }
+  });
+
+  it("cells in the plan with condition=verbatim have a message containing the impl", () => {
+    const verbatimCells = plan.cells.filter((c) => c.condition === "verbatim");
+    for (const cell of verbatimCells) {
+      expect(cell.userMessage).toContain(cell.artifacts.implSource.slice(0, 40));
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reference user-message content
+// ---------------------------------------------------------------------------
+
+describe("buildReferenceMessage() — reference condition user message", () => {
+  it("contains the real import line for crc32c (via JSON-embedded import_line field)", () => {
+    const artifacts = plan.artifactsByAtomId.get("crc32c");
+    const msg = buildReferenceMessage(artifacts);
+    // The import line is embedded inside a JSON object as "import_line": "...",
+    // so double-quotes in the value are JSON-escaped to \". Check the alias and
+    // symbol are present — the alias is safe (hex chars, no escaping).
+    expect(msg).toContain(artifacts.manifestEntry.alias);
+    expect(msg).toContain(artifacts.symbol);
+    expect(msg).toContain("import_line");
+  });
+
+  it("import line matches .yakcc/atoms/<alias> pattern", () => {
+    for (const atom of EXPERIMENT_DEFAULTS.atoms) {
+      const artifacts = plan.artifactsByAtomId.get(atom);
+      expect(artifacts.importLine).toMatch(
+        /^import \{ \w+ \} from "\.yakcc\/atoms\/[0-9a-f]+";$/,
+      );
+    }
+  });
+
+  it("contains the DTS content", () => {
+    const artifacts = plan.artifactsByAtomId.get("lru-ttl-cache");
+    const msg = buildReferenceMessage(artifacts);
+    expect(msg).toContain(artifacts.dtsContent.slice(0, 20));
+  });
+
+  it("mentions .yakcc/manifest.json (ensures Section A fires)", () => {
+    for (const atom of EXPERIMENT_DEFAULTS.atoms) {
+      const artifacts = plan.artifactsByAtomId.get(atom);
+      const msg = buildReferenceMessage(artifacts);
+      expect(msg).toContain(".yakcc/manifest.json");
+    }
+  });
+
+  it("does NOT contain the full impl body (reference path should not write impl)", () => {
+    for (const atom of EXPERIMENT_DEFAULTS.atoms) {
+      const artifacts = plan.artifactsByAtomId.get(atom);
+      const msg = buildReferenceMessage(artifacts);
+      // The reference message should contain the import line but NOT hundreds of lines of impl.
+      // We check that a distinctive interior snippet of the impl is absent.
+      const implLines = artifacts.implSource
+        .split("\n")
+        .filter((l) => l.trim() && !l.trim().startsWith("//") && !l.trim().startsWith("*"))
+        .slice(2, 5)
+        .join("\n");
+      if (implLines.length > 20) {
+        expect(msg).not.toContain(implLines);
+      }
+    }
+  });
+
+  it("cells in the plan with condition=reference contain the import_line JSON key and atom alias", () => {
+    const referenceCells = plan.cells.filter((c) => c.condition === "reference");
+    for (const cell of referenceCells) {
+      // The import line is embedded in a JSON tool-result object, so check the
+      // JSON key and the alias (hex, safe to check directly).
+      expect(cell.userMessage).toContain("import_line");
+      expect(cell.userMessage).toContain(cell.artifacts.manifestEntry.alias);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cost estimate
+// ---------------------------------------------------------------------------
+
+describe("estimatePlanCostUsd() — cost gate", () => {
+  it("returns a positive total cost estimate", () => {
+    const { totalUsd } = estimatePlanCostUsd(plan);
+    expect(totalUsd).toBeGreaterThan(0);
+  });
+
+  it("per-cell costs are all positive", () => {
+    const { perCell } = estimatePlanCostUsd(plan);
+    for (const cell of perCell) {
+      expect(cell.usd).toBeGreaterThan(0);
+    }
+  });
+
+  it("total cost is sum of per-cell costs", () => {
+    const { totalUsd, perCell } = estimatePlanCostUsd(plan);
+    const sumPerCell = perCell.reduce((s, c) => s + c.usd, 0);
+    expect(totalUsd).toBeCloseTo(sumPerCell, 8);
+  });
+
+  it("plan totalEstimatedCostUsd matches estimatePlanCostUsd result", () => {
+    const { totalUsd } = estimatePlanCostUsd(plan);
+    expect(plan.totalEstimatedCostUsd).toBeCloseTo(totalUsd, 8);
+  });
+
+  it("default plan cost is under the default cap ($5.00)", () => {
+    const { totalUsd } = estimatePlanCostUsd(plan);
+    expect(totalUsd).toBeLessThan(EXPERIMENT_DEFAULTS.maxUsd);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Determinism: two buildPlan() calls produce the same messages
+// ---------------------------------------------------------------------------
+
+describe("determinism", () => {
+  it("two sequential buildPlan() calls produce identical user messages", () => {
+    const plan2 = buildPlan();
+    for (let i = 0; i < plan.cells.length; i++) {
+      expect(plan2.cells[i].userMessage).toBe(plan.cells[i].userMessage);
+    }
+  });
+
+  it("two calls produce the same import lines for each atom", () => {
+    const plan2 = buildPlan();
+    for (const atom of EXPERIMENT_DEFAULTS.atoms) {
+      const a1 = plan.artifactsByAtomId.get(atom);
+      const a2 = plan2.artifactsByAtomId.get(atom);
+      expect(a2.importLine).toBe(a1.importLine);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compound integration test
+//
+// Exercises the real production sequence end-to-end:
+//   1. Load impl source from reference-impl.ts (bench/B4-tokens-v5/tasks*)
+//   2. Compute syntheticRoot = SHA-256(impl) — deterministic 64-char hex
+//   3. Call @yakcc/compile addReference(emptyManifest, {root, symbol}) → alias
+//   4. Call referenceImportLine(reference) → import { Symbol } from ".yakcc/atoms/<alias>"
+//   5. Call generateAtomDts(spec, symbol) → .d.ts declaration text
+//   6. Build verbatim user message: embeds full impl source
+//   7. Build reference user message: embeds import line + DTS, NOT impl body
+//   8. Confirm: verbatim msg >> reference msg in length (the collapse)
+//
+// No mocks — all @yakcc/compile calls are real production dist code.
+// No API calls — builds artifacts only.
+// ---------------------------------------------------------------------------
+
+describe("compound integration: real production sequence end-to-end", () => {
+  it("produces correct import line shape for all default atoms", () => {
+    const IMPORT_RE = /^import \{ \w+ \} from "\.yakcc\/atoms\/[0-9a-f]+";$/;
+    for (const atom of EXPERIMENT_DEFAULTS.atoms) {
+      const artifacts = plan.artifactsByAtomId.get(atom);
+      expect(artifacts.importLine).toMatch(IMPORT_RE);
+    }
+  });
+
+  it("reference message is substantially shorter than verbatim message (output collapse)", () => {
+    for (const atom of EXPERIMENT_DEFAULTS.atoms) {
+      const artifacts = plan.artifactsByAtomId.get(atom);
+      const verbatimMsg = buildVerbatimMessage(artifacts);
+      const referenceMsg = buildReferenceMessage(artifacts);
+      // The verbatim message embeds the full impl; the reference embeds only import + DTS.
+      // The verbatim message must be substantially longer.
+      expect(verbatimMsg.length).toBeGreaterThan(referenceMsg.length);
+    }
+  });
+
+  it("avl-tree (large atom): verbatim impl > 8000 chars, reference msg embeds the import line in JSON", () => {
+    const artifacts = plan.artifactsByAtomId.get("avl-tree");
+    expect(artifacts.implSource.length).toBeGreaterThan(8000);
+    const referenceMsg = buildReferenceMessage(artifacts);
+    // The import line is embedded as a JSON field "import_line": "...".
+    // Check the JSON key and the unescaped alias.
+    expect(referenceMsg).toContain("import_line");
+    expect(referenceMsg).toContain(artifacts.manifestEntry.alias);
+    // The import line itself is a single line — no newline inside it
+    expect(artifacts.importLine).not.toContain("\n");
+    // The reference message length is a fraction of the verbatim impl length
+    expect(referenceMsg.length).toBeLessThan(artifacts.implSource.length);
+  });
+
+  it("dijkstra-heap (large atom): reference msg has import line with correct symbol 'Graph'", () => {
+    const artifacts = plan.artifactsByAtomId.get("dijkstra-heap");
+    expect(artifacts.symbol).toBe("Graph");
+    expect(artifacts.importLine).toContain("Graph");
+    expect(artifacts.importLine).toMatch(/^import \{ Graph \} from "\.yakcc\/atoms\/[0-9a-f]+";$/);
+  });
+
+  it("crc32c (small atom): verbatim cell message in plan contains full impl, reference cell does not", () => {
+    const verbatimCell = plan.cells.find(
+      (c) => c.atomId === "crc32c" && c.condition === "verbatim" && c.rep === 0,
+    );
+    const referenceCell = plan.cells.find(
+      (c) => c.atomId === "crc32c" && c.condition === "reference" && c.rep === 0,
+    );
+    expect(verbatimCell).toBeDefined();
+    expect(referenceCell).toBeDefined();
+
+    const artifacts = plan.artifactsByAtomId.get("crc32c");
+
+    // Verbatim: must contain the full impl (not just a snippet)
+    expect(verbatimCell.userMessage).toContain(artifacts.implSource);
+
+    // Reference: must contain the import_line JSON key and the alias (hex, unescaped)
+    expect(referenceCell.userMessage).toContain("import_line");
+    expect(referenceCell.userMessage).toContain(artifacts.manifestEntry.alias);
+
+    // Reference: must NOT contain the verbatim impl body
+    // (first 100 chars of impl after stripping the license header line)
+    const implBody = artifacts.implSource.split("\n").find((l) => l.trim() && !l.startsWith("//"));
+    if (implBody && implBody.length > 20) {
+      expect(referenceCell.userMessage).not.toContain(implBody);
+    }
+  });
+});

--- a/bench/B4-tokens-v5/reference-emit/vitest.config.mjs
+++ b/bench/B4-tokens-v5/reference-emit/vitest.config.mjs
@@ -16,7 +16,10 @@ export default {
     testTimeout: 60_000,
     isolate: true,
     pool: "forks",
-    include: ["bench/B4-tokens-v5/reference-emit/measure.test.mjs"],
+    include: [
+      "bench/B4-tokens-v5/reference-emit/measure.test.mjs",
+      "bench/B4-tokens-v5/reference-emit/paid-experiment.test.mjs",
+    ],
     environment: "node",
     reporter: ["verbose"],
   },


### PR DESCRIPTION
Follow-up to the #1043 epic (refs #1041, #1049). The behavioral counterpart to #1041's deterministic output-collapse measurement.

## What
A focused, **cost-gated** experiment that makes real Anthropic calls to measure the **output tokens a model actually writes** under the two flows — confirming behaviorally what #1041 proved structurally:
- **verbatim** condition: model receives the compiled impl (prompt Section B / #1030) → should write it verbatim.
- **reference** condition: `.yakcc/manifest.json` present + a real `yakcc_reference` artifact (Section A / #1048) → should write only the import line + record the manifest entry + the `.d.ts`.
- Uses the **real** `docs/system-prompts/yakcc-discovery.md` as the system prompt and real `@yakcc/compile` `referenceImportLine`/`generateAtomDts` artifacts.
- Atoms span small (crc32c, lru-ttl-cache) and large (avl-tree, dijkstra-heap); models Haiku + Sonnet; records real `usage.output_tokens` + a behavioral-pass flag.

## Safety
- `--dry` is the **default** (zero API calls; validates wiring + prints a cost estimate).
- `--real` requires `process.env.ANTHROPIC_API_KEY` (**never** reads `.env`, no hardcoded key) and enforces a `--max-usd` cap (default $5). The default 32-cell plan estimates **~$0.40**.
- **75 tests green** (43 new + 32 from #1041's measure); dry-run validated keyless.

## Scope
New files under `bench/B4-tokens-v5/reference-emit/` only. Governed v5 harness, `PROTOCOL.md`, and #1041's `measure.mjs` untouched. The results dossier follows from a `--real` run (operator-gated on the API key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)