### PR TITLE
feat(proof-market+registry): #1087 — counter-proof retraction (Slice F)

### DIFF
--- a/packages/proof-market/src/index.ts
+++ b/packages/proof-market/src/index.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // @yakcc/proof-market — public API surface for the proof incentive lifecycle.
-// Re-exports everything from proof-market.ts so consumers import from "@yakcc/proof-market".
+// Re-exports everything from proof-market.ts and retraction.ts so consumers
+// import from "@yakcc/proof-market".
 
 export {
   ProofMarket,
@@ -44,3 +45,20 @@ export {
   slashReputation,
 } from "./reputation.js";
 export type { ReputationClock, ReputationEvent } from "./reputation.js";
+
+// Retraction (#1087 / Slice F — counter-proof admission)
+export {
+  RetractionMarket,
+  T_RETRACTION_MS,
+  RETRACTION_STAKE_MULTIPLIER,
+  RETRACTION_SLASH_HALF_LIFE_MS,
+  RETRACTION_REWARD_FRACTION,
+} from "./retraction.js";
+export type {
+  RetractionId,
+  RetractionStatus,
+  RetractionRow,
+  RetractionResolution,
+  FileRetractionOptions,
+  ResolveRetractionOptions,
+} from "./retraction.js";

--- a/packages/proof-market/src/proof-market.ts
+++ b/packages/proof-market/src/proof-market.ts
@@ -185,6 +185,21 @@ export class ProofMarket {
   }
 
   /**
+   * Test-only: wrap an externally-managed Database instance. Used by
+   * retraction.test.ts to share one in-memory DB across helper functions
+   * while still going through the ProofMarket API surface. The provided DB
+   * must already have sqlite-vec loaded and migrations applied.
+   */
+  static fromDbForTest(db: Database.Database): ProofMarket {
+    return new ProofMarket(db);
+  }
+
+  /** Test-only: expose the underlying Database for shared-DB scenarios. */
+  getDbForTest(): Database.Database {
+    return this.db;
+  }
+
+  /**
    * Close the underlying SQLite connection. After close(), no other methods may be called.
    */
   close(): void {

--- a/packages/proof-market/src/retraction.test.ts
+++ b/packages/proof-market/src/retraction.test.ts
@@ -1,0 +1,897 @@
+// SPDX-License-Identifier: MIT
+//
+// retraction.test.ts — counter-proof admission tests for Slice F.
+//
+// Production sequence exercised here:
+//   1. A proof bounty is posted and a claimant wins it (ACCEPT path from proof-market.ts).
+//   2. A retractor files a retraction against the accepted claim (fileRetraction).
+//   3. Verifier attestations resolve the retraction (resolveRetraction).
+//   4. Economic consequences are computed: slash amount, retractor reward, treasury share.
+//
+// Test categories:
+//   T-1: Successful retraction within 30 days → full slash region, retractor reward paid.
+//   T-2: Successful retraction at day 89 → small slash (decay).
+//   T-3: Retraction after T_RETRACTION_MS (90 days) → fileRetraction throws.
+//   T-4: Asymmetric stake violation: stake < 2× original → fileRetraction throws.
+//   T-5: Rejected retraction → retractor stake forfeit (status REJECTED, slashAmount=0).
+//   T-6: Multiple concurrent retractions on same claim: first RETRACTED wins,
+//        subsequent auto-REJECTED.
+//   T-7: COMPOUND end-to-end — post bounty → commit → reveal → ACCEPT → retraction filed
+//        → resolved RETRACTED via supermajority attestations (crosses all component boundaries).
+//   T-8: Retraction on non-VALID claim → fileRetraction throws.
+//   T-9: Resolve non-PENDING retraction → resolveRetraction throws.
+//   T-10: computeSlashFraction boundary values.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { ProofMarket as ProofMarketCls } from "./proof-market.js";
+import {
+  type ClaimId,
+  MIN_T_COMMIT_MS,
+  MIN_T_REVEAL_MS,
+} from "./index.js";
+import {
+  RetractionMarket,
+  type RetractionId,
+  RETRACTION_REWARD_FRACTION,
+  RETRACTION_SLASH_HALF_LIFE_MS,
+  RETRACTION_STAKE_MULTIPLIER,
+  T_RETRACTION_MS,
+} from "./retraction.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers shared between proof-market and retraction tests
+// ---------------------------------------------------------------------------
+
+const ATOM_BMR = "a".repeat(64);
+const THEOREM_HASH = "b".repeat(64);
+const REQUESTER = "requester-alice";
+const CLAIMANT_A = "claimant-alpha";
+const RETRACTOR = "retractor-bob";
+const STAKE_UNIT = "reputation_credit";
+const REWARD_UNIT = "reputation_credit";
+const ORIGINAL_STAKE = 100;
+const ORIGINAL_REWARD = 1000;
+
+function nonce(seed: string): Uint8Array {
+  const enc = new TextEncoder();
+  return enc.encode(seed.padEnd(32, "\0").slice(0, 32));
+}
+
+function artifact(label: string): Uint8Array {
+  return new TextEncoder().encode(`proof-artifact-${label}`);
+}
+
+// ---------------------------------------------------------------------------
+// Shared fixture: set up a ProofMarket + RetractionMarket on the same in-memory DB
+// then drive a bounty all the way to ACCEPT so tests can file retractions against it.
+// ---------------------------------------------------------------------------
+
+let pm: ProofMarketCls;
+let rm: RetractionMarket;
+/** The claim_id of the winning VALID claim. */
+let acceptedClaimId: ClaimId;
+/** The revealed_at timestamp of the accepted claim (used as "accepted_at" proxy). */
+let acceptedAt: number;
+
+const T0 = 1_700_000_000_000; // fixed epoch for deterministic timing
+
+/**
+ * Drive a full bounty lifecycle to ACCEPT and return the VALID claim's ID.
+ * Uses the shared `pm` / `rm` instances.
+ */
+function driveToAccept(opts: { t0?: number; originalStake?: number; originalReward?: number } = {}): {
+  claimId: ClaimId;
+  revealedAt: number;
+} {
+  const t0 = opts.t0 ?? T0;
+  const stake = opts.originalStake ?? ORIGINAL_STAKE;
+  const reward = opts.originalReward ?? ORIGINAL_REWARD;
+
+  const bountyId = pm.postBounty(ATOM_BMR, THEOREM_HASH, reward, REWARD_UNIT, REQUESTER, {
+    nowMs: t0,
+    tCommitMs: MIN_T_COMMIT_MS,
+    tRevealMs: MIN_T_REVEAL_MS,
+  });
+
+  const art = artifact("lean4-accepted-proof");
+  const n = nonce("nonce-accepted");
+  const commitHash = ProofMarketCls.computeCommitHash(art, n, CLAIMANT_A);
+  const claimId = pm.commitClaim(bountyId, commitHash, CLAIMANT_A, stake, STAKE_UNIT, {
+    nowMs: t0 + 1000,
+  });
+
+  // Advance to REVEAL
+  pm.transitionBounty(bountyId, { nowMs: t0 + MIN_T_COMMIT_MS, tRevealMs: MIN_T_REVEAL_MS });
+
+  const revealedAt = t0 + MIN_T_COMMIT_MS + 1000;
+  pm.revealClaim(claimId, art, n, { nowMs: revealedAt });
+
+  // Advance to CHECK
+  pm.transitionBounty(bountyId, { nowMs: t0 + MIN_T_COMMIT_MS + MIN_T_REVEAL_MS });
+
+  // Finalize with supermajority valid
+  pm.finalizeBounty(bountyId, [
+    {
+      attestationId: "att-1" as unknown as ReturnType<typeof String.prototype.toString> & {
+        readonly __brand: "AttestationId";
+      },
+      claimId,
+      verifierId: "verifier-1",
+      result: "valid",
+      toolchainVersionHash: "c".repeat(64),
+      signature: "sig-1",
+    },
+    {
+      attestationId: "att-2" as unknown as ReturnType<typeof String.prototype.toString> & {
+        readonly __brand: "AttestationId";
+      },
+      claimId,
+      verifierId: "verifier-2",
+      result: "valid",
+      toolchainVersionHash: "c".repeat(64),
+      signature: "sig-2",
+    },
+    {
+      attestationId: "att-3" as unknown as ReturnType<typeof String.prototype.toString> & {
+        readonly __brand: "AttestationId";
+      },
+      claimId,
+      verifierId: "verifier-3",
+      result: "valid",
+      toolchainVersionHash: "c".repeat(64),
+      signature: "sig-3",
+    },
+  ]);
+
+  return { claimId, revealedAt };
+}
+
+// ---------------------------------------------------------------------------
+// Fixture setup — fresh in-memory DB for each test, shared between PM and RM.
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  // Open ProofMarket first (it applies migrations including v14 proof_retractions).
+  pm = ProofMarketCls.open(":memory:");
+  // Share the same DB with RetractionMarket via the internal db handle.
+  // We accomplish this by having RetractionMarket open its own in-memory DB pointing
+  // to ":memory:" — but since each ":memory:" is a distinct DB, we need to share.
+  // The clean approach: use RetractionMarket.fromDb with the PM's DB handle.
+  // ProofMarket exposes no public db accessor, so we open RM.open(":memory:") and
+  // drive both using their own separate in-memory DBs. This tests RM in isolation.
+  // For the compound test (T-7) we use a shared DB via a file-based temp path.
+  rm = RetractionMarket.open(":memory:");
+
+  // Pre-populate the RM's DB with an accepted claim by driving the full lifecycle.
+  // For isolated RM tests we need a claim in a DB that RM owns.
+  // Strategy: use a single helper that drives the FULL lifecycle through RM's own DB.
+  // RetractionMarket.fromDb wraps an existing DB — so we open PM on RM's DB handle.
+  // Since we cannot access rm.db directly (private), we use RetractionMarket.open
+  // and drive the accept lifecycle using a separate ProofMarket opened on the same path.
+  // For in-memory isolation we accept that each test drives its own lifecycle.
+  // The acceptedClaimId / acceptedAt are populated per-test via the helpers below.
+});
+
+// ---------------------------------------------------------------------------
+// Helper: create a shared DB, drive to accept, return both market handles.
+// ---------------------------------------------------------------------------
+
+function setupSharedDb(opts: { t0?: number; originalStake?: number; originalReward?: number } = {}): {
+  pm: ProofMarketCls;
+  rm: RetractionMarket;
+  claimId: ClaimId;
+  revealedAt: number;
+} {
+  // Open ProofMarket on ":memory:" — it applies all migrations through v14.
+  const localPm = ProofMarketCls.open(":memory:");
+  // Wrap the same underlying DB with RetractionMarket.
+  // We need to access the DB — this is the one legitimate reason to call fromDb.
+  // We achieve this by having RetractionMarket.open open a SECOND in-memory handle
+  // and using that. But to share state we need to pass the DB from PM.
+  // The practical solution: both open the same path. For tests, use a temp file.
+  // However, for simplicity and to avoid temp-file cleanup, we expose a test seam:
+  // open RM using the SAME database by passing a special test shim.
+  //
+  // IMPLEMENTATION NOTE: ProofMarket.open and RetractionMarket.open both call
+  // applyMigrations, which is idempotent. The simplest shared-DB approach for
+  // tests is to open a PM, then open an RM wrapping the same underlying Database
+  // object. ProofMarket stores db as private, so we use a parallel test path:
+  // open both on the same database instance via a test helper in retraction.ts.
+  //
+  // Rather than adding test-only seams to production code, we drive the shared
+  // lifecycle by having the PM drive to ACCEPT, then export the claim_id, and
+  // test the RM using a fresh DB where we manually insert the accepted claim row
+  // using raw SQL (the RM does not care how the row got there, only its status).
+  //
+  // This is the most honest approach: the RM queries proof_claims via FK, which
+  // means it operates against a real schema row regardless of how it was created.
+
+  const { claimId, revealedAt } = driveToAcceptOnPm(localPm, opts);
+
+  // Now open RM on the SAME in-memory DB via fromDb.
+  // ProofMarket exposes no db getter, so we need a different strategy:
+  // Open both markets on a shared Database instance passed via fromDb.
+  // We construct the shared Database manually here, then pass it to both.
+
+  // Re-implement: use a single Database object for both.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const DatabaseCtor = require("better-sqlite3") as typeof import("better-sqlite3").default;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const sqliteVec = require("sqlite-vec") as typeof import("sqlite-vec");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { applyMigrations } = require("@yakcc/registry") as { applyMigrations: (db: unknown) => void };
+
+  const sharedDb = new DatabaseCtor(":memory:");
+  sqliteVec.load(sharedDb);
+  sharedDb.exec("PRAGMA foreign_keys = ON");
+  applyMigrations(sharedDb);
+
+  // Drive to ACCEPT using the shared DB.
+  const sharedPm = ProofMarketCls.fromDbForTest(sharedDb);
+  const { claimId: sharedClaimId, revealedAt: sharedRevealedAt } = driveToAcceptOnPm(
+    sharedPm,
+    opts,
+  );
+  const sharedRm = RetractionMarket.fromDb(sharedDb);
+  localPm.close();
+
+  return { pm: sharedPm, rm: sharedRm, claimId: sharedClaimId, revealedAt: sharedRevealedAt };
+}
+
+function driveToAcceptOnPm(
+  localPm: ProofMarketCls,
+  opts: { t0?: number; originalStake?: number; originalReward?: number } = {},
+): { claimId: ClaimId; revealedAt: number } {
+  const t0 = opts.t0 ?? T0;
+  const stake = opts.originalStake ?? ORIGINAL_STAKE;
+  const reward = opts.originalReward ?? ORIGINAL_REWARD;
+
+  const bountyId = localPm.postBounty(ATOM_BMR, THEOREM_HASH, reward, REWARD_UNIT, REQUESTER, {
+    nowMs: t0,
+    tCommitMs: MIN_T_COMMIT_MS,
+    tRevealMs: MIN_T_REVEAL_MS,
+  });
+
+  const art = artifact("lean4-accepted-proof");
+  const n = nonce("nonce-accepted");
+  const commitHash = ProofMarketCls.computeCommitHash(art, n, CLAIMANT_A);
+  const claimId = localPm.commitClaim(bountyId, commitHash, CLAIMANT_A, stake, STAKE_UNIT, {
+    nowMs: t0 + 1000,
+  });
+
+  localPm.transitionBounty(bountyId, { nowMs: t0 + MIN_T_COMMIT_MS, tRevealMs: MIN_T_REVEAL_MS });
+  const revealedAt = t0 + MIN_T_COMMIT_MS + 1000;
+  localPm.revealClaim(claimId, art, n, { nowMs: revealedAt });
+  localPm.transitionBounty(bountyId, { nowMs: t0 + MIN_T_COMMIT_MS + MIN_T_REVEAL_MS });
+
+  localPm.finalizeBounty(bountyId, [
+    {
+      attestationId: "att-1" as unknown as ReturnType<typeof String.prototype.toString> & {
+        readonly __brand: "AttestationId";
+      },
+      claimId,
+      verifierId: "v1",
+      result: "valid",
+      toolchainVersionHash: "c".repeat(64),
+      signature: "sig1",
+    },
+    {
+      attestationId: "att-2" as unknown as ReturnType<typeof String.prototype.toString> & {
+        readonly __brand: "AttestationId";
+      },
+      claimId,
+      verifierId: "v2",
+      result: "valid",
+      toolchainVersionHash: "c".repeat(64),
+      signature: "sig2",
+    },
+    {
+      attestationId: "att-3" as unknown as ReturnType<typeof String.prototype.toString> & {
+        readonly __brand: "AttestationId";
+      },
+      claimId,
+      verifierId: "v3",
+      result: "valid",
+      toolchainVersionHash: "c".repeat(64),
+      signature: "sig3",
+    },
+  ]);
+
+  return { claimId, revealedAt };
+}
+
+// ---------------------------------------------------------------------------
+// T-10: computeSlashFraction boundary values (pure math, no DB needed)
+// ---------------------------------------------------------------------------
+
+describe("computeSlashFraction — exponential half-life decay", () => {
+  it("returns 1.0 at elapsed=0 (full slash, caught immediately)", () => {
+    expect(RetractionMarket.computeSlashFraction(0)).toBe(1.0);
+  });
+
+  it("returns ~0.5 at elapsed=HALF_LIFE (30 days)", () => {
+    const fraction = RetractionMarket.computeSlashFraction(RETRACTION_SLASH_HALF_LIFE_MS);
+    expect(fraction).toBeCloseTo(0.5, 5);
+  });
+
+  it("returns ~0.25 at elapsed=2×HALF_LIFE (60 days)", () => {
+    const fraction = RetractionMarket.computeSlashFraction(2 * RETRACTION_SLASH_HALF_LIFE_MS);
+    expect(fraction).toBeCloseTo(0.25, 5);
+  });
+
+  it("returns ~0.13 at elapsed=~90 days (near window close)", () => {
+    // 90 days = 3 × 30d half-lives → 2^(-3) = 0.125
+    const fraction = RetractionMarket.computeSlashFraction(3 * RETRACTION_SLASH_HALF_LIFE_MS);
+    expect(fraction).toBeCloseTo(0.125, 5);
+  });
+
+  it("returns a value strictly between 0 and 1 for any positive elapsed", () => {
+    for (const ms of [1, 1000, 1_000_000, T_RETRACTION_MS]) {
+      const f = RetractionMarket.computeSlashFraction(ms);
+      expect(f).toBeGreaterThan(0);
+      expect(f).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-3: Filing after window close throws
+// ---------------------------------------------------------------------------
+
+describe("T-3: retraction after T_RETRACTION_MS window → throws", () => {
+  it("throws when filed more than 90 days after acceptance", () => {
+    const { rm: sharedRm, claimId, revealedAt } = setupSharedDb();
+
+    const afterWindow = revealedAt + T_RETRACTION_MS + 1;
+    expect(() =>
+      sharedRm.fileRetraction(
+        claimId,
+        RETRACTOR,
+        ORIGINAL_STAKE * RETRACTION_STAKE_MULTIPLIER,
+        STAKE_UNIT,
+        null,
+        { nowMs: afterWindow },
+      ),
+    ).toThrow("retraction window closed");
+
+    sharedRm.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-4: Asymmetric stake violation → throws
+// ---------------------------------------------------------------------------
+
+describe("T-4: stake < 2× original → fileRetraction throws", () => {
+  it("throws when stake is exactly 1× original", () => {
+    const { rm: sharedRm, claimId, revealedAt } = setupSharedDb();
+
+    // Stake is equal to original (100), not 2× (200)
+    expect(() =>
+      sharedRm.fileRetraction(claimId, RETRACTOR, ORIGINAL_STAKE, STAKE_UNIT, null, {
+        nowMs: revealedAt + 1000,
+      }),
+    ).toThrow("less than required minimum");
+
+    sharedRm.close();
+  });
+
+  it("throws when stake is 2× - 1 (just below threshold)", () => {
+    const { rm: sharedRm, claimId, revealedAt } = setupSharedDb();
+
+    expect(() =>
+      sharedRm.fileRetraction(
+        claimId,
+        RETRACTOR,
+        ORIGINAL_STAKE * RETRACTION_STAKE_MULTIPLIER - 1,
+        STAKE_UNIT,
+        null,
+        { nowMs: revealedAt + 1000 },
+      ),
+    ).toThrow("less than required minimum");
+
+    sharedRm.close();
+  });
+
+  it("succeeds with exactly 2× stake (boundary inclusive)", () => {
+    const { rm: sharedRm, claimId, revealedAt } = setupSharedDb();
+
+    const retractionId = sharedRm.fileRetraction(
+      claimId,
+      RETRACTOR,
+      ORIGINAL_STAKE * RETRACTION_STAKE_MULTIPLIER,
+      STAKE_UNIT,
+      null,
+      { nowMs: revealedAt + 1000 },
+    );
+    expect(retractionId).toMatch(/^[0-9a-f]{64}$/);
+
+    sharedRm.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-8: Retraction on non-VALID claim → throws
+// ---------------------------------------------------------------------------
+
+describe("T-8: retraction on non-VALID claim", () => {
+  it("throws when original claim does not exist", () => {
+    expect(() =>
+      rm.fileRetraction("no-such-claim", RETRACTOR, 200, STAKE_UNIT, null, {
+        nowMs: T0 + 1000,
+      }),
+    ).toThrow("claim not found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-5: Rejected retraction → status REJECTED, slashAmount=0
+// ---------------------------------------------------------------------------
+
+describe("T-5: rejected retraction (supermajority invalid)", () => {
+  it("sets status to REJECTED and returns zero slash amounts", () => {
+    const { rm: sharedRm, claimId, revealedAt } = setupSharedDb();
+
+    const retractionId = sharedRm.fileRetraction(
+      claimId,
+      RETRACTOR,
+      ORIGINAL_STAKE * RETRACTION_STAKE_MULTIPLIER,
+      STAKE_UNIT,
+      "evidenceHash123",
+      { nowMs: revealedAt + 1000 },
+    );
+
+    // Resolve with all-invalid attestations (no supermajority)
+    const resolution = sharedRm.resolveRetraction(
+      retractionId,
+      [
+        { verifierId: "v1", result: "invalid" },
+        { verifierId: "v2", result: "invalid" },
+        { verifierId: "v3", result: "invalid" },
+      ],
+      { nowMs: revealedAt + 2000, originalRewardAmount: ORIGINAL_REWARD },
+    );
+
+    expect(resolution.status).toBe("REJECTED");
+    expect(resolution.slashAmount).toBe(0);
+    expect(resolution.retractorReward).toBe(0);
+    expect(resolution.treasuryAmount).toBe(0);
+
+    const row = sharedRm.getRetraction(retractionId);
+    expect(row!.status).toBe("REJECTED");
+    expect(row!.resolved_at).toBe(revealedAt + 2000);
+
+    sharedRm.close();
+  });
+
+  it("REJECTED with zero attestations (no verifiers showed up)", () => {
+    const { rm: sharedRm, claimId, revealedAt } = setupSharedDb();
+
+    const retractionId = sharedRm.fileRetraction(
+      claimId,
+      RETRACTOR,
+      ORIGINAL_STAKE * RETRACTION_STAKE_MULTIPLIER,
+      STAKE_UNIT,
+      null,
+      { nowMs: revealedAt + 1000 },
+    );
+
+    const resolution = sharedRm.resolveRetraction(retractionId, [], {
+      nowMs: revealedAt + 2000,
+    });
+
+    expect(resolution.status).toBe("REJECTED");
+
+    sharedRm.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-9: Resolve non-PENDING retraction throws
+// ---------------------------------------------------------------------------
+
+describe("T-9: resolve non-PENDING retraction → throws", () => {
+  it("throws when trying to resolve an already-REJECTED retraction", () => {
+    const { rm: sharedRm, claimId, revealedAt } = setupSharedDb();
+
+    const retractionId = sharedRm.fileRetraction(
+      claimId,
+      RETRACTOR,
+      ORIGINAL_STAKE * RETRACTION_STAKE_MULTIPLIER,
+      STAKE_UNIT,
+      null,
+      { nowMs: revealedAt + 1000 },
+    );
+
+    // Resolve once (REJECT)
+    sharedRm.resolveRetraction(retractionId, [], { nowMs: revealedAt + 2000 });
+
+    // Try to resolve again
+    expect(() =>
+      sharedRm.resolveRetraction(retractionId, [], { nowMs: revealedAt + 3000 }),
+    ).toThrow("not PENDING");
+
+    sharedRm.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-1: Successful retraction within 30 days → full slash region
+// ---------------------------------------------------------------------------
+
+describe("T-1: successful retraction within 30 days (full slash region)", () => {
+  it("resolves RETRACTED with near-full slash when caught quickly (elapsed ~ 1 day)", () => {
+    const { rm: sharedRm, claimId, revealedAt } = setupSharedDb();
+
+    const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+    const retractionId = sharedRm.fileRetraction(
+      claimId,
+      RETRACTOR,
+      ORIGINAL_STAKE * RETRACTION_STAKE_MULTIPLIER,
+      STAKE_UNIT,
+      "counterexample-hash",
+      { nowMs: revealedAt + ONE_DAY_MS },
+    );
+
+    const resolution = sharedRm.resolveRetraction(
+      retractionId,
+      [
+        { verifierId: "v1", result: "valid" },
+        { verifierId: "v2", result: "valid" },
+        { verifierId: "v3", result: "valid" },
+      ],
+      {
+        nowMs: revealedAt + ONE_DAY_MS + 1000,
+        originalRewardAmount: ORIGINAL_REWARD,
+      },
+    );
+
+    expect(resolution.status).toBe("RETRACTED");
+
+    // Slash fraction at 1 day: 2^(-1/30) ≈ 0.977
+    const expectedFraction = Math.pow(2, -(ONE_DAY_MS / RETRACTION_SLASH_HALF_LIFE_MS));
+    expect(resolution.slashFraction).toBeCloseTo(expectedFraction, 5);
+
+    // Slash amount should be close to full reward
+    const expectedSlash = Math.round(ORIGINAL_REWARD * expectedFraction);
+    expect(resolution.slashAmount).toBe(expectedSlash);
+
+    // Retractor reward = RETRACTION_REWARD_FRACTION of slashAmount
+    expect(resolution.retractorReward).toBe(
+      Math.round(expectedSlash * RETRACTION_REWARD_FRACTION),
+    );
+
+    // Treasury gets the rest
+    expect(resolution.treasuryAmount).toBe(resolution.slashAmount - resolution.retractorReward);
+
+    // DB row is updated
+    const row = sharedRm.getRetraction(retractionId);
+    expect(row!.status).toBe("RETRACTED");
+
+    sharedRm.close();
+  });
+
+  it("retractorReward + treasuryAmount = slashAmount (no rounding leakage)", () => {
+    const { rm: sharedRm, claimId, revealedAt } = setupSharedDb();
+
+    const retractionId = sharedRm.fileRetraction(
+      claimId,
+      RETRACTOR,
+      ORIGINAL_STAKE * RETRACTION_STAKE_MULTIPLIER,
+      STAKE_UNIT,
+      null,
+      { nowMs: revealedAt + 1000 },
+    );
+
+    const resolution = sharedRm.resolveRetraction(
+      retractionId,
+      [{ verifierId: "v1", result: "valid" }, { verifierId: "v2", result: "valid" }],
+      { nowMs: revealedAt + 2000, originalRewardAmount: ORIGINAL_REWARD },
+    );
+
+    expect(resolution.status).toBe("RETRACTED");
+    expect(resolution.retractorReward + resolution.treasuryAmount).toBe(resolution.slashAmount);
+
+    sharedRm.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-2: Successful retraction at day 89 → small slash (decay)
+// ---------------------------------------------------------------------------
+
+describe("T-2: successful retraction at day 89 (small slash near window close)", () => {
+  it("resolves RETRACTED with small slash fraction (~0.13 at 90 days)", () => {
+    const { rm: sharedRm, claimId, revealedAt } = setupSharedDb();
+
+    const DAY_89_MS = 89 * 24 * 60 * 60 * 1000;
+    const retractionId = sharedRm.fileRetraction(
+      claimId,
+      RETRACTOR,
+      ORIGINAL_STAKE * RETRACTION_STAKE_MULTIPLIER,
+      STAKE_UNIT,
+      "counterexample-hash-late",
+      { nowMs: revealedAt + DAY_89_MS },
+    );
+
+    const resolveTime = revealedAt + DAY_89_MS + 1000;
+    const resolution = sharedRm.resolveRetraction(
+      retractionId,
+      [{ verifierId: "v1", result: "valid" }, { verifierId: "v2", result: "valid" }],
+      { nowMs: resolveTime, originalRewardAmount: ORIGINAL_REWARD },
+    );
+
+    expect(resolution.status).toBe("RETRACTED");
+
+    // At ~89 days the slash fraction is ~2^(-89/30) ≈ 0.131
+    expect(resolution.slashFraction).toBeLessThan(0.2);
+    expect(resolution.slashFraction).toBeGreaterThan(0.05);
+
+    // Slash amount is much smaller than the full reward
+    expect(resolution.slashAmount).toBeLessThan(ORIGINAL_REWARD * 0.2);
+
+    sharedRm.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-6: Multiple concurrent retractions — first RETRACTED wins, rest auto-REJECTED
+// ---------------------------------------------------------------------------
+
+describe("T-6: multiple concurrent retractions on same claim", () => {
+  it("first successful retraction wins; concurrent pending ones auto-REJECTED", () => {
+    const { rm: sharedRm, claimId, revealedAt } = setupSharedDb();
+
+    const fileTime = revealedAt + 1000;
+
+    // File three independent retractions
+    const r1 = sharedRm.fileRetraction(
+      claimId,
+      "retractor-1",
+      ORIGINAL_STAKE * RETRACTION_STAKE_MULTIPLIER,
+      STAKE_UNIT,
+      "evidence-1",
+      { nowMs: fileTime },
+    );
+    const r2 = sharedRm.fileRetraction(
+      claimId,
+      "retractor-2",
+      ORIGINAL_STAKE * RETRACTION_STAKE_MULTIPLIER,
+      STAKE_UNIT,
+      "evidence-2",
+      { nowMs: fileTime + 100 },
+    );
+    const r3 = sharedRm.fileRetraction(
+      claimId,
+      "retractor-3",
+      ORIGINAL_STAKE * RETRACTION_STAKE_MULTIPLIER,
+      STAKE_UNIT,
+      "evidence-3",
+      { nowMs: fileTime + 200 },
+    );
+
+    // All three are PENDING initially
+    for (const id of [r1, r2, r3]) {
+      expect(sharedRm.getRetraction(id)!.status).toBe("PENDING");
+    }
+
+    // Resolve r1 first — supermajority valid → RETRACTED
+    const resolution1 = sharedRm.resolveRetraction(
+      r1,
+      [{ verifierId: "v1", result: "valid" }, { verifierId: "v2", result: "valid" }],
+      { nowMs: fileTime + 5000, originalRewardAmount: ORIGINAL_REWARD },
+    );
+    expect(resolution1.status).toBe("RETRACTED");
+
+    // r2 and r3 should now be auto-REJECTED (the proof is already retracted)
+    expect(sharedRm.getRetraction(r2)!.status).toBe("REJECTED");
+    expect(sharedRm.getRetraction(r3)!.status).toBe("REJECTED");
+
+    // listRetractions returns all three in filed_at order
+    const allRetractions = sharedRm.listRetractions(claimId);
+    expect(allRetractions).toHaveLength(3);
+    expect(allRetractions[0]!.retraction_id).toBe(r1);
+    expect(allRetractions[1]!.retraction_id).toBe(r2);
+    expect(allRetractions[2]!.retraction_id).toBe(r3);
+
+    sharedRm.close();
+  });
+
+  it("concurrent retraction resolving after first is already RETRACTED → auto-REJECTED immediately", () => {
+    const { rm: sharedRm, claimId, revealedAt } = setupSharedDb();
+
+    const fileTime = revealedAt + 1000;
+
+    const r1 = sharedRm.fileRetraction(
+      claimId,
+      "retractor-1",
+      ORIGINAL_STAKE * RETRACTION_STAKE_MULTIPLIER,
+      STAKE_UNIT,
+      null,
+      { nowMs: fileTime },
+    );
+    const r2 = sharedRm.fileRetraction(
+      claimId,
+      "retractor-2",
+      ORIGINAL_STAKE * RETRACTION_STAKE_MULTIPLIER,
+      STAKE_UNIT,
+      null,
+      { nowMs: fileTime + 100 },
+    );
+
+    // Resolve r1 → RETRACTED (auto-rejects r2)
+    sharedRm.resolveRetraction(
+      r1,
+      [{ verifierId: "v1", result: "valid" }, { verifierId: "v2", result: "valid" }],
+      { nowMs: fileTime + 5000, originalRewardAmount: ORIGINAL_REWARD },
+    );
+
+    // r2 was auto-REJECTED by r1's resolution; trying to explicitly resolve r2 should throw
+    expect(() =>
+      sharedRm.resolveRetraction(
+        r2,
+        [{ verifierId: "v1", result: "valid" }],
+        { nowMs: fileTime + 6000 },
+      ),
+    ).toThrow("not PENDING");
+
+    sharedRm.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-7: COMPOUND end-to-end test — crosses all component boundaries
+//
+// Production sequence:
+//   1. ProofMarket: post bounty → commit → reveal → finalize → ACCEPT
+//   2. RetractionMarket: file retraction (asymmetric stake, within window)
+//   3. RetractionMarket: resolve retraction with supermajority
+//   4. Assert economic outputs: slash fraction, retractor reward, treasury split
+// ---------------------------------------------------------------------------
+
+describe("T-7: compound end-to-end — full lifecycle from bounty post to retraction resolution", () => {
+  it("post→commit→reveal→ACCEPT→retraction filed→resolved RETRACTED; rewards computed correctly", () => {
+    // Construct a shared Database for both markets.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const DatabaseCtor = require("better-sqlite3") as typeof import("better-sqlite3").default;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const sqliteVecMod = require("sqlite-vec") as typeof import("sqlite-vec");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { applyMigrations: applyMig } = require("@yakcc/registry") as {
+      applyMigrations: (db: unknown) => void;
+    };
+
+    const sharedDb = new DatabaseCtor(":memory:");
+    sqliteVecMod.load(sharedDb);
+    sharedDb.exec("PRAGMA foreign_keys = ON");
+    applyMig(sharedDb);
+
+    // --- Phase 1: Proof lifecycle (commit-reveal-ACCEPT) ---
+    const localPm = ProofMarketCls.fromDbForTest(sharedDb);
+    const localRm = RetractionMarket.fromDb(sharedDb);
+
+    const t0 = T0;
+    const bountyId = localPm.postBounty(ATOM_BMR, THEOREM_HASH, ORIGINAL_REWARD, REWARD_UNIT, REQUESTER, {
+      nowMs: t0,
+      tCommitMs: MIN_T_COMMIT_MS,
+      tRevealMs: MIN_T_REVEAL_MS,
+    });
+
+    const art = artifact("compound-proof");
+    const n = nonce("compound-nonce");
+    const commitHash = ProofMarketCls.computeCommitHash(art, n, CLAIMANT_A);
+    const claimId = localPm.commitClaim(bountyId, commitHash, CLAIMANT_A, ORIGINAL_STAKE, STAKE_UNIT, {
+      nowMs: t0 + 500,
+    });
+
+    localPm.transitionBounty(bountyId, {
+      nowMs: t0 + MIN_T_COMMIT_MS,
+      tRevealMs: MIN_T_REVEAL_MS,
+    });
+
+    const revealedAt = t0 + MIN_T_COMMIT_MS + 1000;
+    localPm.revealClaim(claimId, art, n, { nowMs: revealedAt });
+    localPm.transitionBounty(bountyId, { nowMs: t0 + MIN_T_COMMIT_MS + MIN_T_REVEAL_MS });
+
+    localPm.finalizeBounty(bountyId, [
+      {
+        attestationId: "att-e2e-1" as unknown as ReturnType<typeof String.prototype.toString> & {
+          readonly __brand: "AttestationId";
+        },
+        claimId,
+        verifierId: "verifier-e2e-1",
+        result: "valid",
+        toolchainVersionHash: "d".repeat(64),
+        signature: "sig-e2e-1",
+      },
+      {
+        attestationId: "att-e2e-2" as unknown as ReturnType<typeof String.prototype.toString> & {
+          readonly __brand: "AttestationId";
+        },
+        claimId,
+        verifierId: "verifier-e2e-2",
+        result: "valid",
+        toolchainVersionHash: "d".repeat(64),
+        signature: "sig-e2e-2",
+      },
+      {
+        attestationId: "att-e2e-3" as unknown as ReturnType<typeof String.prototype.toString> & {
+          readonly __brand: "AttestationId";
+        },
+        claimId,
+        verifierId: "verifier-e2e-3",
+        result: "valid",
+        toolchainVersionHash: "d".repeat(64),
+        signature: "sig-e2e-3",
+      },
+    ]);
+
+    // Verify ACCEPT state
+    expect(localPm.getBounty(bountyId)!.status).toBe("ACCEPT");
+    expect(localPm.getClaim(claimId)!.status).toBe("VALID");
+
+    // --- Phase 2: Retraction filed (15 days after acceptance) ---
+    const FIFTEEN_DAYS_MS = 15 * 24 * 60 * 60 * 1000;
+    const retractionFileTime = revealedAt + FIFTEEN_DAYS_MS;
+
+    const retractionId = localRm.fileRetraction(
+      claimId,
+      RETRACTOR,
+      ORIGINAL_STAKE * RETRACTION_STAKE_MULTIPLIER, // 2× stake = 200
+      STAKE_UNIT,
+      "counterexample-artifact-hash-e2e",
+      { nowMs: retractionFileTime },
+    );
+
+    const retractionRow = localRm.getRetraction(retractionId);
+    expect(retractionRow).toBeDefined();
+    expect(retractionRow!.status).toBe("PENDING");
+    expect(retractionRow!.original_claim_id).toBe(claimId);
+    expect(retractionRow!.stake_amount).toBe(ORIGINAL_STAKE * RETRACTION_STAKE_MULTIPLIER);
+    expect(retractionRow!.filed_at).toBe(retractionFileTime);
+
+    // --- Phase 3: Resolve retraction with supermajority (2 valid of 3) ---
+    const resolveTime = retractionFileTime + 60_000;
+    const resolution = localRm.resolveRetraction(
+      retractionId,
+      [
+        { verifierId: "retraction-v1", result: "valid" },
+        { verifierId: "retraction-v2", result: "valid" },
+        { verifierId: "retraction-v3", result: "invalid" }, // 2/3 = exactly supermajority
+      ],
+      { nowMs: resolveTime, originalRewardAmount: ORIGINAL_REWARD },
+    );
+
+    // --- Phase 4: Assert economic outputs ---
+    expect(resolution.status).toBe("RETRACTED");
+
+    // elapsed = resolveTime - revealedAt ≈ 15 days + 60s
+    const expectedElapsed = resolveTime - revealedAt;
+    expect(resolution.elapsedMs).toBe(expectedElapsed);
+
+    // slash_fraction = 2^(-elapsed / HALF_LIFE)
+    const expectedFraction = Math.pow(2, -(expectedElapsed / RETRACTION_SLASH_HALF_LIFE_MS));
+    expect(resolution.slashFraction).toBeCloseTo(expectedFraction, 5);
+
+    // At 15 days, slash fraction ≈ 0.71 (more than half, less than full)
+    expect(resolution.slashFraction).toBeGreaterThan(0.5);
+    expect(resolution.slashFraction).toBeLessThan(1.0);
+
+    const expectedSlashAmount = Math.round(ORIGINAL_REWARD * expectedFraction);
+    expect(resolution.slashAmount).toBe(expectedSlashAmount);
+
+    const expectedRetractorReward = Math.round(expectedSlashAmount * RETRACTION_REWARD_FRACTION);
+    expect(resolution.retractorReward).toBe(expectedRetractorReward);
+    expect(resolution.treasuryAmount).toBe(expectedSlashAmount - expectedRetractorReward);
+
+    // Conservation: reward + treasury = slash
+    expect(resolution.retractorReward + resolution.treasuryAmount).toBe(resolution.slashAmount);
+
+    // DB state: retraction is RETRACTED
+    const finalRow = localRm.getRetraction(retractionId);
+    expect(finalRow!.status).toBe("RETRACTED");
+    expect(finalRow!.resolved_at).toBe(resolveTime);
+
+    sharedDb.close();
+  });
+});

--- a/packages/proof-market/src/retraction.ts
+++ b/packages/proof-market/src/retraction.ts
@@ -1,0 +1,559 @@
+// SPDX-License-Identifier: MIT
+//
+// retraction.ts — counter-proof admission (Slice F) for the yakcc proof incentive layer.
+//
+// @decision DEC-PROOF-RETRACTION-001
+// @title Counter-proof admission as a post-ACCEPT retraction state machine
+// @status decided (WI-1087 / issue #1087 / plans/proof-incentive-layer.md §3.3 + §4 Slice F)
+// @rationale
+//   PROBLEM: Even after a proof has been ACCEPTED via supermajority attestation, the
+//   underlying acceptance can be wrong — checker bugs, spec ambiguities, or malicious
+//   checker collusion. Without a retraction mechanism, a bad proof permanently poisons
+//   the atom's proof status.
+//
+//   SOLUTION: Post-ACCEPT counter-proof admission. Anyone may file a RETRACTION_CLAIM
+//   against an accepted proof by providing:
+//     1. A stake of at least RETRACTION_STAKE_MULTIPLIER × original_claim_stake.
+//     2. An evidence artifact hash (counter-example, proof-of-falshood, or proof of
+//        checker malfeasance).
+//
+//   STATE MACHINE (plans/proof-incentive-layer.md §3.3):
+//     ACCEPT (on proof_bounties) → RETRACTION_PENDING → RETRACTED | REJECTED
+//     where "RETRACTION_PENDING" is represented by proof_retractions.status = 'PENDING'.
+//
+//   ASYMMETRIC STAKE (key disincentive against frivolous retractions):
+//     retractor_stake >= RETRACTION_STAKE_MULTIPLIER × original_claim_stake
+//     Default multiplier: 2. Configurable via fileRetraction opts.
+//
+//   TIME-LOCKED FILING WINDOW:
+//     Retractions must be filed within T_RETRACTION_MS (default 90 days) of the original
+//     claim's acceptance (approximated here as the time it was marked VALID, i.e.
+//     revealed_at of the original claim). After this window, a higher-cost sealed-retraction
+//     path (not yet implemented) would be required per §3.3.
+//
+//   SLASH DECAY (proportional time-decay):
+//     The original claimant's reward is slashed proportionally to time elapsed since
+//     acceptance. The decay uses an exponential half-life:
+//       slash_fraction = exp(-ln(2) × elapsed_ms / RETRACTION_SLASH_HALF_LIFE_MS)
+//     At elapsed=0 (caught immediately): slash_fraction ≈ 1.0 (full slash).
+//     At elapsed=HALF_LIFE (30 days): slash_fraction ≈ 0.5 (half slash).
+//     At elapsed=90 days: slash_fraction ≈ 0.13 (small slash near window close).
+//
+//   SLASH DISTRIBUTION (DEC-PROOF-RETRACTION-001 sub-decision):
+//     This is the ONE exception to "slashing-to-treasury" (plans §11 decision log):
+//       - retractor_reward = slash_amount × RETRACTION_REWARD_FRACTION (default 0.5)
+//       - treasury_amount  = slash_amount × (1 - RETRACTION_REWARD_FRACTION)
+//     Justified because: (a) the retractor performed valuable work the verifier missed;
+//     (b) without a reward, nobody would file retractions; (c) asymmetric stake prevents
+//     grief at scale.
+//     On REJECTED retraction: retractor stake forfeited (NOT transferred — same
+//     slashing-as-deprecation rule as failed claims).
+//
+//   CONCURRENT RETRACTIONS (see schema DEC-PROOF-RETRACTION-001 sub-decision):
+//     Multiple concurrent retractions on the same claim are allowed. Once any retraction
+//     resolves to RETRACTED, subsequent PENDING retractions on the same claim are
+//     auto-REJECTED (the proof is already retracted; retractors should not be double-paid).
+//
+//   DATABASE: All state changes are single SQLite transactions against the schema-v14
+//   proof_retractions table (MIGRATION_14_DDL, DEC-PROOF-RETRACTION-001). same
+//   pattern as ProofMarket (proof-market.ts).
+
+import { blake3 } from "@noble/hashes/blake3.js";
+import { bytesToHex } from "@noble/hashes/utils.js";
+import { applyMigrations } from "@yakcc/registry";
+import Database from "better-sqlite3";
+import * as sqliteVec from "sqlite-vec";
+
+// ---------------------------------------------------------------------------
+// Branded ID type
+// ---------------------------------------------------------------------------
+
+export type RetractionId = string & { readonly __brand: "RetractionId" };
+
+// ---------------------------------------------------------------------------
+// Status enum — matches schema-v14 TEXT column values exactly.
+// ---------------------------------------------------------------------------
+
+export type RetractionStatus = "PENDING" | "RETRACTED" | "REJECTED";
+
+// ---------------------------------------------------------------------------
+// Configuration constants
+// ---------------------------------------------------------------------------
+
+/** Default retraction filing window: 90 days in milliseconds. */
+export const T_RETRACTION_MS = 90 * 24 * 60 * 60 * 1000;
+
+/** Minimum stake multiplier: retractor_stake >= MULTIPLIER × original_claim_stake. */
+export const RETRACTION_STAKE_MULTIPLIER = 2;
+
+/**
+ * Slash half-life: 30 days in milliseconds.
+ * At elapsed=0: slash_fraction ≈ 1.0.
+ * At elapsed=30d: slash_fraction ≈ 0.5.
+ * Formula: slash_fraction = 2^(-elapsed_ms / RETRACTION_SLASH_HALF_LIFE_MS)
+ */
+export const RETRACTION_SLASH_HALF_LIFE_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Fraction of the slashed amount that goes to the retractor (the ONE exception to
+ * slashing-to-treasury). The remainder goes to the operator treasury.
+ * Default: 0.5 (retractor gets half the slash; treasury gets the other half).
+ */
+export const RETRACTION_REWARD_FRACTION = 0.5;
+
+// ---------------------------------------------------------------------------
+// Row shapes for read operations
+// ---------------------------------------------------------------------------
+
+export interface RetractionRow {
+  retraction_id: RetractionId;
+  original_claim_id: string;
+  retractor_id: string;
+  stake_amount: number;
+  stake_unit: string;
+  evidence_artifact_hash: string | null;
+  status: RetractionStatus;
+  filed_at: number;
+  resolved_at: number | null;
+}
+
+/**
+ * Result of resolving a retraction. Contains the computed slash and reward amounts
+ * so the application layer can apply actual stake transfers.
+ */
+export interface RetractionResolution {
+  retractionId: RetractionId;
+  originalClaimId: string;
+  status: "RETRACTED" | "REJECTED";
+  /** Non-zero only for RETRACTED. Integer slash amount (from original reward). */
+  slashAmount: number;
+  /** Non-zero only for RETRACTED. Goes to the retractor (slashAmount × RETRACTION_REWARD_FRACTION). */
+  retractorReward: number;
+  /** Non-zero only for RETRACTED. Goes to operator treasury. */
+  treasuryAmount: number;
+  /** Elapsed time in ms between original acceptance and retraction resolution. */
+  elapsedMs: number;
+  /** Computed slash fraction [0.0, 1.0]. */
+  slashFraction: number;
+}
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface FileRetractionOptions {
+  /** Override now (Unix epoch ms). Defaults to Date.now(). For testing. */
+  nowMs?: number;
+  /**
+   * Override stake multiplier requirement (default: RETRACTION_STAKE_MULTIPLIER = 2).
+   * retractor_stake must be >= stakeMultiplier × original_claim_stake.
+   */
+  stakeMultiplier?: number;
+  /** Override retraction window in ms (default: T_RETRACTION_MS = 90 days). */
+  tRetractionMs?: number;
+}
+
+export interface ResolveRetractionOptions {
+  /** Override now (Unix epoch ms). Defaults to Date.now(). For testing. */
+  nowMs?: number;
+  /**
+   * The original bounty reward amount. Used to compute the slash amount.
+   * If not provided, slash is computed from original claim stake_amount as a proxy.
+   */
+  originalRewardAmount?: number;
+}
+
+// ---------------------------------------------------------------------------
+// RetractionMarket — public API surface
+// ---------------------------------------------------------------------------
+
+/**
+ * RetractionMarket owns the counter-proof admission lifecycle (Slice F).
+ *
+ * Every mutation is a single SQLite transaction (better-sqlite3 db.transaction()).
+ * Reads are plain SELECT queries.
+ *
+ * Construction: call `RetractionMarket.open(dbPath)` or, more typically, pass an
+ * already-open Database instance via `RetractionMarket.fromDb(db)` when sharing a
+ * DB with ProofMarket.
+ *
+ * IMPORTANT: The database must have migrations up to v14 applied before use.
+ * `RetractionMarket.open()` applies them automatically. If you construct via
+ * `fromDb()`, call `applyMigrations(db)` beforehand.
+ */
+export class RetractionMarket {
+  private readonly db: Database.Database;
+
+  private constructor(db: Database.Database) {
+    this.db = db;
+  }
+
+  /**
+   * Open (or create) a SQLite database at `dbPath`, load sqlite-vec, apply all
+   * pending schema migrations (including v14 proof_retractions), and return a
+   * RetractionMarket.
+   *
+   * Pass ":memory:" for in-memory databases (testing).
+   */
+  static open(dbPath: string): RetractionMarket {
+    const db = new Database(dbPath);
+    sqliteVec.load(db);
+    db.exec("PRAGMA foreign_keys = ON");
+    applyMigrations(db);
+    return new RetractionMarket(db);
+  }
+
+  /**
+   * Wrap an already-open Database instance.
+   * The caller is responsible for having applied applyMigrations() and loaded sqlite-vec.
+   * Useful when sharing a single DB with ProofMarket.
+   */
+  static fromDb(db: Database.Database): RetractionMarket {
+    return new RetractionMarket(db);
+  }
+
+  /** Close the underlying SQLite connection. */
+  close(): void {
+    this.db.close();
+  }
+
+  // -------------------------------------------------------------------------
+  // fileRetraction — retractor opens a retraction challenge against an accepted claim
+  // -------------------------------------------------------------------------
+
+  /**
+   * File a retraction against an accepted proof claim.
+   *
+   * Guards (all enforced atomically inside a transaction):
+   *   1. The original claim must exist and be in 'VALID' status (ACCEPT path).
+   *   2. The retraction stake must be >= stakeMultiplier × original_claim_stake.
+   *   3. The filing time must be within the retraction window:
+   *        filed_at <= accepted_at + tRetractionMs
+   *      (accepted_at is approximated as the claim's revealed_at; if null, the
+   *       claim is not yet in an accepted state and retraction is rejected).
+   *
+   * Atomic: single db.transaction() call.
+   *
+   * @returns The new RetractionId.
+   */
+  fileRetraction(
+    originalClaimId: string,
+    retractorId: string,
+    stake: number,
+    unit: string,
+    evidenceArtifactHash: string | null,
+    opts?: FileRetractionOptions,
+  ): RetractionId {
+    const nowMs = opts?.nowMs ?? Date.now();
+    const stakeMultiplier = opts?.stakeMultiplier ?? RETRACTION_STAKE_MULTIPLIER;
+    const tRetractionMs = opts?.tRetractionMs ?? T_RETRACTION_MS;
+
+    const retractionId = this.newId() as RetractionId;
+
+    const tx = this.db.transaction(() => {
+      // Load original claim.
+      const claim = this.db
+        .prepare("SELECT claim_id, stake_amount, stake_unit, status, revealed_at FROM proof_claims WHERE claim_id = ?")
+        .get(originalClaimId) as
+        | {
+            claim_id: string;
+            stake_amount: number;
+            stake_unit: string;
+            status: string;
+            revealed_at: number | null;
+          }
+        | undefined;
+
+      if (claim === undefined) {
+        throw new Error(`claim not found: ${originalClaimId}`);
+      }
+      if (claim.status !== "VALID") {
+        throw new Error(
+          `claim ${originalClaimId} is not in VALID status (current: ${claim.status}); ` +
+          `retraction requires an accepted (VALID) claim`,
+        );
+      }
+
+      // Guard 2: asymmetric stake check.
+      const minStake = stakeMultiplier * claim.stake_amount;
+      if (stake < minStake) {
+        throw new Error(
+          `retraction stake ${stake} is less than required minimum ` +
+          `${stakeMultiplier}× original stake ${claim.stake_amount} = ${minStake}`,
+        );
+      }
+
+      // Guard 3: time-lock window check.
+      // accepted_at is approximated as revealed_at (the time the artifact was revealed,
+      // which is the closest timestamp to when the claim was accepted). If revealed_at
+      // is null the claim hasn't been properly accepted yet and we fail defensively.
+      const acceptedAt = claim.revealed_at;
+      if (acceptedAt === null) {
+        throw new Error(
+          `claim ${originalClaimId} has no revealed_at timestamp; cannot determine acceptance time`,
+        );
+      }
+      const windowClose = acceptedAt + tRetractionMs;
+      if (nowMs > windowClose) {
+        throw new Error(
+          `retraction window closed at ${windowClose} (${tRetractionMs}ms after accepted_at=${acceptedAt}); ` +
+          `current time ${nowMs}. A sealed-retraction path (10× stake) is required beyond this window.`,
+        );
+      }
+
+      // Insert the retraction row.
+      this.db
+        .prepare(
+          `INSERT INTO proof_retractions
+            (retraction_id, original_claim_id, retractor_id, stake_amount, stake_unit,
+             evidence_artifact_hash, status, filed_at, resolved_at)
+           VALUES (?, ?, ?, ?, ?, ?, 'PENDING', ?, NULL)`,
+        )
+        .run(retractionId, originalClaimId, retractorId, stake, unit, evidenceArtifactHash, nowMs);
+    });
+    tx();
+    return retractionId;
+  }
+
+  // -------------------------------------------------------------------------
+  // resolveRetraction — verifier attestations drive the retraction to terminal state
+  // -------------------------------------------------------------------------
+
+  /**
+   * Resolve a PENDING retraction using verifier attestations (same supermajority
+   * pattern as finalizeBounty in proof-market.ts).
+   *
+   * Supermajority rule (matching DEC-PROOF-COMMIT-REVEAL-001):
+   *   valid_count / total_count >= 2/3 → RETRACTED
+   *   otherwise → REJECTED
+   *   zero attestations → REJECTED
+   *
+   * On RETRACTED:
+   *   - slash_fraction = 2^(-elapsed_ms / RETRACTION_SLASH_HALF_LIFE_MS)
+   *   - slash_amount   = round(originalRewardAmount × slash_fraction)
+   *   - retractor_reward = round(slash_amount × RETRACTION_REWARD_FRACTION)
+   *   - treasury_amount  = slash_amount - retractor_reward
+   *   - retraction row status → 'RETRACTED', resolved_at = nowMs
+   *   - If any OTHER pending retractions exist on the same claim, they are auto-REJECTED
+   *     (the proof is already retracted; concurrent retractors lose their stakes).
+   *
+   * On REJECTED:
+   *   - retraction row status → 'REJECTED', resolved_at = nowMs
+   *   - retractor stake is forfeit to operator treasury (application layer handles transfer;
+   *     this function mutates status only).
+   *
+   * NOTE: If the claim already has a RETRACTED retraction (i.e., this is a concurrent
+   * retraction on an already-retracted claim), it is auto-REJECTED immediately without
+   * evaluating attestations (the proof is already retracted; the bet is moot).
+   *
+   * Atomic: single db.transaction() call.
+   *
+   * @returns RetractionResolution with slash amounts for the application layer.
+   */
+  resolveRetraction(
+    retractionId: RetractionId,
+    attestations: ReadonlyArray<{
+      verifierId: string;
+      result: "valid" | "invalid";
+    }>,
+    opts?: ResolveRetractionOptions,
+  ): RetractionResolution {
+    const nowMs = opts?.nowMs ?? Date.now();
+
+    let resolution: RetractionResolution | null = null;
+
+    const tx = this.db.transaction(() => {
+      // Load the retraction.
+      const retraction = this.db
+        .prepare(
+          "SELECT retraction_id, original_claim_id, retractor_id, stake_amount, filed_at, status FROM proof_retractions WHERE retraction_id = ?",
+        )
+        .get(retractionId) as
+        | {
+            retraction_id: string;
+            original_claim_id: string;
+            retractor_id: string;
+            stake_amount: number;
+            filed_at: number;
+            status: string;
+          }
+        | undefined;
+
+      if (retraction === undefined) {
+        throw new Error(`retraction not found: ${retractionId}`);
+      }
+      if (retraction.status !== "PENDING") {
+        throw new Error(
+          `retraction ${retractionId} is not PENDING (current: ${retraction.status})`,
+        );
+      }
+
+      // Load the original claim for accepted_at (revealed_at proxy) and reward info.
+      const claim = this.db
+        .prepare("SELECT claim_id, stake_amount, revealed_at FROM proof_claims WHERE claim_id = ?")
+        .get(retraction.original_claim_id) as
+        | { claim_id: string; stake_amount: number; revealed_at: number | null }
+        | undefined;
+
+      if (claim === undefined) {
+        throw new Error(`original claim not found: ${retraction.original_claim_id}`);
+      }
+
+      // Check if there is already a RETRACTED retraction on this claim (concurrent case).
+      const alreadyRetracted = this.db
+        .prepare(
+          "SELECT retraction_id FROM proof_retractions WHERE original_claim_id = ? AND status = 'RETRACTED' LIMIT 1",
+        )
+        .get(retraction.original_claim_id) as { retraction_id: string } | undefined;
+
+      if (alreadyRetracted !== undefined) {
+        // Proof already retracted by a concurrent retraction — auto-REJECT this one.
+        this.db
+          .prepare(
+            "UPDATE proof_retractions SET status = 'REJECTED', resolved_at = ? WHERE retraction_id = ?",
+          )
+          .run(nowMs, retractionId);
+        resolution = {
+          retractionId,
+          originalClaimId: retraction.original_claim_id,
+          status: "REJECTED",
+          slashAmount: 0,
+          retractorReward: 0,
+          treasuryAmount: 0,
+          elapsedMs: 0,
+          slashFraction: 0,
+        };
+        return;
+      }
+
+      // Evaluate supermajority on provided attestations.
+      const total = attestations.length;
+      const validCount = attestations.filter((a) => a.result === "valid").length;
+
+      // Supermajority: validCount / total >= 2/3
+      // Integer form: validCount * 3 >= total * 2 (avoids floating point).
+      const isSupermajority = total > 0 && validCount * 3 >= total * 2;
+
+      if (!isSupermajority) {
+        // REJECTED: retractor stake forfeit (application layer transfers).
+        this.db
+          .prepare(
+            "UPDATE proof_retractions SET status = 'REJECTED', resolved_at = ? WHERE retraction_id = ?",
+          )
+          .run(nowMs, retractionId);
+        resolution = {
+          retractionId,
+          originalClaimId: retraction.original_claim_id,
+          status: "REJECTED",
+          slashAmount: 0,
+          retractorReward: 0,
+          treasuryAmount: 0,
+          elapsedMs: 0,
+          slashFraction: 0,
+        };
+        return;
+      }
+
+      // RETRACTED: compute time-decay slash.
+      const acceptedAt = claim.revealed_at ?? retraction.filed_at;
+      const elapsedMs = Math.max(0, nowMs - acceptedAt);
+      // Exponential half-life decay: slash_fraction = 2^(-elapsed / half_life)
+      const slashFraction = Math.pow(2, -(elapsedMs / RETRACTION_SLASH_HALF_LIFE_MS));
+
+      // Slash base is the original reward amount if provided; else original claim stake.
+      const rewardBase = opts?.originalRewardAmount ?? claim.stake_amount;
+      const slashAmount = Math.round(rewardBase * slashFraction);
+      const retractorReward = Math.round(slashAmount * RETRACTION_REWARD_FRACTION);
+      const treasuryAmount = slashAmount - retractorReward;
+
+      // Mark this retraction RETRACTED.
+      this.db
+        .prepare(
+          "UPDATE proof_retractions SET status = 'RETRACTED', resolved_at = ? WHERE retraction_id = ?",
+        )
+        .run(nowMs, retractionId);
+
+      // Auto-REJECT all other PENDING retractions on the same claim (concurrent retractions
+      // lose their bet now that the proof is retracted — they each independently staked against
+      // the same proof but a different retractor got there first).
+      this.db
+        .prepare(
+          "UPDATE proof_retractions SET status = 'REJECTED', resolved_at = ? " +
+          "WHERE original_claim_id = ? AND status = 'PENDING' AND retraction_id != ?",
+        )
+        .run(nowMs, retraction.original_claim_id, retractionId);
+
+      resolution = {
+        retractionId,
+        originalClaimId: retraction.original_claim_id,
+        status: "RETRACTED",
+        slashAmount,
+        retractorReward,
+        treasuryAmount,
+        elapsedMs,
+        slashFraction,
+      };
+    });
+    tx();
+
+    if (resolution === null) {
+      // This branch is unreachable by construction (every path in the tx sets resolution),
+      // but TypeScript requires a return-type guard.
+      throw new Error("internal error: resolution not set after transaction");
+    }
+    return resolution;
+  }
+
+  // -------------------------------------------------------------------------
+  // Read helpers
+  // -------------------------------------------------------------------------
+
+  /** Fetch a retraction by ID. Returns undefined if not found. */
+  getRetraction(retractionId: RetractionId): RetractionRow | undefined {
+    return this.db
+      .prepare("SELECT * FROM proof_retractions WHERE retraction_id = ?")
+      .get(retractionId) as RetractionRow | undefined;
+  }
+
+  /** List all retractions for a given original claim, ordered by filed_at ascending. */
+  listRetractions(originalClaimId: string): RetractionRow[] {
+    return this.db
+      .prepare(
+        "SELECT * FROM proof_retractions WHERE original_claim_id = ? ORDER BY filed_at ASC",
+      )
+      .all(originalClaimId) as RetractionRow[];
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Compute the time-decay slash fraction for a given elapsed time.
+   *
+   * slash_fraction = 2^(-elapsed_ms / RETRACTION_SLASH_HALF_LIFE_MS)
+   *
+   * At elapsed=0: fraction=1.0 (full slash).
+   * At elapsed=HALF_LIFE: fraction=0.5.
+   * Exported as a static helper so tests can verify the math independently.
+   */
+  static computeSlashFraction(elapsedMs: number): number {
+    return Math.pow(2, -(elapsedMs / RETRACTION_SLASH_HALF_LIFE_MS));
+  }
+
+  /**
+   * Generate a new opaque ID using BLAKE3 over a random 32-byte seed.
+   * Returns a 64-char lowercase hex string.
+   */
+  private newId(): string {
+    const seed = new Uint8Array(32);
+    if (typeof globalThis.crypto !== "undefined" && globalThis.crypto.getRandomValues) {
+      globalThis.crypto.getRandomValues(seed);
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const nodeCrypto = require("node:crypto") as { randomFillSync: (buf: Uint8Array) => void };
+      nodeCrypto.randomFillSync(seed);
+    }
+    return bytesToHex(blake3(seed));
+  }
+}

--- a/packages/registry/src/schema.ts
+++ b/packages/registry/src/schema.ts
@@ -139,8 +139,44 @@
  *
  *   Migration is pure DDL (CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS);
  *   all tables start empty. No backfill required. Closes #1081.
+ *
+ * @decision DEC-PROOF-RETRACTION-001
+ * @title SCHEMA_VERSION 13 → 14; additive migration adding proof_retractions table
+ * @status decided (WI-1087 / issue #1087 / plans/proof-incentive-layer.md §4 Slice F)
+ * @rationale
+ *   Counter-proof admission (Slice F) requires a new table to track retraction lifecycle
+ *   independently of the original proof_claims row. Retractions are a separate economic
+ *   event class: they have their own stake (≥2× the original), their own filing window
+ *   (T_RETRACTION_MS = 90 days), and their own slash/reward disbursement rules.
+ *
+ *   WHY a separate table (not a status on proof_claims):
+ *     1. A retraction is filed by a DIFFERENT actor than the original claimant, against
+ *        a claim that is already in terminal VALID/ACCEPT state. Adding retraction state
+ *        to proof_claims would create a dual-authority write on a row owned by a different actor.
+ *     2. Multiple concurrent retractions on the same claim are allowed (each independent;
+ *        first RETRACTED resolution is canonical). A column on proof_claims cannot represent
+ *        N concurrent retractions.
+ *     3. Retraction stake, retractor identity, and evidence artifact are distinct from the
+ *        original claim's stake and artifact — separate rows avoid nullable-column ambiguity.
+ *
+ *   CONCURRENT RETRACTION POLICY (DEC-PROOF-RETRACTION-001 sub-decision):
+ *     Multiple concurrent retractions on the same original_claim_id are permitted. Each
+ *     retraction is an independent economic bet. Resolution: when any retraction resolves
+ *     to RETRACTED, the original claim is annotated retracted; subsequent retractions on
+ *     the same claim remain in PENDING and will each resolve (RETRACTED or REJECTED)
+ *     independently — the first retractor to succeed receives the reward, later retractions
+ *     are REJECTED (retractor stake forfeited, since the proof is already retracted).
+ *
+ *   SLASH DECAY:
+ *     Slash fraction = exp(-ln(2) * elapsed_ms / RETRACTION_SLASH_HALF_LIFE_MS).
+ *     At elapsed=0: full slash (fraction≈1.0). At elapsed=HALF_LIFE (30 days): slash fraction≈0.5.
+ *     Retractor reward = slash_amount × RETRACTION_REWARD_FRACTION (default 0.5 of slashed).
+ *     The remaining (1-RETRACTION_REWARD_FRACTION) of slashed amount goes to operator treasury.
+ *
+ *   Migration is pure DDL (CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS);
+ *   table starts empty. No backfill required. Closes #1087.
  */
-export const SCHEMA_VERSION = 13;
+export const SCHEMA_VERSION = 14;
 
 // ---------------------------------------------------------------------------
 // Migration 0 → 1: initial schema (v0)
@@ -1055,6 +1091,60 @@ const MIGRATION_13_DDL: readonly string[] = [
 ];
 
 // ---------------------------------------------------------------------------
+// Migration 13 → 14: add proof_retractions table
+// (DEC-PROOF-RETRACTION-001 / WI-1087 / plans/proof-incentive-layer.md §4 Slice F)
+// ---------------------------------------------------------------------------
+
+/**
+ * SQL statements for migration 14.
+ *
+ * Creates the `proof_retractions` table — tracks counter-proof admission events
+ * that challenge an already-ACCEPTED proof claim. Each retraction is an independent
+ * economic bet by a retractor who believes the original proof is unsound.
+ *
+ * See @decision DEC-PROOF-RETRACTION-001 (top-of-file) for the full rationale.
+ *
+ * Pure DDL (CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS); naturally
+ * idempotent. Table starts empty. No backfill required. Closes #1087.
+ *
+ * No ownership columns — DEC-NO-OWNERSHIP-011.
+ */
+const MIGRATION_14_DDL: readonly string[] = [
+  // ---------------------------------------------------------------------------
+  // proof_retractions — one row per retraction attempt against an accepted claim.
+  //
+  // retraction_id:         PRIMARY KEY (opaque TEXT; application supplies e.g. BLAKE3-based ID).
+  // original_claim_id:     FK → proof_claims.claim_id. The accepted claim being challenged.
+  //                        Indexed for "which retractions exist for this claim?" queries.
+  // retractor_id:          Account that filed the retraction. NOT the original claimant.
+  // stake_amount:          Integer stake locked by this retraction (must be >= 2× original stake).
+  // stake_unit:            Denomination (TEXT; same enum space as proof_claims.stake_unit).
+  // evidence_artifact_hash: BLAKE3 of the counter-proof artifact (counterexample, proof-of-falshood).
+  //                         NULL if the retraction was filed without an evidence hash (pre-reveal).
+  // status:                TEXT enum — 'PENDING' | 'RETRACTED' | 'REJECTED'.
+  //                         'PENDING'   = retraction filed, awaiting verifier resolution.
+  //                         'RETRACTED' = counter-proof accepted; original claim overturned.
+  //                         'REJECTED'  = counter-proof rejected; retractor stake forfeited.
+  // filed_at:              Unix epoch milliseconds when the retraction was filed.
+  // resolved_at:           Unix epoch milliseconds when the retraction was resolved (NULL until resolved).
+  // ---------------------------------------------------------------------------
+  `CREATE TABLE IF NOT EXISTS proof_retractions (
+    retraction_id          TEXT    PRIMARY KEY,
+    original_claim_id      TEXT    NOT NULL REFERENCES proof_claims(claim_id),
+    retractor_id           TEXT    NOT NULL,
+    stake_amount           INTEGER NOT NULL,
+    stake_unit             TEXT    NOT NULL,
+    evidence_artifact_hash TEXT,
+    status                 TEXT    NOT NULL,
+    filed_at               INTEGER NOT NULL,
+    resolved_at            INTEGER
+  )`,
+
+  // Index for "which retractions exist for this claim?" — retraction status queries.
+  "CREATE INDEX IF NOT EXISTS idx_proof_retractions_claim ON proof_retractions(original_claim_id)",
+];
+
+// ---------------------------------------------------------------------------
 // Migration driver
 // ---------------------------------------------------------------------------
 
@@ -1104,6 +1194,8 @@ export interface MigrationsDb {
  *   12 → 13: add proof incentive marketplace tables: proof_bounties, proof_claims,
  *            stake_ledger, verifier_attestations, reputation_ledger
  *            (DEC-PROOF-REGISTRY-TABLES-001 / WI-1081 / issue #1081).
+ *   13 → 14: add proof_retractions table for counter-proof admission (Slice F)
+ *            (DEC-PROOF-RETRACTION-001 / WI-1087 / issue #1087).
  *
  * TWO-PHASE INVARIANT FOR MIGRATION 2 → 3:
  *   `applyMigrations` (this function, in schema.ts) owns the DDL phase only:
@@ -1415,5 +1507,22 @@ export function applyMigrations(db: MigrationsDb): void {
       db.exec(sql);
     }
     db.prepare("UPDATE schema_version SET version = ?").run(13);
+  }
+
+  // Migration 13 → 14: add proof_retractions table
+  // (DEC-PROOF-RETRACTION-001 / WI-1087 / plans/proof-incentive-layer.md §4 Slice F).
+  //
+  // Pure DDL — CREATE TABLE IF NOT EXISTS and CREATE INDEX IF NOT EXISTS are both
+  // naturally idempotent. No ADD COLUMN statements, no try/catch needed.
+  // No backfill required: table starts empty; retraction.ts populates it.
+  //
+  // A crash between any DDL statement and the version bump leaves the table
+  // present at version=13; re-entry runs CREATE TABLE/INDEX IF NOT EXISTS as
+  // no-ops and bumps to 14 normally.
+  if (currentVersion < 14) {
+    for (const sql of MIGRATION_14_DDL) {
+      db.exec(sql);
+    }
+    db.prepare("UPDATE schema_version SET version = ?").run(14);
   }
 }

--- a/packages/registry/src/storage.test.ts
+++ b/packages/registry/src/storage.test.ts
@@ -169,7 +169,7 @@ describe("schema migrations", () => {
     applyMigrations(db);
 
     // Version check.
-    expect(SCHEMA_VERSION).toBe(13);
+    expect(SCHEMA_VERSION).toBe(14);
     const row = db.prepare("SELECT version FROM schema_version LIMIT 1").get() as
       | { version: number }
       | undefined;
@@ -184,7 +184,7 @@ describe("schema migrations", () => {
     // Migration 11 bumps schema_version to 11 (registry_meta table).
     // Migration 12 bumps schema_version to 12 (submitted_at column on blocks; PR #818).
     // The canonical_ast_hash backfill (migration 2→3 version bump) is done by openRegistry.
-    expect(row?.version).toBe(13);
+    expect(row?.version).toBe(14);
 
     // blocks table exists with expected columns.
     const cols = db.prepare("PRAGMA table_info(blocks)").all() as Array<{ name: string }>;
@@ -271,7 +271,7 @@ describe("schema migrations", () => {
       | { version: number }
       | undefined;
     // Second application is a no-op; version stays at 10 (all migrations already ran).
-    expect(row?.version).toBe(13);
+    expect(row?.version).toBe(14);
 
     db.close();
   });
@@ -337,7 +337,7 @@ describe("schema migrations", () => {
     const vRow = db.prepare("SELECT version FROM schema_version LIMIT 1").get() as
       | { version: number }
       | undefined;
-    expect(vRow?.version).toBe(13);
+    expect(vRow?.version).toBe(14);
 
     db.close();
   });
@@ -899,7 +899,7 @@ describe("openRegistry backfill (v2 → v3 migration)", () => {
     const versionAfterBackfill = (
       db2.prepare("SELECT version FROM schema_version LIMIT 1").get() as { version: number }
     ).version;
-    expect(versionAfterBackfill).toBe(13);
+    expect(versionAfterBackfill).toBe(14);
     db2.close();
 
     // Phase 3: reopen idempotency — second openRegistry doesn't re-backfill or re-fail.
@@ -1006,7 +1006,7 @@ describe("migration 3 → 4: parent_block_root column", () => {
     const ver = (
       db2.prepare("SELECT version FROM schema_version LIMIT 1").get() as { version: number }
     ).version;
-    expect(ver).toBe(13);
+    expect(ver).toBe(14);
     // parent_block_root column is present.
     const cols = db2.prepare("PRAGMA table_info(blocks)").all() as Array<{ name: string }>;
     expect(cols.map((c) => c.name)).toContain("parent_block_root");
@@ -1919,7 +1919,7 @@ describe("WI-V2-04 L2: migration v5 → v6 and foreign-block primitives", () => 
     const vPost = (
       db.prepare("SELECT version FROM schema_version LIMIT 1").get() as { version: number }
     ).version;
-    expect(vPost).toBe(13);
+    expect(vPost).toBe(14);
 
     // kind column now present.
     const colsPost = (db.prepare("PRAGMA table_info(blocks)").all() as Array<{ name: string }>).map(
@@ -1980,15 +1980,15 @@ describe("WI-V2-04 L2: migration v5 → v6 and foreign-block primitives", () => 
     const vAfterFirst = (
       db.prepare("SELECT version FROM schema_version LIMIT 1").get() as { version: number }
     ).version;
-    expect(vAfterFirst).toBe(13);
-    expect(SCHEMA_VERSION).toBe(13);
+    expect(vAfterFirst).toBe(14);
+    expect(SCHEMA_VERSION).toBe(14);
 
     // Second run — must be a complete no-op; no throws; version stays at 10.
     expect(() => applyMigrations(db)).not.toThrow();
     const vAfterSecond = (
       db.prepare("SELECT version FROM schema_version LIMIT 1").get() as { version: number }
     ).version;
-    expect(vAfterSecond).toBe(13);
+    expect(vAfterSecond).toBe(14);
 
     // Verify column count is stable (no duplicate columns created).
     const cols = (db.prepare("PRAGMA table_info(blocks)").all() as Array<{ name: string }>).map(
@@ -3715,7 +3715,7 @@ describe("migration 7: source-file provenance columns + workspace_plumbing (P1)"
     const versionRow = db.prepare("SELECT version FROM schema_version LIMIT 1").get() as {
       version: number;
     };
-    expect(versionRow.version).toBe(13);
+    expect(versionRow.version).toBe(14);
 
     // blocks table has the three new provenance columns.
     const blockCols = (
@@ -3798,15 +3798,15 @@ describe("migration 7: source-file provenance columns + workspace_plumbing (P1)"
     const v1 = (
       db.prepare("SELECT version FROM schema_version LIMIT 1").get() as { version: number }
     ).version;
-    expect(v1).toBe(13);
-    expect(SCHEMA_VERSION).toBe(13);
+    expect(v1).toBe(14);
+    expect(SCHEMA_VERSION).toBe(14);
 
     // Second run — must be a complete no-op.
     expect(() => applyMigrations(db)).not.toThrow();
     const v2 = (
       db.prepare("SELECT version FROM schema_version LIMIT 1").get() as { version: number }
     ).version;
-    expect(v2).toBe(13);
+    expect(v2).toBe(14);
 
     // Column count is stable — no duplicate columns.
     const cols = (db.prepare("PRAGMA table_info(blocks)").all() as Array<{ name: string }>).map(
@@ -3844,7 +3844,7 @@ describe("migration 7: source-file provenance columns + workspace_plumbing (P1)"
     const versionPost = (
       db2.prepare("SELECT version FROM schema_version LIMIT 1").get() as { version: number }
     ).version;
-    expect(versionPost).toBe(13);
+    expect(versionPost).toBe(14);
 
     // The workspace_plumbing table exists (P1 creates it empty).
     const tables = (


### PR DESCRIPTION
**Slice F of the proof incentive layer.** Post-ACCEPT escalation mechanism — anyone can file a retraction with asymmetric stake to refute an accepted proof. Catches checker bugs and spec ambiguities; closes the safety net.

## Schema bump v13 → v14

New table `proof_retractions` (additive migration; `storage.test.ts` version assertions updated 13→14).

## Retraction state machine

- `fileRetraction(originalClaimId, retractorId, stake, ...)` → retractionId
  - **Asymmetric stake**: throws if `stake < 2 × original_claim_stake`
  - **Time-locked**: throws if filed > `T_RETRACTION_MS` (90 days) after accept
- `resolveRetraction(retractionId, attestations)`:
  - Supermajority of valid attestations → `RETRACTED`
  - Original claimant slashed proportional to time-since-accept (full slash at t=0, halved at `RETRACTION_SLASH_HALF_LIFE_MS` = 30 days)
  - **Retractor gets fraction of slashed amount** — the ONE exception to slashing-to-treasury, justified because retractor performed valuable work the original verifier missed
  - On `REJECTED`: retractor stake forfeit to operator treasury
- First successful retraction wins; concurrent pending retractions on the same claim auto-`REJECTED`

## Tests — 52 pass (19 retraction + 33 existing proof-market)

- 90-day expiry, asymmetric stake boundaries (1×, 2×−1, exactly 2×), `REJECTED` stake forfeit, retraction-of-retraction guards
- Time-decayed slash math (1 day, 89 days)
- Retractor reward invariant (reward + treasury = slash, no rounding leakage)
- Compound: post → commit → reveal → ACCEPT → retraction → RETRACTED

## Decision

`@decision DEC-PROOF-RETRACTION-001` — retraction state machine + asymmetric stake + time-decayed slash. The exception to slashing-to-treasury.

Closes #1087

## Test plan

- [x] `pnpm --filter @yakcc/proof-market test` — 52 pass
- [x] `pnpm --filter @yakcc/registry test` — 347 pass (storage version assertions updated)
- [x] `pnpm --filter @yakcc/proof-market exec tsc --noEmit -p .` — clean
- [x] `pnpm -r build` — clean