### PR TITLE
fix(mcp-registry): #1069 yakcc_reference/compile open registry with the matching embedding provider

### DIFF
--- a/packages/mcp-registry/src/tools/compile.ts
+++ b/packages/mcp-registry/src/tools/compile.ts
@@ -341,26 +341,20 @@ export function createCompileTool(opts?: CreateCompileToolOptions): ToolModule {
 /**
  * Default registry opener for production use.
  *
- * Resolves the registry path from YAKCC_REGISTRY_PATH env var or falls back
- * to ".yakcc/registry.sqlite" relative to process.cwd().
- * Uses createOfflineEmbeddingProvider for deterministic, low-latency embeddings
- * (same approach as resolve.ts defaultOpenRegistry — DEC-HOOK-PHASE-3-L3-MCP-001-C).
+ * Delegates to openRegistryMatchingStoredProvider so the registry opens
+ * successfully against BOTH local-embedded (Xenova/bge-small-en-v1.5) and
+ * offline-embedded (yakcc/offline-blake3-stub) registries. Previously used
+ * createOfflineEmbeddingProvider explicitly, which threw a provider-mismatch
+ * error against any standard local-embedded registry (issue #1069).
  *
- * Note: compile does not use embeddings for root lookup, but openRegistry
- * requires an embedding provider for schema consistency. Offline provider
- * is zero-cost for operations that never query the vector index.
+ * @decision DEC-1069-REFEMIT-PROVIDER-001
  */
 async function defaultOpenRegistry(): Promise<Registry> {
-  const { resolve } = await import("node:path");
-  const { openRegistry } = await import("@yakcc/registry");
-  const { createOfflineEmbeddingProvider } = await import("@yakcc/contracts");
-
-  const DEFAULT_REGISTRY_PATH = ".yakcc/registry.sqlite";
-  const registryPath =
-    process.env.YAKCC_REGISTRY_PATH ?? resolve(process.cwd(), DEFAULT_REGISTRY_PATH);
-
-  const provider = createOfflineEmbeddingProvider();
-  return openRegistry(registryPath, { embeddings: provider });
+  const { resolveDefaultRegistryPath, openRegistryMatchingStoredProvider } = await import(
+    "./registry-open.js"
+  );
+  const registryPath = await resolveDefaultRegistryPath();
+  return openRegistryMatchingStoredProvider(registryPath);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/mcp-registry/src/tools/reference.ts
+++ b/packages/mcp-registry/src/tools/reference.ts
@@ -653,22 +653,21 @@ function errorContent(error: string, message: string): MCPContent[] {
 /**
  * Default registry opener for production use.
  *
- * Resolves the registry path from YAKCC_REGISTRY_PATH env var or falls back
- * to ".yakcc/registry.sqlite" relative to process.cwd().
- * Uses createOfflineEmbeddingProvider for deterministic, low-latency embeddings
- * (same approach as compile.ts defaultOpenRegistry).
+ * Delegates to openRegistryMatchingStoredProvider so the registry opens
+ * successfully against BOTH local-embedded (Xenova/bge-small-en-v1.5) and
+ * offline-embedded (yakcc/offline-blake3-stub) registries. Previously used
+ * createOfflineEmbeddingProvider explicitly, which threw a provider-mismatch
+ * error against any standard local-embedded registry — silently degrading
+ * apply-mode to verbatim output (issue #1069).
+ *
+ * @decision DEC-1069-REFEMIT-PROVIDER-001
  */
 async function defaultOpenRegistry(): Promise<Registry> {
-  const { resolve } = await import("node:path");
-  const { openRegistry } = await import("@yakcc/registry");
-  const { createOfflineEmbeddingProvider } = await import("@yakcc/contracts");
-
-  const DEFAULT_REGISTRY_PATH = ".yakcc/registry.sqlite";
-  const registryPath =
-    process.env.YAKCC_REGISTRY_PATH ?? resolve(process.cwd(), DEFAULT_REGISTRY_PATH);
-
-  const provider = createOfflineEmbeddingProvider();
-  return openRegistry(registryPath, { embeddings: provider });
+  const { resolveDefaultRegistryPath, openRegistryMatchingStoredProvider } = await import(
+    "./registry-open.js"
+  );
+  const registryPath = await resolveDefaultRegistryPath();
+  return openRegistryMatchingStoredProvider(registryPath);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/mcp-registry/src/tools/registry-open.test.ts
+++ b/packages/mcp-registry/src/tools/registry-open.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for openRegistryMatchingStoredProvider (registry-open.ts).
+ *
+ * @decision DEC-1069-REFEMIT-PROVIDER-001
+ * @title registry-open — provider-matching helper for reference+compile tools
+ * @status decided (wi-1069)
+ * @rationale
+ *   openRegistryMatchingStoredProvider must open registries embedded with EITHER
+ *   createLocalEmbeddingProvider (Xenova/bge-small-en-v1.5, standard production
+ *   registries) OR createOfflineEmbeddingProvider (yakcc/offline-blake3-stub,
+ *   bootstrap registries) without throwing a provider-mismatch error.
+ *
+ *   Test strategy:
+ *   (1) Opens a registry whose stored model is Xenova/bge-small-en-v1.5 without
+ *       throwing. The registry is created with a lightweight fake provider whose
+ *       modelId is "Xenova/bge-small-en-v1.5" (matches the real LOCAL_MODEL_ID)
+ *       so the guard accepts it.  No model download is required because
+ *       openRegistryMatchingStoredProvider only calls embed() on a vector search,
+ *       which these tests never issue.
+ *   (2) Opens a registry whose stored model is "yakcc/offline-blake3-stub" without
+ *       throwing (fallback arm of the probe chain).
+ *   (3) An unrecoverable error (bad file path, not a mismatch) is re-thrown.
+ *
+ *   This is the compound-interaction test for the production fix: it exercises
+ *   the full openRegistryMatchingStoredProvider path end-to-end, crossing the
+ *   local-provider probe → mismatch detection → offline fallback boundaries.
+ *
+ * Implements: yakcc#1069
+ */
+
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { openRegistryMatchingStoredProvider } from "./registry-open.js";
+
+// ---------------------------------------------------------------------------
+// Helpers — create seeded registry files on disk
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a real SQLite registry at `filePath` using the given modelId.
+ *
+ * Uses a lightweight fake EmbeddingProvider (no model download) whose modelId
+ * is set to `modelId`. The registry stores this modelId in registry_meta so
+ * openRegistryMatchingStoredProvider's probe logic exercises the right branch.
+ */
+async function seedRegistryFile(filePath: string, modelId: string): Promise<void> {
+  const { openRegistry } = await import("@yakcc/registry");
+  const fakeProvider = {
+    modelId,
+    dimension: 384,
+    async embed(_text: string): Promise<Float32Array> {
+      // Deterministic dummy vector — never used in these tests.
+      return new Float32Array(384).fill(0.1);
+    },
+  };
+  // Open (creates the file) and immediately close — we just need the metadata written.
+  const reg = await openRegistry(filePath, { embeddings: fakeProvider });
+  await reg.close();
+}
+
+// ---------------------------------------------------------------------------
+// Suite setup — create temp dir inside project tmp/ (Sacred Practice #3)
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  const projectTmp = new URL("../../../../../tmp", import.meta.url).pathname;
+  await mkdir(projectTmp, { recursive: true });
+  // Unique per-test directory to avoid collision between parallel runs.
+  const unique = `registry-open-test-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  tmpDir = join(projectTmp, unique);
+  await mkdir(tmpDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// (1) Opens a local-embedded (Xenova/bge-small-en-v1.5) registry successfully
+// ---------------------------------------------------------------------------
+
+describe("openRegistryMatchingStoredProvider — local-embedded registry (compound)", () => {
+  it(
+    "(1) opens a registry stored with Xenova/bge-small-en-v1.5 without mismatch error",
+    async () => {
+      // Seed a registry that stores "Xenova/bge-small-en-v1.5" as the embedding model.
+      // This simulates the standard production registry built by yakcc bootstrap or
+      // seedRegistry() on the default local path.
+      const registryPath = join(tmpDir, "local-embedded.sqlite");
+      await seedRegistryFile(registryPath, "Xenova/bge-small-en-v1.5");
+
+      // This is the compound-interaction test: openRegistryMatchingStoredProvider
+      // probe-opens with createLocalEmbeddingProvider() → modelId matches stored
+      // "Xenova/bge-small-en-v1.5" → no throw → registry returned.
+      // Pre-fix: calling openRegistry with createOfflineEmbeddingProvider() explicitly
+      // would throw embedding_model_mismatch here (the production bug, issue #1069).
+      let registry: Awaited<ReturnType<typeof openRegistryMatchingStoredProvider>> | undefined;
+      await expect(
+        openRegistryMatchingStoredProvider(registryPath).then((r) => {
+          registry = r;
+          return r;
+        }),
+      ).resolves.toBeDefined();
+
+      // Registry is functional: enumerateSpecs returns an empty async iterable (no blocks stored).
+      const specs = await registry!.enumerateSpecs();
+      expect(Array.isArray(specs)).toBe(true);
+
+      await registry!.close();
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (2) Opens an offline-embedded (yakcc/offline-blake3-stub) registry successfully
+// ---------------------------------------------------------------------------
+
+describe("openRegistryMatchingStoredProvider — offline-embedded registry", () => {
+  it(
+    "(2) opens a registry stored with yakcc/offline-blake3-stub via fallback arm",
+    async () => {
+      // Seed a registry that stores "yakcc/offline-blake3-stub".
+      // This simulates a registry built by yakcc bootstrap (offline/air-gapped mode).
+      const registryPath = join(tmpDir, "offline-embedded.sqlite");
+      await seedRegistryFile(registryPath, "yakcc/offline-blake3-stub");
+
+      // openRegistryMatchingStoredProvider tries local provider first → mismatch
+      // ("Xenova/bge-small-en-v1.5" ≠ "yakcc/offline-blake3-stub") → retries with
+      // createOfflineEmbeddingProvider() → matches → registry returned.
+      let registry: Awaited<ReturnType<typeof openRegistryMatchingStoredProvider>> | undefined;
+      await expect(
+        openRegistryMatchingStoredProvider(registryPath).then((r) => {
+          registry = r;
+          return r;
+        }),
+      ).resolves.toBeDefined();
+
+      const specs = await registry!.enumerateSpecs();
+      expect(Array.isArray(specs)).toBe(true);
+
+      await registry!.close();
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (3) Unrecoverable errors (not mismatch) are re-thrown
+// ---------------------------------------------------------------------------
+
+describe("openRegistryMatchingStoredProvider — non-mismatch errors propagate", () => {
+  it("(3) throws on a path that is not a valid SQLite file", async () => {
+    // Write a non-SQLite file to trigger an open error.
+    const badPath = join(tmpDir, "not-a-db.sqlite");
+    await writeFile(badPath, "this is not sqlite\n", "utf8");
+
+    // Should throw — the error is not embedding_model_mismatch, so it propagates.
+    await expect(openRegistryMatchingStoredProvider(badPath)).rejects.toThrow();
+  });
+});

--- a/packages/mcp-registry/src/tools/registry-open.ts
+++ b/packages/mcp-registry/src/tools/registry-open.ts
@@ -1,0 +1,116 @@
+/**
+ * Shared registry opener for MCP tools that do not use embeddings.
+ *
+ * @decision DEC-1069-REFEMIT-PROVIDER-001
+ * @title openRegistryMatchingStoredProvider — detect stored embedding model, open with matching provider
+ * @status decided (wi-1069)
+ * @rationale
+ *   yakcc_reference and yakcc_compile do not use vector search, but openRegistry
+ *   requires an embedding provider whose modelId matches the one used to build the
+ *   registry (packages/registry enforces a provider-consistency guard at open time).
+ *
+ *   Standard production registries are embedded with createLocalEmbeddingProvider
+ *   (Xenova/bge-small-en-v1.5); bootstrap/offline registries use
+ *   createOfflineEmbeddingProvider (yakcc/offline-blake3-stub). Passing the wrong
+ *   explicit provider throws "Registry was embedded with model X, but current
+ *   provider uses Y" → registry_unavailable mismatch error in reference/compile.
+ *
+ *   Fix: probe the stored model before opening.
+ *   Strategy: try opening with the local provider first (covers the standard
+ *   production case). If openRegistry throws with reason="embedding_model_mismatch",
+ *   fall back to the offline provider. Both attempts use explicit providers so the
+ *   guard fires loudly — no silent model rewrites (DEC-EMBED-REGISTRY-META-002).
+ *
+ *   Why try-local-first, not no-provider: passing no explicit provider would
+ *   suppress the guard entirely (callerSetExplicitProvider=false), which can
+ *   silently attach the wrong provider to the Registry object. The try-then-match
+ *   approach guarantees the attached provider matches the stored one — correct
+ *   behaviour if embedding is ever exercised on a reference/compile code path.
+ *
+ *   Why not raw SQLite probe: would require a direct better-sqlite3 dependency in
+ *   mcp-registry; the two-provider fallback chain covers all current production
+ *   cases without pulling in a new dep.
+ *
+ *   Single authority: reference.ts and compile.ts both call this helper — no
+ *   duplicate defaultOpenRegistry implementations (Sacred Practice #12).
+ *
+ *   Error contract: any open failure other than embedding_model_mismatch is
+ *   re-thrown; the caller is responsible for wrapping in errorContent.
+ *
+ * @see packages/registry/src/storage.ts — DEC-EMBED-REGISTRY-META-002 (guard behaviour)
+ * Implements: yakcc#1069
+ */
+
+import type { Registry } from "@yakcc/registry";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the registry path from env or default, then open it with a provider
+ * that matches the stored embedding model.
+ *
+ * Algorithm:
+ *   1. Try openRegistry with createLocalEmbeddingProvider (covers Xenova/bge-small
+ *      and all LOCAL_KNOWN_MODELS registries).
+ *   2. If that throws with reason="embedding_model_mismatch", retry with
+ *      createOfflineEmbeddingProvider (covers yakcc/offline-blake3-stub).
+ *   3. Any other error is re-thrown directly.
+ *
+ * @param registryPath Absolute path to the registry SQLite file.
+ * @returns Registry opened with the matching embedding provider.
+ * @throws {Error} If the registry cannot be opened for reasons other than
+ *   a recoverable provider mismatch.
+ */
+export async function openRegistryMatchingStoredProvider(registryPath: string): Promise<Registry> {
+  const { openRegistry } = await import("@yakcc/registry");
+  const { createLocalEmbeddingProvider, createOfflineEmbeddingProvider } = await import(
+    "@yakcc/contracts"
+  );
+
+  // Step 1: try local provider (production default — Xenova/bge-small-en-v1.5
+  // or any LOCAL_KNOWN_MODELS entry).
+  try {
+    return await openRegistry(registryPath, {
+      embeddings: createLocalEmbeddingProvider(),
+    });
+  } catch (err) {
+    // Re-throw anything that is not a recoverable provider mismatch.
+    if (!isProviderMismatchError(err)) {
+      throw err;
+    }
+  }
+
+  // Step 2: local provider did not match — try the offline deterministic
+  // provider (yakcc/offline-blake3-stub). If this also mismatches, the error
+  // propagates to the caller as a genuine registry_unavailable condition.
+  return openRegistry(registryPath, {
+    embeddings: createOfflineEmbeddingProvider(),
+  });
+}
+
+/**
+ * Resolve the default registry path for MCP tool use.
+ *
+ * Priority:
+ *   1. YAKCC_REGISTRY_PATH env var (absolute or relative to cwd)
+ *   2. ".yakcc/registry.sqlite" relative to process.cwd()
+ */
+export async function resolveDefaultRegistryPath(): Promise<string> {
+  const { resolve } = await import("node:path");
+  const DEFAULT_REGISTRY_PATH = ".yakcc/registry.sqlite";
+  return process.env.YAKCC_REGISTRY_PATH ?? resolve(process.cwd(), DEFAULT_REGISTRY_PATH);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** True if `err` is the specific embedding-model-mismatch error from openRegistry. */
+function isProviderMismatchError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err as Error & { reason?: string }).reason === "embedding_model_mismatch"
+  );
+}


### PR DESCRIPTION
Fixes a real production reliability bug in the now-standard compose-by-reference path, uncovered by the #1068 benchmark.

## The bug (confirmed from a live trace)
`yakcc_reference({atom_id, project_root})` returned `registry_unavailable`:
> *"Registry was embedded with model `Xenova/bge-small-en-v1.5`, but the current provider uses `yakcc/offline-blake3-stub`."*

`yakcc_reference` and `yakcc_compile` opened the registry with `createOfflineEmbeddingProvider`, which trips `@yakcc/registry`'s provider-consistency guard against a registry embedded with the **local** provider (bge-small) — which is what `yakcc_resolve` and all standard/corpus registries use. So the reference-emit path **silently degraded to verbatim authoring** whenever the registry was local-embedded.

## Fix
New shared helper `openRegistryMatchingStoredProvider(registryPath)` (single authority, used by both `reference.ts` and `compile.ts` `defaultOpenRegistry`): opens with `createLocalEmbeddingProvider` first (covers bge-small), falls back to `createOfflineEmbeddingProvider` on mismatch (covers offline-built registries like bootstrap). These tools don't embed (prefix-match only) — this just satisfies the consistency guard. Error-as-content preserved; `packages/registry` guard untouched (it's correct).

## Verified
- **201 mcp-registry tests green** (+3: registry-open + a local-embedded-registry reference test).
- **End-to-end:** `yakcc_reference` against the bge-small corpus now returns `import_line` + `applied: true` (was `registry_unavailable`).

Closes #1069. Unblocks the production compose-by-reference path and the B4-v5 reference-emit benchmark (#1068/#1070). Build/typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)