### PR TITLE
feat(proof-market): #1085 — reputation ledger consumers (Slice E impl)

### DIFF
--- a/packages/proof-market/src/index.ts
+++ b/packages/proof-market/src/index.ts
@@ -24,3 +24,23 @@ export type {
   ClaimRow,
   PostBountyOptions,
 } from "./proof-market.js";
+
+// Reputation track (#1085 / Slice E impl)
+export {
+  RC_ATOM_ACCEPTED,
+  RC_PROOF_CLAIM_ACCEPTED,
+  RC_VERIFIER_ATTESTATION_CORRECT,
+  RC_CLAIM_SLASHED,
+  RC_VERIFIER_DISSENT,
+  RC_BOOTSTRAP_GRANT,
+  RC_HALF_LIFE_MS,
+  SYBIL_MAX_ACTIVE_CLAIMS,
+  accrueReputation,
+  applyDecay,
+  bootstrapGrantIfNeeded,
+  checkSybilLimit,
+  getReputation,
+  reputationDeltaForEvent,
+  slashReputation,
+} from "./reputation.js";
+export type { ReputationClock, ReputationEvent } from "./reputation.js";

--- a/packages/proof-market/src/reputation.test.ts
+++ b/packages/proof-market/src/reputation.test.ts
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: MIT
+//
+// Tests for the reputation ledger consumers (#1085 / Slice E impl).
+//
+// Uses an in-memory SQLite with the v13 schema (proof_claims +
+// reputation_ledger tables) so the tests exercise real SQL paths.
+
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  RC_ATOM_ACCEPTED,
+  RC_BOOTSTRAP_GRANT,
+  RC_CLAIM_SLASHED,
+  RC_HALF_LIFE_MS,
+  RC_PROOF_CLAIM_ACCEPTED,
+  RC_VERIFIER_ATTESTATION_CORRECT,
+  RC_VERIFIER_DISSENT,
+  SYBIL_MAX_ACTIVE_CLAIMS,
+  accrueReputation,
+  applyDecay,
+  bootstrapGrantIfNeeded,
+  checkSybilLimit,
+  getReputation,
+  reputationDeltaForEvent,
+  slashReputation,
+  type ReputationClock,
+} from "./reputation.js";
+
+// ---------------------------------------------------------------------------
+// In-memory test DB with the v13 reputation_ledger + proof_claims subset
+// ---------------------------------------------------------------------------
+
+function makeDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE reputation_ledger (
+      account_id TEXT PRIMARY KEY,
+      score REAL NOT NULL,
+      last_event_at INTEGER NOT NULL
+    );
+    CREATE TABLE proof_claims (
+      claim_id TEXT PRIMARY KEY,
+      bounty_id TEXT NOT NULL,
+      claimant_id TEXT NOT NULL,
+      commit_hash TEXT,
+      stake_amount INTEGER,
+      stake_unit TEXT,
+      revealed_artifact_hash TEXT,
+      status TEXT NOT NULL,
+      committed_at INTEGER,
+      revealed_at INTEGER
+    );
+    CREATE INDEX idx_proof_claims_claimant ON proof_claims (claimant_id);
+  `);
+  return db;
+}
+
+class FakeClock implements ReputationClock {
+  constructor(public t: number) {}
+  now(): number {
+    return this.t;
+  }
+  advance(ms: number): void {
+    this.t += ms;
+  }
+}
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = makeDb();
+});
+
+afterEach(() => {
+  db.close();
+});
+
+// ---------------------------------------------------------------------------
+// Accrual
+// ---------------------------------------------------------------------------
+
+describe("accrueReputation — event deltas", () => {
+  it.each([
+    ["atom_accepted", RC_ATOM_ACCEPTED] as const,
+    ["proof_claim_accepted", RC_PROOF_CLAIM_ACCEPTED] as const,
+    ["verifier_attestation_correct", RC_VERIFIER_ATTESTATION_CORRECT] as const,
+    ["claim_slashed", RC_CLAIM_SLASHED] as const,
+    ["verifier_dissent", RC_VERIFIER_DISSENT] as const,
+  ])("applies %s -> delta=%i (on top of bootstrap grant)", (event, expectedDelta) => {
+    const clock = new FakeClock(1_000_000);
+    const score = accrueReputation(db, "alice", event, clock);
+    // First event: bootstrap grant (100) + the event delta
+    expect(score).toBe(RC_BOOTSTRAP_GRANT + expectedDelta);
+  });
+
+  it("reputationDeltaForEvent matches the constants table", () => {
+    expect(reputationDeltaForEvent("atom_accepted")).toBe(RC_ATOM_ACCEPTED);
+    expect(reputationDeltaForEvent("proof_claim_accepted")).toBe(RC_PROOF_CLAIM_ACCEPTED);
+    expect(reputationDeltaForEvent("verifier_attestation_correct")).toBe(
+      RC_VERIFIER_ATTESTATION_CORRECT,
+    );
+    expect(reputationDeltaForEvent("claim_slashed")).toBe(RC_CLAIM_SLASHED);
+    expect(reputationDeltaForEvent("verifier_dissent")).toBe(RC_VERIFIER_DISSENT);
+  });
+
+  it("multiple events accumulate (no decay over zero elapsed time)", () => {
+    const clock = new FakeClock(1_000_000);
+    accrueReputation(db, "alice", "atom_accepted", clock);
+    accrueReputation(db, "alice", "atom_accepted", clock);
+    accrueReputation(db, "alice", "proof_claim_accepted", clock);
+    expect(getReputation(db, "alice", clock)).toBe(
+      RC_BOOTSTRAP_GRANT + 2 * RC_ATOM_ACCEPTED + RC_PROOF_CLAIM_ACCEPTED,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bootstrap
+// ---------------------------------------------------------------------------
+
+describe("bootstrapGrantIfNeeded", () => {
+  it("grants RC_BOOTSTRAP_GRANT on first call for a new account", () => {
+    const clock = new FakeClock(1_000_000);
+    const granted = bootstrapGrantIfNeeded(db, "alice", clock);
+    expect(granted).toBe(true);
+    expect(getReputation(db, "alice", clock)).toBe(RC_BOOTSTRAP_GRANT);
+  });
+
+  it("does NOT grant a second time", () => {
+    const clock = new FakeClock(1_000_000);
+    expect(bootstrapGrantIfNeeded(db, "alice", clock)).toBe(true);
+    expect(bootstrapGrantIfNeeded(db, "alice", clock)).toBe(false);
+    expect(getReputation(db, "alice", clock)).toBe(RC_BOOTSTRAP_GRANT);
+  });
+
+  it("subsequent accrueReputation does not re-grant bootstrap", () => {
+    const clock = new FakeClock(1_000_000);
+    accrueReputation(db, "alice", "atom_accepted", clock); // 100 + 5
+    accrueReputation(db, "alice", "atom_accepted", clock); // 105 + 5
+    expect(getReputation(db, "alice", clock)).toBe(RC_BOOTSTRAP_GRANT + 2 * RC_ATOM_ACCEPTED);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slashing — non-transferable property
+// ---------------------------------------------------------------------------
+
+describe("slashReputation — non-transferable", () => {
+  it("decrements the slashed account; no other account row is created or touched", () => {
+    const clock = new FakeClock(1_000_000);
+    accrueReputation(db, "alice", "proof_claim_accepted", clock); // 100 + 50 = 150
+    bootstrapGrantIfNeeded(db, "refuter", clock); // refuter has 100 RC
+
+    const aliceBefore = getReputation(db, "alice", clock);
+    const refuterBefore = getReputation(db, "refuter", clock);
+
+    slashReputation(db, "alice", 50, "claim_invalid_proof", clock);
+
+    expect(getReputation(db, "alice", clock)).toBe(aliceBefore - 50);
+    // Critical: nothing transferred to refuter
+    expect(getReputation(db, "refuter", clock)).toBe(refuterBefore);
+  });
+
+  it("throws on non-positive amount", () => {
+    expect(() => slashReputation(db, "alice", 0, "test")).toThrow(TypeError);
+    expect(() => slashReputation(db, "alice", -5, "test")).toThrow(TypeError);
+  });
+
+  it("ledger row count is exactly 1 after slashing one account from a fresh state", () => {
+    const clock = new FakeClock(1_000_000);
+    slashReputation(db, "alice", 1, "test", clock);
+    const rows = db.prepare("SELECT COUNT(*) AS n FROM reputation_ledger").get() as { n: number };
+    expect(rows.n).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Decay — linear half-life
+// ---------------------------------------------------------------------------
+
+describe("decay — linear half-life", () => {
+  it("score halves after RC_HALF_LIFE_MS", () => {
+    const t0 = 1_000_000_000;
+    const clock = new FakeClock(t0);
+    bootstrapGrantIfNeeded(db, "alice", clock);
+    expect(getReputation(db, "alice", clock)).toBe(RC_BOOTSTRAP_GRANT);
+    clock.advance(RC_HALF_LIFE_MS);
+    expect(getReputation(db, "alice", clock)).toBeCloseTo(RC_BOOTSTRAP_GRANT / 2, 4);
+  });
+
+  it("score quarters after 2× half-life", () => {
+    const t0 = 1_000_000_000;
+    const clock = new FakeClock(t0);
+    bootstrapGrantIfNeeded(db, "alice", clock);
+    clock.advance(RC_HALF_LIFE_MS * 2);
+    expect(getReputation(db, "alice", clock)).toBeCloseTo(RC_BOOTSTRAP_GRANT / 4, 4);
+  });
+
+  it("applyDecay updates the stored checkpoint to the decayed value", () => {
+    const t0 = 1_000_000_000;
+    const clock = new FakeClock(t0);
+    bootstrapGrantIfNeeded(db, "alice", clock);
+    clock.advance(RC_HALF_LIFE_MS);
+    applyDecay(db, "alice", clock);
+    // Reading immediately after applyDecay (zero elapsed) gives the checkpoint
+    const row = db
+      .prepare("SELECT score FROM reputation_ledger WHERE account_id = ?")
+      .get("alice") as { score: number };
+    expect(row.score).toBeCloseTo(RC_BOOTSTRAP_GRANT / 2, 4);
+  });
+
+  it("returns 0 for unknown accounts", () => {
+    expect(getReputation(db, "ghost")).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sybil rate-limit
+// ---------------------------------------------------------------------------
+
+describe("checkSybilLimit", () => {
+  it("does not throw when no active claims", () => {
+    expect(() => checkSybilLimit(db, "alice")).not.toThrow();
+  });
+
+  it("does not throw at SYBIL_MAX_ACTIVE_CLAIMS - 1", () => {
+    for (let i = 0; i < SYBIL_MAX_ACTIVE_CLAIMS - 1; i++) {
+      db.prepare(
+        "INSERT INTO proof_claims (claim_id, bounty_id, claimant_id, status) VALUES (?, ?, ?, ?)",
+      ).run(`claim-${i}`, "bounty-1", "alice", "COMMITTED");
+    }
+    expect(() => checkSybilLimit(db, "alice")).not.toThrow();
+  });
+
+  it("throws ESYBIL_LIMIT at SYBIL_MAX_ACTIVE_CLAIMS", () => {
+    for (let i = 0; i < SYBIL_MAX_ACTIVE_CLAIMS; i++) {
+      db.prepare(
+        "INSERT INTO proof_claims (claim_id, bounty_id, claimant_id, status) VALUES (?, ?, ?, ?)",
+      ).run(`claim-${i}`, "bounty-1", "alice", "COMMITTED");
+    }
+    try {
+      checkSybilLimit(db, "alice");
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect((err as Error & { code: string }).code).toBe("ESYBIL_LIMIT");
+    }
+  });
+
+  it("ignores finalized claims (VALID / INVALID / LAPSED) when counting", () => {
+    // Sybil cap is concurrent ACTIVE claims, not lifetime claims
+    for (let i = 0; i < SYBIL_MAX_ACTIVE_CLAIMS + 10; i++) {
+      db.prepare(
+        "INSERT INTO proof_claims (claim_id, bounty_id, claimant_id, status) VALUES (?, ?, ?, ?)",
+      ).run(`claim-${i}`, "bounty-1", "alice", "VALID");
+    }
+    expect(() => checkSybilLimit(db, "alice")).not.toThrow();
+  });
+
+  it("counts REVEALED claims toward the cap (still active)", () => {
+    for (let i = 0; i < SYBIL_MAX_ACTIVE_CLAIMS; i++) {
+      db.prepare(
+        "INSERT INTO proof_claims (claim_id, bounty_id, claimant_id, status) VALUES (?, ?, ?, ?)",
+      ).run(`claim-${i}`, "bounty-1", "alice", "REVEALED");
+    }
+    expect(() => checkSybilLimit(db, "alice")).toThrow(/ESYBIL_LIMIT/);
+  });
+});

--- a/packages/proof-market/src/reputation.ts
+++ b/packages/proof-market/src/reputation.ts
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: MIT
+//
+// Reputation ledger consumers for the proof-incentive market.
+//
+// @decision DEC-PROOF-STAKE-ECONOMICS-001 (implementation site)
+// @title Reputation ledger consumers — accrue / slash / decay / bootstrap / sybil
+// @status accepted (Slice E implementation, #1085)
+// @rationale
+//   Implementation of the reputation track specified in
+//   docs/proof-incentive-economics.md. The spec is authoritative; this module
+//   mirrors the spec's accrual rates, decay half-life, slash semantics, and
+//   sybil-resistance rules. If the spec changes, the constants below must
+//   change to match.
+//
+//   Key invariants:
+//   1. Reputation is non-transferable. slashReputation() decrements an
+//      account's balance without writing to any other account.
+//   2. Bootstrap grant (100 RC) is one-time per account, gated on absence of
+//      any row in reputation_ledger.
+//   3. Linear half-life decay (180 days) is applied at read time. The stored
+//      `score` is an undecayed checkpoint; readers see the decayed value.
+//   4. Sybil rate-limit (5 concurrent active claims per account) is enforced
+//      via checkSybilLimit() which the lifecycle (commitClaim) must call.
+//
+// Issue: #1085 (Slice E impl). Plan: plans/proof-incentive-layer.md §4 Slice E.
+// Authority: docs/proof-incentive-economics.md.
+
+import type Database from "better-sqlite3";
+
+// ---------------------------------------------------------------------------
+// Accrual constants (mirror of economics spec § 2)
+// ---------------------------------------------------------------------------
+
+/** +5 RC per accepted atom submission. */
+export const RC_ATOM_ACCEPTED = 5;
+
+/** +50 RC per accepted proof claim. 10× atom because proofs are scarcer. */
+export const RC_PROOF_CLAIM_ACCEPTED = 50;
+
+/** +2 RC per correct verifier attestation. */
+export const RC_VERIFIER_ATTESTATION_CORRECT = 2;
+
+/** −100 RC per slashed claim. */
+export const RC_CLAIM_SLASHED = -100;
+
+/** −10 RC per dissenting verifier attestation. */
+export const RC_VERIFIER_DISSENT = -10;
+
+/** Bootstrap grant: new accounts get this on first event (one-time). */
+export const RC_BOOTSTRAP_GRANT = 100;
+
+/** Decay half-life in milliseconds. 180 days, linear half-life. */
+export const RC_HALF_LIFE_MS = 180 * 24 * 60 * 60 * 1000;
+
+/** Maximum concurrent active claims per account before sybil rate-limit fires. */
+export const SYBIL_MAX_ACTIVE_CLAIMS = 5;
+
+// ---------------------------------------------------------------------------
+// Event types
+// ---------------------------------------------------------------------------
+
+export type ReputationEvent =
+  | "atom_accepted"
+  | "proof_claim_accepted"
+  | "verifier_attestation_correct"
+  | "claim_slashed"
+  | "verifier_dissent";
+
+const EVENT_DELTAS: Record<ReputationEvent, number> = {
+  atom_accepted: RC_ATOM_ACCEPTED,
+  proof_claim_accepted: RC_PROOF_CLAIM_ACCEPTED,
+  verifier_attestation_correct: RC_VERIFIER_ATTESTATION_CORRECT,
+  claim_slashed: RC_CLAIM_SLASHED,
+  verifier_dissent: RC_VERIFIER_DISSENT,
+};
+
+/** Public lookup so callers can preview the delta a given event will apply. */
+export function reputationDeltaForEvent(event: ReputationEvent): number {
+  return EVENT_DELTAS[event];
+}
+
+// ---------------------------------------------------------------------------
+// Time abstraction (so tests can inject synthetic timestamps)
+// ---------------------------------------------------------------------------
+
+export interface ReputationClock {
+  now(): number;
+}
+
+const REAL_CLOCK: ReputationClock = {
+  now: () => Date.now(),
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function accrueReputation(
+  db: Database.Database,
+  account_id: string,
+  event: ReputationEvent,
+  clock: ReputationClock = REAL_CLOCK,
+): number {
+  bootstrapGrantIfNeeded(db, account_id, clock);
+  applyReputationDelta(db, account_id, EVENT_DELTAS[event], clock.now());
+  return getReputation(db, account_id, clock);
+}
+
+export function slashReputation(
+  db: Database.Database,
+  account_id: string,
+  amount: number,
+  _reason: string,
+  clock: ReputationClock = REAL_CLOCK,
+): number {
+  if (amount <= 0) {
+    throw new TypeError(`slashReputation: amount must be positive, got ${amount}`);
+  }
+  bootstrapGrantIfNeeded(db, account_id, clock);
+  applyReputationDelta(db, account_id, -amount, clock.now());
+  return getReputation(db, account_id, clock);
+}
+
+export function getReputation(
+  db: Database.Database,
+  account_id: string,
+  clock: ReputationClock = REAL_CLOCK,
+): number {
+  const row = db
+    .prepare("SELECT score, last_event_at FROM reputation_ledger WHERE account_id = ?")
+    .get(account_id) as { score: number; last_event_at: number } | undefined;
+  if (row === undefined) return 0;
+  const elapsed = clock.now() - row.last_event_at;
+  if (elapsed <= 0) return row.score;
+  const halfLives = elapsed / RC_HALF_LIFE_MS;
+  return row.score * Math.pow(0.5, halfLives);
+}
+
+export function applyDecay(
+  db: Database.Database,
+  account_id: string,
+  clock: ReputationClock = REAL_CLOCK,
+): number {
+  const decayed = getReputation(db, account_id, clock);
+  db.prepare(
+    "UPDATE reputation_ledger SET score = ?, last_event_at = ? WHERE account_id = ?",
+  ).run(decayed, clock.now(), account_id);
+  return decayed;
+}
+
+export function bootstrapGrantIfNeeded(
+  db: Database.Database,
+  account_id: string,
+  clock: ReputationClock = REAL_CLOCK,
+): boolean {
+  const existing = db
+    .prepare("SELECT 1 FROM reputation_ledger WHERE account_id = ?")
+    .get(account_id);
+  if (existing !== undefined) return false;
+  db.prepare(
+    "INSERT INTO reputation_ledger (account_id, score, last_event_at) VALUES (?, ?, ?)",
+  ).run(account_id, RC_BOOTSTRAP_GRANT, clock.now());
+  return true;
+}
+
+export function checkSybilLimit(db: Database.Database, account_id: string): void {
+  const row = db
+    .prepare(
+      "SELECT COUNT(*) AS n FROM proof_claims WHERE claimant_id = ? AND status IN ('COMMITTED', 'REVEALED')",
+    )
+    .get(account_id) as { n: number };
+  if (row.n >= SYBIL_MAX_ACTIVE_CLAIMS) {
+    const err = new Error(
+      `ESYBIL_LIMIT: account ${account_id} has ${row.n} active claims (max ${SYBIL_MAX_ACTIVE_CLAIMS})`,
+    );
+    (err as Error & { code: string }).code = "ESYBIL_LIMIT";
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal
+// ---------------------------------------------------------------------------
+
+function applyReputationDelta(
+  db: Database.Database,
+  account_id: string,
+  delta: number,
+  now: number,
+): void {
+  const existing = db
+    .prepare("SELECT score, last_event_at FROM reputation_ledger WHERE account_id = ?")
+    .get(account_id) as { score: number; last_event_at: number } | undefined;
+
+  if (existing === undefined) {
+    db.prepare(
+      "INSERT INTO reputation_ledger (account_id, score, last_event_at) VALUES (?, ?, ?)",
+    ).run(account_id, delta, now);
+    return;
+  }
+
+  const elapsed = now - existing.last_event_at;
+  const halfLives = elapsed / RC_HALF_LIFE_MS;
+  const decayed = elapsed > 0 ? existing.score * Math.pow(0.5, halfLives) : existing.score;
+
+  db.prepare(
+    "UPDATE reputation_ledger SET score = ?, last_event_at = ? WHERE account_id = ?",
+  ).run(decayed + delta, now, account_id);
+}


### PR DESCRIPTION
Implementation of the reputation track specified in `docs/proof-incentive-economics.md` (`DEC-PROOF-STAKE-ECONOMICS-001`). Slice E impl of the proof incentive layer.

## What

`packages/proof-market/src/reputation.ts` exports consumer functions over the `reputation_ledger` table (schema v13, #1081):

- `accrueReputation(account, event)` — applies spec deltas: +5/atom, +50/proof, +2/correct attestation, −100/slash, −10/dissent
- `slashReputation(account, amount, reason)` — **NON-TRANSFERABLE deletion**: no other ledger row is touched. Preserves grief-resistance.
- `getReputation(account)` — applies linear half-life decay at read time
- `applyDecay(account)` — checkpoints the decayed value
- `bootstrapGrantIfNeeded(account)` — one-time 100 RC grant
- `checkSybilLimit(account)` — throws `ESYBIL_LIMIT` at 5 concurrent active claims

All numerical constants exported (`RC_*`, `SYBIL_MAX_ACTIVE_CLAIMS`, `RC_HALF_LIFE_MS`) so consumers don't hardcode. The economics spec is authority; this module mirrors it.

## Tests — 55 pass (33 existing + 22 new)

- Each accrual event applies the documented delta
- Bootstrap grant fires exactly once per account
- **Slash non-transferability** (key invariant): refuter's row untouched after slash
- Linear half-life decay: score halves at 180d, quarters at 360d
- Sybil rate-limit fires at the 6th concurrent active claim (counts COMMITTED + REVEALED; ignores finalized)

## Decision

`@decision DEC-PROOF-STAKE-ECONOMICS-001` (implementation site) — reputation track consumers. `docs/proof-incentive-economics.md` is authority.

Closes #1085

## Test plan

- [x] `pnpm --filter @yakcc/proof-market test` — 55 pass
- [x] `pnpm -r build` — clean
- [x] `pnpm --filter @yakcc/proof-market exec tsc --noEmit -p .` — clean