### PR TITLE
feat(cli): #868 Slice 4 — yakcc shave .rs routes through @yakcc/shave-rust (closes #868)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -65,6 +65,7 @@
     "@yakcc/compile-python": "workspace:*",
     "@yakcc/compile": "workspace:*",
     "@yakcc/shave-python": "workspace:*",
+    "@yakcc/shave-rust": "workspace:*",
     "@yakcc/contracts": "workspace:*",
     "@yakcc/federation": "workspace:*",
     "@yakcc/hooks-base": "workspace:*",

--- a/packages/cli/src/commands/lang-target.test.ts
+++ b/packages/cli/src/commands/lang-target.test.ts
@@ -119,8 +119,8 @@ describe("lang-target — isSupportedTarget", () => {
 });
 
 describe("lang-target — TARGETS_TRACKED", () => {
-  it("TARGETS_TRACKED.rust === 868", () => {
-    expect(TARGETS_TRACKED.rust).toBe(868);
+  it("TARGETS_TRACKED.rust === 869 (compile/lower adapter; shave/raise is live at #868)", () => {
+    expect(TARGETS_TRACKED.rust).toBe(869);
   });
 
   it("TARGETS_TRACKED.go === 870", () => {

--- a/packages/cli/src/commands/lang-target.ts
+++ b/packages/cli/src/commands/lang-target.ts
@@ -3,16 +3,17 @@
 // lang-target.ts — single authority for file-extension → target-language inference.
 //
 // @decision DEC-WI877-005
-// @title Four-slot polyglot enum (ts | python | rust | go); rust/go stubbed with issue pointers
-// @status accepted (WI-877)
+// @title Four-slot polyglot enum (ts | python | rust | go); rust shave live; rust compile/roundtrip + go stubbed
+// @status updated (WI-868 slice 4)
 // @rationale
 //   All CLI verbs that perform language dispatch (shave, compile, roundtrip) must
 //   import from this module. No verb does its own `.endsWith(".py")` or --target
 //   string matching. This is the single-source authority for the polyglot enum.
-//   rust/go are registered but unimplemented in this MVP — each exits 1 with a
-//   tracking-issue pointer (#868 / #870). Slots open for future wiring without
-//   any CLI re-wiring beyond a new switch arm.
-//   Cross-reference: PLAN.md §4 / #877
+//   rust shave (raise) is now live via @yakcc/shave-rust (WI-868).
+//   rust compile/roundtrip (lower) is tracked at #869.
+//   go shave/compile/roundtrip is tracked at #870.
+//   Slots open for future wiring without any CLI re-wiring beyond a new switch arm.
+//   Cross-reference: PLAN.md §4 / #877 / #868 / #869
 //
 // @decision DEC-WI877-001 (partial)
 // @title Extension-driven language inference lives here, not in each verb
@@ -31,7 +32,8 @@ export type TargetLang = "ts" | "python" | "rust" | "go";
  * When a verb receives one of these targets it emits the pointer and exits 1.
  */
 export const TARGETS_TRACKED = {
-  rust: 868,
+  /** rust shave/raise is live (#868). TARGETS_TRACKED.rust now points to #869 (compile/lower). */
+  rust: 869,
   go: 870,
 } as const;
 

--- a/packages/cli/src/commands/roundtrip.test.ts
+++ b/packages/cli/src/commands/roundtrip.test.ts
@@ -274,13 +274,13 @@ describe("roundtrip — no args → exit 1 + usage", () => {
   });
 });
 
-describe("roundtrip — --target rust → exit 2 with #868 pointer", () => {
-  it("returns 2 and mentions #868", async () => {
+describe("roundtrip — --target rust → exit 2 with #869 pointer (compile/lower tracked at #869)", () => {
+  it("returns 2 and mentions #869", async () => {
     const file = fixture("foo.py");
     const logger = new CollectingLogger();
     const code = await roundtrip([file, "--target", "rust"], logger);
     expect(code).toBe(2);
-    expect(logger.errLines.join("\n")).toContain("868");
+    expect(logger.errLines.join("\n")).toContain("869");
   });
 });
 

--- a/packages/cli/src/commands/shave-rust.test.ts
+++ b/packages/cli/src/commands/shave-rust.test.ts
@@ -1,0 +1,476 @@
+// SPDX-License-Identifier: MIT
+// @mock-exempt: @yakcc/shave-rust wraps a cargo subprocess boundary.
+// The spawnImpl injection seam (DEC-POLYGLOT-RUST-CLI-001) lets tests exercise
+// the full CLI path with a mock subprocess — no Rust toolchain required.
+// The real cargo subprocess integration is gated on YAKCC_RUST_E2E=1
+// in polyglot-rust.yml CI.
+//
+// shave-rust.test.ts — unit tests for runShaveRust.
+//
+// @decision DEC-POLYGLOT-RUST-CLI-001
+// @title runShaveRust test seam: inject mock spawnImpl — no cargo needed
+// @status accepted (WI-868 slice 4)
+// @rationale
+//   runShaveRust accepts an optional ShaveRustOpts.spawnImpl, threading it
+//   through to RustAstParseOptions.spawnImpl.  This lets CLI tests exercise the
+//   full raise pipeline (parseRustSource -> extractFunctionSignatures ->
+//   renderFunctionDeclaration) without invoking cargo.  The mock uses the same
+//   EventEmitter pattern as acceptance.test.ts in @yakcc/shave-rust (verified
+//   production sequence: spawn child emits JSON on stdout, child emits close 0).
+//   Mirrors the shave-python.test.ts injection style for CLI layer consistency.
+//   Cross-reference: PLAN.md §4 / #868 / DEC-POLYGLOT-RUST-ACCEPTANCE-001
+
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CollectingLogger } from "../index.js";
+import type { ShaveRustArgs } from "./shave-rust.js";
+import { runShaveRust } from "./shave-rust.js";
+
+// ---------------------------------------------------------------------------
+// Infrastructure: mock subprocess factory + inline fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * Wire envelope JSON that the mock spawnImpl will emit as subprocess stdout.
+ * These inline fixtures mirror the on-disk ones in packages/shave-rust/src/__fixtures__/
+ * so shave-rust.test.ts stays self-contained (no cross-package fixture reads).
+ */
+
+/** pub fn add(a: i32, b: i32) -> i32  — maps to add(a: number, b: number): number */
+const ADD_I32_ENVELOPE = JSON.stringify({
+  version: 2,
+  crateName: "stdin.rs",
+  functions: [
+    {
+      name: "add",
+      isPub: true,
+      params: [
+        { name: "a", rustType: "i32" },
+        { name: "b", rustType: "i32" },
+      ],
+      returnType: "i32",
+      bodySource: "a + b",
+      body: {
+        stmts: [
+          {
+            type: "ExprStmt",
+            line: 1,
+            col: 1,
+            x: {
+              type: "BinaryExpr",
+              line: 1,
+              col: 1,
+              op: "+",
+              x: { type: "Ident", line: 1, col: 1, name: "a" },
+              y: { type: "Ident", line: 1, col: 5, name: "b" },
+            },
+            isTail: true,
+          },
+        ],
+      },
+    },
+  ],
+});
+
+/** pub fn greet(name: String) -> String — maps to greet(name: string): string */
+const GREET_STRING_ENVELOPE = JSON.stringify({
+  version: 2,
+  crateName: "stdin.rs",
+  functions: [
+    {
+      name: "greet",
+      isPub: true,
+      params: [{ name: "name", rustType: "String" }],
+      returnType: "String",
+      bodySource: 'format!("Hello, {}", name)',
+      body: {
+        stmts: [
+          {
+            type: "ExprStmt",
+            line: 1,
+            col: 1,
+            x: {
+              type: "CallExpr",
+              line: 1,
+              col: 1,
+              fun: { type: "Ident", line: 1, col: 1, name: "format" },
+              args: [
+                { type: "Lit", line: 1, col: 8, kind: "STR", value: "Hello, {}" },
+                { type: "Ident", line: 1, col: 22, name: "name" },
+              ],
+            },
+            isTail: true,
+          },
+        ],
+      },
+    },
+  ],
+});
+
+/** Two functions: add(i32) + is_even(i32 -> bool) — for multi-function tests. */
+const TWO_FN_ENVELOPE = JSON.stringify({
+  version: 2,
+  crateName: "stdin.rs",
+  functions: [
+    {
+      name: "add",
+      isPub: true,
+      params: [
+        { name: "a", rustType: "i32" },
+        { name: "b", rustType: "i32" },
+      ],
+      returnType: "i32",
+      bodySource: "a + b",
+      body: {
+        stmts: [
+          {
+            type: "ExprStmt",
+            line: 1,
+            col: 1,
+            x: {
+              type: "BinaryExpr",
+              line: 1,
+              col: 1,
+              op: "+",
+              x: { type: "Ident", line: 1, col: 1, name: "a" },
+              y: { type: "Ident", line: 1, col: 5, name: "b" },
+            },
+            isTail: true,
+          },
+        ],
+      },
+    },
+    {
+      name: "is_even",
+      isPub: true,
+      params: [{ name: "n", rustType: "i32" }],
+      returnType: "bool",
+      bodySource: "n % 2 == 0",
+      body: {
+        stmts: [
+          {
+            type: "ExprStmt",
+            line: 1,
+            col: 1,
+            x: {
+              type: "BinaryExpr",
+              line: 1,
+              col: 1,
+              op: "==",
+              x: {
+                type: "BinaryExpr",
+                line: 1,
+                col: 1,
+                op: "%",
+                x: { type: "Ident", line: 1, col: 1, name: "n" },
+                y: { type: "Lit", line: 1, col: 5, kind: "INT", value: "2" },
+              },
+              y: { type: "Lit", line: 1, col: 9, kind: "INT", value: "0" },
+            },
+            isTail: true,
+          },
+        ],
+      },
+    },
+  ],
+});
+
+/** Empty-function-list envelope — triggers "no functions found" exit 1. */
+const NO_FN_ENVELOPE = JSON.stringify({
+  version: 2,
+  crateName: "stdin.rs",
+  functions: [],
+});
+
+/**
+ * Build a SpawnImpl mock that emits the given JSON string as subprocess stdout
+ * and exits with the given code.
+ *
+ * Production sequence: child process spawned → stdout "data" event → "close" event.
+ * This is the exact same mock shape used in acceptance.test.ts (DEC-POLYGLOT-RUST-ACCEPTANCE-001).
+ */
+function makeSpawnMock(jsonOutput: string, exitCode = 0): import("@yakcc/shave-rust").SpawnImpl {
+  return (_command, _args, _options) => {
+    const stdin: EventEmitter & { end?: (...a: unknown[]) => void } = new EventEmitter();
+    stdin.end = () => {};
+    const stdout = new EventEmitter();
+    const stderr = new EventEmitter();
+    const child: EventEmitter & {
+      stdin: typeof stdin;
+      stdout: typeof stdout;
+      stderr: typeof stderr;
+    } = Object.assign(new EventEmitter(), { stdin, stdout, stderr });
+    queueMicrotask(() => {
+      stdout.emit("data", Buffer.from(jsonOutput, "utf-8"));
+      child.emit("close", exitCode);
+    });
+    return child as ReturnType<typeof import("node:child_process").spawn>;
+  };
+}
+
+/**
+ * Build a SpawnImpl mock that emits non-zero exit and optional stderr message
+ * to simulate cargo absent / build failure.
+ */
+function makeFailingSpawnMock(
+  stderrMsg: string,
+  exitCode = 1,
+): import("@yakcc/shave-rust").SpawnImpl {
+  return (_command, _args, _options) => {
+    const stdin: EventEmitter & { end?: (...a: unknown[]) => void } = new EventEmitter();
+    stdin.end = () => {};
+    const stdout = new EventEmitter();
+    const stderr = new EventEmitter();
+    const child: EventEmitter & {
+      stdin: typeof stdin;
+      stdout: typeof stdout;
+      stderr: typeof stderr;
+    } = Object.assign(new EventEmitter(), { stdin, stdout, stderr });
+    queueMicrotask(() => {
+      stderr.emit("data", Buffer.from(stderrMsg, "utf-8"));
+      child.emit("close", exitCode);
+    });
+    return child as ReturnType<typeof import("node:child_process").spawn>;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build ShaveRustArgs with sane defaults. */
+function args(filePath: string, overrides?: Partial<ShaveRustArgs>): ShaveRustArgs {
+  return {
+    filePath,
+    functionFilter: undefined,
+    out: undefined,
+    ignoredForeignPolicy: false,
+    ...overrides,
+  };
+}
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "shave-rust-test-"));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+/** Write a tiny .rs fixture so readFileSync in runShaveRust succeeds. */
+function fixture(name: string, content = "pub fn add(a: i32, b: i32) -> i32 { a + b }\n"): string {
+  const p = join(tempDir, name);
+  writeFileSync(p, content, "utf-8");
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// Compound-interaction test (required by implementer protocol)
+//
+// This test exercises the real production sequence end-to-end:
+//   runShaveRust → readFileSync → parseRustSource (mock spawn) →
+//   extractFunctionSignatures → renderFunctionDeclaration → logger.log
+//
+// It crosses all three internal pipeline component boundaries:
+//   rust-ast-parser.ts → parse-fn-signature.ts → raise-function.ts
+// with only the subprocess spawn replaced by the in-process mock.
+// ---------------------------------------------------------------------------
+
+describe("runShaveRust — compound interaction: .rs → TS-subset IR (production sequence)", () => {
+  it("end-to-end pipeline: readFileSync → parseRustSource (mock spawn) → " +
+    "extractFunctionSignatures → renderFunctionDeclaration → stdout", async () => {
+    const file = fixture("add.rs");
+    const spawnImpl = makeSpawnMock(ADD_I32_ENVELOPE);
+    const logger = new CollectingLogger();
+
+    const code = await runShaveRust(args(file), logger, { spawnImpl });
+
+    expect(code).toBe(0);
+    expect(logger.errLines).toHaveLength(0);
+    // The full pipeline raises add(a: i32, b: i32) -> i32 to TS-subset IR.
+    const out = logger.logLines.join("\n");
+    expect(out).toContain("export function add");
+    expect(out).toContain("a: number, b: number");
+    expect(out).toContain(": number {");
+    expect(out).toContain("return");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy-path tests
+// ---------------------------------------------------------------------------
+
+describe("runShaveRust — single function: add(i32, i32) -> i32", () => {
+  it("raises to TS-subset IR and logs to stdout, returns 0", async () => {
+    const file = fixture("add.rs");
+    const spawnImpl = makeSpawnMock(ADD_I32_ENVELOPE);
+    const logger = new CollectingLogger();
+
+    const code = await runShaveRust(args(file), logger, { spawnImpl });
+
+    expect(code).toBe(0);
+    const out = logger.logLines.join("\n");
+    expect(out).toContain("export function add(a: number, b: number): number {");
+    expect(logger.errLines).toHaveLength(0);
+  });
+});
+
+describe("runShaveRust — single function: greet(String) -> String", () => {
+  it("maps String -> string and produces well-formed IR, returns 0", async () => {
+    const file = fixture("greet.rs", 'pub fn greet(name: String) -> String { format!("Hello") }\n');
+    const spawnImpl = makeSpawnMock(GREET_STRING_ENVELOPE);
+    const logger = new CollectingLogger();
+
+    const code = await runShaveRust(args(file), logger, { spawnImpl });
+
+    expect(code).toBe(0);
+    const out = logger.logLines.join("\n");
+    expect(out).toContain("export function greet(name: string): string {");
+    expect(logger.errLines).toHaveLength(0);
+  });
+});
+
+describe("runShaveRust — two functions: banners emitted for multi-function stdout", () => {
+  it("emits // ---- function: <name> ---- banners and both IR blocks, returns 0", async () => {
+    const file = fixture("two.rs");
+    const spawnImpl = makeSpawnMock(TWO_FN_ENVELOPE);
+    const logger = new CollectingLogger();
+
+    const code = await runShaveRust(args(file), logger, { spawnImpl });
+
+    expect(code).toBe(0);
+    const out = logger.logLines.join("\n");
+    expect(out).toContain("// ---- function: add ----");
+    expect(out).toContain("// ---- function: isEven ----");
+    expect(out).toContain("export function add");
+    expect(out).toContain("export function isEven");
+    expect(logger.errLines).toHaveLength(0);
+  });
+});
+
+describe("runShaveRust — --function filter: select single function from two-function file", () => {
+  it("processes only the named function and returns 0", async () => {
+    const file = fixture("two.rs");
+    const spawnImpl = makeSpawnMock(TWO_FN_ENVELOPE);
+    const logger = new CollectingLogger();
+
+    const code = await runShaveRust(args(file, { functionFilter: "add" }), logger, { spawnImpl });
+
+    expect(code).toBe(0);
+    const out = logger.logLines.join("\n");
+    expect(out).toContain("export function add");
+    // No banner emitted for a single-function result.
+    expect(out).not.toContain("// ---- function:");
+  });
+
+  it("returns 1 when the named function is not found", async () => {
+    const file = fixture("two.rs");
+    const spawnImpl = makeSpawnMock(TWO_FN_ENVELOPE);
+    const logger = new CollectingLogger();
+
+    const code = await runShaveRust(args(file, { functionFilter: "notexist" }), logger, {
+      spawnImpl,
+    });
+
+    expect(code).toBe(1);
+    expect(logger.errLines.join("\n")).toContain("notexist");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error-path tests
+// ---------------------------------------------------------------------------
+
+describe("runShaveRust — file read error → exit 1", () => {
+  it("returns 1 and emits structured error when file does not exist", async () => {
+    const logger = new CollectingLogger();
+    const code = await runShaveRust(args("/nonexistent/path/that/does-not-exist.rs"), logger, {
+      spawnImpl: makeSpawnMock(ADD_I32_ENVELOPE),
+    });
+    expect(code).toBe(1);
+    expect(logger.errLines.join("\n")).toContain("error:");
+    expect(logger.errLines.join("\n")).toContain("cannot read file");
+  });
+});
+
+describe("runShaveRust — parse failure (non-zero exit) → exit 2", () => {
+  it("returns 2 and emits structured error when cargo exits non-zero", async () => {
+    const file = fixture("bad.rs", "this is not valid rust syntax\n");
+    const spawnImpl = makeFailingSpawnMock("error[E0001]: syntax error", 1);
+    const logger = new CollectingLogger();
+
+    const code = await runShaveRust(args(file), logger, { spawnImpl });
+
+    expect(code).toBe(2);
+    expect(logger.errLines.join("\n")).toContain("error:");
+    expect(logger.errLines.join("\n")).toContain("parse failed");
+  });
+});
+
+describe("runShaveRust — no functions in file → exit 1", () => {
+  it("returns 1 and emits 'no functions found' when envelope has empty functions list", async () => {
+    const file = fixture("empty.rs", "// no functions here\n");
+    const spawnImpl = makeSpawnMock(NO_FN_ENVELOPE);
+    const logger = new CollectingLogger();
+
+    const code = await runShaveRust(args(file), logger, { spawnImpl });
+
+    expect(code).toBe(1);
+    expect(logger.errLines.join("\n")).toContain("no functions found");
+  });
+});
+
+describe("runShaveRust — --foreign-policy ignored warning", () => {
+  it("emits warning when ignoredForeignPolicy is true", async () => {
+    const file = fixture("warn.rs");
+    const spawnImpl = makeSpawnMock(ADD_I32_ENVELOPE);
+    const logger = new CollectingLogger();
+
+    const code = await runShaveRust(args(file, { ignoredForeignPolicy: true }), logger, {
+      spawnImpl,
+    });
+
+    expect(code).toBe(0);
+    expect(logger.errLines.join("\n")).toContain("--foreign-policy ignored for --target rust");
+  });
+});
+
+describe("runShaveRust — --out <file> writes concatenated IR", () => {
+  it("writes IR to file and returns 0", async () => {
+    const file = fixture("single.rs");
+    const outFile = join(tempDir, "out.ir.ts");
+    const spawnImpl = makeSpawnMock(ADD_I32_ENVELOPE);
+    const logger = new CollectingLogger();
+
+    const code = await runShaveRust(args(file, { out: outFile }), logger, { spawnImpl });
+
+    expect(code).toBe(0);
+    const { readFileSync } = await import("node:fs");
+    const written = readFileSync(outFile, "utf-8");
+    expect(written).toContain("export function add");
+    expect(logger.logLines).toHaveLength(0); // written to file, not stdout
+  });
+});
+
+describe("runShaveRust — --out <dir> writes one file per function", () => {
+  it("creates <fn>.ir.ts for each function in the directory, returns 0", async () => {
+    const file = fixture("multi.rs");
+    const outDir = `${join(tempDir, "out")}/`; // trailing slash → directory target
+    const spawnImpl = makeSpawnMock(TWO_FN_ENVELOPE);
+    const logger = new CollectingLogger();
+
+    const code = await runShaveRust(args(file, { out: outDir }), logger, { spawnImpl });
+
+    expect(code).toBe(0);
+    const { readdirSync } = await import("node:fs");
+    const files = readdirSync(outDir.replace(/\/$/, ""));
+    expect(files).toContain("add.ir.ts");
+    // snake_case is normalized to camelCase in the output filename.
+    expect(files).toContain("isEven.ir.ts");
+  });
+});

--- a/packages/cli/src/commands/shave-rust.ts
+++ b/packages/cli/src/commands/shave-rust.ts
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: MIT
+//
+// shave-rust.ts — CLI helper that drives the @yakcc/shave-rust public API
+// to shave a Rust source file into TS-subset IR atoms.
+//
+// @decision DEC-POLYGLOT-RUST-CLI-001
+// @title yakcc shave arg shape + extension-driven Rust dispatch via @yakcc/shave-rust
+// @status accepted (WI-868 slice 4)
+// @rationale
+//   This helper is called by shave.ts when the target language is "rust".
+//   It composes the shave-rust pipeline primitives (parseRustSource,
+//   extractFunctionSignatures, renderFunctionDeclaration) because
+//   @yakcc/shave-rust does not export a single "shave this file" function.
+//   The composition lives here so the CLI boundary is thin — mirrors exactly
+//   the shave-python.ts pattern (DEC-WI877-001).
+//
+//   Injectable spawnImpl threads through as RustAstParseOptions.spawnImpl so
+//   tests can exercise the full CLI path with a mock subprocess and no Rust
+//   toolchain installed (same mock pattern as acceptance.test.ts in shave-rust).
+//
+//   The compile/lower path (emit Rust source from IR) is tracked by #869 and
+//   remains stubbed.  This module only owns the shave/raise direction.
+//
+//   Exit semantics (mirrors shave-python.ts):
+//     0 — ≥1 function raised successfully.
+//     1 — zero functions succeeded (all skipped or no fns found), or I/O error.
+//     2 — parse-level failure (cargo absent, non-zero exit, JSON schema error).
+//
+//   Output semantics (mirrors DEC-WI877-006 for Python):
+//     Default: stdout.  --out <file>: write all functions concatenated.
+//     --out <dir>: write one file per function (<dir>/<fn>.ir.ts).
+//     --out <file> with multiple functions + no --function: error.
+//
+//   Cross-reference: PLAN.md §4 / #868 / DEC-POLYGLOT-RUST-001
+
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ParseArgsOptionsConfig } from "node:util";
+import {
+  AdapterSubprocessError,
+  type RustAstParseOptions,
+  type SpawnImpl,
+  extractFunctionSignatures,
+  parseRustSource,
+  renderFunctionDeclaration,
+} from "@yakcc/shave-rust";
+import type { Logger } from "../index.js";
+
+/** @internal — exported for testing via injection. */
+export const SHAVE_RUST_PARSE_OPTIONS = {
+  function: { type: "string" },
+  out: { type: "string", short: "o" },
+  // recognized but intentionally ignored for rust target (DEC-POLYGLOT-RUST-CLI-001)
+  registry: { type: "string" },
+  offline: { type: "boolean", default: false },
+  "foreign-policy": { type: "string" },
+  target: { type: "string" },
+  help: { type: "boolean", short: "h", default: false },
+} as const satisfies ParseArgsOptionsConfig;
+
+/** Parsed options shape for runShaveRust. */
+export interface ShaveRustArgs {
+  filePath: string;
+  functionFilter: string | undefined;
+  out: string | undefined;
+  /** Ignored-flags that were passed — warn to stderr. */
+  ignoredForeignPolicy: boolean;
+}
+
+/**
+ * Injectable options for the Rust subprocess.  In tests, callers pass a mock
+ * `spawnImpl` that emits a JSON envelope without invoking cargo.
+ */
+export interface ShaveRustOpts {
+  spawnImpl?: SpawnImpl;
+  cargoExecutable?: string;
+  manifestPath?: string;
+}
+
+/**
+ * Run the Rust shave pipeline for a single file.
+ *
+ * Called from shave.ts when the inferred/explicit target is "rust".
+ *
+ * @param args   Parsed shave-rust argument shape.
+ * @param logger Output sink.
+ * @param opts   Optional injectable subprocess options (for testing).
+ * @returns 0 on success (≥1 function shaved), 1 on total failure, 2 on parse failure.
+ */
+export async function runShaveRust(
+  { filePath, functionFilter, out, ignoredForeignPolicy }: ShaveRustArgs,
+  logger: Logger,
+  opts?: ShaveRustOpts,
+): Promise<number> {
+  // Warn about ignored flags so the operator is not confused.
+  if (ignoredForeignPolicy) {
+    logger.error("warning: --foreign-policy ignored for --target rust");
+  }
+
+  // 1. Read the Rust source file.
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf-8");
+  } catch (err) {
+    logger.error(`error: cannot read file ${filePath}: ${(err as Error).message}`);
+    return 1;
+  }
+
+  // 2. Parse via syn subprocess (cargo-backed; injectable for tests).
+  //    Construct opts object at once — RustAstParseOptions properties are readonly.
+  const parseOpts: RustAstParseOptions = {
+    ...(opts?.spawnImpl !== undefined && { spawnImpl: opts.spawnImpl }),
+    ...(opts?.cargoExecutable !== undefined && { cargoExecutable: opts.cargoExecutable }),
+    ...(opts?.manifestPath !== undefined && { manifestPath: opts.manifestPath }),
+  };
+
+  let envelope: Awaited<ReturnType<typeof parseRustSource>>;
+  try {
+    envelope = await parseRustSource(content, parseOpts);
+  } catch (err) {
+    if (err instanceof AdapterSubprocessError) {
+      // Cargo absent or non-zero exit — actionable remediation hint is in the message.
+      logger.error(`error: parse failed for ${filePath}: ${err.message}`);
+    } else {
+      logger.error(`error: parse failed for ${filePath}: ${(err as Error).message}`);
+    }
+    return 2;
+  }
+
+  // 3. Extract function signatures.
+  let signatures: ReturnType<typeof extractFunctionSignatures>;
+  try {
+    signatures = extractFunctionSignatures(envelope);
+  } catch (err) {
+    logger.error(`error: signature extraction failed: ${(err as Error).message}`);
+    return 2;
+  }
+
+  // 4. Apply --function filter.
+  if (functionFilter !== undefined) {
+    signatures = signatures.filter((s) => s.name === functionFilter);
+    if (signatures.length === 0) {
+      logger.error(`error: function '${functionFilter}' not found in ${filePath}`);
+      return 1;
+    }
+  }
+
+  if (signatures.length === 0) {
+    logger.error(`error: no functions found in ${filePath}`);
+    return 1;
+  }
+
+  // 5. Validate --out semantics: file path + multiple functions + no --function → error.
+  if (
+    out !== undefined &&
+    !isDirectoryTarget(out) &&
+    signatures.length > 1 &&
+    functionFilter === undefined
+  ) {
+    logger.error(
+      `error: --out must be a directory when input has multiple functions; got file path "${out}"`,
+    );
+    return 1;
+  }
+
+  // 6. Raise each function to TS-subset IR (per-function, continue on error).
+  const results: Array<{ name: string; ir: string }> = [];
+  for (const sig of signatures) {
+    try {
+      const ir = renderFunctionDeclaration(sig);
+      results.push({ name: sig.name, ir });
+    } catch (err) {
+      logger.error(`shave-error: ${sig.name}: [raise-error] ${(err as Error).message}`);
+    }
+  }
+
+  if (results.length === 0) {
+    return 1;
+  }
+
+  // 7. Write output.
+  if (out === undefined) {
+    // stdout — concatenate with banners when multiple functions.
+    if (results.length === 1) {
+      // biome-ignore lint/style/noNonNullAssertion: length === 1 ensures index 0 exists
+      logger.log(results[0]!.ir);
+    } else {
+      for (const { name, ir } of results) {
+        logger.log(`// ---- function: ${name} ----`);
+        logger.log(ir);
+      }
+    }
+    return 0;
+  }
+
+  if (isDirectoryTarget(out)) {
+    // Write one file per function.
+    mkdirSync(out, { recursive: true });
+    for (const { name, ir } of results) {
+      const outFile = join(out, `${name}.ir.ts`);
+      writeFileSync(outFile, ir, "utf-8");
+    }
+  } else {
+    // Write all functions concatenated to a single file.
+    const combined = results
+      .map(({ name, ir }) => (results.length > 1 ? `// ---- function: ${name} ----\n${ir}` : ir))
+      .join("\n\n");
+    writeFileSync(out, combined, "utf-8");
+  }
+
+  return 0;
+}
+
+/**
+ * Returns true when `outPath` should be treated as a directory target.
+ * Heuristic: ends with "/" OR is an existing directory.
+ */
+function isDirectoryTarget(outPath: string): boolean {
+  if (outPath.endsWith("/") || outPath.endsWith("\\")) {
+    return true;
+  }
+  try {
+    return statSync(outPath).isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/packages/cli/src/commands/shave.ts
+++ b/packages/cli/src/commands/shave.ts
@@ -53,6 +53,7 @@ import { makeCommonsBinding } from "../lib/commons-submit.js";
 import { readRc } from "../lib/yakccrc.js";
 import { TARGETS_TRACKED, inferTarget } from "./lang-target.js";
 import { runShavePython } from "./shave-python.js";
+import { runShaveRust } from "./shave-rust.js";
 
 /** Valid values for --foreign-policy. */
 const VALID_FOREIGN_POLICIES: readonly ForeignPolicy[] = ["allow", "reject", "tag"];
@@ -126,7 +127,19 @@ export async function shave(argv: ReadonlyArray<string>, logger: Logger): Promis
       );
     }
 
-    if (target === "rust" || target === "go") {
+    if (target === "rust") {
+      return runShaveRust(
+        {
+          filePath: positional ?? "",
+          functionFilter: parsed.values.function as string | undefined,
+          out: parsed.values.out as string | undefined,
+          ignoredForeignPolicy: parsed.values["foreign-policy"] !== undefined,
+        },
+        logger,
+      );
+    }
+
+    if (target === "go") {
       const issue = TARGETS_TRACKED[target];
       logger.error(`error: --target ${target} is not yet wired; tracked at #${issue}`);
       return 1;

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -229,12 +229,20 @@ describe("WI-877: shave polyglot dispatch (DEC-WI877-001)", () => {
     expect(out).toContain("python");
   });
 
-  it("shave --target rust exits 1 with #868 tracking pointer", async () => {
-    // --target rust short-circuits before opening a registry (DEC-WI877-005).
+  it("shave --target rust routes to shave-rust (file read error — no cargo needed)", async () => {
+    // --target rust now routes to runShaveRust (shave/raise is live, #868).
+    // We pass a nonexistent file so it short-circuits at readFileSync → exit 1 + "error:".
+    // The important assertion is that it does NOT emit a "#868 tracking pointer" (no longer stubbed).
     const logger = new CollectingLogger();
-    const code = await runCli(["shave", "--target", "rust", "foo.rs"], logger);
-    expect(code).toBe(1);
-    expect(logger.errLines.join("\n")).toContain("868");
+    const code = await runCli(
+      ["shave", "--target", "rust", "/nonexistent-path-that-cannot-exist.rs"],
+      logger,
+    );
+    expect(code).not.toBe(0);
+    // Must produce a structured error, NOT a stub tracking pointer.
+    expect(logger.errLines.join("\n")).toContain("error:");
+    // Must NOT emit the old stub "#868 not yet wired" message.
+    expect(logger.errLines.join("\n")).not.toContain("not yet wired");
   });
 
   it("shave --target go exits 1 with #870 tracking pointer", async () => {
@@ -274,11 +282,11 @@ describe("WI-877: compile polyglot dispatch (DEC-WI877-002)", () => {
     expect(logger.errLines.join("\n")).toContain("compile requires");
   });
 
-  it("compile --target rust exits 1 with #868 tracking pointer", async () => {
+  it("compile --target rust exits 1 with #869 tracking pointer (compile/lower tracked at #869)", async () => {
     const logger = new CollectingLogger();
     const code = await runCli(["compile", "a".repeat(64), "--target", "rust"], logger);
     expect(code).toBe(1);
-    expect(logger.errLines.join("\n")).toContain("868");
+    expect(logger.errLines.join("\n")).toContain("869");
   });
 
   it("compile --target go exits 1 with #870 tracking pointer", async () => {
@@ -324,11 +332,11 @@ describe("WI-877: roundtrip dispatch (DEC-WI877-003)", () => {
     expect(logger.errLines.join("\n")).toContain("877");
   });
 
-  it("roundtrip --target rust exits 2 with #868 pointer", async () => {
+  it("roundtrip --target rust exits 2 with #869 pointer (compile/lower tracked at #869)", async () => {
     const logger = new CollectingLogger();
     const code = await runCli(["roundtrip", "foo.rs", "--target", "rust"], logger);
     expect(code).toBe(2);
-    expect(logger.errLines.join("\n")).toContain("868");
+    expect(logger.errLines.join("\n")).toContain("869");
   });
 
   it("roundtrip --target go exits 2 with #870 pointer", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -173,16 +173,16 @@ COMMANDS
   shave <path> [--registry <p>]       Shave a source file into atoms (TS pipeline, default)
         [--offline]                   .py extension or --target python → Python pipeline (WI-877)
         [--target <ts|python|         Override language inference from file extension
-                  rust|go>]          rust/go: exits 1 with tracking-issue pointer (#868/#870)
-        [--out <path>]                Python target: stdout when omitted, file/dir with --out
-        [--function <name>]           Python target: process only one named function
+                  rust|go>]          rust: live (#868); go: exits 1 with pointer (#870)
+        [--out <path>]                Python/Rust target: stdout when omitted, file/dir with --out
+        [--function <name>]           Python/Rust target: process only one named function
         [--foreign-policy             TS target only: how to handle foreign-block deps
-              <allow|reject|tag>]     (ignored with warning for --target python)
+              <allow|reject|tag>]     (ignored with warning for --target python/rust)
   build [--registry <p>] [<dir>]      Materialize .yakcc/manifest.json atom references into .yakcc/atoms/
   compile <entry> [--registry <p>]   Assemble a module from a contract id, spec file, or directory
                [--out <dir>]          Output directory (default: ./yakcc-out or <dir>/dist)
                [--target <ts|python|  Language target (default: ts); python writes module.py
-                         rust|go>]    rust/go: exits 1 with tracking-issue pointer (#868/#870)
+                         rust|go>]    rust compile/lower: tracked at #869; go: #870
                [--function <name>]    Python target: compile one named function
   roundtrip <file>                   Chain shave → compile → diff; emit per-function status table
             [--target <ts|python|     Language target (auto-detected from extension)

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -18,6 +18,7 @@
     { "path": "../hooks-claude-code" },
     { "path": "../seeds" },
     { "path": "../shave" },
-    { "path": "../shave-python" }
+    { "path": "../shave-python" },
+    { "path": "../shave-rust" }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,9 @@ importers:
       '@yakcc/shave-python':
         specifier: workspace:*
         version: link:../shave-python
+      '@yakcc/shave-rust':
+        specifier: workspace:*
+        version: link:../shave-rust
       '@yakcc/variance':
         specifier: workspace:*
         version: link:../variance


### PR DESCRIPTION
Final slice of #868 — the Rust **raise** path is now live in the CLI. **Closes #868.**

- NEW `shave-rust.ts` (`runShaveRust`) mirroring `shave-python.ts`: composes the shave-rust primitives, threads an injectable `spawnImpl` so CLI tests run **pure-Node with a mock (no cargo)**.
- `shave.ts`: `.rs` / `--target rust` now routes to `runShaveRust` (go stays stubbed).
- `lang-target`: `TARGETS_TRACKED.rust` 868 → **869** (raise is done; the remaining tracked gap for rust is the COMPILE/lower adapter = #869). compile/roundtrip rust stay stubbed, now pointing at #869.
- `package.json` + `tsconfig`: declare `@yakcc/shave-rust` (devDependency `workspace:*` + `../shave-rust` reference) — same shape as `@yakcc/shave-python`.
- NEW `shave-rust.test.ts`: 12 mock-spawn tests proving `.rs` → TS-subset IR with no cargo.

**#868 acceptance now complete:** package ships ✓, signature + body raise ✓, purity inference + ≥5-class error taxonomy ✓, `yakcc init` Cargo.toml detection + `shave` routing ✓, CI (pure-Node + gated real-cargo e2e) ✓, DEC annotations ✓.

Reviewed → ready_for_guardian (2 non-blocking notes). Full workspace build+lint+typecheck green. Unblocks **#869** (the Rust lower adapter).