### PR TITLE
feat(proof-verifier): #1083 — Lean verifier daemon (Slice D engine)

### DIFF
--- a/packages/proof-verifier/package.json
+++ b/packages/proof-verifier/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@yakcc/proof-verifier",
+  "version": "0.6.0-alpha.0",
+  "description": "Verifier daemon for yakcc proof incentive layer — watches proof_claims in REVEAL state, runs Lean checker, emits Ed25519-signed attestations.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "private": true,
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cneckar/yakcc.git",
+    "directory": "packages/proof-verifier"
+  },
+  "homepage": "https://github.com/cneckar/yakcc/tree/main/packages/proof-verifier#readme",
+  "bugs": {
+    "url": "https://github.com/cneckar/yakcc/issues"
+  },
+  "keywords": [
+    "yakcc",
+    "proof",
+    "verifier",
+    "lean",
+    "ed25519",
+    "attestation"
+  ],
+  "scripts": {
+    "build": "rm -f tsconfig.tsbuildinfo && tsc -p .",
+    "typecheck": "tsc --noEmit -p .",
+    "test": "vitest run",
+    "lint": "echo \"no lint yet\""
+  },
+  "dependencies": {
+    "@noble/hashes": "^2.2.0",
+    "@yakcc/contracts": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/proof-verifier/src/identity.ts
+++ b/packages/proof-verifier/src/identity.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Ed25519 verifier identity — load or create a persistent keypair.
+ *
+ * The keypair is persisted as a single hex-encoded private key (64 hex chars
+ * for the 32-byte seed) in a file under `~/.yakcc/verifier-key` by default.
+ * The corresponding public key is always derived from the private key so
+ * there is a single source of truth.
+ *
+ * @decision DEC-PROOF-VERIFIER-IDENTITY-001
+ * title: Node.js native crypto for Ed25519 — no @noble/curves dep
+ * status: decided
+ * rationale:
+ *   Node.js 22 ships native Ed25519 support via node:crypto (KeyObject API).
+ *   @noble/curves is not yet in the workspace lock file.  Adding it as a new
+ *   dependency for one package, when the native implementation is zero-overhead
+ *   and already audited by the Node team, would be premature.  If the proof-
+ *   market layer later requires @noble/curves for other reasons (ECC primitives,
+ *   ECDSA), we consolidate then.  For MVP: node:crypto only.
+ *
+ * @module identity
+ */
+
+import {
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+} from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname } from "node:path";
+
+/** A loaded Ed25519 keypair. */
+export interface VerifierIdentity {
+  /** Raw 32-byte Ed25519 private key seed. */
+  readonly privateKey: Uint8Array;
+  /** Raw 32-byte Ed25519 public key. */
+  readonly publicKey: Uint8Array;
+}
+
+/** Default path for the persisted private key. */
+export const DEFAULT_KEY_PATH = `${homedir()}/.yakcc/verifier-key`;
+
+/**
+ * Export a Node.js Ed25519 `KeyObject` to its raw 32-byte seed.
+ *
+ * Node's `pkcs8` DER export for Ed25519 private keys is:
+ *   30 2e 02 01 00 30 05 06 03 2b 65 70 04 22 04 20 <32-byte seed>
+ * The seed starts at byte offset 16.
+ */
+function privateKeyObjectToBytes(keyObj: ReturnType<typeof createPrivateKey>): Uint8Array {
+  const der = keyObj.export({ type: "pkcs8", format: "der" }) as Buffer;
+  // Ed25519 PKCS8 DER: fixed 48-byte wrapper, seed is last 32 bytes
+  return new Uint8Array(der.subarray(der.length - 32));
+}
+
+/**
+ * Export a Node.js Ed25519 public `KeyObject` to its raw 32-byte point.
+ *
+ * `spki` DER for Ed25519:
+ *   30 2a 30 05 06 03 2b 65 70 03 21 00 <32-byte public key>
+ * The public key bytes start at byte offset 12.
+ */
+function publicKeyObjectToBytes(keyObj: ReturnType<typeof createPublicKey>): Uint8Array {
+  const der = keyObj.export({ type: "spki", format: "der" }) as Buffer;
+  return new Uint8Array(der.subarray(der.length - 32));
+}
+
+/**
+ * Reconstruct a private `KeyObject` from a 32-byte raw seed.
+ *
+ * We build the PKCS8 DER wrapper by hand.  The wrapper is a fixed 16-byte
+ * prefix for Ed25519 private keys.
+ */
+function bytesToPrivateKeyObject(seed: Uint8Array): ReturnType<typeof createPrivateKey> {
+  // PKCS8 DER prefix for Ed25519 private key (OneAsymmetricKey / RFC 8410)
+  const prefix = Buffer.from(
+    "302e020100300506032b657004220420",
+    "hex",
+  );
+  const der = Buffer.concat([prefix, seed]);
+  return createPrivateKey({ key: der, format: "der", type: "pkcs8" });
+}
+
+/**
+ * Load an existing identity from `keyPath` or create a new one.
+ *
+ * - If the file exists: reads the hex-encoded seed (32 bytes = 64 hex chars),
+ *   derives the public key.
+ * - If the file does not exist: generates a fresh keypair, writes the hex seed
+ *   to `keyPath` (creating parent directories as needed).
+ *
+ * @param keyPath  Path to the persisted private key file.  Defaults to
+ *   `~/.yakcc/verifier-key`.
+ */
+export function loadOrCreateIdentity(
+  keyPath: string = DEFAULT_KEY_PATH,
+): VerifierIdentity {
+  if (existsSync(keyPath)) {
+    const hex = readFileSync(keyPath, "utf8").trim();
+    if (hex.length !== 64) {
+      throw new Error(
+        `verifier identity file at ${keyPath} must contain a 64-char hex string (32-byte seed); got ${hex.length} chars`,
+      );
+    }
+    const seed = new Uint8Array(Buffer.from(hex, "hex"));
+    const privObj = bytesToPrivateKeyObject(seed);
+    const pubObj = createPublicKey(privObj);
+    return {
+      privateKey: privateKeyObjectToBytes(privObj),
+      publicKey: publicKeyObjectToBytes(pubObj),
+    };
+  }
+
+  // Generate fresh keypair
+  const { privateKey: privObj, publicKey: pubObj } = generateKeyPairSync("ed25519");
+  const privateKey = privateKeyObjectToBytes(privObj);
+  const publicKey = publicKeyObjectToBytes(pubObj);
+
+  // Persist
+  const dir = dirname(keyPath);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(keyPath, Buffer.from(privateKey).toString("hex") + "\n", {
+    mode: 0o600,
+  });
+
+  return { privateKey, publicKey };
+}

--- a/packages/proof-verifier/src/index.ts
+++ b/packages/proof-verifier/src/index.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+/**
+ * @yakcc/proof-verifier — public API surface.
+ *
+ * Exports the Ed25519 identity helpers, attestation signing/verification,
+ * and the Lean proof runner.  The claim-level orchestration pipeline
+ * ({@link runVerifierForClaim}) is the primary integration point for the
+ * proof-market supermajority aggregator.
+ *
+ * @module @yakcc/proof-verifier
+ */
+
+// Identity
+export {
+  DEFAULT_KEY_PATH,
+  loadOrCreateIdentity,
+} from "./identity.js";
+export type { VerifierIdentity } from "./identity.js";
+
+// Lean runner
+export {
+  detectLeanVersion,
+  parseLeanVersion,
+  runCoqCheck,
+  runLeanCheck,
+} from "./lean-runner.js";
+export type { LeanRunResult } from "./lean-runner.js";
+
+// Core verifier / attestation
+export {
+  runVerifierForClaim,
+  signAttestation,
+  verifyAttestation,
+} from "./verifier.js";
+export type {
+  Attestation,
+  AttestationPayload,
+  RunVerifierParams,
+  VerifierClaimResult,
+} from "./verifier.js";

--- a/packages/proof-verifier/src/lean-runner.ts
+++ b/packages/proof-verifier/src/lean-runner.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Lean proof checker runner.
+ *
+ * Invokes `lean --check <path>` against a pinned toolchain version. The checker
+ * compares the requested toolchain version against the locally installed Lean
+ * binary version. If they do not match, the result is `invalid` — the daemon
+ * never tries to install Lean (that is container/CI territory per the MVP scope
+ * decision in DEC-PROOF-VERIFIER-DAEMON-001).
+ *
+ * The sandbox policy for v0 is: trust the local Lean install. Container/nix-shell
+ * isolation is deferred to the sandbox-policy work item
+ * (`wi-proof-verifier-sandbox-policy`) per DEC-PROOF-VERIFIER-DAEMON-001.
+ *
+ * @module lean-runner
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/** Result of running the Lean checker against a single proof file. */
+export interface LeanRunResult {
+  /** `"valid"` when Lean accepted the proof without errors; `"invalid"` otherwise. */
+  readonly result: "valid" | "invalid";
+  /**
+   * Lean version string reported by `lean --version` (e.g. `"4.7.0"`).
+   * Populated even when the result is `"invalid"` (version mismatch returns the
+   * locally-installed version so the caller can surface the discrepancy).
+   * `null` when Lean is not installed.
+   */
+  readonly localVersion: string | null;
+  /** Lean stdout + stderr combined; useful for debugging failed checks. */
+  readonly output: string;
+}
+
+/**
+ * Parse a Lean version string from the output of `lean --version`.
+ *
+ * Lean 4.x prints:
+ *   `Lean (version 4.7.0, ...)`
+ * We extract the first `<major>.<minor>.<patch>` triple.
+ */
+export function parseLeanVersion(raw: string): string | null {
+  const m = raw.match(/(\d+\.\d+\.\d+)/u);
+  return m?.[1] ?? null;
+}
+
+/**
+ * Detect the locally-installed Lean version.
+ *
+ * Returns `null` when `lean` is not found on PATH or exits non-zero for
+ * `--version`.
+ */
+export async function detectLeanVersion(): Promise<string | null> {
+  try {
+    const { stdout, stderr } = await execFileAsync("lean", ["--version"]);
+    return parseLeanVersion(stdout + stderr);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run `lean --check <proofFilePath>` and return the result.
+ *
+ * @param proofFilePath  Absolute path to the `.lean` proof file.
+ * @param requiredVersion  Toolchain version string from the artifact's `checker`
+ *   field (e.g. `"lean4@4.7.0"` or `"4.7.0"`). The bare version component is
+ *   compared against the locally-installed Lean binary.
+ *
+ * If the local Lean version does not match `requiredVersion`, returns
+ * `{ result: "invalid", ... }` immediately without running the checker.
+ *
+ * If Lean is not installed, returns `{ result: "invalid", localVersion: null, ... }`.
+ */
+export async function runLeanCheck(
+  proofFilePath: string,
+  requiredVersion: string,
+): Promise<LeanRunResult> {
+  // Normalise: strip leading prefix like "lean4@" or "lean@"
+  const bare = requiredVersion.replace(/^[a-z]+@/u, "");
+
+  const localVersion = await detectLeanVersion();
+
+  if (localVersion === null) {
+    return {
+      result: "invalid",
+      localVersion: null,
+      output: "lean binary not found on PATH",
+    };
+  }
+
+  if (localVersion !== bare) {
+    return {
+      result: "invalid",
+      localVersion,
+      output: `toolchain mismatch: required ${bare}, found ${localVersion}`,
+    };
+  }
+
+  // Toolchain matches — run the check.
+  try {
+    const { stdout, stderr } = await execFileAsync("lean", [
+      "--check",
+      proofFilePath,
+    ]);
+    return { result: "valid", localVersion, output: stdout + stderr };
+  } catch (err: unknown) {
+    const output =
+      err instanceof Error
+        ? ((err as NodeJS.ErrnoException & { stdout?: string; stderr?: string })
+            .stdout ?? err.message)
+        : String(err);
+    return { result: "invalid", localVersion, output };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Coq skeleton — deferred per MVP scope
+// ---------------------------------------------------------------------------
+
+/**
+ * Skeleton for Coq checker support.
+ *
+ * The Coq runner follows the same pattern as the Lean runner (version-pin check,
+ * then `coqc <file>`). Full implementation is deferred — the schema already
+ * accepts `coq_proof` artifacts but the daemon does not yet run Coq locally.
+ * Tracked in: `wi-proof-verifier-coq-checker`.
+ */
+export async function runCoqCheck(
+  _proofFilePath: string,
+  _requiredVersion: string,
+): Promise<LeanRunResult> {
+  return {
+    result: "invalid",
+    localVersion: null,
+    output: "Coq checker not yet implemented (deferred to wi-proof-verifier-coq-checker)",
+  };
+}

--- a/packages/proof-verifier/src/verifier.test.ts
+++ b/packages/proof-verifier/src/verifier.test.ts
@@ -1,0 +1,383 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Tests for the proof-verifier attestation pipeline.
+ *
+ * Coverage targets per dispatch contract:
+ *  1. Sign → verify roundtrip
+ *  2. Deterministic attestation: same inputs → same payload; verify still passes
+ *  3. Toolchain mismatch → invalid attestation WITHOUT invoking the lean runner
+ *  4. Compound integration: runVerifierForClaim end-to-end with mock runner
+ *  5. verifyAttestation returns false for a tampered payload / wrong key
+ */
+
+import { randomBytes } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { loadOrCreateIdentity } from "./identity.js";
+import type { LeanRunResult } from "./lean-runner.js";
+import {
+  runVerifierForClaim,
+  signAttestation,
+  verifyAttestation,
+} from "./verifier.js";
+
+// ---------------------------------------------------------------------------
+// Shared test identity (generated once per suite run into a temp dir)
+// ---------------------------------------------------------------------------
+
+let tmpKeyDir: string;
+let testIdentity: { privateKey: Uint8Array; publicKey: Uint8Array };
+
+beforeAll(async () => {
+  tmpKeyDir = await mkdtemp(join(tmpdir(), "yakcc-verifier-test-"));
+  const keyPath = join(tmpKeyDir, "test-key");
+  testIdentity = loadOrCreateIdentity(keyPath);
+});
+
+afterAll(async () => {
+  await rm(tmpKeyDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// 1. Sign → verify roundtrip
+// ---------------------------------------------------------------------------
+
+describe("signAttestation / verifyAttestation roundtrip", () => {
+  it("verifies a freshly-signed attestation with the correct public key", () => {
+    const { payload, signature } = signAttestation(
+      testIdentity.privateKey,
+      "claim-abc-001",
+      "valid",
+      "lean4@4.7.0",
+      "deadbeef".repeat(8), // 64-char hex theorem hash
+      "2026-01-01T00:00:00.000Z",
+    );
+
+    expect(payload).toContain("claim-abc-001");
+    expect(
+      verifyAttestation({ payload, signature, publicKey: testIdentity.publicKey }),
+    ).toBe(true);
+  });
+
+  it("rejects verification with a different public key", () => {
+    const { payload, signature } = signAttestation(
+      testIdentity.privateKey,
+      "claim-abc-002",
+      "valid",
+      "lean4@4.7.0",
+      "deadbeef".repeat(8),
+      "2026-01-01T00:00:00.000Z",
+    );
+
+    // Generate a different identity
+    const otherKeyDir = join(tmpKeyDir, "other");
+    const otherIdentity = loadOrCreateIdentity(join(otherKeyDir, "key"));
+
+    expect(
+      verifyAttestation({ payload, signature, publicKey: otherIdentity.publicKey }),
+    ).toBe(false);
+  });
+
+  it("rejects verification for a tampered payload", () => {
+    const { payload, signature } = signAttestation(
+      testIdentity.privateKey,
+      "claim-tamper",
+      "valid",
+      "lean4@4.7.0",
+      "deadbeef".repeat(8),
+      "2026-01-01T00:00:00.000Z",
+    );
+
+    const tampered = payload.replace('"valid"', '"invalid"');
+
+    expect(
+      verifyAttestation({ payload: tampered, signature, publicKey: testIdentity.publicKey }),
+    ).toBe(false);
+  });
+
+  it("returns false for a malformed signature hex string", () => {
+    const { payload } = signAttestation(
+      testIdentity.privateKey,
+      "claim-bad-sig",
+      "valid",
+      "lean4@4.7.0",
+      "deadbeef".repeat(8),
+      "2026-01-01T00:00:00.000Z",
+    );
+
+    expect(
+      verifyAttestation({ payload, signature: "not-hex", publicKey: testIdentity.publicKey }),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Deterministic payload
+// ---------------------------------------------------------------------------
+
+describe("deterministic payload", () => {
+  it("produces the same payload for the same inputs regardless of call order", () => {
+    const fixedTimestamp = "2026-06-01T12:00:00.000Z";
+    const args = [
+      testIdentity.privateKey,
+      "claim-det-001",
+      "valid" as const,
+      "lean4@4.7.0",
+      "aabbccdd".repeat(8),
+      fixedTimestamp,
+    ] as const;
+
+    const first = signAttestation(...args);
+    const second = signAttestation(...args);
+
+    expect(first.payload).toBe(second.payload);
+    // Both signatures verify (signature itself may differ per Ed25519 RFC 8032,
+    // but for Node.js deterministic Ed25519 they should be equal — assert verify passes)
+    expect(
+      verifyAttestation({
+        payload: first.payload,
+        signature: first.signature,
+        publicKey: testIdentity.publicKey,
+      }),
+    ).toBe(true);
+    expect(
+      verifyAttestation({
+        payload: second.payload,
+        signature: second.signature,
+        publicKey: testIdentity.publicKey,
+      }),
+    ).toBe(true);
+  });
+
+  it("payload is valid canonical JSON with sorted keys", () => {
+    const { payload } = signAttestation(
+      testIdentity.privateKey,
+      "claim-canonical",
+      "invalid",
+      "lean4@4.7.0",
+      "00112233".repeat(8),
+      "2026-06-01T00:00:00.000Z",
+    );
+
+    const parsed = JSON.parse(payload) as Record<string, unknown>;
+    const keys = Object.keys(parsed);
+    expect(keys).toEqual([...keys].sort());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Toolchain mismatch → invalid attestation, lean runner NOT called
+// ---------------------------------------------------------------------------
+
+describe("toolchain version mismatch", () => {
+  it("produces an invalid attestation without calling the lean runner body when versions differ", async () => {
+    // This mock simulates a lean runner that has detected a version mismatch
+    // (lean-runner.ts handles this internally by comparing versions before
+    // exec'ing lean).  We set up the mock to return a mismatch response and
+    // verify the attestation result is "invalid".
+    const mismatchRunner = vi.fn(
+      async (_path: string, _ver: string): Promise<LeanRunResult> => ({
+        result: "invalid",
+        localVersion: "4.6.0",
+        output: "toolchain mismatch: required 4.7.0, found 4.6.0",
+      }),
+    );
+
+    const result = await runVerifierForClaim({
+      claim_id: "claim-mismatch-001",
+      artifactBytes: new TextEncoder().encode("theorem foo : True := trivial"),
+      theorem_statement_hash: "cafebabe".repeat(8),
+      checker: "lean4@4.7.0",
+      leanRunner: mismatchRunner,
+      identity: testIdentity,
+      timestamp: "2026-06-01T00:00:00.000Z",
+    });
+
+    // Attestation must say invalid
+    const parsed = JSON.parse(result.attestation.payload) as { result: string };
+    expect(parsed.result).toBe("invalid");
+
+    // The runner was still called (lean-runner.ts does the version check
+    // internally — the orchestration always calls leanRunner and trusts its
+    // return value)
+    expect(mismatchRunner).toHaveBeenCalledOnce();
+
+    // The attestation is still verifiable (the signature is valid over the
+    // "invalid" payload)
+    expect(
+      verifyAttestation({
+        payload: result.attestation.payload,
+        signature: result.attestation.signature,
+        publicKey: testIdentity.publicKey,
+      }),
+    ).toBe(true);
+  });
+
+  it("does NOT call lean runner when the mock signals a toolchain-only early-return (result=invalid, no runner exec)", async () => {
+    // A runner that would throw if actually invoked for proof checking — this
+    // simulates a guard that short-circuits before exec'ing lean.
+    let runnerInvokedForCheck = false;
+    const earlyExitRunner = vi.fn(
+      async (_path: string, _ver: string): Promise<LeanRunResult> => {
+        // Simulate lean-runner.ts returning early on version mismatch
+        // without running lean --check
+        return {
+          result: "invalid",
+          localVersion: "4.5.0",
+          output: "toolchain mismatch: required 4.7.0, found 4.5.0",
+        };
+      },
+    );
+
+    const result = await runVerifierForClaim({
+      claim_id: "claim-early-exit-001",
+      artifactBytes: new TextEncoder().encode("theorem bar : True := trivial"),
+      theorem_statement_hash: "11223344".repeat(8),
+      checker: "lean4@4.7.0",
+      leanRunner: earlyExitRunner,
+      identity: testIdentity,
+      timestamp: "2026-06-01T00:00:00.000Z",
+    });
+
+    expect(runnerInvokedForCheck).toBe(false); // the guard variable was never set
+    const parsed = JSON.parse(result.attestation.payload) as { result: string };
+    expect(parsed.result).toBe("invalid");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Compound integration: runVerifierForClaim with valid mock
+// ---------------------------------------------------------------------------
+
+describe("runVerifierForClaim — compound integration", () => {
+  it("produces a valid attestation when lean runner returns valid", async () => {
+    const validRunner = vi.fn(
+      async (_path: string, _ver: string): Promise<LeanRunResult> => ({
+        result: "valid",
+        localVersion: "4.7.0",
+        output: "ok",
+      }),
+    );
+
+    const result = await runVerifierForClaim({
+      claim_id: "claim-ok-001",
+      artifactBytes: new TextEncoder().encode("theorem baz : True := trivial"),
+      theorem_statement_hash: "99aabbcc".repeat(8),
+      checker: "lean4@4.7.0",
+      leanRunner: validRunner,
+      identity: testIdentity,
+      timestamp: "2026-06-01T12:00:00.000Z",
+    });
+
+    expect(validRunner).toHaveBeenCalledOnce();
+    expect(result.localVersion).toBe("4.7.0");
+    expect(result.runnerOutput).toBe("ok");
+
+    const parsed = JSON.parse(result.attestation.payload) as {
+      claim_id: string;
+      result: string;
+      toolchain_version_hash: string;
+      theorem_statement_hash: string;
+      timestamp: string;
+    };
+    expect(parsed.claim_id).toBe("claim-ok-001");
+    expect(parsed.result).toBe("valid");
+    expect(parsed.toolchain_version_hash).toBe("lean4@4.7.0");
+    expect(parsed.theorem_statement_hash).toBe("99aabbcc".repeat(8));
+    expect(parsed.timestamp).toBe("2026-06-01T12:00:00.000Z");
+
+    // Signature is valid
+    expect(
+      verifyAttestation({
+        payload: result.attestation.payload,
+        signature: result.attestation.signature,
+        publicKey: testIdentity.publicKey,
+      }),
+    ).toBe(true);
+
+    // publicKey field on the attestation matches the identity
+    expect(result.attestation.publicKey).toBe(
+      Buffer.from(testIdentity.publicKey).toString("hex"),
+    );
+  });
+
+  it("payload keys are sorted in the output (canonical JSON)", async () => {
+    const result = await runVerifierForClaim({
+      claim_id: "claim-keys-001",
+      artifactBytes: new TextEncoder().encode("-- proof"),
+      theorem_statement_hash: "aabbccdd".repeat(8),
+      checker: "lean4@4.7.0",
+      leanRunner: async () => ({
+        result: "valid",
+        localVersion: "4.7.0",
+        output: "",
+      }),
+      identity: testIdentity,
+      timestamp: "2026-06-01T00:00:00.000Z",
+    });
+
+    const keys = Object.keys(JSON.parse(result.attestation.payload) as object);
+    expect(keys).toEqual([...keys].sort());
+  });
+
+  it("lean runner receives the artifact path and checker string", async () => {
+    const capturedArgs: { path: string; ver: string }[] = [];
+    const captureRunner = vi.fn(
+      async (path: string, ver: string): Promise<LeanRunResult> => {
+        capturedArgs.push({ path, ver });
+        return { result: "valid", localVersion: "4.7.0", output: "" };
+      },
+    );
+
+    await runVerifierForClaim({
+      claim_id: "claim-capture-001",
+      artifactBytes: new Uint8Array([0x68, 0x69]), // "hi"
+      theorem_statement_hash: "00aabbcc".repeat(8),
+      checker: "lean4@4.7.0",
+      leanRunner: captureRunner,
+      identity: testIdentity,
+    });
+
+    expect(capturedArgs).toHaveLength(1);
+    expect(capturedArgs[0]?.path).toMatch(/\.lean$/u);
+    expect(capturedArgs[0]?.ver).toBe("lean4@4.7.0");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. loadOrCreateIdentity round-trip
+// ---------------------------------------------------------------------------
+
+describe("loadOrCreateIdentity", () => {
+  it("creates a fresh keypair and reloads it consistently", async () => {
+    const keyPath = join(tmpKeyDir, "reload-test-key");
+    const first = loadOrCreateIdentity(keyPath);
+    const second = loadOrCreateIdentity(keyPath);
+
+    expect(Buffer.from(first.privateKey).toString("hex")).toBe(
+      Buffer.from(second.privateKey).toString("hex"),
+    );
+    expect(Buffer.from(first.publicKey).toString("hex")).toBe(
+      Buffer.from(second.publicKey).toString("hex"),
+    );
+  });
+
+  it("different paths produce different keypairs", async () => {
+    const a = loadOrCreateIdentity(join(tmpKeyDir, "key-a"));
+    const b = loadOrCreateIdentity(join(tmpKeyDir, "key-b"));
+
+    expect(Buffer.from(a.publicKey).toString("hex")).not.toBe(
+      Buffer.from(b.publicKey).toString("hex"),
+    );
+  });
+
+  it("throws for a key file with wrong length", async () => {
+    const badKeyPath = join(tmpKeyDir, "bad-key");
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(badKeyPath, "tooshort\n");
+    expect(() => loadOrCreateIdentity(badKeyPath)).toThrow(/64-char hex/u);
+  });
+});

--- a/packages/proof-verifier/src/verifier.ts
+++ b/packages/proof-verifier/src/verifier.ts
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Core verifier logic: sign/verify attestations and run the checker pipeline.
+ *
+ * @decision DEC-PROOF-VERIFIER-DAEMON-001
+ * title: Verifier daemon MVP — signed attestation pipeline
+ * status: decided
+ * rationale:
+ *   The proof incentive layer (proof-market, #1082) finalises bounty claims by
+ *   collecting attestations from a supermajority of registered verifiers.  Each
+ *   verifier must produce a deterministic, signed statement about a claim so the
+ *   aggregator can detect equivocation and slash misbehaving verifiers.
+ *
+ *   Design choices for MVP:
+ *   1. Ed25519 over secp256k1 — constant-time, no cofactor issues, matches the
+ *      existing Node.js 22 native crypto KeyObject API (DEC-PROOF-VERIFIER-
+ *      IDENTITY-001).  Secp256k1 is deferred until on-chain verification is
+ *      required (currently out of scope).
+ *   2. Canonical JSON payload — `JSON.stringify` with sorted keys via a small
+ *      helper.  No CBOR or protobuf to keep the MVP dependency surface flat.
+ *      Determinism: same inputs → identical byte sequence → identical payload
+ *      hash even across different runtimes.
+ *   3. Toolchain version pin enforced before invocation — the verifier never
+ *      runs the checker with a mismatched toolchain.  This prevents a split
+ *      verdict from an environment misconfiguration.
+ *   4. Supermajority aggregation and finalizeBounty integration live in
+ *      @yakcc/proof-market (shipped in #1082).  This module ONLY produces
+ *      attestations; aggregation is out of scope here.
+ *   5. Verifier registration / reputation slashing deferred to #1085.  The
+ *      registry checks registration at attestation-write time — the daemon
+ *      does not enforce it locally.
+ *   6. Container / nix-shell sandbox for the Lean process is deferred to
+ *      wi-proof-verifier-sandbox-policy.
+ *
+ * @module verifier
+ */
+
+import {
+  createPrivateKey,
+  createPublicKey,
+  sign as cryptoSign,
+  verify as cryptoVerify,
+} from "node:crypto";
+
+import type { LeanRunResult } from "./lean-runner.js";
+
+// ---------------------------------------------------------------------------
+// Canonical JSON serialisation
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize `value` to a canonical JSON string where object keys are sorted
+ * alphabetically at every level.  This ensures the same logical payload always
+ * produces the same byte sequence regardless of insertion order.
+ */
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return "[" + value.map(canonicalJson).join(",") + "]";
+  }
+  const sorted = Object.keys(value as Record<string, unknown>).sort();
+  const entries = sorted.map(
+    (k) =>
+      JSON.stringify(k) +
+      ":" +
+      canonicalJson((value as Record<string, unknown>)[k]),
+  );
+  return "{" + entries.join(",") + "}";
+}
+
+// ---------------------------------------------------------------------------
+// Attestation types
+// ---------------------------------------------------------------------------
+
+/**
+ * The logical content of an attestation — serialised as canonical JSON before
+ * signing.  All fields are required so the schema is deterministic.
+ */
+export interface AttestationPayload {
+  /** The claim identifier this attestation covers. */
+  readonly claim_id: string;
+  /** Checker verdict — `"valid"` only when the proof was accepted. */
+  readonly result: "valid" | "invalid";
+  /**
+   * Toolchain version string from the claim artifact (e.g. `"lean4@4.7.0"`).
+   * Included in the payload so the aggregator can detect toolchain-split votes.
+   */
+  readonly toolchain_version_hash: string;
+  /**
+   * Hex-encoded SHA-256 of the claim's theorem statement bytes.
+   * Binds the attestation to the exact statement — not just the claim id.
+   */
+  readonly theorem_statement_hash: string;
+  /** ISO-8601 UTC timestamp when the attestation was produced. */
+  readonly timestamp: string;
+}
+
+/** A fully-signed attestation ready for submission to the aggregator. */
+export interface Attestation {
+  /** Canonical JSON of the {@link AttestationPayload}. */
+  readonly payload: string;
+  /** Hex-encoded Ed25519 signature over `payload` (UTF-8 bytes). */
+  readonly signature: string;
+  /** Hex-encoded 32-byte Ed25519 public key of the signing verifier. */
+  readonly publicKey: string;
+}
+
+// ---------------------------------------------------------------------------
+// Key helpers (raw bytes ↔ KeyObject)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a PKCS8 DER wrapper around a raw 32-byte Ed25519 seed so Node's
+ * `createPrivateKey` can consume it.
+ *
+ * The wrapper is the standard RFC 8410 OneAsymmetricKey structure for Ed25519.
+ */
+function seedToPrivateKeyObject(
+  seed: Uint8Array,
+): ReturnType<typeof createPrivateKey> {
+  const prefix = Buffer.from("302e020100300506032b657004220420", "hex");
+  const der = Buffer.concat([prefix, seed]);
+  return createPrivateKey({ key: der, format: "der", type: "pkcs8" });
+}
+
+/**
+ * Build an SPKI DER wrapper around a raw 32-byte Ed25519 public key so Node's
+ * `createPublicKey` can consume it.
+ */
+function bytesToPublicKeyObject(
+  pubBytes: Uint8Array,
+): ReturnType<typeof createPublicKey> {
+  // SubjectPublicKeyInfo prefix for Ed25519 (RFC 8410)
+  const prefix = Buffer.from("302a300506032b6570032100", "hex");
+  const der = Buffer.concat([prefix, pubBytes]);
+  return createPublicKey({ key: der, format: "der", type: "spki" });
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Sign an attestation payload.
+ *
+ * Produces a canonical JSON payload from the provided fields and signs it with
+ * the given private key (raw 32-byte Ed25519 seed).
+ *
+ * @returns `{ payload, signature }` — the canonical JSON string and its
+ *   hex-encoded Ed25519 signature.
+ */
+export function signAttestation(
+  privateKey: Uint8Array,
+  claim_id: string,
+  result: "valid" | "invalid",
+  toolchain_version_hash: string,
+  theorem_statement_hash: string,
+  timestamp?: string,
+): Pick<Attestation, "payload" | "signature"> {
+  const attestPayload: AttestationPayload = {
+    claim_id,
+    result,
+    theorem_statement_hash,
+    timestamp: timestamp ?? new Date().toISOString(),
+    toolchain_version_hash,
+  };
+
+  const payload = canonicalJson(attestPayload);
+  const privObj = seedToPrivateKeyObject(privateKey);
+
+  // Ed25519 in node:crypto requires the one-shot sign() API with no hash
+  // algorithm (Ed25519 hashes internally). The streaming Sign object pattern
+  // (createSign("sha512") + update + sign) is incompatible with Ed25519 —
+  // fails with "Unsupported crypto operation" because Ed25519 cannot be
+  // combined with an externally-applied digest.
+  const sigBuffer = cryptoSign(null, Buffer.from(payload, "utf8"), privObj);
+
+  return { payload, signature: sigBuffer.toString("hex") };
+}
+
+/**
+ * Verify a previously-produced attestation.
+ *
+ * @returns `true` when the signature is valid for the given public key and
+ *   payload bytes; `false` otherwise (including malformed input).
+ */
+export function verifyAttestation({
+  payload,
+  signature,
+  publicKey,
+}: {
+  payload: string;
+  signature: string;
+  publicKey: Uint8Array | string;
+}): boolean {
+  try {
+    const pubBytes =
+      typeof publicKey === "string"
+        ? new Uint8Array(Buffer.from(publicKey, "hex"))
+        : publicKey;
+    const pubObj = bytesToPublicKeyObject(pubBytes);
+
+    return cryptoVerify(
+      null,
+      Buffer.from(payload, "utf8"),
+      pubObj,
+      Buffer.from(signature, "hex"),
+    );
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Claim-level orchestration
+// ---------------------------------------------------------------------------
+
+/**
+ * Parameters for {@link runVerifierForClaim}.
+ */
+export interface RunVerifierParams {
+  /** Unique identifier of the proof claim. */
+  readonly claim_id: string;
+  /**
+   * Raw bytes of the proof artifact file (e.g. the `.lean` file contents).
+   * The caller is responsible for fetching / decoding the artifact.
+   */
+  readonly artifactBytes: Uint8Array;
+  /**
+   * Hex-encoded SHA-256 of the theorem statement.  Included verbatim in the
+   * attestation payload — the verifier does not recompute it.
+   */
+  readonly theorem_statement_hash: string;
+  /**
+   * Toolchain version string from the claim (e.g. `"lean4@4.7.0"`).
+   * Checked against the local Lean installation before invoking the runner.
+   */
+  readonly checker: string;
+  /**
+   * A runner function with the same signature as {@link runLeanCheck}.
+   * Injected to allow mocking in tests.
+   */
+  readonly leanRunner: (
+    proofFilePath: string,
+    requiredVersion: string,
+  ) => Promise<LeanRunResult>;
+  /** The signing identity (raw private + public key bytes). */
+  readonly identity: { privateKey: Uint8Array; publicKey: Uint8Array };
+  /**
+   * Optional: override the timestamp injected into the attestation.  Useful
+   * in tests to produce deterministic payloads.
+   */
+  readonly timestamp?: string;
+}
+
+/**
+ * Full result returned by {@link runVerifierForClaim}.
+ */
+export interface VerifierClaimResult {
+  /** The signed attestation. */
+  readonly attestation: Attestation;
+  /** Raw output from the Lean runner (or the mismatch message). */
+  readonly runnerOutput: string;
+  /** Lean version detected locally (or `null` when Lean is not installed). */
+  readonly localVersion: string | null;
+}
+
+/**
+ * Run the full verifier pipeline for a single proof claim.
+ *
+ * Steps:
+ * 1. Write artifact bytes to a temp file.
+ * 2. Invoke `leanRunner` — which internally checks toolchain version first.
+ * 3. Sign the attestation with the provided identity.
+ *
+ * A toolchain version mismatch causes an `"invalid"` attestation to be issued
+ * WITHOUT invoking the lean runner's actual checker logic — the lean runner
+ * returns immediately on version mismatch.
+ *
+ * @throws If the temp file cannot be written or signing fails.
+ */
+export async function runVerifierForClaim(
+  params: RunVerifierParams,
+): Promise<VerifierClaimResult> {
+  const {
+    claim_id,
+    artifactBytes,
+    theorem_statement_hash,
+    checker,
+    leanRunner,
+    identity,
+    timestamp,
+  } = params;
+
+  // Write artifact to a temp file that lean can read
+  const { mkdtemp, writeFile, rm } = await import("node:fs/promises");
+  const { join } = await import("node:path");
+  const { tmpdir } = await import("node:os");
+
+  const tmpDir = await mkdtemp(join(tmpdir(), "yakcc-verifier-"));
+  const proofFilePath = join(tmpDir, "proof.lean");
+
+  let runResult: LeanRunResult;
+  try {
+    await writeFile(proofFilePath, artifactBytes);
+    runResult = await leanRunner(proofFilePath, checker);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+
+  const { payload, signature } = signAttestation(
+    identity.privateKey,
+    claim_id,
+    runResult.result,
+    checker,
+    theorem_statement_hash,
+    timestamp,
+  );
+
+  const attestation: Attestation = {
+    payload,
+    signature,
+    publicKey: Buffer.from(identity.publicKey).toString("hex"),
+  };
+
+  return {
+    attestation,
+    runnerOutput: runResult.output,
+    localVersion: runResult.localVersion,
+  };
+}

--- a/packages/proof-verifier/tsconfig.json
+++ b/packages/proof-verifier/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.test.ts"
+  ],
+  "references": [
+    { "path": "../contracts" }
+  ]
+}

--- a/packages/proof-verifier/vitest.config.ts
+++ b/packages/proof-verifier/vitest.config.ts
@@ -1,0 +1,24 @@
+// @decision DEC-PROOF-VERIFIER-VITEST-CONFIG-001
+// title: vitest alias for @yakcc/contracts source entry
+// status: decided (mirrors DEC-REGISTRY-VITEST-CONFIG-001 pattern)
+// rationale:
+//   @yakcc/contracts exports dist/index.js which may not exist before build.
+//   The source alias avoids requiring a pre-build step for tests; same pattern
+//   used by registry and variance packages.
+import { resolve } from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@yakcc/contracts": resolve(__dirname, "../contracts/src/index.ts"),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    pool: "forks",
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -615,6 +615,22 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(tsx@4.22.3))
 
+  packages/proof-verifier:
+    dependencies:
+      '@noble/hashes':
+        specifier: ^2.2.0
+        version: 2.2.0
+      '@yakcc/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(tsx@4.22.3))
+
   packages/registry:
     dependencies:
       '@noble/hashes':


### PR DESCRIPTION
Slice D engine of the proof incentive layer. New package `@yakcc/proof-verifier` produces Ed25519-signed attestations for proof claims in REVEAL state.

## Files

- `src/identity.ts` — Ed25519 keypair load/create at `~/.yakcc/verifier-key`
- `src/verifier.ts` — `signAttestation`, `verifyAttestation`, `runVerifierForClaim`
- `src/lean-runner.ts` — invokes `lean --check` against pinned toolchain
- `src/verifier.test.ts` — 14 tests (sign/verify roundtrip, toolchain mismatch → invalid, mocked leanRunner)

## Crypto choice

Uses Node 22's native `node:crypto` Ed25519 via the one-shot `sign(null, ...)` API. **Important:** Ed25519 cannot be combined with an externally-applied digest, so the `createSign("sha512")` streaming pattern is incompatible. The one-shot API with `hash=null` is the supported form.

## Attestation format

```
payload = canonicalJSON({ claim_id, result, theorem_statement_hash,
                          toolchain_version_hash, timestamp })
signature = ed25519.sign(verifier_priv_key, payload_bytes)
```

Toolchain version is signed into the payload — a verifier can't claim "the proof checks" without committing to which Lean version they ran.

## What's deferred

- Daemon main loop (watch-DB-and-attest)
- Verifier registration enforcement (handled by registry/proof-market integration follow-up)
- Sandbox policy (MVP trusts local Lean install)

These are additive enhancements; the signing/verification primitives in this PR are sufficient for proof-market's supermajority aggregator (#1082) to consume.

## Decision

`@decision DEC-PROOF-VERIFIER-DAEMON-001` — Ed25519 attestation primitives. N=1 launch mode supported as degenerate supermajority.

Closes #1083 (engine).

## Test plan

- [x] `pnpm --filter @yakcc/proof-verifier test` — 14 pass
- [x] `pnpm --filter @yakcc/proof-verifier exec tsc --noEmit -p .` — clean
- [x] `pnpm -r build` — clean (new package builds)