### PR TITLE
fix(bench): #1068 B4-v5 reference-emit oracle resolves short atom_id to full root

### DIFF
--- a/bench/B4-tokens-v5/harness/harness-unit.test.mjs
+++ b/bench/B4-tokens-v5/harness/harness-unit.test.mjs
@@ -541,3 +541,90 @@ describe('OFFLINE SANITY PROOF: materializeAtomSource → oracle for crc32c (no 
     ).toBe(true);
   }, 30_000);
 });
+
+// ─── SHORT-ID RESOLUTION PROOF (DEC-BENCH-B4-V5-SHORTID-RESOLVE-001) ─────────
+//
+// Required evidence: materializeAtomSource(corpus, short_crc32c_id) resolves the
+// short id to the full root and returns source passing the crc32c oracle.
+//
+// This is the production-path fix: yakcc_resolve returns 8-char short ids in its
+// candidates envelope. Before this fix, passing a short id to materializeAtomSource
+// caused assemble() to fail silently (0/0). After the fix, the short id is resolved
+// to the full 64-char root via the registry's full block set before assemble() is called.
+//
+// Production sequence exercised (DEC-BENCH-B4-V5-SHORTID-RESOLVE-001):
+//   1. yakcc_resolve returns auto_accept with candidates[0].atom_id = 'f0834da0' (8-char)
+//   2. Hooked arm calls materializeAtomSource(corpusPath, 'f0834da0')
+//   3. materializeAtomSource detects short id (length < 64), calls resolveShortId()
+//   4. resolveShortId enumerates full registry → prefix-match → unique full root
+//   5. assemble(fullRoot, registry) → source
+//   6. runOracle('crc32c', source) → oracle_passed = true
+
+// The 8-char short id is the first 8 chars of CRC32C_CORPUS_ROOT (f0834da0...).
+// In production, yakcc_resolve returns this as candidates[0].atom_id.
+const CRC32C_SHORT_ID = CRC32C_CORPUS_ROOT.slice(0, 8); // 'f0834da0'
+
+describe('SHORT-ID RESOLUTION PROOF: materializeAtomSource(short_id) → oracle (DEC-BENCH-B4-V5-SHORTID-RESOLVE-001)', () => {
+  it('short crc32c id resolves to full root and assembles without error', async () => {
+    if (!existsSync(BENCH_CORPUS)) {
+      console.warn('SKIP: bench corpus not found:', BENCH_CORPUS);
+      return;
+    }
+
+    // Step 1: call materializeAtomSource with the 8-char short id (the production input)
+    const result = await materializeAtomSource(BENCH_CORPUS, CRC32C_SHORT_ID);
+
+    // The resolution must succeed: no error
+    expect(result.error, `short-id resolution failed: ${result.error}`).toBeUndefined();
+    expect(typeof result.source).toBe('string');
+    expect(result.source.length).toBeGreaterThan(0);
+
+    // The materialized source must be identical to what the full-root path produces
+    // (content-addressed: same root → same source).
+    const fullRootResult = await materializeAtomSource(BENCH_CORPUS, CRC32C_CORPUS_ROOT);
+    expect(fullRootResult.error).toBeUndefined();
+    expect(result.source).toBe(fullRootResult.source);
+  }, 30_000);
+
+  it('short crc32c id materializes source that passes the crc32c oracle (compound production sequence)', async () => {
+    // This is the compound-interaction test required by the evaluation contract:
+    // it crosses short-id resolution, assemble(), and the oracle in one sequence.
+    if (!existsSync(BENCH_CORPUS)) {
+      console.warn('SKIP: bench corpus not found:', BENCH_CORPUS);
+      return;
+    }
+
+    // Step 1–4: resolve short id → full root → assemble (the production short-id path)
+    const result = await materializeAtomSource(BENCH_CORPUS, CRC32C_SHORT_ID);
+    expect(result.error, `materialize(short_id) failed: ${result.error}`).toBeUndefined();
+
+    // Step 5: run the crc32c oracle on the materialized source
+    const { runOracle } = await import(new URL(`file://${join(__dirname, 'oracle-runner.mjs')}`).href);
+    const oracle = await runOracle('crc32c', result.source);
+
+    // Well-formed oracle result
+    expect(typeof oracle.oracle_passed).toBe('boolean');
+    expect(typeof oracle.oracle_pass_count).toBe('number');
+    expect(typeof oracle.oracle_total).toBe('number');
+    expect(Array.isArray(oracle.oracle_failures)).toBe(true);
+
+    // THE KEY PROOF: short-id resolution → assemble → oracle must pass.
+    // Before the fix: assemble() received a short id → not_found → 0/0.
+    // After the fix: resolved to full root → correct assembly → oracle passes.
+    expect(
+      oracle.oracle_passed,
+      `crc32c oracle failed via short id '${CRC32C_SHORT_ID}' (${oracle.oracle_pass_count}/${oracle.oracle_total}): ${JSON.stringify(oracle.oracle_failures)}`
+    ).toBe(true);
+  }, 30_000);
+
+  it('materializeAtomSource returns not_found for a short id with no match', async () => {
+    if (!existsSync(BENCH_CORPUS)) {
+      console.warn('SKIP: bench corpus not found:', BENCH_CORPUS);
+      return;
+    }
+    // '00000000' is guaranteed not to prefix-match any real atom root
+    const result = await materializeAtomSource(BENCH_CORPUS, '00000000');
+    expect(result.error).toMatch(/Short id not found in registry/);
+    expect(result.failure_class).toBe('atom_fetch_failed');
+  }, 30_000);
+});

--- a/bench/B4-tokens-v5/harness/refemit-helpers.mjs
+++ b/bench/B4-tokens-v5/harness/refemit-helpers.mjs
@@ -201,15 +201,64 @@ async function getRegistry(registryPath) {
 }
 
 /**
- * Materialize the full assembled source for an atom from its block_merkle_root.
+ * Resolve a possibly-short atom_id to a unique full 64-char BlockMerkleRoot.
+ *
+ * Mirrors packages/mcp-registry/src/tools/compile.ts `resolveAtomId`
+ * (DEC-1028-COMPILE-FULL-ROOTS-001): enumerates the FULL registry block set
+ * via enumerateSpecs() → selectBlocks() and prefix-matches the short id.
+ *
+ * @decision DEC-BENCH-B4-V5-SHORTID-RESOLVE-001
+ * @title materializeAtomSource short-id → full-root resolution before assemble()
+ * @status accepted
+ * @rationale
+ *   yakcc_resolve returns 8-char atom_id prefixes (short ids) in its candidates
+ *   envelope. When the hooked arm calls materializeAtomSource with that short id,
+ *   assemble() cannot locate the block (it needs the full 64-char root). The fix
+ *   mirrors compile.ts WI-1028: enumerate the FULL registry root set and
+ *   prefix-match. Unique match → resolved full root. Zero/ambiguous → clear error.
+ *   One authority: the registry's own block set (no seed-only fallback).
+ *
+ * @param {import("../../../packages/registry/dist/index.js").Registry} registry
+ *   An already-open registry instance (from getRegistry()).
+ * @param {string} shortId  A non-64-char prefix (e.g. 8-char crc32c short id).
+ * @returns {Promise<{kind: "full", root: string} | {kind: "not_found"} | {kind: "ambiguous", matches: string[]}>}
+ */
+async function resolveShortId(registry, shortId) {
+  const prefix = shortId.toLowerCase();
+  // Enumerate the FULL registry block root set (DEC-1028-COMPILE-FULL-ROOTS-001).
+  // Same pattern as packages/mcp-registry/src/tools/compile.ts:186-191
+  // and packages/registry/src/rebuild.ts:104-112.
+  const specHashes = await registry.enumerateSpecs();
+  const fullRoots = [];
+  for (const sh of specHashes) {
+    const roots = await registry.selectBlocks(sh);
+    for (const root of roots) fullRoots.push(root);
+  }
+
+  const matches = fullRoots.filter((r) => r.startsWith(prefix));
+
+  if (matches.length === 0) return { kind: "not_found" };
+  if (matches.length > 1) return { kind: "ambiguous", matches };
+  return { kind: "full", root: matches[0] };
+}
+
+/**
+ * Materialize the full assembled source for an atom from its block_merkle_root
+ * or a short 8-char prefix id.
  *
  * Uses the REAL @yakcc/compile assemble() — the same DFS resolver that
  * yakcc_compile and `yakcc build` use.  This is the authoritative oracle path
  * for auto_accept: it verifies the resolved atom's materialized impl passes the
  * task oracle, proving the reference-emit substitution is semantically correct.
  *
+ * Accepts either:
+ *   - A full 64-char BlockMerkleRoot (passed straight through to assemble())
+ *   - A short id (8+ chars, non-64): resolved to the full root via the registry's
+ *     FULL block set (enumerateSpecs → selectBlocks, prefix-match).
+ *     Mirrors the production short-id resolution in compile.ts (WI-1028).
+ *
  * @param {string} registryPath  Absolute path to the registry SQLite file.
- * @param {string} atomRoot      The 64-char block_merkle_root (full root).
+ * @param {string} atomRoot      64-char BlockMerkleRoot OR short 8-char prefix id.
  * @returns {Promise<{source: string} | {error: string, failure_class: string}>}
  */
 export async function materializeAtomSource(registryPath, atomRoot) {
@@ -234,9 +283,31 @@ export async function materializeAtomSource(registryPath, atomRoot) {
     const compileDist = join(REPO_ROOT, "packages", "compile", "dist");
     const { assemble } = await import(new URL(`file://${join(compileDist, "assemble.js")}`).href);
 
-    // assemble() needs the full 64-char root; short IDs need to be resolved first.
-    // For the bench oracle, candidates[0].root from yakcc_resolve is always the full root.
-    const root = atomRoot.toLowerCase();
+    // Resolve short id → full 64-char root before calling assemble().
+    // assemble() requires the full BlockMerkleRoot; passing a short id silently
+    // produces a not-found error (0/0 oracle result).
+    //
+    // Resolution: if atomRoot is already 64 chars, use it directly.
+    // Otherwise, enumerate the full registry block set and prefix-match
+    // (DEC-BENCH-B4-V5-SHORTID-RESOLVE-001, mirrors compile.ts WI-1028).
+    let root = atomRoot.toLowerCase();
+
+    if (root.length < 64) {
+      const resolved = await resolveShortId(registry, root);
+      if (resolved.kind === "not_found") {
+        return {
+          error: `Short id not found in registry: ${root}`,
+          failure_class: "atom_fetch_failed",
+        };
+      }
+      if (resolved.kind === "ambiguous") {
+        return {
+          error: `Short id is ambiguous (${resolved.matches.length} matches): ${root}`,
+          failure_class: "atom_fetch_failed",
+        };
+      }
+      root = resolved.root;
+    }
 
     const artifact = await assemble(root, registry);
     return { source: artifact.source };


### PR DESCRIPTION
## Bug

The B4-v5 reference-emit oracle was reporting 0/0 (silent failure). `yakcc_resolve` returns **short 8-char** `atom_id`s in its candidates envelope. `materializeAtomSource` passed that short id straight to `assemble()`, which requires the **full 64-char `BlockMerkleRoot`** — so assembly failed with `atom_assemble_failed` and the oracle scored 0/0 instead of running the task oracle.

## Fix

Add `resolveShortId()` to `refemit-helpers.mjs`: `enumerateSpecs → selectBlocks → unique-prefix match`, mirroring `compile.ts` `resolveAtomId` (DEC-1028-COMPILE-FULL-ROOTS-001). `materializeAtomSource` now resolves short→full via the registry's full block set when `root.length < 64`; 64-char roots pass through unchanged. This unblocks the B4-v5 reference-emit arm (0/0 → real pass).

## Proof

- **Offline (no API):** `materializeAtomSource(corpus, 'f0834da0')` returns source that passes the crc32c oracle.
- `harness-unit` **33/33 green**, including 3 new short-id resolution tests (resolve→assemble, materialize→oracle compound production sequence, and not_found for an unmatched short id).

Scope: bench-harness only — 2 files (`refemit-helpers.mjs`, `harness-unit.test.mjs`).

Closes #1068.