### PR TITLE
feat(cli): #1095 — yakcc proof CLI verbs (bounty post / claim commit / claim reveal)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,9 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.40.0",
+    "@noble/hashes": "^2.2.0",
     "@xenova/transformers": "^2.17.2",
+    "@yakcc/proof-market": "workspace:*",
     "assemblyscript": "^0.27.0",
     "better-sqlite3": "^12.9.0",
     "sqlite-vec": "^0.1.9",

--- a/packages/cli/src/commands/proof.test.ts
+++ b/packages/cli/src/commands/proof.test.ts
@@ -1,0 +1,364 @@
+// SPDX-License-Identifier: MIT
+//
+// proof.test.ts — Integration tests for `yakcc proof bounty post`,
+//                 `yakcc proof claim commit`, and `yakcc proof claim reveal`.
+//
+// These tests exercise the real production sequence end-to-end:
+//   1. Open a ProofMarket backed by :memory: SQLite.
+//   2. Post a bounty (proof bounty post).
+//   3. Commit a claim — stash file is written (proof claim commit).
+//   4. Transition the bounty to REVEAL status (direct engine call).
+//   5. Reveal the claim — reads stash, calls revealClaim, deletes stash (proof claim reveal).
+//
+// The homedir injection seam (ProofOptions.homedirFn) redirects all stash writes
+// to a per-test tmpdir so no $HOME state is mutated.
+//
+// The registryPath injection seam uses ":memory:" so no disk SQLite is created.
+
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ProofMarket } from "@yakcc/proof-market";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CollectingLogger } from "../index.js";
+import { type ProofClaimStash, proof } from "./proof.js";
+
+// ---------------------------------------------------------------------------
+// Test fixture helpers
+// ---------------------------------------------------------------------------
+
+/** Create a fresh per-test tmpdir and return a homedirFn pointing into it. */
+function makeTmpHome(): { homedirFn: () => string; tmpHome: string } {
+  const tmpHome = mkdtempSync(join(tmpdir(), "proof-test-"));
+  return { homedirFn: () => tmpHome, tmpHome };
+}
+
+/**
+ * Return a path to a small artifact file inside a tmpdir.
+ * We write a few bytes so the artifact bytes are non-empty and deterministic.
+ */
+function makeArtifactFile(tmpHome: string): string {
+  const { writeFileSync } = require("node:fs");
+  const path = join(tmpHome, "artifact.lean");
+  writeFileSync(path, "-- test lean proof artifact\ntheorem foo : 1 + 1 = 2 := rfl\n");
+  return path;
+}
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+/** A valid 64-char lowercase hex theorem statement hash (32 zero bytes for tests). */
+const TEST_THEOREM_HASH = "0".repeat(64);
+
+/** A valid 64-char lowercase hex atom_bmr. */
+const TEST_ATOM_BMR = "a".repeat(64);
+
+// ---------------------------------------------------------------------------
+// bounty post
+// ---------------------------------------------------------------------------
+
+describe("proof bounty post", () => {
+  it("returns a bounty_id on stdout for valid inputs", async () => {
+    const logger = new CollectingLogger();
+    const { homedirFn } = makeTmpHome();
+
+    const exitCode = await proof(
+      ["bounty", "post", TEST_ATOM_BMR, "--theorem", TEST_THEOREM_HASH, "--reward", "100"],
+      logger,
+      { registryPath: ":memory:", homedirFn },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(logger.errLines).toEqual([]);
+    // bounty_id is a 64-char lowercase hex string
+    expect(logger.logLines).toHaveLength(1);
+    expect(logger.logLines[0]).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("exits 1 when atom_bmr positional is missing", async () => {
+    const logger = new CollectingLogger();
+    const { homedirFn } = makeTmpHome();
+
+    const exitCode = await proof(
+      ["bounty", "post", "--theorem", TEST_THEOREM_HASH, "--reward", "100"],
+      logger,
+      { registryPath: ":memory:", homedirFn },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(logger.errLines[0]).toMatch(/missing required positional/);
+  });
+
+  it("exits 1 when --theorem is missing", async () => {
+    const logger = new CollectingLogger();
+    const { homedirFn } = makeTmpHome();
+
+    const exitCode = await proof(["bounty", "post", TEST_ATOM_BMR, "--reward", "100"], logger, {
+      registryPath: ":memory:",
+      homedirFn,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(logger.errLines[0]).toMatch(/--theorem is required/);
+  });
+
+  it("exits 1 when --reward is missing", async () => {
+    const logger = new CollectingLogger();
+    const { homedirFn } = makeTmpHome();
+
+    const exitCode = await proof(
+      ["bounty", "post", TEST_ATOM_BMR, "--theorem", TEST_THEOREM_HASH],
+      logger,
+      { registryPath: ":memory:", homedirFn },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(logger.errLines[0]).toMatch(/--reward is required/);
+  });
+
+  it("exits 1 when --reward is not a positive integer", async () => {
+    const logger = new CollectingLogger();
+    const { homedirFn } = makeTmpHome();
+
+    const exitCode = await proof(
+      ["bounty", "post", TEST_ATOM_BMR, "--theorem", TEST_THEOREM_HASH, "--reward", "0"],
+      logger,
+      { registryPath: ":memory:", homedirFn },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(logger.errLines[0]).toMatch(/--reward must be a positive integer/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// claim commit
+// ---------------------------------------------------------------------------
+
+describe("proof claim commit", () => {
+  let tmpHome: string;
+  let homedirFn: () => string;
+  let artifactPath: string;
+  let bountyId: string;
+
+  beforeEach(async () => {
+    ({ homedirFn, tmpHome } = makeTmpHome());
+    artifactPath = makeArtifactFile(tmpHome);
+
+    // Post a bounty first (needed for commitClaim to find the bounty).
+    const logger = new CollectingLogger();
+    const exitCode = await proof(
+      ["bounty", "post", TEST_ATOM_BMR, "--theorem", TEST_THEOREM_HASH, "--reward", "50"],
+      logger,
+      { registryPath: ":memory:", homedirFn },
+    );
+    // NOTE: :memory: SQLite is created fresh each invocation of ProofMarket.open().
+    // Because claim commit opens a SEPARATE :memory: DB it won't find the bounty.
+    // For the stash-shape test below we test directly against a shared DB path.
+    // bountyId here is from a separate DB — used only for argument passing tests.
+    expect(exitCode).toBe(0);
+    bountyId = logger.logLines[0] as string;
+  });
+
+  it("exits 1 when bounty_id positional is missing", async () => {
+    const logger = new CollectingLogger();
+    const exitCode = await proof(
+      ["claim", "commit", "--artifact", artifactPath, "--stake", "10"],
+      logger,
+      { registryPath: ":memory:", homedirFn },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(logger.errLines[0]).toMatch(/missing required positional/);
+  });
+
+  it("exits 1 when --artifact is missing", async () => {
+    const logger = new CollectingLogger();
+    const exitCode = await proof(["claim", "commit", bountyId, "--stake", "10"], logger, {
+      registryPath: ":memory:",
+      homedirFn,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(logger.errLines[0]).toMatch(/--artifact is required/);
+  });
+
+  it("exits 1 when artifact file does not exist", async () => {
+    const logger = new CollectingLogger();
+    const exitCode = await proof(
+      ["claim", "commit", bountyId, "--artifact", "/nonexistent/path.lean", "--stake", "10"],
+      logger,
+      { registryPath: ":memory:", homedirFn },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(logger.errLines[0]).toMatch(/artifact file not found/);
+  });
+
+  it("writes a stash file with correct shape when commit succeeds", async () => {
+    // Use a real file-backed SQLite (in tmpdir) so bounty post and claim commit
+    // share the same DB and commitClaim can find the bounty.
+    const dbPath = join(tmpHome, "proof.sqlite");
+    const logger = new CollectingLogger();
+
+    // Post bounty into shared DB.
+    const postCode = await proof(
+      ["bounty", "post", TEST_ATOM_BMR, "--theorem", TEST_THEOREM_HASH, "--reward", "50"],
+      logger,
+      { registryPath: dbPath, homedirFn },
+    );
+    expect(postCode).toBe(0);
+    const sharedBountyId = logger.logLines[0] as string;
+
+    // Commit claim into same DB.
+    const commitLogger = new CollectingLogger();
+    const commitCode = await proof(
+      ["claim", "commit", sharedBountyId, "--artifact", artifactPath, "--stake", "10"],
+      commitLogger,
+      { registryPath: dbPath, homedirFn },
+    );
+    expect(commitCode).toBe(0);
+    expect(commitLogger.errLines).toEqual([]);
+
+    const claimId = commitLogger.logLines[0];
+    expect(claimId).toMatch(/^[0-9a-f]{64}$/);
+
+    // Verify stash file exists and has the expected shape.
+    const stashFile = join(tmpHome, ".yakcc", "proof-claims", `${claimId}.json`);
+    const stashRaw = readFileSync(stashFile, "utf8");
+    const stash = JSON.parse(stashRaw) as ProofClaimStash;
+
+    expect(stash.claim_id).toBe(claimId);
+    expect(stash.bounty_id).toBe(sharedBountyId);
+    expect(typeof stash.artifact_b64).toBe("string");
+    expect(stash.artifact_b64.length).toBeGreaterThan(0);
+    expect(typeof stash.nonce_b64).toBe("string");
+    expect(Buffer.from(stash.nonce_b64, "base64")).toHaveLength(32);
+    expect(typeof stash.claimant_id).toBe("string");
+    expect(typeof stash.committed_at_iso).toBe("string");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// claim reveal
+// ---------------------------------------------------------------------------
+
+describe("proof claim reveal", () => {
+  it("exits 1 when claim_id positional is missing", async () => {
+    const { homedirFn } = makeTmpHome();
+    const logger = new CollectingLogger();
+
+    const exitCode = await proof(["claim", "reveal"], logger, {
+      registryPath: ":memory:",
+      homedirFn,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(logger.errLines[0]).toMatch(/missing required positional/);
+  });
+
+  it("exits 1 when stash file does not exist", async () => {
+    const { homedirFn } = makeTmpHome();
+    const logger = new CollectingLogger();
+
+    const exitCode = await proof(["claim", "reveal", "a".repeat(64)], logger, {
+      registryPath: ":memory:",
+      homedirFn,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(logger.errLines[0]).toMatch(/no stash found for claim/);
+  });
+
+  it("reads stash, calls revealClaim, deletes stash on success", async () => {
+    const { homedirFn, tmpHome } = makeTmpHome();
+    const artifactPath = makeArtifactFile(tmpHome);
+    const dbPath = join(tmpHome, "proof-reveal.sqlite");
+
+    // Step 1: Post a bounty.
+    const postLogger = new CollectingLogger();
+    await proof(
+      ["bounty", "post", TEST_ATOM_BMR, "--theorem", TEST_THEOREM_HASH, "--reward", "50"],
+      postLogger,
+      { registryPath: dbPath, homedirFn },
+    );
+    const sharedBountyId = postLogger.logLines[0] as string;
+
+    // Step 2: Commit a claim.
+    const commitLogger = new CollectingLogger();
+    const commitCode = await proof(
+      ["claim", "commit", sharedBountyId, "--artifact", artifactPath, "--stake", "10"],
+      commitLogger,
+      { registryPath: dbPath, homedirFn },
+    );
+    expect(commitCode).toBe(0);
+    const claimId = commitLogger.logLines[0] as string;
+
+    // Verify stash exists before reveal.
+    const stashFile = join(tmpHome, ".yakcc", "proof-claims", `${claimId}.json`);
+    expect(() => readFileSync(stashFile)).not.toThrow();
+
+    // Step 3: Manually transition the bounty to REVEAL status so revealClaim
+    // can proceed. The CLI does not expose transitionBounty (daemon responsibility),
+    // so we call the engine directly here.
+    const market = ProofMarket.open(dbPath);
+    const pastTime = Date.now() + 25 * 60 * 60 * 1000; // 25h in the future → commit window closed
+    market.transitionBounty(
+      sharedBountyId as ReturnType<typeof market.getBounty> extends infer R
+        ? R extends { bounty_id: infer B }
+          ? B
+          : never
+        : never,
+      {
+        nowMs: pastTime,
+      },
+    );
+    market.close();
+
+    // Step 4: Reveal.
+    const revealLogger = new CollectingLogger();
+    const revealCode = await proof(["claim", "reveal", claimId], revealLogger, {
+      registryPath: dbPath,
+      homedirFn,
+    });
+    expect(revealCode).toBe(0);
+    expect(revealLogger.errLines).toEqual([]);
+    expect(revealLogger.logLines[0]).toMatch(new RegExp(claimId));
+
+    // Stash must be deleted after successful reveal.
+    expect(() => readFileSync(stashFile)).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unknown subcommand
+// ---------------------------------------------------------------------------
+
+describe("proof dispatch", () => {
+  it("exits 1 and prints usage for unknown subcommand", async () => {
+    const { homedirFn } = makeTmpHome();
+    const logger = new CollectingLogger();
+
+    const exitCode = await proof(["unknown", "sub"], logger, {
+      registryPath: ":memory:",
+      homedirFn,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(logger.errLines[0]).toMatch(/unknown proof subcommand/);
+  });
+
+  it("exits 1 and prints usage when no subcommand given", async () => {
+    const { homedirFn } = makeTmpHome();
+    const logger = new CollectingLogger();
+
+    const exitCode = await proof([], logger, {
+      registryPath: ":memory:",
+      homedirFn,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(logger.errLines[0]).toMatch(/missing proof subcommand/);
+  });
+});

--- a/packages/cli/src/commands/proof.ts
+++ b/packages/cli/src/commands/proof.ts
@@ -1,0 +1,525 @@
+// SPDX-License-Identifier: MIT
+//
+// proof.ts — handlers for `yakcc proof bounty post`, `yakcc proof claim commit`,
+//            and `yakcc proof claim reveal`.
+//
+// @decision DEC-PROOF-CLI-001
+// @title Three CLI verbs over @yakcc/proof-market engine (WI-1095)
+// @status decided (WI-1095 / issue #1095)
+// @rationale
+//   The proof-market engine (ProofMarket class) landed in #1082 and is the sole
+//   authority for the commit-reveal lifecycle state machine (DEC-PROOF-COMMIT-REVEAL-001).
+//   These CLI verbs are pure glue: argparse → engine call → format output.
+//
+//   THREE VERBS:
+//     1. `yakcc proof bounty post <atom_bmr> --theorem <hash|path> --reward <n>`
+//        Posts a new bounty. Returns bounty_id on stdout.
+//
+//     2. `yakcc proof claim commit <bounty_id> --artifact <path> --stake <n>`
+//        Reads artifact bytes, generates a 32-byte random nonce, computes commit_hash,
+//        calls commitClaim(), and stashes (artifact_bytes_b64, nonce_b64, claim_id)
+//        to ~/.yakcc/proof-claims/<claim_id>.json for use by the reveal step.
+//        Returns claim_id on stdout.
+//
+//     3. `yakcc proof claim reveal <claim_id>`
+//        Reads stash from ~/.yakcc/proof-claims/<claim_id>.json, calls revealClaim(),
+//        deletes the stash on success (leaves it on failure for retry).
+//
+//   REGISTRY PATH: resolved from YAKCC_PROOF_REGISTRY env var, then --registry flag,
+//   then DEFAULT_PROOF_REGISTRY_PATH (.yakcc/registry.sqlite in cwd). This mirrors
+//   the pattern used by other commands (registry-init.ts DEFAULT_REGISTRY_PATH).
+//
+//   STASH DIRECTORY: resolved via an injected homedir() function so tests can redirect
+//   stash writes to a temp dir without touching $HOME.
+//
+//   REQUESTER IDENTITY: defaults to git config user.email (spawned via child_process),
+//   then "anonymous" if git is unavailable. Overridable via --requester flag.
+//
+//   NODE:UTIL PARSEARGS: consistent with the rest of the yakcc CLI surface (DEC-V0-CLI-004).
+//   No external argparse dependency.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+import { type BountyId, type ClaimId, ProofMarket } from "@yakcc/proof-market";
+import type { Logger } from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default proof registry path, relative to cwd. Mirrors DEFAULT_REGISTRY_PATH in registry-init.ts. */
+export const DEFAULT_PROOF_REGISTRY_PATH = ".yakcc/registry.sqlite";
+
+/** Default reward unit. v0 reputation-credit economy. */
+const DEFAULT_REWARD_UNIT = "reputation_credit";
+
+/** Default stake unit. */
+const DEFAULT_STAKE_UNIT = "reputation_credit";
+
+// ---------------------------------------------------------------------------
+// Stash helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape of the local stash file written by `claim commit` and read by `claim reveal`.
+ *
+ * Stored at: <homedirFn()>/.yakcc/proof-claims/<claim_id>.json
+ *
+ * Fields:
+ *   claim_id         — the ClaimId returned by commitClaim()
+ *   bounty_id        — the BountyId this claim belongs to (informational)
+ *   artifact_b64     — Buffer.from(artifactBytes).toString("base64")
+ *   nonce_b64        — Buffer.from(nonce).toString("base64")
+ *   claimant_id      — identity string used to compute the commit_hash
+ *   committed_at_iso — ISO-8601 timestamp of the commit (for human inspection)
+ */
+export interface ProofClaimStash {
+  claim_id: string;
+  bounty_id: string;
+  artifact_b64: string;
+  nonce_b64: string;
+  claimant_id: string;
+  committed_at_iso: string;
+}
+
+/** Return the stash directory path for a given home dir. */
+function stashDir(homedirFn: () => string): string {
+  return join(homedirFn(), ".yakcc", "proof-claims");
+}
+
+/** Return the full path to a claim's stash file. */
+function stashPath(claimId: string, homedirFn: () => string): string {
+  return join(stashDir(homedirFn), `${claimId}.json`);
+}
+
+/** Write a claim stash to disk. Creates the directory if it does not exist. */
+function writeStash(stash: ProofClaimStash, homedirFn: () => string): void {
+  const dir = stashDir(homedirFn);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(stashPath(stash.claim_id, homedirFn), JSON.stringify(stash, null, 2), "utf8");
+}
+
+/** Read a claim stash from disk. Throws if the file does not exist or is malformed. */
+function readStash(claimId: string, homedirFn: () => string): ProofClaimStash {
+  const path = stashPath(claimId, homedirFn);
+  if (!existsSync(path)) {
+    throw new Error(
+      `no stash found for claim ${claimId} at ${path}\nDid you run \`yakcc proof claim commit\` first?`,
+    );
+  }
+  const raw = readFileSync(path, "utf8");
+  try {
+    return JSON.parse(raw) as ProofClaimStash;
+  } catch {
+    throw new Error(`stash file at ${path} is not valid JSON`);
+  }
+}
+
+/** Delete a claim stash from disk. No-ops if the file does not exist. */
+function deleteStash(claimId: string, homedirFn: () => string): void {
+  const path = stashPath(claimId, homedirFn);
+  if (existsSync(path)) {
+    rmSync(path);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Identity helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the requester/claimant identity.
+ *
+ * Resolution order:
+ *   1. Explicit --requester / --claimant argument.
+ *   2. git config user.email (spawned synchronously; failure → fallthrough).
+ *   3. "anonymous".
+ */
+function resolveIdentity(explicitId?: string): string {
+  if (explicitId !== undefined && explicitId.trim().length > 0) {
+    return explicitId.trim();
+  }
+  try {
+    const email = execFileSync("git", ["config", "user.email"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 2000,
+    }).trim();
+    if (email.length > 0) return email;
+  } catch {
+    // git unavailable or no config — fall through.
+  }
+  return "anonymous";
+}
+
+// ---------------------------------------------------------------------------
+// Theorem statement hash helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the theorem statement hash.
+ *
+ * If `value` looks like a 64-char lowercase hex string, return it as-is.
+ * Otherwise treat it as a file path, read the file bytes, and compute
+ * BLAKE3(bytes) — the canonical theorem statement hash (plans/proof-incentive-layer.md §3.1).
+ *
+ * The BLAKE3 computation is deferred to a dynamic import of @noble/hashes/blake3
+ * to avoid pulling it in at the top-level import cost for commands that do not need it.
+ * In practice the CLI already depends on proof-market which loads @noble/hashes.
+ */
+async function resolveTheoremHash(value: string): Promise<string> {
+  if (/^[0-9a-f]{64}$/.test(value)) {
+    return value;
+  }
+  // Treat as a file path.
+  if (!existsSync(value)) {
+    throw new Error(`--theorem: file not found: ${value}`);
+  }
+  const bytes = readFileSync(value);
+  const { blake3 } = await import("@noble/hashes/blake3.js");
+  const { bytesToHex } = await import("@noble/hashes/utils.js");
+  return bytesToHex(blake3(bytes));
+}
+
+// ---------------------------------------------------------------------------
+// Injectable options (for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Injection seam for `proof` commands.
+ *
+ * Tests override:
+ *   homedirFn   → tmpdir so stash writes don't touch $HOME.
+ *   registryPath → ":memory:" for in-process SQLite.
+ */
+export interface ProofOptions {
+  /** Override home directory for stash storage. Defaults to node:os.homedir(). */
+  homedirFn?: () => string;
+  /** Override registry path. Defaults to YAKCC_PROOF_REGISTRY env var or DEFAULT_PROOF_REGISTRY_PATH. */
+  registryPath?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * Handler for `yakcc proof bounty post <atom_bmr> --theorem <hash|path>
+ *   --reward <amount> [--unit <unit>] [--requester <id>] [--registry <path>]`.
+ *
+ * Prints the returned bounty_id on stdout.
+ */
+async function proofBountyPost(
+  argv: readonly string[],
+  logger: Logger,
+  opts?: ProofOptions,
+): Promise<number> {
+  const parseArgsConfig = {
+    args: [...argv],
+    options: {
+      theorem: { type: "string" as const },
+      reward: { type: "string" as const },
+      unit: { type: "string" as const },
+      requester: { type: "string" as const },
+      registry: { type: "string" as const },
+    },
+    allowPositionals: true as const,
+    strict: true as const,
+  };
+
+  let parsed: ReturnType<typeof parseArgs<typeof parseArgsConfig>>;
+  try {
+    parsed = parseArgs(parseArgsConfig);
+  } catch (err) {
+    logger.error(`error: ${(err as Error).message}`);
+    logger.error(
+      "Usage: yakcc proof bounty post <atom_bmr> --theorem <hash|path> --reward <amount> [--unit <unit>] [--requester <id>]",
+    );
+    return 1;
+  }
+
+  const positionals = parsed.positionals;
+  if (positionals.length < 1) {
+    logger.error("error: missing required positional: <atom_bmr>");
+    logger.error(
+      "Usage: yakcc proof bounty post <atom_bmr> --theorem <hash|path> --reward <amount>",
+    );
+    return 1;
+  }
+  // positionals.length < 1 guarded above; [0] is always defined here.
+  const atomBmr = positionals[0] as string;
+
+  const theoremRaw = parsed.values.theorem;
+  if (theoremRaw === undefined) {
+    logger.error("error: --theorem is required");
+    return 1;
+  }
+  const rewardRaw = parsed.values.reward;
+  if (rewardRaw === undefined) {
+    logger.error("error: --reward is required");
+    return 1;
+  }
+  const rewardAmount = Number.parseInt(rewardRaw, 10);
+  if (!Number.isFinite(rewardAmount) || rewardAmount <= 0) {
+    logger.error(`error: --reward must be a positive integer; got: ${rewardRaw}`);
+    return 1;
+  }
+
+  const rewardUnit = parsed.values.unit ?? DEFAULT_REWARD_UNIT;
+  const requesterId = resolveIdentity(parsed.values.requester);
+  const registryPath =
+    opts?.registryPath ??
+    parsed.values.registry ??
+    process.env.YAKCC_PROOF_REGISTRY ??
+    DEFAULT_PROOF_REGISTRY_PATH;
+
+  let theoremHash: string;
+  try {
+    theoremHash = await resolveTheoremHash(theoremRaw);
+  } catch (err) {
+    logger.error(`error: ${(err as Error).message}`);
+    return 1;
+  }
+
+  const market = ProofMarket.open(registryPath);
+  let bountyId: BountyId;
+  try {
+    bountyId = market.postBounty(atomBmr, theoremHash, rewardAmount, rewardUnit, requesterId);
+  } finally {
+    market.close();
+  }
+
+  logger.log(bountyId);
+  return 0;
+}
+
+/**
+ * Handler for `yakcc proof claim commit <bounty_id> --artifact <path>
+ *   --stake <amount> [--unit <unit>] [--claimant <id>] [--registry <path>]`.
+ *
+ * Stashes (artifact_bytes_b64, nonce_b64, claim_id) to
+ * ~/.yakcc/proof-claims/<claim_id>.json and prints claim_id on stdout.
+ */
+async function proofClaimCommit(
+  argv: readonly string[],
+  logger: Logger,
+  opts?: ProofOptions,
+): Promise<number> {
+  const parseArgsConfig = {
+    args: [...argv],
+    options: {
+      artifact: { type: "string" as const },
+      stake: { type: "string" as const },
+      unit: { type: "string" as const },
+      claimant: { type: "string" as const },
+      registry: { type: "string" as const },
+    },
+    allowPositionals: true as const,
+    strict: true as const,
+  };
+
+  let parsed: ReturnType<typeof parseArgs<typeof parseArgsConfig>>;
+  try {
+    parsed = parseArgs(parseArgsConfig);
+  } catch (err) {
+    logger.error(`error: ${(err as Error).message}`);
+    logger.error(
+      "Usage: yakcc proof claim commit <bounty_id> --artifact <path> --stake <amount> [--unit <unit>] [--claimant <id>]",
+    );
+    return 1;
+  }
+
+  const positionals = parsed.positionals;
+  if (positionals.length < 1) {
+    logger.error("error: missing required positional: <bounty_id>");
+    logger.error("Usage: yakcc proof claim commit <bounty_id> --artifact <path> --stake <amount>");
+    return 1;
+  }
+  const bountyId = positionals[0] as BountyId;
+
+  const artifactPath = parsed.values.artifact;
+  if (artifactPath === undefined) {
+    logger.error("error: --artifact is required");
+    return 1;
+  }
+  if (!existsSync(artifactPath)) {
+    logger.error(`error: artifact file not found: ${artifactPath}`);
+    return 1;
+  }
+  const stakeRaw = parsed.values.stake;
+  if (stakeRaw === undefined) {
+    logger.error("error: --stake is required");
+    return 1;
+  }
+  const stakeAmount = Number.parseInt(stakeRaw, 10);
+  if (!Number.isFinite(stakeAmount) || stakeAmount <= 0) {
+    logger.error(`error: --stake must be a positive integer; got: ${stakeRaw}`);
+    return 1;
+  }
+
+  const stakeUnit = parsed.values.unit ?? DEFAULT_STAKE_UNIT;
+  const claimantId = resolveIdentity(parsed.values.claimant);
+  const registryPath =
+    opts?.registryPath ??
+    parsed.values.registry ??
+    process.env.YAKCC_PROOF_REGISTRY ??
+    DEFAULT_PROOF_REGISTRY_PATH;
+  const homedirFn = opts?.homedirFn ?? homedir;
+
+  const artifactBytes = readFileSync(artifactPath);
+
+  // Generate a 32-byte cryptographically secure nonce.
+  const nonce = new Uint8Array(32);
+  globalThis.crypto.getRandomValues(nonce);
+
+  const commitHash = ProofMarket.computeCommitHash(
+    new Uint8Array(artifactBytes.buffer, artifactBytes.byteOffset, artifactBytes.byteLength),
+    nonce,
+    claimantId,
+  );
+
+  const market = ProofMarket.open(registryPath);
+  let claimId: ClaimId;
+  try {
+    claimId = market.commitClaim(bountyId, commitHash, claimantId, stakeAmount, stakeUnit);
+  } finally {
+    market.close();
+  }
+
+  // Stash locally for the reveal step.
+  const stash: ProofClaimStash = {
+    claim_id: claimId,
+    bounty_id: bountyId,
+    artifact_b64: Buffer.from(artifactBytes).toString("base64"),
+    nonce_b64: Buffer.from(nonce).toString("base64"),
+    claimant_id: claimantId,
+    committed_at_iso: new Date().toISOString(),
+  };
+  writeStash(stash, homedirFn);
+
+  logger.log(claimId);
+  return 0;
+}
+
+/**
+ * Handler for `yakcc proof claim reveal <claim_id> [--registry <path>]`.
+ *
+ * Reads stash from ~/.yakcc/proof-claims/<claim_id>.json,
+ * calls revealClaim(), deletes the stash on success (leaves it for retry on failure).
+ */
+async function proofClaimReveal(
+  argv: readonly string[],
+  logger: Logger,
+  opts?: ProofOptions,
+): Promise<number> {
+  const parseArgsConfig = {
+    args: [...argv],
+    options: {
+      registry: { type: "string" as const },
+    },
+    allowPositionals: true as const,
+    strict: true as const,
+  };
+
+  let parsed: ReturnType<typeof parseArgs<typeof parseArgsConfig>>;
+  try {
+    parsed = parseArgs(parseArgsConfig);
+  } catch (err) {
+    logger.error(`error: ${(err as Error).message}`);
+    logger.error("Usage: yakcc proof claim reveal <claim_id> [--registry <path>]");
+    return 1;
+  }
+
+  const positionals = parsed.positionals;
+  if (positionals.length < 1) {
+    logger.error("error: missing required positional: <claim_id>");
+    logger.error("Usage: yakcc proof claim reveal <claim_id>");
+    return 1;
+  }
+  const claimId = positionals[0] as ClaimId;
+
+  const registryPath =
+    opts?.registryPath ??
+    parsed.values.registry ??
+    process.env.YAKCC_PROOF_REGISTRY ??
+    DEFAULT_PROOF_REGISTRY_PATH;
+  const homedirFn = opts?.homedirFn ?? homedir;
+
+  // Read stash — do this before opening the DB so we fail early if stash is missing.
+  let stash: ProofClaimStash;
+  try {
+    stash = readStash(claimId, homedirFn);
+  } catch (err) {
+    logger.error(`error: ${(err as Error).message}`);
+    return 1;
+  }
+
+  const artifactBytes = new Uint8Array(Buffer.from(stash.artifact_b64, "base64"));
+  const nonce = new Uint8Array(Buffer.from(stash.nonce_b64, "base64"));
+
+  const market = ProofMarket.open(registryPath);
+  try {
+    market.revealClaim(claimId, artifactBytes, nonce);
+  } catch (err) {
+    // Leave stash in place so the user can retry after fixing the underlying issue
+    // (e.g., bounty not yet in REVEAL status; retry after transitionBounty fires).
+    market.close();
+    logger.error(`error: reveal failed: ${(err as Error).message}`);
+    logger.error(`stash preserved at: ${stashPath(claimId, homedirFn)}`);
+    return 1;
+  }
+  market.close();
+
+  // Success — delete the stash file.
+  deleteStash(claimId, homedirFn);
+  logger.log(`revealed claim ${claimId}`);
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Top-level dispatcher
+// ---------------------------------------------------------------------------
+
+/**
+ * Top-level handler for `yakcc proof <subcommand> ...`.
+ *
+ * Dispatches on the two-word subcommand: "bounty post" or "claim commit|reveal".
+ *
+ * @param argv   - Remaining argv after `proof` has been consumed.
+ * @param logger - Output sink (CollectingLogger in tests, CONSOLE_LOGGER in production).
+ * @param opts   - Injectable options for tests (homedirFn, registryPath).
+ * @returns Process exit code (0 = success, non-zero = error).
+ */
+export async function proof(
+  argv: readonly string[],
+  logger: Logger,
+  opts?: ProofOptions,
+): Promise<number> {
+  const [sub1, sub2, ...rest] = argv;
+
+  if (sub1 === "bounty" && sub2 === "post") {
+    return proofBountyPost(rest, logger, opts);
+  }
+  if (sub1 === "claim" && sub2 === "commit") {
+    return proofClaimCommit(rest, logger, opts);
+  }
+  if (sub1 === "claim" && sub2 === "reveal") {
+    return proofClaimReveal(rest, logger, opts);
+  }
+
+  if (sub1 === undefined) {
+    logger.error("error: missing proof subcommand");
+  } else {
+    logger.error(`error: unknown proof subcommand: ${sub1} ${sub2 ?? ""}`.trimEnd());
+  }
+  logger.error(
+    "Usage:\n" +
+      "  yakcc proof bounty post <atom_bmr> --theorem <hash|path> --reward <amount>\n" +
+      "  yakcc proof claim commit <bounty_id> --artifact <path> --stake <amount>\n" +
+      "  yakcc proof claim reveal <claim_id>",
+  );
+  return 1;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,6 +50,7 @@ import { hooksCursorInstall } from "./commands/hooks-cursor-install.js";
 import { hooksClaudeCodeInstall } from "./commands/hooks-install.js";
 import { hooksWindsurfInstall } from "./commands/hooks-windsurf-install.js";
 import { init } from "./commands/init.js";
+import { proof } from "./commands/proof.js";
 import { propose } from "./commands/propose.js";
 import { query } from "./commands/query.js";
 import { registryExport } from "./commands/registry-export.js";
@@ -326,6 +327,15 @@ export async function runCli(
       // subcommand and rest are unused in A1 (the stub ignores all args).
       const compileSelfArgv = subcommand !== undefined ? [subcommand, ...rest] : rest;
       return compileSelf(compileSelfArgv, logger);
+    }
+
+    case "proof": {
+      // `yakcc proof bounty post <atom_bmr> ...`
+      // `yakcc proof claim commit <bounty_id> ...`
+      // `yakcc proof claim reveal <claim_id>`
+      // See proof.ts (DEC-PROOF-CLI-001) for the full dispatch and arg schema.
+      const proofArgv = subcommand !== undefined ? [subcommand, ...rest] : rest;
+      return proof(proofArgv, logger);
     }
 
     case "propose": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,9 +180,15 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.40.0
         version: 0.40.1
+      '@noble/hashes':
+        specifier: ^2.2.0
+        version: 2.2.0
       '@xenova/transformers':
         specifier: ^2.17.2
         version: 2.17.2
+      '@yakcc/proof-market':
+        specifier: workspace:*
+        version: link:../proof-market
       assemblyscript:
         specifier: ^0.27.0
         version: 0.27.37


### PR DESCRIPTION
## Summary

Three CLI verbs over the `@yakcc/proof-market` engine that landed in #1082:

```bash
yakcc proof bounty post <atom_bmr> --theorem <hash|path> --reward <n> [--unit <reputation_credit|token|usd>]
yakcc proof claim commit <bounty_id> --artifact <path> --stake <n> [--unit ...]
yakcc proof claim reveal <claim_id>
```

The `commit` verb generates a 32-byte nonce, computes `BLAKE3(artifact || nonce || claimant_id)` per `DEC-PROOF-COMMIT-REVEAL-001`, calls `ProofMarket.commitClaim`, and stashes `(artifact_bytes_b64, nonce_b64)` to `~/.yakcc/proof-claims/<claim_id>.json` so the reveal step can recover the artifact + nonce. The `reveal` verb reads the stash, calls `revealClaim`, and deletes the stash on success (leaves it on failure for retry).

Closes #1095. Documented as Step 1/2/3 CLI fallbacks in `docs/PROOF_BOUNTY_WALKTHROUGH.md` (already on main).

## Files

- `packages/cli/src/commands/proof.ts` — handler (DEC-PROOF-CLI-001)
- `packages/cli/src/commands/proof.test.ts` — 14 tests
- `packages/cli/src/index.ts` — dispatch case
- `packages/cli/package.json` — `@yakcc/proof-market` dep + `@noble/hashes`
- `pnpm-lock.yaml`

## Test plan

- [x] `pnpm install` — clean
- [x] `pnpm -r build` — 36/36 workspace packages green (composite tsc)
- [x] `pnpm vitest run src/commands/proof.test.ts` — 14/14 passing
- [x] `pnpm --filter @yakcc/cli lint` — biome clean
- [x] Branch rebased on origin/main (zero local-only divergence at branch-creation; pulled in #1080–#1097 fast-forward)
- [ ] CI green