### PR TITLE
feat(bench/B4-v5): #1059 — add --tasks-file flag to phase2-v5.mjs

### DIFF
--- a/bench/B4-tokens-v5/harness/phase2-v5.mjs
+++ b/bench/B4-tokens-v5/harness/phase2-v5.mjs
@@ -121,6 +121,10 @@ const { values: flags } = parseArgs({
     smoke: { type: "boolean", default: false },
     // --tier=full makes dry-run show all 9 cells
     tier: { type: "string", default: "full" },
+    // --tasks-file selects the task corpus (default tasks.json). #1049's
+    // hard-atom matrix lives at tasks-hard.json; PROTOCOL.md methodology is
+    // unchanged — this is a runner-convenience selector only (#1059).
+    "tasks-file": { type: "string", default: "tasks.json" },
   },
   strict: false,
 });
@@ -130,6 +134,7 @@ const SMOKE = flags.smoke ?? false;
 const N_REPS = SMOKE ? 1 : Number.parseInt(flags["n-reps"] ?? "3", 10);
 const TASK_ID = SMOKE ? "crc32c" : (flags.task ?? "all");
 const CELL_ID = SMOKE ? "E" : (flags.cell ?? "all");
+const TASKS_FILE = flags["tasks-file"] ?? "tasks.json";
 
 const PHASE2_CAP_USD = V5_CAP_USD;
 const MAX_TOOL_CYCLES = 5;
@@ -369,7 +374,7 @@ async function main() {
   console.log("Hooked arm: reference-emit (DEC-BENCH-B4-V5-REFEMIT-ARM-001)");
   console.log("");
 
-  const manifest = JSON.parse(readFileSync(join(BENCH_ROOT, "tasks.json"), "utf8"));
+  const manifest = JSON.parse(readFileSync(join(BENCH_ROOT, TASKS_FILE), "utf8"));
   const tasks = manifest.tasks.filter((t) => TASK_ID === "all" || t.id === TASK_ID);
   const cells = PHASE2_CELLS.filter(
     (c) => CELL_ID === "all" || c.cell_id === CELL_ID.toUpperCase(),


### PR DESCRIPTION
## Summary

`bench/B4-tokens-v5/harness/phase2-v5.mjs` hard-coded `tasks.json` as the task corpus. #1049's hard-atom matrix lives at `tasks-hard.json` but the operator had no way to point the matrix runner at it without editing the harness or copying atoms.

This PR adds a `--tasks-file <path>` flag (default `tasks.json`). Unblocks the operator-gated paid measurement for the validation half of #1041/#1049.

```
node bench/B4-tokens-v5/harness/phase2-v5.mjs --tasks-file tasks-hard.json --n-reps 3
```

PROTOCOL.md (DEC-BENCH-B4-V5-PROTOCOL-001) is unchanged — this is runner convenience, not a methodology change.

Closes #1059.

## Real-path proof (dry-run)

| Invocation | Result |
|---|---|
| `--tier full` (default) | 6 tasks × 9 cells × 3 reps = **162 runs** (tasks.json) |
| `--tier full --tasks-file tasks-hard.json` | 3 hard atoms × 9 cells × 3 reps = **81 runs** (avl-tree, pratt-expr-eval, dijkstra-heap) |

## Files

- `bench/B4-tokens-v5/harness/phase2-v5.mjs` (+6 / -1)

## Test plan

- [x] Dry-run with default → produces tasks.json matrix
- [x] Dry-run with `--tasks-file tasks-hard.json` → produces hard-atom matrix
- [x] PROTOCOL.md, tasks.json, tasks-hard.json untouched
- [ ] CI green