### PR TITLE
feat(mcp-registry): #1088 — proof_requirement 4-mode discovery integration (Slice G)

### DIFF
--- a/packages/mcp-registry/src/tools/resolve.test.ts
+++ b/packages/mcp-registry/src/tools/resolve.test.ts
@@ -583,3 +583,589 @@ describe("openRegistry mock integration — createResolveTool uses injected fact
     expect(vi.mocked(openRegistry)).toBeDefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Proof layer — proof_requirement modes
+// (DEC-PROOF-DISCOVERY-QUERY-REQUIREMENT-001)
+// ---------------------------------------------------------------------------
+
+// @mock-exempt: yakccResolve wraps SQLite (external DB boundary — see line 1 annotation).
+// proofStatusProvider is a plain injected function (DEC-PROOF-DISCOVERY-INTEGRATION-001
+// data-source seam), not a vi.mock(). All vi.mock() targets in this file are
+// @yakcc/hooks-base (SQLite), @yakcc/registry (SQLite), @yakcc/contracts (native
+// embedding layer) — all external boundaries as documented at the top of this file.
+
+/**
+ * Proof-layer test suite.
+ *
+ * Production sequence exercised end-to-end (compound interaction):
+ *   1. LLM calls yakcc_resolve with proof_requirement=<mode>
+ *   2. Handler parses and validates proof_requirement
+ *   3. Handler calls yakccResolve (mocked — SQLite external boundary)
+ *   4. applyProofScoring adjusts scores via injected proofStatusProvider
+ *   5. deriveConfidenceTier operates on adjusted scores
+ *   6. Envelope includes verification_level, proof_status, accepted_proofs per candidate
+ *
+ * All proof-layer tests use airgap=1 so the local-only path is exercised in isolation.
+ */
+describe("yakcc_resolve handler — proof layer: proof_requirement parameter", () => {
+  const savedAirgap = process.env.YAKCC_AIRGAPPED;
+
+  beforeEach(() => {
+    process.env.YAKCC_AIRGAPPED = "1"; // local-only path, no http
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete process.env.YAKCC_PROOF_BONUS;
+    delete process.env.YAKCC_RETRACTION_PENALTY;
+    if (savedAirgap !== undefined) {
+      process.env.YAKCC_AIRGAPPED = savedAirgap;
+    } else {
+      delete process.env.YAKCC_AIRGAPPED;
+    }
+  });
+
+  it("proof_requirement defaults to 'preferred' when omitted — no error, candidates returned", async () => {
+    vi.mocked(yakccResolve).mockResolvedValue(makeWeakResult());
+    const tool = createResolveTool({ openRegistry: async () => STUB_REGISTRY });
+    const http = makeHttp();
+    const result = await tool.handler({ intent: { title: "test" } }, http);
+    const parsed = JSON.parse(result[0]!.text) as { error?: string; confidence_tier: string };
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.confidence_tier).toBe("candidate_list");
+  });
+
+  it("proof_requirement='ignored' — no proof bonus applied (score unchanged from semantic match)", async () => {
+    // One candidate at score 0.55. In ignored mode no +0.10 bonus for accepted atoms.
+    vi.mocked(yakccResolve).mockResolvedValue(makeWeakResult());
+    const tool = createResolveTool({
+      openRegistry: async () => STUB_REGISTRY,
+      proofStatusProvider: (_id) => "accepted",
+    });
+    const http = makeHttp();
+    const result = await tool.handler(
+      { intent: { title: "test" }, proof_requirement: "ignored" },
+      http,
+    );
+    const parsed = JSON.parse(result[0]!.text) as {
+      confidence_tier: string;
+      candidates: Array<{ score: number; proof_status: string }>;
+    };
+    expect(parsed.confidence_tier).toBe("candidate_list");
+    // No bonus in ignored mode — score stays at 0.55 (not 0.65)
+    expect(parsed.candidates[0]!.score).toBeCloseTo(0.55, 5);
+  });
+
+  // Compound-interaction test: exercises the full production sequence end-to-end:
+  // input parse → yakccResolve call → applyProofScoring → deriveConfidenceTier → envelope.
+  it("preferred mode — accepted atom promoted above unproven atom (compound end-to-end)", async () => {
+    process.env.YAKCC_PROOF_BONUS = "0.10";
+    // Two candidates at equal semantic score 0.80
+    vi.mocked(yakccResolve).mockResolvedValue({
+      status: "matched",
+      candidates: [
+        {
+          address: "aaaaaa11",
+          behavior: "accepted atom",
+          signature: "(x: string) => string",
+          score: 0.8,
+          guarantees: [],
+          tests: { count: 3 },
+          usage: null,
+        },
+        {
+          address: "bbbbbb22",
+          behavior: "unproven atom",
+          signature: "(x: string) => string",
+          score: 0.8,
+          guarantees: [],
+          tests: { count: 3 },
+          usage: null,
+        },
+      ],
+    });
+    // Provider returns accepted for first atom, none for second
+    const tool = createResolveTool({
+      openRegistry: async () => STUB_REGISTRY,
+      proofStatusProvider: (id) => (id === "aaaaaa11" ? "accepted" : "none"),
+    });
+    const http = makeHttp();
+    const result = await tool.handler(
+      { intent: { title: "hash string" }, proof_requirement: "preferred" },
+      http,
+    );
+    const parsed = JSON.parse(result[0]!.text) as {
+      candidates: Array<{ atom_id: string; score: number; proof_status: string }>;
+    };
+    // accepted atom should be ranked first with higher score after bonus
+    expect(parsed.candidates[0]!.atom_id).toBe("aaaaaa11");
+    expect(parsed.candidates[0]!.score).toBeGreaterThan(parsed.candidates[1]!.score);
+    expect(parsed.candidates[0]!.proof_status).toBe("accepted");
+    expect(parsed.candidates[1]!.proof_status).toBe("none");
+  });
+
+  it("preferred mode — proof bonus can promote atom to auto_accept tier", async () => {
+    process.env.YAKCC_PROOF_BONUS = "0.10";
+    // Score 0.82 + 0.10 bonus = 0.92 which is > HYBRID_AUTO_ACCEPT_THRESHOLD (0.85) with big gap
+    vi.mocked(yakccResolve).mockResolvedValue({
+      status: "matched",
+      candidates: [
+        {
+          address: "cc112233",
+          behavior: "just below threshold",
+          signature: "(x: number) => number",
+          score: 0.82,
+          guarantees: [],
+          tests: { count: 2 },
+          usage: null,
+        },
+      ],
+    });
+    const tool = createResolveTool({
+      openRegistry: async () => STUB_REGISTRY,
+      proofStatusProvider: (_id) => "accepted",
+    });
+    const http = makeHttp();
+    const result = await tool.handler(
+      { intent: { title: "clamp number" }, proof_requirement: "preferred" },
+      http,
+    );
+    const parsed = JSON.parse(result[0]!.text) as { confidence_tier: string };
+    // With 0.10 bonus: 0.82 + 0.10 = 0.92, triggers HIGH_CONFIDENCE_THRESHOLD auto_accept
+    expect(parsed.confidence_tier).toBe("auto_accept");
+  });
+
+  it("required mode — accepted atoms pass the filter and are returned", async () => {
+    vi.mocked(yakccResolve).mockResolvedValue({
+      status: "matched",
+      candidates: [
+        {
+          address: "proof1111",
+          behavior: "proven function",
+          signature: "(x: string) => number",
+          score: 0.88,
+          guarantees: [],
+          tests: { count: 4 },
+          usage: null,
+        },
+      ],
+    });
+    const tool = createResolveTool({
+      openRegistry: async () => STUB_REGISTRY,
+      proofStatusProvider: (_id) => "accepted",
+    });
+    const http = makeHttp();
+    const result = await tool.handler(
+      { intent: { title: "proven op" }, proof_requirement: "required" },
+      http,
+    );
+    const parsed = JSON.parse(result[0]!.text) as {
+      confidence_tier: string;
+      candidates: Array<{ proof_status: string }>;
+    };
+    expect(parsed.confidence_tier).not.toBe("no_candidates");
+    expect(parsed.candidates).toHaveLength(1);
+    expect(parsed.candidates[0]!.proof_status).toBe("accepted");
+  });
+
+  it("required mode — no accepted atoms → confidence_tier=no_candidates + reason=no_proven_atoms_match", async () => {
+    vi.mocked(yakccResolve).mockResolvedValue(makeAutoAcceptResult()); // score 0.95 but unproven
+    const tool = createResolveTool({
+      openRegistry: async () => STUB_REGISTRY,
+      proofStatusProvider: (_id) => "none",
+    });
+    const http = makeHttp();
+    const result = await tool.handler(
+      { intent: { title: "hash string" }, proof_requirement: "required" },
+      http,
+    );
+    const parsed = JSON.parse(result[0]!.text) as {
+      confidence_tier: string;
+      reason: string;
+    };
+    expect(parsed.confidence_tier).toBe("no_candidates");
+    expect(parsed.reason).toBe("no_proven_atoms_match");
+  });
+
+  it("required mode — pending atoms are filtered out (only accepted survives)", async () => {
+    vi.mocked(yakccResolve).mockResolvedValue(makeWeakResult());
+    const tool = createResolveTool({
+      openRegistry: async () => STUB_REGISTRY,
+      proofStatusProvider: (_id) => "pending",
+    });
+    const http = makeHttp();
+    const result = await tool.handler(
+      { intent: { title: "test" }, proof_requirement: "required" },
+      http,
+    );
+    const parsed = JSON.parse(result[0]!.text) as { confidence_tier: string; reason: string };
+    expect(parsed.confidence_tier).toBe("no_candidates");
+    expect(parsed.reason).toBe("no_proven_atoms_match");
+  });
+
+  it("per_block mode — accepted per-block object parses and does not error", async () => {
+    vi.mocked(yakccResolve).mockResolvedValue(makeWeakResult());
+    const tool = createResolveTool({
+      openRegistry: async () => STUB_REGISTRY,
+      proofStatusProvider: (_id) => "accepted",
+    });
+    const http = makeHttp();
+    const result = await tool.handler(
+      {
+        intent: { title: "parse thing" },
+        proof_requirement: { per_block: { hash: "required", format: "ignored" } },
+      },
+      http,
+    );
+    const parsed = JSON.parse(result[0]!.text) as { error?: string; confidence_tier: string };
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.confidence_tier).toBe("candidate_list");
+  });
+
+  it("inputSchema includes proof_requirement property", () => {
+    const tool = createResolveTool({ openRegistry: async () => STUB_REGISTRY });
+    expect(tool.inputSchema.properties).toHaveProperty("proof_requirement");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Proof layer — retraction penalty
+// (DEC-PROOF-RETRACTION-SCORE-PENALTY-001)
+// ---------------------------------------------------------------------------
+
+// @mock-exempt: same rationale as above — yakccResolve is an external SQLite boundary.
+
+describe("yakcc_resolve handler — retraction penalty applies in ALL modes", () => {
+  const savedAirgap = process.env.YAKCC_AIRGAPPED;
+
+  beforeEach(() => {
+    process.env.YAKCC_AIRGAPPED = "1";
+    process.env.YAKCC_RETRACTION_PENALTY = "-0.20";
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete process.env.YAKCC_RETRACTION_PENALTY;
+    delete process.env.YAKCC_PROOF_BONUS;
+    if (savedAirgap !== undefined) {
+      process.env.YAKCC_AIRGAPPED = savedAirgap;
+    } else {
+      delete process.env.YAKCC_AIRGAPPED;
+    }
+  });
+
+  it("retracted atom loses -0.20 in ignored mode (penalty applies even when proof selection ignored)", async () => {
+    // Score 0.88 - 0.20 = 0.68 → below auto_accept threshold → candidate_list
+    vi.mocked(yakccResolve).mockResolvedValue({
+      status: "matched",
+      candidates: [
+        {
+          address: "retract1",
+          behavior: "retracted function",
+          signature: "(x: number) => number",
+          score: 0.88,
+          guarantees: [],
+          tests: { count: 2 },
+          usage: null,
+        },
+      ],
+    });
+    const tool = createResolveTool({
+      openRegistry: async () => STUB_REGISTRY,
+      proofStatusProvider: (_id) => "retracted",
+    });
+    const http = makeHttp();
+    const result = await tool.handler(
+      { intent: { title: "test" }, proof_requirement: "ignored" },
+      http,
+    );
+    const parsed = JSON.parse(result[0]!.text) as {
+      confidence_tier: string;
+      candidates: Array<{ score: number; proof_status: string }>;
+    };
+    // Was 0.88 → after -0.20 penalty = 0.68, below auto_accept (0.85)
+    expect(parsed.confidence_tier).toBe("candidate_list");
+    expect(parsed.candidates[0]!.score).toBeCloseTo(0.68, 5);
+    expect(parsed.candidates[0]!.proof_status).toBe("retracted");
+  });
+
+  it("retracted atom loses -0.20 in preferred mode", async () => {
+    vi.mocked(yakccResolve).mockResolvedValue({
+      status: "matched",
+      candidates: [
+        {
+          address: "retract2",
+          behavior: "retracted preferred function",
+          signature: "(x: number) => number",
+          score: 0.88,
+          guarantees: [],
+          tests: { count: 2 },
+          usage: null,
+        },
+      ],
+    });
+    const tool = createResolveTool({
+      openRegistry: async () => STUB_REGISTRY,
+      proofStatusProvider: (_id) => "retracted",
+    });
+    const http = makeHttp();
+    const result = await tool.handler(
+      { intent: { title: "test" }, proof_requirement: "preferred" },
+      http,
+    );
+    const parsed = JSON.parse(result[0]!.text) as {
+      confidence_tier: string;
+      candidates: Array<{ score: number }>;
+    };
+    expect(parsed.confidence_tier).toBe("candidate_list");
+    expect(parsed.candidates[0]!.score).toBeCloseTo(0.68, 5);
+  });
+
+  it("retracted top candidate in auto_accept → surfaces reason=retracted_top_candidate", async () => {
+    // Penalty env-tuned small (-0.05) so retracted atom still clears auto_accept threshold
+    process.env.YAKCC_RETRACTION_PENALTY = "-0.05";
+    vi.mocked(yakccResolve).mockResolvedValue({
+      status: "matched",
+      candidates: [
+        {
+          address: "topretract",
+          behavior: "retracted top match",
+          signature: "(x: string) => string",
+          // 0.96 - 0.05 = 0.91 > 0.85 with gap > 0.05 → auto_accept
+          score: 0.96,
+          guarantees: [],
+          tests: { count: 3 },
+          usage: null,
+        },
+      ],
+    });
+    const tool = createResolveTool({
+      openRegistry: async () => STUB_REGISTRY,
+      proofStatusProvider: (_id) => "retracted",
+    });
+    const http = makeHttp();
+    const result = await tool.handler(
+      { intent: { title: "hash" }, proof_requirement: "preferred" },
+      http,
+    );
+    const parsed = JSON.parse(result[0]!.text) as {
+      confidence_tier: string;
+      reason?: string;
+    };
+    expect(parsed.confidence_tier).toBe("auto_accept");
+    expect(parsed.reason).toBe("retracted_top_candidate");
+  });
+
+  it("env-tunable YAKCC_RETRACTION_PENALTY overrides default (severe penalty)", async () => {
+    process.env.YAKCC_RETRACTION_PENALTY = "-0.50";
+    vi.mocked(yakccResolve).mockResolvedValue({
+      status: "matched",
+      candidates: [
+        {
+          address: "bigpenalty",
+          behavior: "penalized function",
+          signature: "(x: number) => number",
+          score: 0.99,
+          guarantees: [],
+          tests: { count: 3 },
+          usage: null,
+        },
+      ],
+    });
+    const tool = createResolveTool({
+      openRegistry: async () => STUB_REGISTRY,
+      proofStatusProvider: (_id) => "retracted",
+    });
+    const http = makeHttp();
+    const result = await tool.handler(
+      { intent: { title: "test" }, proof_requirement: "preferred" },
+      http,
+    );
+    const parsed = JSON.parse(result[0]!.text) as {
+      candidates: Array<{ score: number }>;
+    };
+    // 0.99 - 0.50 = 0.49 (clamped to ≥0)
+    expect(parsed.candidates[0]!.score).toBeCloseTo(0.49, 5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Proof layer — envelope fields
+// (DEC-PROOF-DISCOVERY-INTEGRATION-001)
+// ---------------------------------------------------------------------------
+
+// @mock-exempt: same rationale as proof_requirement section above.
+
+describe("yakcc_resolve handler — proof envelope fields (verification_level, proof_status, accepted_proofs)", () => {
+  const savedAirgap = process.env.YAKCC_AIRGAPPED;
+
+  beforeEach(() => {
+    process.env.YAKCC_AIRGAPPED = "1";
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    if (savedAirgap !== undefined) {
+      process.env.YAKCC_AIRGAPPED = savedAirgap;
+    } else {
+      delete process.env.YAKCC_AIRGAPPED;
+    }
+  });
+
+  it("local candidate carries verification_level=L0 for property_tests-only atom", async () => {
+    vi.mocked(yakccResolve).mockResolvedValue(makeWeakResult());
+    const tool = createResolveTool({ openRegistry: async () => STUB_REGISTRY });
+    const http = makeHttp();
+    const result = await tool.handler({ intent: { title: "test" } }, http);
+    const parsed = JSON.parse(result[0]!.text) as {
+      candidates: Array<{ verification_level: string }>;
+    };
+    expect(parsed.candidates[0]!.verification_level).toBe("L0");
+  });
+
+  it("local candidate carries proof_status from injected provider", async () => {
+    vi.mocked(yakccResolve).mockResolvedValue(makeWeakResult());
+    const tool = createResolveTool({
+      openRegistry: async () => STUB_REGISTRY,
+      proofStatusProvider: (_id) => "pending",
+    });
+    const http = makeHttp();
+    const result = await tool.handler({ intent: { title: "test" } }, http);
+    const parsed = JSON.parse(result[0]!.text) as {
+      candidates: Array<{ proof_status: string }>;
+    };
+    expect(parsed.candidates[0]!.proof_status).toBe("pending");
+  });
+
+  it("accepted_proofs is an empty array in MVP stub (proof-claims tables not yet populated)", async () => {
+    vi.mocked(yakccResolve).mockResolvedValue(makeWeakResult());
+    const tool = createResolveTool({
+      openRegistry: async () => STUB_REGISTRY,
+      proofStatusProvider: (_id) => "accepted",
+    });
+    const http = makeHttp();
+    const result = await tool.handler({ intent: { title: "test" } }, http);
+    const parsed = JSON.parse(result[0]!.text) as {
+      candidates: Array<{ accepted_proofs: unknown[] }>;
+    };
+    expect(Array.isArray(parsed.candidates[0]!.accepted_proofs)).toBe(true);
+    expect(parsed.candidates[0]!.accepted_proofs).toHaveLength(0);
+  });
+
+  it("auto_accept path also includes proof envelope fields on candidates", async () => {
+    vi.mocked(yakccResolve).mockResolvedValue(makeAutoAcceptResult());
+    const tool = createResolveTool({
+      openRegistry: async () => STUB_REGISTRY,
+      proofStatusProvider: (_id) => "none",
+    });
+    const http = makeHttp();
+    const result = await tool.handler({ intent: { title: "hash string" } }, http);
+    const parsed = JSON.parse(result[0]!.text) as {
+      confidence_tier: string;
+      candidates: Array<{
+        verification_level: string;
+        proof_status: string;
+        accepted_proofs: unknown[];
+      }>;
+    };
+    expect(parsed.confidence_tier).toBe("auto_accept");
+    expect(parsed.candidates[0]!.verification_level).toBe("L0");
+    expect(parsed.candidates[0]!.proof_status).toBe("none");
+    expect(Array.isArray(parsed.candidates[0]!.accepted_proofs)).toBe(true);
+  });
+
+  // @mock-exempt: mirrors the established mock pattern in this test file —
+  // yakccResolve is the unit-under-test's collaborator from @yakcc/hooks-base
+  // and is replaced via vi.mock() at the top of the describe block.
+  it("proof_status=accepted surfaces via proofStatusProvider", async () => {
+    vi.mocked(yakccResolve).mockResolvedValue({
+      status: "matched",
+      candidates: [
+        {
+          address: "l3atom111",
+          behavior: "formally proven function",
+          signature: "(x: number) => boolean",
+          score: 0.78,
+          guarantees: ["formally verified"],
+          tests: { count: 1 },
+          usage: null,
+        },
+      ],
+    });
+    const tool = createResolveTool({
+      openRegistry: async () => STUB_REGISTRY,
+      proofStatusProvider: (_id) => "accepted",
+    });
+    const http = makeHttp();
+    const result = await tool.handler({ intent: { title: "test" } }, http);
+    const parsed = JSON.parse(result[0]!.text) as {
+      candidates: Array<{ verification_level: string; proof_status: string }>;
+    };
+    expect(parsed.candidates[0]!.proof_status).toBe("accepted");
+    // verification_level: derived from atom proof artifacts in a follow-up
+    // (#1080 validator output → resolver's status provider). For now the
+    // marketplace signal lives on proof_status.
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Proof layer — proof_requirement input validation
+// (DEC-PROOF-DISCOVERY-QUERY-REQUIREMENT-001)
+// ---------------------------------------------------------------------------
+
+// @mock-exempt: same rationale as proof_requirement section above.
+
+describe("yakcc_resolve handler — proof_requirement input validation", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("invalid scalar proof_requirement → returns error content, does not throw", async () => {
+    vi.mocked(yakccResolve).mockResolvedValue(makeEmptyResult());
+    const tool = createResolveTool({ openRegistry: async () => STUB_REGISTRY });
+    const http = makeHttp();
+    const result = await tool.handler(
+      { intent: { title: "test" }, proof_requirement: "badmode" },
+      http,
+    );
+    const parsed = JSON.parse(result[0]!.text) as { error: string };
+    expect(parsed.error).toBe("invalid_input");
+  });
+
+  it("per_block with invalid mode value → returns error content", async () => {
+    vi.mocked(yakccResolve).mockResolvedValue(makeEmptyResult());
+    const tool = createResolveTool({ openRegistry: async () => STUB_REGISTRY });
+    const http = makeHttp();
+    const result = await tool.handler(
+      { intent: { title: "test" }, proof_requirement: { per_block: { hash: "badmode" } } },
+      http,
+    );
+    const parsed = JSON.parse(result[0]!.text) as { error: string };
+    expect(parsed.error).toBe("invalid_input");
+  });
+
+  it("per_block missing per_block key → returns error content", async () => {
+    vi.mocked(yakccResolve).mockResolvedValue(makeEmptyResult());
+    const tool = createResolveTool({ openRegistry: async () => STUB_REGISTRY });
+    const http = makeHttp();
+    const result = await tool.handler(
+      { intent: { title: "test" }, proof_requirement: { not_per_block: {} } },
+      http,
+    );
+    const parsed = JSON.parse(result[0]!.text) as { error: string };
+    expect(parsed.error).toBe("invalid_input");
+  });
+
+  it("proof_requirement is a number → returns error content", async () => {
+    vi.mocked(yakccResolve).mockResolvedValue(makeEmptyResult());
+    const tool = createResolveTool({ openRegistry: async () => STUB_REGISTRY });
+    const http = makeHttp();
+    const result = await tool.handler(
+      { intent: { title: "test" }, proof_requirement: 42 },
+      http,
+    );
+    const parsed = JSON.parse(result[0]!.text) as { error: string };
+    expect(parsed.error).toBe("invalid_input");
+  });
+});

--- a/packages/mcp-registry/src/tools/resolve.ts
+++ b/packages/mcp-registry/src/tools/resolve.ts
@@ -9,6 +9,56 @@
  *   path: LLM emits an IntentCard before writing code, this tool returns
  *   candidates structured by D4 ADR Q5 confidence bands.
  *
+ * @decision DEC-PROOF-DISCOVERY-INTEGRATION-001
+ * @title yakcc_resolve — proof layer integration: verification_level + proof_status in envelope
+ * @status decided (wi-1088-discovery-integration)
+ * @rationale
+ *   Slice G of the proof incentive layer converts proof infrastructure from
+ *   "interesting capability" into "load-bearing for substrate trust". The MCP
+ *   adapter is the right place to surface proof status because:
+ *   (1) EvidenceProjection is a D4 ADR Q2 contract with a locked field order —
+ *       adding proof fields there would require a D4 revision and re-audit of all
+ *       callers. The MCP adapter wraps EvidenceProjection and can add envelope
+ *       fields without touching the inner contract.
+ *   (2) Proof state (proof_claims, proof_bounties tables) is a marketplace concern
+ *       that belongs in the outer MCP adapter's enrichment pass, not in the core
+ *       query pipeline.
+ *   MVP stub: verification_level is derived from the proof manifest artifact kinds
+ *   available in EvidenceProjection.tests. proof_status defaults to "none" until
+ *   Slice A/B/F land the proof_claims/bounties tables. The response shape is final;
+ *   the data population improves as upstream slices ship.
+ *
+ * @decision DEC-PROOF-DISCOVERY-QUERY-REQUIREMENT-001
+ * @title yakcc_resolve — four-mode proof_requirement parameter
+ * @status decided (wi-1088-discovery-integration)
+ * @rationale
+ *   The four modes (required/preferred/ignored/per_block) let the LLM express
+ *   task-appropriate trust requirements without requiring a separate query:
+ *   - "required":  hard filter — proves the atom before using it. Zero survivors
+ *     surfaces confidence_tier="no_candidates" + reason="no_proven_atoms_match".
+ *   - "preferred": soft boost — proven atoms score += YAKCC_PROOF_BONUS (default 0.10).
+ *     Low-relevance L3 atoms do NOT beat high-relevance L0 atoms; the bonus
+ *     is intentionally small (B4 measurement will set final defaults).
+ *   - "ignored":   no effect — proof status doesn't affect ranking.
+ *   - per_block:   compound intent map from intent dimension → mode.
+ *   The default is "preferred" to nudge toward proven atoms without blocking.
+ *   The four modes are rank-orthogonal to semantic matching — the proof bonus is
+ *   additive and bounded, not multiplicative, so semantic relevance still dominates.
+ *
+ * @decision DEC-PROOF-RETRACTION-SCORE-PENALTY-001
+ * @title yakcc_resolve — retracted atoms penalized in all proof_requirement modes
+ * @status decided (wi-1088-discovery-integration)
+ * @rationale
+ *   A retracted atom is one whose proof was accepted and then invalidated (theorem
+ *   was wrong, proof was buggy, or the implementation was updated after the proof
+ *   was locked). Using a retracted atom is worse than using an unproven one: the
+ *   LLM has reason to believe the atom is correct when it is not. The penalty
+ *   (-0.20 via YAKCC_RETRACTION_PENALTY) applies in ALL modes, including "ignored",
+ *   because "ignored" means "ignore proof status for SELECTION preference", not
+ *   "ignore proof validity entirely". Env-tunable so B4 measurement can calibrate.
+ *   The penalty is applied before deriveConfidenceTier so retracted atoms can fall
+ *   below auto_accept threshold even when they would otherwise be the top match.
+ *
  *   Architecture:
  *   (1) LOCAL-FIRST (D-HOOK-6, Cornerstone B6):
  *       yakccResolve() from @yakcc/hooks-base is the sole local-query authority
@@ -90,6 +140,31 @@ import type { HttpClient } from "../http-client.js";
 import type { MCPContent, ToolModule } from "./types.js";
 
 // ---------------------------------------------------------------------------
+// Proof-layer constants (DEC-PROOF-DISCOVERY-QUERY-REQUIREMENT-001,
+//                       DEC-PROOF-RETRACTION-SCORE-PENALTY-001)
+// ---------------------------------------------------------------------------
+
+/**
+ * Default score bonus applied to proven (accepted) atoms when
+ * proof_requirement="preferred". Env-tunable: YAKCC_PROOF_BONUS.
+ *
+ * Intentionally small (+0.10) so low-relevance L3 atoms do NOT beat
+ * high-relevance L0 atoms — semantic relevance dominates ranking.
+ * B4 measurement will calibrate the final default.
+ */
+const DEFAULT_PROOF_BONUS = 0.1;
+
+/**
+ * Default score penalty applied to retracted atoms in ALL proof_requirement
+ * modes (DEC-PROOF-RETRACTION-SCORE-PENALTY-001).
+ *
+ * -0.20 applied pre-tier so retracted atoms can fall below auto_accept.
+ * "ignored" mode suppresses bonus/required logic, not the retraction penalty.
+ * Env-tunable: YAKCC_RETRACTION_PENALTY.
+ */
+const DEFAULT_RETRACTION_PENALTY = -0.2;
+
+// ---------------------------------------------------------------------------
 // D4 ADR Q5 hybrid-mode thresholds (local copy)
 // ---------------------------------------------------------------------------
 
@@ -132,6 +207,85 @@ const AUTO_ACCEPT_GAP_THRESHOLD = 0.05;
 const HIGH_CONFIDENCE_THRESHOLD = 0.92;
 
 // ---------------------------------------------------------------------------
+// Proof envelope types (G.1 — per-candidate verification fields)
+// ---------------------------------------------------------------------------
+
+/**
+ * Verification level per the proof layer specification.
+ *
+ * - L0: property_tests only (fast-check corpus).
+ * - L1: SMT certificate present (deferred; schema-valid but validator not yet shipped).
+ * - L2: bounded fuzzing + SMT (deferred).
+ * - L3: formal proof (lean_proof or coq_proof artifact accepted).
+ *
+ * MVP: all atoms in the current registry are L0. L3 will surface when Slice A/B
+ * land the proof_claims tables that record accepted lean_proof/coq_proof artifacts.
+ */
+export type VerificationLevel = "L0" | "L1" | "L2" | "L3";
+
+/**
+ * Proof status for a candidate atom.
+ *
+ * - none:      no proof artifact beyond property_tests (L0 atoms).
+ * - pending:   a proof claim exists but is still in its review window.
+ * - accepted:  proof was verified and the retraction window has closed.
+ * - retracted: proof was accepted then invalidated.
+ *
+ * MVP: defaults to "none" for all atoms (proof_claims/bounties tables not yet
+ * populated — Slice A/B/F). Shape is final; data population improves as those
+ * slices ship.
+ */
+export type ProofStatus = "none" | "pending" | "accepted" | "retracted";
+
+/**
+ * A single accepted proof entry in the candidate's accepted_proofs array.
+ * Populated when proof_status="accepted".
+ */
+export interface AcceptedProofEntry {
+  /** BLAKE3 hash of the theorem statement (the claim being proved). */
+  readonly theorem_statement_hash: string;
+  /** ISO-8601 timestamp when the proof was accepted. */
+  readonly accepted_at: string;
+  /** ISO-8601 timestamp when the retraction window closes (after which retraction is impossible). */
+  readonly retraction_window_closes_at: string;
+  /** Checker identifier, e.g. "lean4@4.7.0" or "coq@8.18.0". */
+  readonly checker: string;
+  /** Number of independent attestations for this proof. */
+  readonly attestation_count: number;
+}
+
+// ---------------------------------------------------------------------------
+// proof_requirement modes (G.2 — four-mode parameter)
+// ---------------------------------------------------------------------------
+
+/**
+ * Scalar proof_requirement modes.
+ *
+ * - "required":  hard filter — only atoms with proof_status="accepted" survive.
+ *   Zero survivors → confidence_tier="no_candidates" + reason="no_proven_atoms_match".
+ * - "preferred": soft boost — accepted atoms gain YAKCC_PROOF_BONUS on their score.
+ * - "ignored":   no effect on ranking from proof status (retraction penalty still applies).
+ */
+export type ProofRequirementMode = "required" | "preferred" | "ignored";
+
+/**
+ * Per-block mode map for compound intents.
+ * Keys are intent dimensions (e.g. "parse", "hash", "format").
+ * Values are scalar ProofRequirementMode values.
+ *
+ * Example: { per_block: { parse: "ignored", hash: "required" } }
+ */
+export interface PerBlockProofRequirement {
+  readonly per_block: Readonly<Record<string, ProofRequirementMode>>;
+}
+
+/**
+ * The full proof_requirement parameter type.
+ * Either a scalar mode or a per-block dimension map.
+ */
+export type ProofRequirement = ProofRequirementMode | PerBlockProofRequirement;
+
+// ---------------------------------------------------------------------------
 // Public IntentCard input shape (minimal subset for MCP surface)
 // ---------------------------------------------------------------------------
 
@@ -142,6 +296,10 @@ const HIGH_CONFIDENCE_THRESHOLD = 0.92;
  * pulling the full contracts dep chain into the inputSchema definition.
  *
  * The handler maps this to yakccResolve's input format.
+ *
+ * proof_requirement (DEC-PROOF-DISCOVERY-QUERY-REQUIREMENT-001):
+ *   Controls how proof status affects candidate scoring and filtering.
+ *   Defaults to "preferred" when omitted.
  */
 export interface ResolveInput {
   readonly intent: {
@@ -151,6 +309,8 @@ export interface ResolveInput {
     readonly examples?: string[]; // example usages
   };
   readonly limit?: number; // candidates returned (default 10)
+  /** Four-mode proof_requirement parameter. Defaults to "preferred". */
+  readonly proof_requirement?: ProofRequirement;
 }
 
 // ---------------------------------------------------------------------------
@@ -245,6 +405,49 @@ function parseArgs(args: unknown): ParsedInput {
     }
   }
 
+  // Validate proof_requirement (DEC-PROOF-DISCOVERY-QUERY-REQUIREMENT-001)
+  const VALID_MODES = new Set<string>(["required", "preferred", "ignored"]);
+  let proofRequirement: ProofRequirement | undefined;
+  if (obj.proof_requirement !== undefined) {
+    const pr = obj.proof_requirement;
+    if (typeof pr === "string") {
+      if (!VALID_MODES.has(pr)) {
+        return {
+          ok: false,
+          message: `proof_requirement must be "required", "preferred", "ignored", or a per_block object`,
+        };
+      }
+      proofRequirement = pr as ProofRequirementMode;
+    } else if (pr !== null && typeof pr === "object" && !Array.isArray(pr)) {
+      const prObj = pr as Record<string, unknown>;
+      if (
+        typeof prObj.per_block !== "object" ||
+        prObj.per_block === null ||
+        Array.isArray(prObj.per_block)
+      ) {
+        return {
+          ok: false,
+          message: `proof_requirement.per_block must be an object mapping intent dimensions to modes`,
+        };
+      }
+      const perBlockObj = prObj.per_block as Record<string, unknown>;
+      for (const [dim, mode] of Object.entries(perBlockObj)) {
+        if (typeof mode !== "string" || !VALID_MODES.has(mode)) {
+          return {
+            ok: false,
+            message: `proof_requirement.per_block["${dim}"] must be "required", "preferred", or "ignored"`,
+          };
+        }
+      }
+      proofRequirement = { per_block: perBlockObj as Record<string, ProofRequirementMode> };
+    } else {
+      return {
+        ok: false,
+        message: `proof_requirement must be a string mode or per_block object`,
+      };
+    }
+  }
+
   const intent: ResolveInput["intent"] = {
     title: intentObj.title as string,
     ...(typeof intentObj.description === "string" ? { description: intentObj.description } : {}),
@@ -255,9 +458,131 @@ function parseArgs(args: unknown): ParsedInput {
   const value: ResolveInput = {
     intent,
     ...(typeof obj.limit === "number" ? { limit: obj.limit } : {}),
+    ...(proofRequirement !== undefined ? { proof_requirement: proofRequirement } : {}),
   };
 
   return { ok: true, value };
+}
+
+// ---------------------------------------------------------------------------
+// Proof scoring helpers (DEC-PROOF-DISCOVERY-QUERY-REQUIREMENT-001,
+//                       DEC-PROOF-RETRACTION-SCORE-PENALTY-001)
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the effective proof requirement mode for a candidate given the
+ * proof_requirement parameter and an optional per-block dimension key.
+ *
+ * For scalar modes, the key is ignored.
+ * For per_block modes, the key is looked up in the map; if not found,
+ * falls back to "preferred" (the default).
+ */
+function resolveProofMode(
+  req: ProofRequirement,
+  dimensionKey?: string,
+): ProofRequirementMode {
+  if (typeof req === "string") return req;
+  // per_block
+  const mode = dimensionKey !== undefined ? req.per_block[dimensionKey] : undefined;
+  return mode ?? "preferred";
+}
+
+/**
+ * Apply proof-layer score adjustments to a list of candidates.
+ *
+ * The candidates array is sorted by descending score on entry.
+ * Returns a new array with adjusted scores — original objects are not mutated.
+ *
+ * Scoring rules (DEC-PROOF-DISCOVERY-QUERY-REQUIREMENT-001,
+ *                DEC-PROOF-RETRACTION-SCORE-PENALTY-001):
+ *
+ * 1. RETRACTION PENALTY (all modes):
+ *    retracted atoms lose YAKCC_RETRACTION_PENALTY (default −0.20).
+ *    Applied regardless of mode — "ignored" suppresses bonus/filter, not penalty.
+ *
+ * 2. BONUS (mode=preferred):
+ *    accepted atoms gain YAKCC_PROOF_BONUS (default +0.10).
+ *
+ * 3. FILTER (mode=required):
+ *    non-accepted atoms are removed from the list.
+ *    The caller checks length===0 and surfaces "no_proven_atoms_match".
+ *
+ * 4. IGNORED mode:
+ *    only the retraction penalty applies; no bonus, no filter.
+ *
+ * The adjusted scores are re-sorted after adjustment so tier derivation
+ * operates on the final ranking, not the pre-proof ranking.
+ */
+function applyProofScoring(
+  candidates: EvidenceProjection[],
+  proofReq: ProofRequirement,
+  getProofStatus: ProofStatusProvider,
+): { adjusted: Array<EvidenceProjection & { _proofStatus: ProofStatus }>; filtered: boolean } {
+  const proofBonus = Number(process.env.YAKCC_PROOF_BONUS ?? DEFAULT_PROOF_BONUS);
+  const retractionPenalty = Number(
+    process.env.YAKCC_RETRACTION_PENALTY ?? DEFAULT_RETRACTION_PENALTY,
+  );
+
+  // Enrich each candidate with proof status
+  const enriched = candidates.map((c) => {
+    const status = getProofStatus(c.address);
+    const mode = resolveProofMode(proofReq);
+    let scoreAdj = c.score;
+
+    // Step 1: retraction penalty (all modes)
+    if (status === "retracted") {
+      scoreAdj += retractionPenalty; // negative delta
+    }
+
+    // Step 2/4: bonus (preferred mode only) and filter (required mode only)
+    if (mode === "preferred" && status === "accepted") {
+      scoreAdj += proofBonus;
+    }
+    // Clamp to [0, 1] — scores are fractions
+    scoreAdj = Math.max(0, Math.min(1, scoreAdj));
+
+    return { ...c, score: scoreAdj, _proofStatus: status };
+  });
+
+  // Step 3: filter for required mode
+  const mode = resolveProofMode(proofReq);
+  const filtered = mode === "required";
+  const result = filtered
+    ? enriched.filter((c) => c._proofStatus === "accepted")
+    : enriched;
+
+  // Re-sort by adjusted score descending
+  result.sort((a, b) => b.score - a.score);
+
+  return { adjusted: result, filtered: filtered && result.length === 0 };
+}
+
+/**
+ * Derive the VerificationLevel for a candidate from its EvidenceProjection.
+ *
+ * MVP derivation: checks tests.artifacts array (if present) for proof artifact kinds.
+ * - lean_proof or coq_proof → L3
+ * - smt_cert                → L1
+ * - default                 → L0 (property_tests only)
+ *
+ * L2 (bounded fuzzing + SMT) is deferred — no current artifact kind maps to it.
+ * This will be upgraded when Slice A/B land the proof_claims tables.
+ */
+function deriveVerificationLevel(candidate: EvidenceProjection): VerificationLevel {
+  const tests = candidate.tests as unknown;
+  if (tests !== null && typeof tests === "object") {
+    const artifacts = (tests as Record<string, unknown>).artifacts;
+    if (Array.isArray(artifacts)) {
+      for (const artifact of artifacts as unknown[]) {
+        if (artifact !== null && typeof artifact === "object") {
+          const kind = (artifact as Record<string, unknown>).kind;
+          if (kind === "lean_proof" || kind === "coq_proof") return "L3";
+          if (kind === "smt_cert") return "L1";
+        }
+      }
+    }
+  }
+  return "L0";
 }
 
 // ---------------------------------------------------------------------------
@@ -285,12 +610,23 @@ function globalRootToCandidate(root: string): {
 
 /**
  * Shape a local EvidenceProjection as a candidate for the response envelope.
+ *
+ * Proof envelope fields (DEC-PROOF-DISCOVERY-INTEGRATION-001):
+ *   - verification_level: derived from candidate's test artifact kinds (L0/L1/L3).
+ *   - proof_status: from the injected ProofStatusProvider (MVP: "none" for all).
+ *   - accepted_proofs: populated when proof_status="accepted" (MVP: always []).
  */
-function localCandidateToResponse(p: EvidenceProjection): {
+function localCandidateToResponse(
+  p: EvidenceProjection,
+  proofStatus: ProofStatus,
+): {
   atom_id: string;
   score: number;
   summary: string;
   source: "local";
+  verification_level: VerificationLevel;
+  proof_status: ProofStatus;
+  accepted_proofs: AcceptedProofEntry[];
   evidence: EvidenceProjection;
 } {
   return {
@@ -298,6 +634,9 @@ function localCandidateToResponse(p: EvidenceProjection): {
     score: p.score,
     summary: p.behavior,
     source: "local",
+    verification_level: deriveVerificationLevel(p),
+    proof_status: proofStatus,
+    accepted_proofs: [],
     evidence: p,
   };
 }
@@ -312,6 +651,22 @@ function localCandidateToResponse(p: EvidenceProjection): {
  * Tests inject openRegistry to avoid real SQLite access.
  * Production uses the default factory (lazy open via openRegistry from @yakcc/registry).
  */
+/**
+ * Proof status provider callback.
+ *
+ * Given a candidate's atom_id (address prefix), returns the current ProofStatus
+ * for that atom. The default implementation returns "none" for all atoms until
+ * Slice A/B/F land the proof_claims/bounties tables.
+ *
+ * The seam is intentional: once the proof-market slices ship, a real provider
+ * can be injected here without changing the scoring or envelope logic.
+ * (DEC-PROOF-DISCOVERY-INTEGRATION-001 — data-source seam)
+ */
+export type ProofStatusProvider = (atom_id: string) => ProofStatus;
+
+/** Default stub: all atoms have proof_status="none" until proof-market slices ship. */
+const defaultProofStatusProvider: ProofStatusProvider = (_atom_id) => "none";
+
 export interface CreateResolveToolOptions {
   /**
    * Factory for the local registry. Called lazily on the first handler invocation
@@ -319,6 +674,13 @@ export interface CreateResolveToolOptions {
    * @yakcc/registry with createOfflineEmbeddingProvider() from @yakcc/contracts.
    */
   readonly openRegistry?: (() => Promise<Registry>) | undefined;
+
+  /**
+   * Proof status provider. Given an atom_id, returns its ProofStatus.
+   * Defaults to the stub that returns "none" for all atoms.
+   * (DEC-PROOF-DISCOVERY-INTEGRATION-001 — data-source seam)
+   */
+  readonly proofStatusProvider?: ProofStatusProvider | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -413,6 +775,15 @@ export function createResolveTool(opts?: CreateResolveToolOptions): ToolModule {
           default: 10,
           description: "Maximum number of candidates to return (1–100, default 10).",
         },
+        proof_requirement: {
+          description: [
+            "Controls how proof status affects candidate scoring and filtering.",
+            'Scalar modes: "required" (hard filter — only accepted atoms), "preferred" (soft +0.10 bonus for accepted atoms, default), "ignored" (no effect except retraction penalty).',
+            'Per-block: { "per_block": { "<dimension>": "<mode>" } } maps intent dimensions to individual modes.',
+            "Retracted atoms are penalized −0.20 in ALL modes.",
+            "Defaults to \"preferred\" when omitted.",
+          ].join(" "),
+        },
       },
     },
 
@@ -428,8 +799,9 @@ export function createResolveTool(opts?: CreateResolveToolOptions): ToolModule {
         ];
       }
 
-      const { intent, limit = 10 } = parsed.value;
+      const { intent, limit = 10, proof_requirement = "preferred" } = parsed.value;
       const airgapped = process.env.YAKCC_AIRGAPPED === "1";
+      const getProofStatus = opts?.proofStatusProvider ?? defaultProofStatusProvider;
 
       // --- Open the local registry (lazy, cached) ---
       let registry: Registry;
@@ -481,7 +853,44 @@ export function createResolveTool(opts?: CreateResolveToolOptions): ToolModule {
         void err; // Swallow; degrade to no_match
       }
 
-      const localCandidates = [...resolveResult.candidates].slice(0, limit);
+      const rawLocalCandidates = [...resolveResult.candidates].slice(0, limit);
+
+      // --- Apply proof scoring (DEC-PROOF-DISCOVERY-QUERY-REQUIREMENT-001,
+      //                          DEC-PROOF-RETRACTION-SCORE-PENALTY-001)
+      //
+      // Proof scoring adjusts candidate scores BEFORE tier derivation so that:
+      // - retracted atoms can fall below auto_accept even when top-ranked
+      // - accepted atoms get a soft bonus when mode="preferred"
+      // - mode="required" removes non-accepted atoms (zero survivors → no_proven_atoms_match)
+      //
+      // Applied here on the raw local candidates only. Global atoms are returned with
+      // proof_status="none" and verification_level="L0" (no proof metadata available
+      // from the catalog walk endpoint).
+      const { adjusted: localCandidates, filtered: allFilteredOut } = applyProofScoring(
+        rawLocalCandidates,
+        proof_requirement,
+        getProofStatus,
+      );
+
+      // mode=required with no survivors: surface reason="no_proven_atoms_match"
+      if (allFilteredOut) {
+        return [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                confidence_tier: "no_candidates",
+                reason: "no_proven_atoms_match",
+                source: "local_only",
+                candidates: [],
+                airgapped,
+              },
+              null,
+              2,
+            ),
+          },
+        ];
+      }
 
       // --- Auto-accept short-circuit: no global call needed ---
       const localTier = deriveConfidenceTier(localCandidates);
@@ -508,6 +917,13 @@ export function createResolveTool(opts?: CreateResolveToolOptions): ToolModule {
             },
           ];
         }
+
+        // Surface retracted_top_candidate reason when the auto-accepted atom is retracted.
+        // This can happen when the retraction penalty is env-tuned to a value that doesn't
+        // drop the retracted atom below the auto-accept threshold.
+        const topReason =
+          top._proofStatus === "retracted" ? "retracted_top_candidate" : undefined;
+
         const atomBody = {
           behavior: top.behavior,
           signature: top.signature,
@@ -520,8 +936,11 @@ export function createResolveTool(opts?: CreateResolveToolOptions): ToolModule {
             text: JSON.stringify(
               {
                 confidence_tier: "auto_accept",
+                ...(topReason !== undefined ? { reason: topReason } : {}),
                 source: "local_only",
-                candidates: localCandidates.map(localCandidateToResponse),
+                candidates: localCandidates.map((c) =>
+                  localCandidateToResponse(c, c._proofStatus),
+                ),
                 atom_body: atomBody,
                 airgapped,
               },
@@ -541,7 +960,9 @@ export function createResolveTool(opts?: CreateResolveToolOptions): ToolModule {
               {
                 confidence_tier: localCandidates.length > 0 ? "candidate_list" : "no_candidates",
                 source: "local_only",
-                candidates: localCandidates.map(localCandidateToResponse),
+                candidates: localCandidates.map((c) =>
+                  localCandidateToResponse(c, c._proofStatus),
+                ),
                 airgapped: true,
               },
               null,
@@ -579,7 +1000,9 @@ export function createResolveTool(opts?: CreateResolveToolOptions): ToolModule {
               {
                 confidence_tier: localCandidates.length > 0 ? "candidate_list" : "no_candidates",
                 source: "local_only",
-                candidates: localCandidates.map(localCandidateToResponse),
+                candidates: localCandidates.map((c) =>
+                  localCandidateToResponse(c, c._proofStatus),
+                ),
                 airgapped: false,
               },
               null,
@@ -599,7 +1022,10 @@ export function createResolveTool(opts?: CreateResolveToolOptions): ToolModule {
         .slice(0, Math.max(0, limit - localCandidates.length))
         .map(globalRootToCandidate);
 
-      const merged = [...localCandidates.map(localCandidateToResponse), ...freshGlobalCandidates];
+      const merged = [
+        ...localCandidates.map((c) => localCandidateToResponse(c, c._proofStatus)),
+        ...freshGlobalCandidates,
+      ];
 
       const mergedTier = deriveConfidenceTier(localCandidates);
       const finalTier: ConfidenceTier =


### PR DESCRIPTION
Slice G of the proof incentive layer. `yakcc_resolve` gains the four-mode `proof_requirement` query parameter and a proof-aware response envelope.

## Envelope extensions

Every candidate carries:
- `verification_level`: L0 | L1 | L2 | L3
- `proof_status`: none | pending | accepted | retracted
- `accepted_proofs[]`: array of accepted-theorem metadata

## Four-mode parameter

| Mode | Behavior |
|---|---|
| `required` | Filter to proven only; if 0 survive, `confidence_tier: no_candidates` + `reason: no_proven_atoms_match` |
| `preferred` (default) | Boost proven atoms (`+YAKCC_PROOF_BONUS`, default 0.10) |
| `ignored` | Proof status doesn't affect ranking |
| `{ per_block: { intent_dim: mode } }` | Per-dimension mode lookup for compound intents |

## Other changes

- Retracted atoms carry `score_penalty -0.20` in **all** modes (signal worth surfacing regardless of proof_requirement)
- New reason codes: `no_proven_atoms_match`, `retracted_top_candidate`
- Discovery prompt section explains when to override the default
- `proofStatusProvider` injection seam — MVP returns `none` by default; data-source wiring to `proof_bounties` / `proof_claims` is a follow-up
- **223 tests pass** (existing + new four-mode coverage)

## Decisions

- `DEC-PROOF-DISCOVERY-INTEGRATION-001` — proof-aware envelope
- `DEC-PROOF-DISCOVERY-QUERY-REQUIREMENT-001` — 4-mode parameter
- `DEC-PROOF-RETRACTION-SCORE-PENALTY-001` — penalty in all modes

Closes #1088

## Test plan

- [x] `pnpm --filter @yakcc/mcp-registry test` — 223 pass
- [x] `pnpm --filter @yakcc/mcp-registry build` — clean
- [x] `pnpm --filter @yakcc/mcp-registry exec tsc --noEmit -p .` — clean