### PR TITLE
fix(cli): #1112 Slice B — uninstall.test.ts hermetic via --local (~13 min → 6.7s)

### DIFF
--- a/packages/cli/src/commands/uninstall.test.ts
+++ b/packages/cli/src/commands/uninstall.test.ts
@@ -96,7 +96,7 @@ async function initBothClaudeAndCursor(dir: string, fakeHome: string): Promise<v
   mkdirSync(join(fakeHome, ".claude"), { recursive: true });
   mkdirSync(join(fakeHome, ".config", "Cursor"), { recursive: true });
   const code = await init(
-    ["--target", dir, "--ide", "claude-code,cursor", "--no-seed"],
+    ["--target", dir, "--ide", "claude-code,cursor", "--no-seed", "--local"],
     new CollectingLogger(),
     {
       overrideHome: fakeHome,
@@ -209,9 +209,13 @@ describe("uninstall --purge — removes .yakcc/ and .yakccrc.json (EC-S2-T3)", (
   it("purge removes .yakcc/ directory and .yakccrc.json", async () => {
     const fakeHome = join(tmpDir, "fakehome-t3");
     mkdirSync(join(fakeHome, ".claude"), { recursive: true });
-    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
-      overrideHome: fakeHome,
-    });
+    await init(
+      ["--target", tmpDir, "--ide", "claude-code", "--no-seed", "--local"],
+      new CollectingLogger(),
+      {
+        overrideHome: fakeHome,
+      },
+    );
 
     expect(existsSync(join(tmpDir, ".yakcc"))).toBe(true);
     expect(existsSync(join(tmpDir, ".yakccrc.json"))).toBe(true);
@@ -229,9 +233,13 @@ describe("uninstall --purge — removes .yakcc/ and .yakccrc.json (EC-S2-T3)", (
   it("purge: hook files are also removed (uninstall loop runs before purge)", async () => {
     const fakeHome = join(tmpDir, "fakehome-t3b");
     mkdirSync(join(fakeHome, ".claude"), { recursive: true });
-    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
-      overrideHome: fakeHome,
-    });
+    await init(
+      ["--target", tmpDir, "--ide", "claude-code", "--no-seed", "--local"],
+      new CollectingLogger(),
+      {
+        overrideHome: fakeHome,
+      },
+    );
 
     await uninstall(["--target", tmpDir, "--purge"], new CollectingLogger(), {
       overrideHome: fakeHome,
@@ -243,9 +251,13 @@ describe("uninstall --purge — removes .yakcc/ and .yakccrc.json (EC-S2-T3)", (
   it("purge: summary contains 'purged' (DEC-CLI-UNINSTALL-PURGE-001 / EC-S2-T8)", async () => {
     const fakeHome = join(tmpDir, "fakehome-t3c");
     mkdirSync(join(fakeHome, ".claude"), { recursive: true });
-    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
-      overrideHome: fakeHome,
-    });
+    await init(
+      ["--target", tmpDir, "--ide", "claude-code", "--no-seed", "--local"],
+      new CollectingLogger(),
+      {
+        overrideHome: fakeHome,
+      },
+    );
 
     const logger = new CollectingLogger();
     await uninstall(["--target", tmpDir, "--purge"], logger, { overrideHome: fakeHome });
@@ -295,7 +307,7 @@ describe("uninstall --ide claude-code,cline — removes both (EC-S2-T5)", () => 
 
     // Init all four IDEs
     const initCode = await init(
-      ["--target", tmpDir, "--ide", "claude-code,cursor,cline,continue", "--no-seed"],
+      ["--target", tmpDir, "--ide", "claude-code,cursor,cline,continue", "--no-seed", "--local"],
       new CollectingLogger(),
       { overrideHome: fakeHome },
     );
@@ -375,9 +387,13 @@ describe("uninstall — idempotent re-run (EC-S2-T7)", () => {
   it("calling uninstall twice after an init exits 0 both times", async () => {
     const fakeHome = join(tmpDir, "fakehome-t7");
     mkdirSync(join(fakeHome, ".claude"), { recursive: true });
-    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
-      overrideHome: fakeHome,
-    });
+    await init(
+      ["--target", tmpDir, "--ide", "claude-code", "--no-seed", "--local"],
+      new CollectingLogger(),
+      {
+        overrideHome: fakeHome,
+      },
+    );
 
     const code1 = await uninstall(["--target", tmpDir], new CollectingLogger(), {
       overrideHome: fakeHome,
@@ -399,9 +415,13 @@ describe("uninstall — concise summary output (EC-S2-T8)", () => {
   it("default uninstall: summary log is ≤6 non-empty lines", async () => {
     const fakeHome = join(tmpDir, "fakehome-t8a");
     mkdirSync(join(fakeHome, ".claude"), { recursive: true });
-    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
-      overrideHome: fakeHome,
-    });
+    await init(
+      ["--target", tmpDir, "--ide", "claude-code", "--no-seed", "--local"],
+      new CollectingLogger(),
+      {
+        overrideHome: fakeHome,
+      },
+    );
 
     const logger = new CollectingLogger();
     await uninstall(["--target", tmpDir], logger, { overrideHome: fakeHome });
@@ -413,9 +433,13 @@ describe("uninstall — concise summary output (EC-S2-T8)", () => {
   it("purge uninstall: summary contains 'purged' AND IDE removal info", async () => {
     const fakeHome = join(tmpDir, "fakehome-t8b");
     mkdirSync(join(fakeHome, ".claude"), { recursive: true });
-    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
-      overrideHome: fakeHome,
-    });
+    await init(
+      ["--target", tmpDir, "--ide", "claude-code", "--no-seed", "--local"],
+      new CollectingLogger(),
+      {
+        overrideHome: fakeHome,
+      },
+    );
 
     const logger = new CollectingLogger();
     await uninstall(["--target", tmpDir, "--purge"], logger, { overrideHome: fakeHome });
@@ -434,9 +458,13 @@ describe("uninstall — concise summary output (EC-S2-T8)", () => {
   it("default uninstall: summary mentions 'Registry preserved'", async () => {
     const fakeHome = join(tmpDir, "fakehome-t8c");
     mkdirSync(join(fakeHome, ".claude"), { recursive: true });
-    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
-      overrideHome: fakeHome,
-    });
+    await init(
+      ["--target", tmpDir, "--ide", "claude-code", "--no-seed", "--local"],
+      new CollectingLogger(),
+      {
+        overrideHome: fakeHome,
+      },
+    );
 
     const logger = new CollectingLogger();
     await uninstall(["--target", tmpDir], logger, { overrideHome: fakeHome });
@@ -461,9 +489,13 @@ describe("runCli dispatch — routes 'uninstall' to the uninstall handler (EC-S2
   it("runCli uninstall result matches direct uninstall() call", async () => {
     const fakeHome = join(tmpDir, "fakehome-t9");
     mkdirSync(join(fakeHome, ".claude"), { recursive: true });
-    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
-      overrideHome: fakeHome,
-    });
+    await init(
+      ["--target", tmpDir, "--ide", "claude-code", "--no-seed", "--local"],
+      new CollectingLogger(),
+      {
+        overrideHome: fakeHome,
+      },
+    );
 
     const loggerViaRunCli = new CollectingLogger();
     const codeViaRunCli = await runCli(["uninstall", "--target", tmpDir], loggerViaRunCli, {});
@@ -533,9 +565,13 @@ describe("uninstall — .yakccrc.json schema invariants (EC-S2-I3)", () => {
   it("version is still 1 after uninstall", async () => {
     const fakeHome = join(tmpDir, "fakehome-i3");
     mkdirSync(join(fakeHome, ".claude"), { recursive: true });
-    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
-      overrideHome: fakeHome,
-    });
+    await init(
+      ["--target", tmpDir, "--ide", "claude-code", "--no-seed", "--local"],
+      new CollectingLogger(),
+      {
+        overrideHome: fakeHome,
+      },
+    );
 
     await uninstall(["--target", tmpDir], new CollectingLogger(), { overrideHome: fakeHome });
 
@@ -546,9 +582,13 @@ describe("uninstall — .yakccrc.json schema invariants (EC-S2-I3)", () => {
   it("installedHooks is [] (not absent) after default uninstall", async () => {
     const fakeHome = join(tmpDir, "fakehome-i3b");
     mkdirSync(join(fakeHome, ".claude"), { recursive: true });
-    await init(["--target", tmpDir, "--ide", "claude-code", "--no-seed"], new CollectingLogger(), {
-      overrideHome: fakeHome,
-    });
+    await init(
+      ["--target", tmpDir, "--ide", "claude-code", "--no-seed", "--local"],
+      new CollectingLogger(),
+      {
+        overrideHome: fakeHome,
+      },
+    );
 
     await uninstall(["--target", tmpDir], new CollectingLogger(), { overrideHome: fakeHome });
 
@@ -574,7 +614,7 @@ describe("compound interaction: init → uninstall end-to-end", () => {
 
     // Step 1: init with claude-code + cline
     const initCode = await init(
-      ["--target", tmpDir, "--ide", "claude-code,cline", "--no-seed"],
+      ["--target", tmpDir, "--ide", "claude-code,cline", "--no-seed", "--local"],
       new CollectingLogger(),
       { overrideHome: fakeHome },
     );
@@ -617,7 +657,7 @@ describe("compound interaction: init → uninstall end-to-end", () => {
     mkdirSync(join(fakeHome, ".claude"), { recursive: true });
 
     const initCode = await init(
-      ["--target", tmpDir, "--ide", "claude-code", "--no-seed"],
+      ["--target", tmpDir, "--ide", "claude-code", "--no-seed", "--local"],
       new CollectingLogger(),
       { overrideHome: fakeHome },
     );


### PR DESCRIPTION
## Summary (Slice B of #1112)

Same root cause + fix pattern as Slice A (PR #1122). `packages/cli/src/commands/uninstall.test.ts` had 15 `init()` call sites; only 1 (`:145`) used `--local`. The other 14 each waited the full 60s vitest timeout on an unreachable network call to `https://registry.yakcc.com` (default peer per PR #773, 60s mirror timeout per PR #816).

This PR adds `"--local"` to the 14 sites. 0 sites legitimately need federation (none required a `runFederation` stub). 0 pre-existing masked bugs surfaced (Slice A uncovered 2; uninstall.test.ts was cleaner).

biome format pass applied to satisfy line-length rules after edits.

Production code (`init.ts`, `uninstall.ts`, `vitest.config.ts`) untouched per planner `DEC-1112-FIX-SURFACE-001` — default-peer + 60s is intentional UX.

With Slice A (#1122) + Slice B (this PR), the `@yakcc/cli` test suite's **~49 minutes of timeout burn** is eliminated.

Closes #1112 (Slice B). Plan: `plans/wi-1112-fast-nightly.md` (already on main from Slice A).

## Wall-clock impact

| Before | After |
|---|---|
| ~13 tests × 60s = ~13 min | 27 tests in 6.72s |

## Files

- `packages/cli/src/commands/uninstall.test.ts` (+74 / -34, includes biome reformat)

## Test plan

- [x] `pnpm -r build` clean
- [x] `pnpm --filter @yakcc/cli vitest run src/commands/uninstall.test.ts` — 27/27 pass in 6.72s
- [x] `pnpm --filter @yakcc/cli lint` clean
- [x] Production source (init.ts, uninstall.ts, vitest.config.ts) untouched
- [ ] CI green