### PR TITLE
fix(contracts+shave): #1109 — cap IntentCard behavior at ≤200 chars (restores self-shave on main)

### DIFF
--- a/packages/contracts/src/query-from-source.test.ts
+++ b/packages/contracts/src/query-from-source.test.ts
@@ -300,7 +300,7 @@ describe("queryIntentCardFromSource — absent JSDoc, D1 fallback", () => {
 
     // Behavior falls back to the signature string (e.g. "function add(a, b) -> number").
     expect(typeof card.behavior).toBe("string");
-    expect(card.behavior!.length).toBeGreaterThan(0);
+    expect(card.behavior?.length).toBeGreaterThan(0);
     // Should include the function name "add" in the fallback.
     expect(card.behavior).toMatch(/add/);
   });
@@ -389,6 +389,118 @@ describe("queryIntentCardFromSource — compound end-to-end (arrayMedian fixture
         }
       }
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 9: behavior field always ≤ 200 chars (DEC-INTENT-BEHAVIOR-CAP-001, #1109)
+//
+// Production sequence: queryIntentCardFromSource is called on a TS source file that
+// has no per-export JSDoc (so the JSDoc-summary path is skipped) and a function
+// signature that, when rendered as a string, exceeds 200 chars.  Without the cap
+// the card.behavior violates validate-intent-card.ts:146 and self-shave goes RED.
+// ---------------------------------------------------------------------------
+
+/**
+ * Source with a long signature string — no JSDoc, params have long names.
+ * The rendered signatureString format is "function <name>(<paramNames>) -> <ret>",
+ * which for the names chosen here produces a 222-char string that exceeds 200.
+ * (buildSignatureString uses param names only, not types.)
+ */
+const LONG_SIGNATURE_SOURCE = `
+export function processComplexDataTransformationWithValidation(
+  inputDataSourceConfigurationSpec: string,
+  outputTransformationPipelineOptionsMap: string,
+  validationAndErrorHandlingStrategyConfig: string,
+  metadataEnrichmentAndTaggingPolicyRules: string
+): string {
+  return inputDataSourceConfigurationSpec;
+}
+`.trim();
+
+/**
+ * Source with a JSDoc summary of exactly 200 chars — must NOT be truncated.
+ * "A".repeat(195) + " foo." = 200 chars total.
+ */
+const JSDOC_EXACTLY_200_CHARS = `
+/**
+ * ${"A".repeat(195)} foo.
+ */
+export function f(): void {}
+`.trim();
+
+/**
+ * Source that mimics the resolve.ts shape: file-level JSDoc block, no per-export JSDoc
+ * on the factory function, long param/return types.  This is the regression fixture for #1109.
+ */
+const RESOLVE_LIKE_SOURCE = `
+/**
+ * Tool: yakcc_resolve
+ *
+ * @decision DEC-SOME-DECISION-001
+ * @title some decision title for this tool
+ * @status accepted
+ * @rationale
+ *   This file has a very long file-level JSDoc and no per-export JSDoc on the
+ *   factory function below.
+ */
+
+export type ProofStatus = "none" | "pending" | "accepted" | "retracted";
+
+export interface CreateResolveToolOptions {
+  readonly openRegistry?: (() => Promise<{ close(): void }>) | undefined;
+  readonly proofStatusProvider?: ((atom_id: string) => ProofStatus) | undefined;
+}
+
+export function createResolveTool(opts?: CreateResolveToolOptions): { name: string; handler: () => Promise<void> } {
+  return { name: "yakcc_resolve", handler: async () => {} };
+}
+`.trim();
+
+describe("queryIntentCardFromSource — behavior ≤ 200 chars cap (DEC-INTENT-BEHAVIOR-CAP-001, #1109)", () => {
+  // Test A: no-JSDoc source with a long signature → behavior must be capped to ≤200.
+  it("Test A: caps behavior to ≤200 chars and appends '...' when signature exceeds 200 chars", () => {
+    const card = queryIntentCardFromSource(LONG_SIGNATURE_SOURCE);
+
+    expect(card.behavior.length).toBeLessThanOrEqual(200);
+    expect(card.behavior.endsWith("...")).toBe(true);
+    // Starts with the original signature prefix so the function name is preserved.
+    expect(card.behavior.startsWith("function processComplexDataTransformationWithValidation")).toBe(true);
+  });
+
+  it("Test A (length invariant): truncated behavior is exactly 200 chars (197 content + '...')", () => {
+    const card = queryIntentCardFromSource(LONG_SIGNATURE_SOURCE);
+    expect(card.behavior.length).toBe(200);
+  });
+
+  // Test B: JSDoc summary of exactly 200 chars → no truncation, no "..." appended.
+  it("Test B: does NOT append '...' when JSDoc summary is exactly 200 chars", () => {
+    const card = queryIntentCardFromSource(JSDOC_EXACTLY_200_CHARS);
+
+    expect(card.behavior.length).toBeLessThanOrEqual(200);
+    expect(card.behavior.endsWith("...")).toBe(false);
+    expect(card.behavior.endsWith("foo.")).toBe(true);
+  });
+
+  // Test C: resolve.ts-shaped source (file-level JSDoc, no per-export JSDoc, long sig).
+  it("Test C: resolve.ts-shaped source — behavior is ≤200 chars (regression for #1109)", () => {
+    const card = queryIntentCardFromSource(RESOLVE_LIKE_SOURCE);
+
+    expect(card.behavior.length).toBeLessThanOrEqual(200);
+  });
+
+  it("Test C (compound / end-to-end): full production sequence on resolve-like fixture", () => {
+    // Crosses all boundaries: ts-morph parse → pickPrimaryDeclaration (no per-export JSDoc)
+    // → extractSignatureFromNode → behavior cap → QueryIntentCard assembly.
+    const card = queryIntentCardFromSource(RESOLVE_LIKE_SOURCE);
+
+    expect(typeof card).toBe("object");
+    expect(card).not.toBeNull();
+    expect(typeof card.behavior).toBe("string");
+    // Schema constraint: behavior ≤ 200.
+    expect(card.behavior.length).toBeLessThanOrEqual(200);
+    // createResolveTool was resolved (exports found, card is non-empty).
+    expect(card.behavior.length).toBeGreaterThan(0);
   });
 });
 

--- a/packages/contracts/src/query-from-source.ts
+++ b/packages/contracts/src/query-from-source.ts
@@ -135,10 +135,23 @@ export function queryIntentCardFromSource(
   const jsdoc = extractJsDoc(declarationNode);
 
   // Behavior field: JSDoc summary → signature string → fragment fallback.
-  const behavior: string =
+  // @decision DEC-INTENT-BEHAVIOR-CAP-001
+  // @title behavior field truncated to ≤200 chars at the producer (#1109)
+  // @status accepted
+  // @rationale
+  //   packages/shave/src/intent/validate-intent-card.ts:146 enforces behavior.length ≤ 200.
+  //   The JSDoc-summary path is already bounded by extractFirstSentence (slice 197 + "...").
+  //   The signature-string and fragment-fallback paths are unbounded — a file with no JSDoc
+  //   and a long function signature (e.g. packages/mcp-registry/src/tools/resolve.ts at 257
+  //   chars) causes an IntentCardSchemaError and breaks self-shave CI.  The schema is the
+  //   contract; the producer must respect it.  Truncation follows the same 197-char-slice +
+  //   "..." pattern as extractFirstSentence.  See: #1109.
+  const rawBehavior: string =
     jsdoc.summary ??
     sig.signatureString ??
     buildFragmentFallback(sourceFile.getStatements().length, source.length);
+  const behavior: string =
+    rawBehavior.length <= 200 ? rawBehavior : `${rawBehavior.slice(0, 197)}...`;
 
   // Build the QueryIntentCard, omitting absent dimensions (D1 rule).
   // behavior dimension — always present (has at least a fragment fallback).

--- a/packages/shave/src/intent/static-extract.test.ts
+++ b/packages/shave/src/intent/static-extract.test.ts
@@ -396,12 +396,106 @@ function weird(x: number) { return x; }
     }
   });
 
-  it("behavior is at most 200 characters", () => {
+  it("behavior is at most 200 characters (JSDoc path)", () => {
     // A very long JSDoc description should be truncated
     const longDesc = "A ".repeat(120); // 240 chars
     const source = `/** ${longDesc}. */ export function f(): void {}`;
     const card = extract(source);
     expect(card.behavior.length).toBeLessThanOrEqual(200);
+  });
+
+  // -------------------------------------------------------------------------
+  // DEC-INTENT-BEHAVIOR-CAP-001: behavior ≤ 200 chars — signature-string path
+  // The fix lives in static-extract.ts (sibling: query-from-source.ts).
+  // Regression for #1109: mcp-registry/src/tools/resolve.ts had a 257-char
+  // signature that caused IntentCardSchemaError on self-shave CI.
+  // -------------------------------------------------------------------------
+
+  /**
+   * Source with a long function signature and no JSDoc. The rendered
+   * signatureString format is "function <name>(<paramNames>) -> <ret>".
+   * With the names below the string exceeds 200 chars — it must be capped.
+   */
+  const LONG_SIGNATURE_SOURCE = `
+export function processComplexDataTransformationWithValidation(
+  inputDataSourceConfigurationSpec: string,
+  outputTransformationPipelineOptionsMap: string,
+  validationAndErrorHandlingStrategyConfig: string,
+  metadataEnrichmentAndTaggingPolicyRules: string
+): string {
+  return inputDataSourceConfigurationSpec;
+}
+`.trim();
+
+  /**
+   * Source that mimics the resolve.ts shape: file-level JSDoc block, no
+   * per-export JSDoc on the factory function, long param/return types.
+   * This is the regression fixture for #1109.
+   */
+  const RESOLVE_LIKE_SOURCE = `
+/**
+ * Tool: yakcc_resolve
+ *
+ * @decision DEC-SOME-DECISION-001
+ * @title some decision title for this tool
+ * @status accepted
+ * @rationale
+ *   This file has a very long file-level JSDoc and no per-export JSDoc on the
+ *   factory function below.
+ */
+
+export type ProofStatus = "none" | "pending" | "accepted" | "retracted";
+
+export interface CreateResolveToolOptions {
+  readonly openRegistry?: (() => Promise<{ close(): void }>) | undefined;
+  readonly proofStatusProvider?: ((atom_id: string) => ProofStatus) | undefined;
+}
+
+export function createResolveTool(opts?: CreateResolveToolOptions): { name: string; handler: () => Promise<void> } {
+  return { name: "yakcc_resolve", handler: async () => {} };
+}
+`.trim();
+
+  it("Test A (DEC-INTENT-BEHAVIOR-CAP-001): no-JSDoc + long signature → capped to ≤200 chars ending '...'", () => {
+    const card = extract(LONG_SIGNATURE_SOURCE);
+    expect(card.behavior.length).toBeLessThanOrEqual(200);
+    expect(card.behavior.endsWith("...")).toBe(true);
+    // Function name is preserved at the start
+    expect(card.behavior.startsWith("function processComplexDataTransformationWithValidation")).toBe(true);
+  });
+
+  it("Test A (length invariant): truncated behavior is exactly 200 chars (197 content + '...')", () => {
+    const card = extract(LONG_SIGNATURE_SOURCE);
+    expect(card.behavior.length).toBe(200);
+  });
+
+  it("Test B (DEC-INTENT-BEHAVIOR-CAP-001): JSDoc summary ≤200 chars → not truncated, no '...' appended", () => {
+    // JSDoc summary of exactly 200 chars — must NOT be truncated
+    const summary = "A".repeat(195) + " foo."; // 200 chars
+    const source = `/** ${summary} */ export function f(): void {}`;
+    const card = extract(source);
+    expect(card.behavior.length).toBeLessThanOrEqual(200);
+    expect(card.behavior.endsWith("...")).toBe(false);
+    expect(card.behavior.endsWith("foo.")).toBe(true);
+  });
+
+  it("Test C (DEC-INTENT-BEHAVIOR-CAP-001): resolve.ts-shaped source → behavior ≤200 chars (regression #1109)", () => {
+    const card = extract(RESOLVE_LIKE_SOURCE);
+    expect(card.behavior.length).toBeLessThanOrEqual(200);
+  });
+
+  it("Test C (compound / end-to-end): full staticExtract + validateIntentCard on resolve-like fixture", () => {
+    // Production sequence: staticExtract() → pickPrimaryDeclaration (no per-export JSDoc found)
+    // → extractSignatureFromNode → rawBehavior cap → validateIntentCard passes.
+    // Previously: unbounded signatureString caused IntentCardSchemaError.
+    const card = extract(RESOLVE_LIKE_SOURCE);
+    expect(typeof card).toBe("object");
+    expect(card).not.toBeNull();
+    expect(typeof card.behavior).toBe("string");
+    // Schema constraint: behavior ≤ 200.
+    expect(card.behavior.length).toBeLessThanOrEqual(200);
+    // createResolveTool was resolved — card is non-empty.
+    expect(card.behavior.length).toBeGreaterThan(0);
   });
 
   // -------------------------------------------------------------------------

--- a/packages/shave/src/intent/static-extract.ts
+++ b/packages/shave/src/intent/static-extract.ts
@@ -138,9 +138,24 @@ export function staticExtract(unitSource: string, envelope: StaticExtractEnvelop
   const jsdoc = extractJsDoc(primary);
   const sig = extractSignatureFromNode(primary);
 
-  // Behavior field: JSDoc summary → signature string → fragment fallback
-  const behavior =
+  // Behavior field: JSDoc summary → signature string → fragment fallback.
+  // @decision DEC-INTENT-BEHAVIOR-CAP-001
+  // @title behavior field truncated to ≤200 chars at the producer (#1109)
+  // @status accepted
+  // @rationale
+  //   validate-intent-card.ts:146 enforces behavior.length ≤ 200.
+  //   The JSDoc-summary path is already bounded by extractFirstSentence (slice 197 + "...").
+  //   The signature-string and fragment-fallback paths are unbounded — a file with no JSDoc
+  //   and a long function signature (e.g. packages/mcp-registry/src/tools/resolve.ts at 257
+  //   chars) causes an IntentCardSchemaError and breaks self-shave CI.  The schema is the
+  //   contract; the producer must respect it.  Truncation follows the same 197-char-slice +
+  //   "..." pattern as extractFirstSentence.
+  //   Sibling enforcement point: packages/contracts/src/query-from-source.ts (same invariant).
+  //   See: #1109.
+  const rawBehavior: string =
     jsdoc.summary ?? sig.signatureString ?? buildFragmentFallback(sourceFile, unitSource);
+  const behavior: string =
+    rawBehavior.length <= 200 ? rawBehavior : `${rawBehavior.slice(0, 197)}...`;
 
   // Inputs: one entry per parameter.
   // ExtractedParam.typeAnnotation → IntentParam.typeHint (field rename only).


### PR DESCRIPTION
## Summary

The IntentCard schema (`validate-intent-card.ts`) caps `behavior` at ≤200 chars. Both producers — `packages/contracts/src/query-from-source.ts` and `packages/shave/src/intent/static-extract.ts` — fall back from `jsdoc.summary` (bounded by `extractFirstSentence`) to `sig.signatureString` or `buildFragmentFallback`, neither of which were bounded.

`packages/mcp-registry/src/tools/resolve.ts` (no per-export JSDoc, long re-exported type signatures) produced a 257-char behavior → `IntentCardSchemaError` → self-shave two-pass bootstrap equivalence RED on main for the last few days.

**Fix:** truncate at the producer using the same `slice(0,197) + "..."` pattern that `extractFirstSentence` already uses. The schema stays as-is (it IS the contract).

DEC-INTENT-BEHAVIOR-CAP-001 documents the invariant across both producers.

## Real-path proof

```
$ yakcc shave packages/mcp-registry/src/tools/resolve.ts
... (shave atom output)
exit=0
```

No more `IntentCardSchemaError`.

## Files

- `packages/contracts/src/query-from-source.ts` — cap behavior (+15 lines)
- `packages/contracts/src/query-from-source.test.ts` — 5 new tests (+114)
- `packages/shave/src/intent/static-extract.ts` — cap behavior (+19 lines, mirrors contracts side)
- `packages/shave/src/intent/static-extract.test.ts` — 4 new tests (+96)

## Test plan

- [x] `pnpm -r build` — full workspace composite tsc green
- [x] `pnpm --filter @yakcc/contracts test` — 382 passing (5 new + 377 existing)
- [x] `pnpm --filter @yakcc/shave test --filter=static-extract` — 32 passing
- [x] `yakcc shave packages/mcp-registry/src/tools/resolve.ts` exits 0
- [ ] CI green (especially the previously-red two-pass bootstrap equivalence)