### PR TITLE
feat(contracts): #1080 — validateProofManifestL3 (Slice A of proof incentive layer)

### DIFF
--- a/docs/archive/developer/VERIFICATION.md
+++ b/docs/archive/developer/VERIFICATION.md
@@ -161,6 +161,13 @@ by registry. The level hierarchy is a strict partial order; a higher level
 strictly refines a lower one. Levels are opt-in per block; L0 is the v0
 floor and remains the default.
 
+**L3 status update (2026-06):** L3 validator is now **in-progress** (was deferred).
+Activated via `validateProofManifestL3` in `@yakcc/contracts` (#1080 / `DEC-PROOF-L3-VALIDATOR-001`).
+The L0-only gate (`DEC-TRIPLET-L0-ONLY-019`) is preserved for the L0 path; the L3
+path is a parallel validator function and doesn't loosen L0 safety. Economic layer
+on top of L3 is planned at `plans/proof-incentive-layer.md` (Slices A–G, issues
+#1080–#1090).
+
 ---
 
 ## Block as cryptographic triplet

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -266,6 +266,7 @@ export {
   type ProofManifest,
   type ArtifactKind,
   validateProofManifestL0,
+  validateProofManifestL3,
 } from "./proof-manifest.js";
 export {
   type BlockTriplet,

--- a/packages/contracts/src/proof-manifest.l3.test.ts
+++ b/packages/contracts/src/proof-manifest.l3.test.ts
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: MIT
+// Unit tests for validateProofManifestL3 (DEC-PROOF-L3-VALIDATOR-001 / #1080).
+//
+// Production sequence covered:
+//   A contributor bundles a lean_proof or coq_proof artifact in proof/ alongside
+//   (optionally) property_tests. The registry's verifier calls validateProofManifestL3
+//   on the parsed manifest.json before invoking the Lean/Coq checker. The validator
+//   must reject manifests that would let a checker run against a malformed or
+//   ambiguous artifact declaration.
+
+import { describe, expect, it } from "vitest";
+import { validateProofManifestL3 } from "./proof-manifest.js";
+
+// ---------------------------------------------------------------------------
+// Happy-path: bare L3 manifests
+// ---------------------------------------------------------------------------
+
+describe("validateProofManifestL3 — bare L3 manifests", () => {
+  it("accepts a manifest with a single lean_proof artifact", () => {
+    const m = {
+      artifacts: [
+        { kind: "lean_proof", path: "refinement.lean", checker: "lean4@4.7.0" },
+      ],
+    };
+    const result = validateProofManifestL3(m);
+    expect(result.artifacts).toHaveLength(1);
+    expect(result.artifacts[0]?.kind).toBe("lean_proof");
+    expect(result.artifacts[0]?.checker).toBe("lean4@4.7.0");
+  });
+
+  it("accepts a manifest with a single coq_proof artifact", () => {
+    const m = {
+      artifacts: [
+        { kind: "coq_proof", path: "refinement.v", checker: "coq@8.20" },
+      ],
+    };
+    const result = validateProofManifestL3(m);
+    expect(result.artifacts).toHaveLength(1);
+    expect(result.artifacts[0]?.kind).toBe("coq_proof");
+    expect(result.artifacts[0]?.checker).toBe("coq@8.20");
+  });
+
+  it("accepts a manifest with both lean_proof and coq_proof artifacts", () => {
+    const m = {
+      artifacts: [
+        { kind: "lean_proof", path: "proof/lean/refinement.lean", checker: "lean4@4.7.0" },
+        { kind: "coq_proof", path: "proof/coq/refinement.v", checker: "coq@8.20" },
+      ],
+    };
+    const result = validateProofManifestL3(m);
+    expect(result.artifacts).toHaveLength(2);
+  });
+
+  it("accepts a path with proof/ prefix", () => {
+    const m = {
+      artifacts: [
+        { kind: "lean_proof", path: "proof/refinement.lean", checker: "lean4@4.7.0" },
+      ],
+    };
+    expect(() => validateProofManifestL3(m)).not.toThrow();
+  });
+
+  it("accepts an optional proof_spec_status annotation", () => {
+    const m = {
+      artifacts: [
+        { kind: "lean_proof", path: "refinement.lean", checker: "lean4@4.7.0" },
+      ],
+      proof_spec_status: "auto-generated",
+    };
+    expect(() => validateProofManifestL3(m)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy-path: mixed L0 + L3 manifests
+// ---------------------------------------------------------------------------
+
+describe("validateProofManifestL3 — mixed L0 + L3", () => {
+  it("accepts property_tests alongside lean_proof (L0+L3 coexistence)", () => {
+    const m = {
+      artifacts: [
+        { kind: "property_tests", path: "tests.fast-check.ts" },
+        { kind: "lean_proof", path: "refinement.lean", checker: "lean4@4.7.0" },
+      ],
+    };
+    const result = validateProofManifestL3(m);
+    expect(result.artifacts).toHaveLength(2);
+  });
+
+  it("accepts property_spec alongside lean_proof", () => {
+    const m = {
+      artifacts: [
+        { kind: "property_spec", path: "properties.json" },
+        { kind: "lean_proof", path: "refinement.lean", checker: "lean4@4.7.0" },
+      ],
+    };
+    expect(() => validateProofManifestL3(m)).not.toThrow();
+  });
+
+  it("accepts property_tests + property_spec + lean_proof + coq_proof together", () => {
+    // Production sequence: a maximally-attested block with L0 and L3 artifacts.
+    const m = {
+      artifacts: [
+        { kind: "property_tests", path: "tests.fast-check.ts" },
+        { kind: "property_spec", path: "properties.json" },
+        { kind: "lean_proof", path: "proof/lean/refinement.lean", checker: "lean4@4.7.0" },
+        { kind: "coq_proof", path: "proof/coq/refinement.v", checker: "coq@8.20" },
+      ],
+    };
+    const result = validateProofManifestL3(m);
+    expect(result.artifacts).toHaveLength(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rejection: missing checker field
+// ---------------------------------------------------------------------------
+
+describe("validateProofManifestL3 — checker field required", () => {
+  it("rejects a lean_proof artifact with no checker field", () => {
+    expect(() =>
+      validateProofManifestL3({
+        artifacts: [{ kind: "lean_proof", path: "refinement.lean" }],
+      }),
+    ).toThrow(/missing the required "checker" field/);
+  });
+
+  it("rejects a coq_proof artifact with no checker field", () => {
+    expect(() =>
+      validateProofManifestL3({
+        artifacts: [{ kind: "coq_proof", path: "refinement.v" }],
+      }),
+    ).toThrow(/missing the required "checker" field/);
+  });
+
+  it("rejects a lean_proof artifact with an empty checker string", () => {
+    expect(() =>
+      validateProofManifestL3({
+        artifacts: [{ kind: "lean_proof", path: "refinement.lean", checker: "" }],
+      }),
+    ).toThrow(/checker must be a non-empty string/);
+  });
+
+  it("rejects when only the second of two lean_proofs has no checker", () => {
+    expect(() =>
+      validateProofManifestL3({
+        artifacts: [
+          { kind: "lean_proof", path: "a.lean", checker: "lean4@4.7.0" },
+          { kind: "lean_proof", path: "b.lean" }, // missing checker
+        ],
+      }),
+    ).toThrow(/missing the required "checker" field/);
+  });
+
+  it("does not require checker on property_tests (L0 kind in mixed manifest)", () => {
+    // property_tests sits alongside lean_proof; checker is not required on it.
+    const m = {
+      artifacts: [
+        { kind: "property_tests", path: "tests.fast-check.ts" },
+        { kind: "lean_proof", path: "refinement.lean", checker: "lean4@4.7.0" },
+      ],
+    };
+    expect(() => validateProofManifestL3(m)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rejection: path traversal
+// ---------------------------------------------------------------------------
+
+describe("validateProofManifestL3 — path traversal rejection", () => {
+  it("rejects a path with .. traversal", () => {
+    expect(() =>
+      validateProofManifestL3({
+        artifacts: [
+          { kind: "lean_proof", path: "../secrets/id_rsa", checker: "lean4@4.7.0" },
+        ],
+      }),
+    ).toThrow(/contains ".." traversal/);
+  });
+
+  it("rejects a path with embedded .. segment", () => {
+    expect(() =>
+      validateProofManifestL3({
+        artifacts: [
+          { kind: "lean_proof", path: "proof/../etc/passwd", checker: "lean4@4.7.0" },
+        ],
+      }),
+    ).toThrow(/contains ".." traversal/);
+  });
+
+  it("rejects a deeply-nested .. traversal", () => {
+    expect(() =>
+      validateProofManifestL3({
+        artifacts: [
+          {
+            kind: "coq_proof",
+            path: "proof/sub/../../outside",
+            checker: "coq@8.20",
+          },
+        ],
+      }),
+    ).toThrow(/contains ".." traversal/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rejection: path outside proof/
+// ---------------------------------------------------------------------------
+
+describe("validateProofManifestL3 — path must resolve under proof/", () => {
+  it("rejects a path with a directory prefix other than proof/", () => {
+    expect(() =>
+      validateProofManifestL3({
+        artifacts: [
+          { kind: "lean_proof", path: "src/refinement.lean", checker: "lean4@4.7.0" },
+        ],
+      }),
+    ).toThrow(/must resolve under proof\//);
+  });
+
+  it("rejects an absolute path", () => {
+    expect(() =>
+      validateProofManifestL3({
+        artifacts: [
+          { kind: "lean_proof", path: "/tmp/refinement.lean", checker: "lean4@4.7.0" },
+        ],
+      }),
+    ).toThrow(/must be relative/);
+  });
+
+  it("accepts a bare filename (no directory separator)", () => {
+    // bare filename resolves under proof/ by convention — manifest lives there.
+    expect(() =>
+      validateProofManifestL3({
+        artifacts: [
+          { kind: "lean_proof", path: "refinement.lean", checker: "lean4@4.7.0" },
+        ],
+      }),
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rejection: L1/L2 kinds in a L3 manifest
+// ---------------------------------------------------------------------------
+
+describe("validateProofManifestL3 — L1/L2 kinds rejected", () => {
+  it("rejects smt_cert in the manifest (L2 kind)", () => {
+    expect(() =>
+      validateProofManifestL3({
+        artifacts: [
+          { kind: "smt_cert", path: "refinement.smt2", theory: ["bv8"] },
+        ],
+      }),
+    ).toThrow(/smt_cert.*L2 kinds/);
+  });
+
+  it("rejects fuzz_bounds_witness in the manifest (L2 kind)", () => {
+    expect(() =>
+      validateProofManifestL3({
+        artifacts: [
+          { kind: "fuzz_bounds_witness", path: "bounds.json" },
+        ],
+      }),
+    ).toThrow(/fuzz_bounds_witness.*L2 kinds/);
+  });
+
+  it("rejects smt_cert mixed with lean_proof", () => {
+    // Mixed L2+L3 is explicitly rejected — L3 validator owns only lean/coq artifacts.
+    expect(() =>
+      validateProofManifestL3({
+        artifacts: [
+          { kind: "lean_proof", path: "refinement.lean", checker: "lean4@4.7.0" },
+          { kind: "smt_cert", path: "refinement.smt2", theory: ["bv8"] },
+        ],
+      }),
+    ).toThrow(/smt_cert.*L2 kinds/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rejection: no L3 artifacts at all
+// ---------------------------------------------------------------------------
+
+describe("validateProofManifestL3 — must contain at least one formal artifact", () => {
+  it("rejects a manifest with only property_tests (no L3 artifact)", () => {
+    expect(() =>
+      validateProofManifestL3({
+        artifacts: [{ kind: "property_tests", path: "tests.fast-check.ts" }],
+      }),
+    ).toThrow(/at least one lean_proof or coq_proof artifact/);
+  });
+
+  it("rejects an empty artifacts array", () => {
+    expect(() =>
+      validateProofManifestL3({ artifacts: [] }),
+    ).toThrow(/at least one artifact/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Structural rejection: malformed input
+// ---------------------------------------------------------------------------
+
+describe("validateProofManifestL3 — malformed input rejection", () => {
+  it("rejects null", () => {
+    expect(() => validateProofManifestL3(null)).toThrow(/expected a non-null object/);
+  });
+
+  it("rejects a bare array", () => {
+    expect(() => validateProofManifestL3([])).toThrow(/expected a non-null object/);
+  });
+
+  it("rejects a primitive", () => {
+    expect(() => validateProofManifestL3(42)).toThrow(/expected a non-null object/);
+  });
+
+  it("rejects an object missing the artifacts field", () => {
+    expect(() => validateProofManifestL3({})).toThrow(/missing required field "artifacts"/);
+  });
+
+  it("rejects an artifact entry with a missing kind field", () => {
+    expect(() =>
+      validateProofManifestL3({ artifacts: [{ path: "refinement.lean" }] }),
+    ).toThrow(/missing required field "kind"/);
+  });
+
+  it("rejects an artifact entry with a missing path field", () => {
+    expect(() =>
+      validateProofManifestL3({
+        artifacts: [{ kind: "lean_proof", checker: "lean4@4.7.0" }],
+      }),
+    ).toThrow(/missing required field "path"/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compound-interaction: production sequence end-to-end
+// ---------------------------------------------------------------------------
+
+describe("validateProofManifestL3 — compound production sequence", () => {
+  // Models the full registry ingestion path: a contributor submits a block at
+  // L3 with both an L0 property-test corpus and a Lean proof. The validator
+  // must accept it and return a properly-typed ProofManifest whose fields the
+  // Merkle-root computation and checker invocation both read.
+  it("round-trips through JSON serialization (production ingest path)", () => {
+    const original = {
+      artifacts: [
+        { kind: "property_tests", path: "tests.fast-check.ts" },
+        { kind: "property_spec", path: "properties.json", generator: "fast-check-v3" },
+        {
+          kind: "lean_proof",
+          path: "proof/refinement.lean",
+          checker: "lean4@4.7.0",
+        },
+      ],
+      proof_spec_status: "auto-generated" as const,
+    };
+
+    // Simulate JSON round-trip (manifest.json is parsed from disk).
+    const parsed = JSON.parse(JSON.stringify(original)) as unknown;
+    const result = validateProofManifestL3(parsed);
+
+    // Merkle-root computation reads artifacts in order.
+    expect(result.artifacts).toHaveLength(3);
+    expect(result.artifacts[0]?.kind).toBe("property_tests");
+    expect(result.artifacts[1]?.kind).toBe("property_spec");
+    expect(result.artifacts[2]?.kind).toBe("lean_proof");
+
+    // Checker invocation reads the checker field.
+    expect(result.artifacts[2]?.checker).toBe("lean4@4.7.0");
+
+    // Optional top-level annotation survives.
+    expect(result.proof_spec_status).toBe("auto-generated");
+  });
+});

--- a/packages/contracts/src/proof-manifest.ts
+++ b/packages/contracts/src/proof-manifest.ts
@@ -204,3 +204,204 @@ export function validateProofManifestL0(value: unknown): ProofManifest {
 
   return obj as unknown as ProofManifest;
 }
+
+// ---------------------------------------------------------------------------
+// L3 validator
+// ---------------------------------------------------------------------------
+
+// @decision DEC-PROOF-L3-VALIDATOR-001
+// Title: L3 manifest validator — parallel function, not L0 relaxation
+// Status: decided (closes #1080, Slice A of plans/proof-incentive-layer.md)
+// Rationale:
+//   DEC-TRIPLET-L0-ONLY-019 gates validateProofManifestL0 to property_tests /
+//   property_spec only and explicitly defers L3 validators. This function is
+//   that deferred L3 path: a standalone validator for manifests carrying
+//   lean_proof / coq_proof artifacts. The L0 path is unchanged and continues
+//   to enforce its own rules. L3 is a *parallel* validator, not a fork or
+//   relaxation.
+//
+//   Accepted artifact kinds at L3:
+//   - lean_proof  (required: checker field, e.g. "lean4@4.7.0")
+//   - coq_proof   (required: checker field, e.g. "coq@8.20")
+//   - property_tests / property_spec — L0 artifacts are allowed to coexist
+//     with L3 artifacts in the same manifest (mixed L0+L3 is valid). The
+//     manifest may carry the property-test evidence alongside the formal proof.
+//
+//   Rejected artifact kinds at L3 (deferred to their own validators):
+//   - smt_cert (L2)
+//   - fuzz_bounds_witness (L2)
+//
+//   On formal_spec: we do NOT add a new formal_spec ArtifactKind in this
+//   slice. The L3 spec lemma lives inside (or alongside) the proof artifact
+//   file and is referenced from within the Lean/Coq proof source. Adding
+//   formal_spec as a separate kind would grow the enum without a concrete
+//   consumer. If a separate formal_spec artifact is needed (e.g., for Merkle-
+//   root coverage of the spec lemma independently of the proof), a future
+//   slice can add it. The DEC annotation there must forward-reference this one.
+
+/**
+ * The set of artifact kinds that an L3 manifest may declare.
+ *
+ * lean_proof and coq_proof are the L3-specific kinds (require checker).
+ * property_tests and property_spec may coexist with L3 artifacts.
+ * smt_cert and fuzz_bounds_witness are L2 kinds and are explicitly rejected
+ * here; their validators are separately deferred.
+ */
+const L3_ALLOWED_KINDS = new Set<ArtifactKind>(["lean_proof", "coq_proof", "property_tests", "property_spec"]);
+
+/**
+ * The L3-specific artifact kinds that require the `checker` field.
+ */
+const L3_FORMAL_KINDS = new Set<ArtifactKind>(["lean_proof", "coq_proof"]);
+
+/**
+ * The artifact kinds that belong to L1/L2 and must not appear in an L3 manifest.
+ * Having these signals a mixed-tier manifest that this validator rejects cleanly.
+ */
+const L2_DEFERRED_KINDS = new Set<ArtifactKind>(["smt_cert", "fuzz_bounds_witness"]);
+
+/**
+ * Validate a path field for an L3 artifact.
+ *
+ * Rules:
+ * - must be a non-empty string
+ * - must be relative (must not start with "/")
+ * - must not contain ".." traversal segments
+ * - must start with "proof/" or be inside "proof/" when treated as relative
+ *   to the block root. Paths that are bare filenames without a directory
+ *   component are also accepted, as they resolve under proof/ by convention
+ *   (the manifest itself lives in proof/).
+ *
+ * Returns undefined on success; a descriptive error string on failure.
+ */
+function validateL3ArtifactPath(path: string): string | undefined {
+  if (path.length === 0) {
+    return "path must be a non-empty string";
+  }
+  if (path.startsWith("/")) {
+    return `path "${path}" must be relative (must not start with "/")`;
+  }
+  // Reject any path segment that is ".." — catches "../../etc/passwd" and "proof/../etc".
+  const segments = path.split("/");
+  if (segments.some((seg) => seg === "..")) {
+    return `path "${path}" contains ".." traversal`;
+  }
+  // Paths must resolve under proof/. The manifest lives in proof/, so a bare
+  // filename like "refinement.lean" is fine. Paths with a directory prefix
+  // must start with "proof/".
+  if (segments.length > 1 && !path.startsWith("proof/")) {
+    return `path "${path}" must resolve under proof/ (either a bare filename or start with "proof/")`;
+  }
+  return undefined;
+}
+
+/**
+ * Validate and narrow an unknown value to ProofManifest for L3 blocks.
+ *
+ * L3 validation rules:
+ * 1. The value must be a non-null object with an "artifacts" array.
+ * 2. The manifest must contain at least one L3 artifact (lean_proof or coq_proof).
+ * 3. Every lean_proof / coq_proof artifact MUST have a non-empty "checker" field.
+ * 4. Every artifact path must be non-empty, relative, contain no ".." traversal,
+ *    and resolve under the proof/ directory.
+ * 5. L2 artifact kinds (smt_cert, fuzz_bounds_witness) are explicitly rejected;
+ *    their validators are deferred (DEC-TRIPLET-L0-ONLY-019).
+ * 6. L0 artifact kinds (property_tests, property_spec) are allowed alongside
+ *    L3 artifacts — mixed L0+L3 manifests are valid.
+ *
+ * Cross-reference: DEC-PROOF-L3-VALIDATOR-001, DEC-TRIPLET-L0-ONLY-019
+ *
+ * Throws a TypeError with a descriptive message on invalid input.
+ */
+export function validateProofManifestL3(value: unknown): ProofManifest {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("validateProofManifestL3: expected a non-null object");
+  }
+
+  const obj = value as Record<string, unknown>;
+
+  if (!("artifacts" in obj) || obj.artifacts === undefined) {
+    throw new TypeError('validateProofManifestL3: missing required field "artifacts"');
+  }
+
+  if (!Array.isArray(obj.artifacts)) {
+    throw new TypeError('validateProofManifestL3: field "artifacts" must be an array');
+  }
+
+  const artifacts = obj.artifacts as unknown[];
+
+  if (artifacts.length === 0) {
+    throw new TypeError(
+      "validateProofManifestL3: manifest must contain at least one artifact",
+    );
+  }
+
+  let formalCount = 0;
+
+  for (let i = 0; i < artifacts.length; i++) {
+    const entry = artifacts[i];
+    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new TypeError(`validateProofManifestL3: artifacts[${i}] must be a non-null object`);
+    }
+
+    const artifact = entry as Record<string, unknown>;
+
+    if (!("kind" in artifact) || artifact.kind === undefined) {
+      throw new TypeError(`validateProofManifestL3: artifacts[${i}] missing required field "kind"`);
+    }
+
+    if (!("path" in artifact) || artifact.path === undefined) {
+      throw new TypeError(`validateProofManifestL3: artifacts[${i}] missing required field "path"`);
+    }
+
+    if (typeof artifact.path !== "string") {
+      throw new TypeError(`validateProofManifestL3: artifacts[${i}].path must be a string`);
+    }
+
+    const kind = artifact.kind as string;
+
+    // Explicit rejection of L2-tier kinds: they belong to deferred validators.
+    if (L2_DEFERRED_KINDS.has(kind as ArtifactKind)) {
+      throw new TypeError(
+        `validateProofManifestL3: artifacts[${i}].kind is "${kind}" — smt_cert and fuzz_bounds_witness are L2 kinds; use the L2 validator (deferred, DEC-TRIPLET-L0-ONLY-019). L3 manifests may only contain lean_proof, coq_proof, property_tests, or property_spec.`,
+      );
+    }
+
+    // Reject any unknown kind not in the L3 allowed set.
+    if (!L3_ALLOWED_KINDS.has(kind as ArtifactKind)) {
+      throw new TypeError(
+        `validateProofManifestL3: artifacts[${i}].kind is "${kind}" — unrecognized artifact kind`,
+      );
+    }
+
+    // Validate path for all artifacts.
+    const pathErr = validateL3ArtifactPath(artifact.path);
+    if (pathErr !== undefined) {
+      throw new TypeError(`validateProofManifestL3: artifacts[${i}].path: ${pathErr}`);
+    }
+
+    // L3 formal kinds require the checker field.
+    if (L3_FORMAL_KINDS.has(kind as ArtifactKind)) {
+      formalCount++;
+      if (!("checker" in artifact) || artifact.checker === undefined) {
+        throw new TypeError(
+          `validateProofManifestL3: artifacts[${i}] (kind="${kind}") is missing the required "checker" field (e.g. "lean4@4.7.0" or "coq@8.20"). The checker version is part of the attestation identity — DEC-PROOF-L3-VALIDATOR-001.`,
+        );
+      }
+      if (typeof artifact.checker !== "string" || artifact.checker.length === 0) {
+        throw new TypeError(
+          `validateProofManifestL3: artifacts[${i}].checker must be a non-empty string`,
+        );
+      }
+    }
+  }
+
+  // The manifest must contain at least one L3 formal artifact.
+  if (formalCount === 0) {
+    throw new TypeError(
+      "validateProofManifestL3: manifest must contain at least one lean_proof or coq_proof artifact",
+    );
+  }
+
+  return obj as unknown as ProofManifest;
+}


### PR DESCRIPTION
First slice of the proof incentive layer (`plans/proof-incentive-layer.md`).

Activates L3 (machine-checked formal proof) artifacts in the proof manifest validator. The `ArtifactKind` enum already included `lean_proof`, `coq_proof`, `smt_cert` — but the L0 validator (`DEC-TRIPLET-L0-ONLY-019`) rejected anything non-L0, blocking L3 work. This adds a parallel `validateProofManifestL3` while preserving the L0 path unchanged.

## What

- `validateProofManifestL3` exported from `@yakcc/contracts`
- Requires `checker` field on every L3 artifact (e.g. `lean4@4.7.0`)
- Validates `path` under `proof/`; rejects traversal
- Mixed L0+L3 manifests accepted; L1/L2 kinds rejected (separately deferred)
- 31 new L3-specific tests covering bare, mixed, missing checker, path traversal, L1/L2 rejection, coq_proof fixtures

`VERIFICATION.md` updated: L3 moves from deferred to in-progress.

## Decision

`@decision DEC-PROOF-L3-VALIDATOR-001` — supersedes `DEC-TRIPLET-L0-ONLY-019` for the L3 path only. L0 path is unchanged; L3 is a parallel validator function.

Closes #1080

## Test plan

- [x] `pnpm --filter @yakcc/contracts test` — 377 pass (31 new L3 tests included)
- [x] `pnpm --filter @yakcc/contracts exec tsc --noEmit -p .` — clean
- [x] `pnpm -r build` — clean