### PR TITLE
fix(airgap): #1123 bge-native air-gap seed — conditional offline pin + cache-warm

### DIFF
--- a/bench/B6-airgap/run.mjs
+++ b/bench/B6-airgap/run.mjs
@@ -131,16 +131,23 @@ function step(n, desc) {
 // IMPORTANT (Windows): ESM dynamic imports require file:// URLs — bare Windows
 // paths like "C:/..." are rejected with ERR_UNSUPPORTED_ESM_URL_SCHEME.
 // pathToFileURL() converts platform paths to proper file:// URLs.
+//
+// @decision DEC-1123-SEED-BGE-NATIVE-001 / DEC-1123-CACHE-WARM-IN-HARNESS-001:
+// B6a children now use the native bge provider (no offline provider injection).
+// YAKCC_AIRGAPPED=1 engages the conditional pin in createLocalEmbeddingProvider()
+// (DEC-1123-CONDITIONAL-OFFLINE-PIN-001), so the model is loaded from the pre-warmed
+// cache without any outbound fetch. The warm (done before this function is called,
+// outside the interceptor window) ensures the cache is populated.
 function runYakcc(args, { cwd, interceptOut, env = {} } = {}) {
   // Build the inline ESM wrapper that imports runCli and calls it.
   // We resolve to the dist/index.js of @yakcc/cli in the workspace.
   const cliDistUrl = pathToFileURL(resolve(REPO_ROOT, "packages/cli/dist/index.js")).href;
-  const contractsDistUrl = pathToFileURL(resolve(REPO_ROOT, "packages/contracts/dist/embeddings.js")).href;
   const argsJson = JSON.stringify(args);
+  // No longer inject createOfflineEmbeddingProvider() — children use the real bge
+  // provider, pinned offline by YAKCC_AIRGAPPED=1 in spawnEnv below.
   const esmWrapper = `
 import { runCli } from ${JSON.stringify(cliDistUrl)};
-import { createOfflineEmbeddingProvider } from ${JSON.stringify(contractsDistUrl)};
-const code = await runCli(${argsJson}, undefined, { embeddings: createOfflineEmbeddingProvider() });
+const code = await runCli(${argsJson});
 process.exit(code);
 `;
 
@@ -157,10 +164,17 @@ process.exit(code);
   // The existing network interceptor (network-interceptor.cjs) is the secondary defense —
   // belt-and-braces so either layer alone keeps B6a green.
   // DEC-TELEMETRY-EXPORT-B6A-AUTO-DISABLE-007 (plans/wi-546-telemetry-export.md §2.2)
+  //
+  // @decision DEC-1123-CONDITIONAL-OFFLINE-PIN-001: YAKCC_AIRGAPPED=1 engages the
+  // conditional allowRemoteModels=false pin in createLocalEmbeddingProvider(). The
+  // bge model must already be in the @xenova/transformers cache (warmed by warmBgeCache()
+  // before this function is ever called). If the cache is cold, the pin throws LOUD
+  // rather than fetching — which is the correct air-gap behavior.
   const spawnEnv = {
     ...process.env,
     ...env,
     YAKCC_TELEMETRY_DISABLED: "1",
+    YAKCC_AIRGAPPED: "1",
     YAKCC_BENCH_INTERCEPT_OUT: interceptOut,
   };
 
@@ -234,6 +248,69 @@ if (!existsSync(contractsDist)) {
 
 const allowlistPath = resolve(__dirname, "allowlist.json");
 const allowlist = JSON.parse(readFileSync(allowlistPath, "utf8")).allowedDestinations;
+
+// ---------------------------------------------------------------------------
+// warmBgeCache — pre-warm the bge model BEFORE the network interceptor
+// ---------------------------------------------------------------------------
+//
+// @decision DEC-1123-CACHE-WARM-IN-HARNESS-001
+// @title Warm the bge model in the harness process before the interceptor window
+// @status accepted (WI-1123)
+// @rationale
+//   In CI the @xenova/transformers model cache is cold. The B6a children load
+//   the model from cache (via YAKCC_AIRGAPPED=1 + allowRemoteModels=false), but
+//   only if the cache is populated first. This function does a one-time warm
+//   in the harness process BEFORE the network interceptor machinery is engaged
+//   (the interceptor is loaded per-child via --require, not in this process).
+//   Harness-process network I/O is not recorded by the interceptor — it runs
+//   outside the monitored region. The warm writes to the deduped pnpm
+//   @xenova/transformers/.cache/ directory shared by all spawned children
+//   (Layer 3 in the WI-1123 root-cause map).
+//
+//   YAKCC_AIRGAPPED must NOT be set during the warm (pin off = online fetch allowed).
+//   The warm is the only legitimate outbound access during the entire benchmark run.
+//
+//   Real-air-gap-user implication (documented): a genuinely air-gapped user must
+//   provision the bge model offline once before running yakcc. The warm models that
+//   provisioning step. The conditional pin then guarantees no runtime fetch.
+
+async function warmBgeCache() {
+  info("Warming bge model cache (online, before interceptor window)...");
+
+  // Import createLocalEmbeddingProvider from the built contracts dist.
+  // This runs in the harness process (no interceptor), so a network fetch here
+  // is intentional and does NOT count as an outbound violation.
+  const contractsDistUrl = pathToFileURL(resolve(REPO_ROOT, "packages/contracts/dist/embeddings.js")).href;
+  let createLocalEmbeddingProvider;
+  try {
+    const mod = await import(contractsDistUrl);
+    createLocalEmbeddingProvider = mod.createLocalEmbeddingProvider;
+  } catch (err) {
+    process.stderr.write(`WARN: warmBgeCache: failed to import contracts dist: ${err.message}\n`);
+    process.stderr.write(`      B6a may fail if cache is cold and children cannot fetch.\n`);
+    return;
+  }
+
+  // Create a provider in ONLINE mode (airgapped: false) so the model can be
+  // downloaded if not yet cached, even when YAKCC_AIRGAPPED=1 is inherited from
+  // the parent shell (e.g. CI sets it before invoking the harness).
+  // The explicit false overrides isAirgapMode() — see DEC-1123-CONDITIONAL-OFFLINE-PIN-001.
+  const warmProvider = createLocalEmbeddingProvider(undefined, undefined, { airgapped: false });
+
+  const warmStart = Date.now();
+  try {
+    // One embed call is enough to trigger the model load and populate the cache.
+    await warmProvider.embed("warm");
+    const elapsed = Date.now() - warmStart;
+    info(`Bge cache warm complete (${elapsed}ms). Children will load from cache.`);
+  } catch (err) {
+    process.stderr.write(`WARN: warmBgeCache: embed("warm") FAILED: ${err.message}\n`);
+    process.stderr.write(`      REASON: The bge model is not in the @xenova cache.\n`);
+    process.stderr.write(`      B6a children run under YAKCC_AIRGAPPED=1 and CANNOT fetch.\n`);
+    process.stderr.write(`      They will fail with "bge model not cached" unless the cache\n`);
+    process.stderr.write(`      is populated by some other means before this run.\n`);
+  }
+}
 
 // ---------------------------------------------------------------------------
 // B6a — offline (air-gapped) benchmark
@@ -638,6 +715,11 @@ const mode = harnessArgs.mode;
 let exitCode = 0;
 
 if (mode === "b6a" || mode === "all") {
+  // @decision DEC-1123-CACHE-WARM-IN-HARNESS-001: warm BEFORE the interceptor window.
+  // The warm runs in this harness process (no per-child interceptor loaded here),
+  // so any model download does NOT register as an outbound violation in B6a.
+  // YAKCC_AIRGAPPED must NOT be set in the harness process during the warm.
+  await warmBgeCache();
   const b6aResult = await runB6a();
   if (b6aResult === false) exitCode = 1;
 }

--- a/packages/cli/src/commands/seed-yakcc.test.ts
+++ b/packages/cli/src/commands/seed-yakcc.test.ts
@@ -35,9 +35,28 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { CollectingLogger } from "../index.js";
 import { seedYakccCorpus } from "./seed-yakcc.js";
 
-// Offline embedding provider — prevents any test from falling back to
-// createLocalEmbeddingProvider() (network-dependent, fails in sandbox).
+// Offline embedding provider — used for the TARGET registry (fresh temp-file
+// SQLite initialized with offline-blake3-stub model). Prevents any registry
+// open from falling back to createLocalEmbeddingProvider() (network-dependent).
 const offlineEmbeddings = createOfflineEmbeddingProvider();
+
+// BGE-matching stub provider — used when opening the BOOTSTRAP SOURCE registry.
+// The bootstrap sqlite (bootstrap/yakcc.registry.sqlite) was embedded with
+// Xenova/bge-small-en-v1.5 (DEC-1123-SEED-BGE-NATIVE-001). openRegistry()
+// checks the stored embedding_model_id against the provider's modelId and throws
+// embedding_model_mismatch when they differ and embeddings exist.
+// seedYakccCorpus uses opts.embeddings as the source db provider; the target
+// registry is separately opened by the caller with offlineEmbeddings.
+// This stub matches the bootstrap modelId without loading the real ONNX model
+// (embed() returns zeros — acceptable because seed IMPORTS stored embeddings
+// rather than recomputing them; embed() is never called on the source db).
+const bgeStubEmbeddings = {
+  modelId: "Xenova/bge-small-en-v1.5",
+  dimension: 384,
+  async embed(_text: string): Promise<Float32Array> {
+    return new Float32Array(384);
+  },
+};
 
 // ---------------------------------------------------------------------------
 // Bootstrap corpus path resolution
@@ -105,9 +124,11 @@ beforeAll(async () => {
     // seedYakccCorpus now returns SeedResult (DEC-CLI-INIT-SEED-LOUD-001).
     // BOOTSTRAP_CORPUS_PATH is non-null here (guarded above), so the result is
     // either "seeded" (success) or a throw (present-but-broken corpus).
+    // bgeStubEmbeddings matches the bootstrap db's stored modelId (DEC-1123-SEED-BGE-NATIVE-001)
+    // without loading the real ONNX model — offline safe.
     const seedResult = await seedYakccCorpus(
       reg2,
-      { embeddings: offlineEmbeddings, corpusPath: BOOTSTRAP_CORPUS_PATH as string },
+      { embeddings: bgeStubEmbeddings, corpusPath: BOOTSTRAP_CORPUS_PATH as string },
       logger,
     );
     if (seedResult.status !== "seeded") {
@@ -161,7 +182,7 @@ describe.skipIf(BOOTSTRAP_CORPUS_PATH === null)("seedYakccCorpus", () => {
     const reg = await openRegistry(registryPath, { embeddings: offlineEmbeddings });
     const secondResult = await seedYakccCorpus(
       reg,
-      { embeddings: offlineEmbeddings, corpusPath: BOOTSTRAP_CORPUS_PATH as string },
+      { embeddings: bgeStubEmbeddings, corpusPath: BOOTSTRAP_CORPUS_PATH as string },
       logger,
     );
     await reg.close();
@@ -219,7 +240,7 @@ describe.skipIf(BOOTSTRAP_CORPUS_PATH === null)("seedYakccCorpus", () => {
     const reg = await openRegistry(registryPath, { embeddings: offlineEmbeddings });
     await seedYakccCorpus(
       reg,
-      { embeddings: offlineEmbeddings, corpusPath: BOOTSTRAP_CORPUS_PATH as string },
+      { embeddings: bgeStubEmbeddings, corpusPath: BOOTSTRAP_CORPUS_PATH as string },
       logger,
     );
     await reg.close();
@@ -400,7 +421,7 @@ describe.skipIf(BOOTSTRAP_CORPUS_PATH === null)("seed command --yakcc flag integ
       const { seed } = await import("./seed.js");
       const logger = new CollectingLogger();
       const exitCode = await seed(["--yakcc", "--registry", freshRegistryPath], logger, {
-        embeddings: offlineEmbeddings,
+        embeddings: bgeStubEmbeddings,
         corpusPath: BOOTSTRAP_CORPUS_PATH as string,
       });
 
@@ -411,7 +432,10 @@ describe.skipIf(BOOTSTRAP_CORPUS_PATH === null)("seed command --yakcc flag integ
       expect(output).toContain("yakcc seed --yakcc");
 
       // Verify atoms were actually imported.
-      const reg2 = await openRegistry(freshRegistryPath, { embeddings: offlineEmbeddings });
+      // seed() opened freshRegistryPath with bgeStubEmbeddings (same opts.embeddings),
+      // so the target registry now stores "Xenova/bge-small-en-v1.5" as its modelId.
+      // Re-open with bgeStubEmbeddings to avoid the embedding_model_mismatch guard.
+      const reg2 = await openRegistry(freshRegistryPath, { embeddings: bgeStubEmbeddings });
       const manifest = await reg2.exportManifest();
       await reg2.close();
       expect(manifest.length).toBeGreaterThanOrEqual(1);

--- a/packages/cli/src/commands/seed-yakcc.ts
+++ b/packages/cli/src/commands/seed-yakcc.ts
@@ -38,14 +38,16 @@
 //   are imported.
 //
 //   EMBEDDING: each imported block is re-embedded using the user's configured
-//   embedding provider. The bootstrap sqlite was stored with a zero-vector provider
-//   (DEC-V2-BOOTSTRAP-EMBEDDING-001). The user's registry gets real embeddings,
-//   enabling semantic `yakcc query` to work correctly after import.
+//   embedding provider. The bootstrap sqlite was re-embedded with bge-small-en-v1.5
+//   as part of issue #1017 (DEC-1123-SEED-BGE-NATIVE-001, supersedes the old
+//   DEC-V2-BOOTSTRAP-EMBEDDING-001 zero-vector scheme). The user's registry gets
+//   real bge-small embeddings, enabling semantic `yakcc query` to work correctly.
 
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { BlockMerkleRoot } from "@yakcc/contracts";
+import { createLocalEmbeddingProvider } from "@yakcc/contracts";
 import { type Registry, type RegistryOptions, openRegistry } from "@yakcc/registry";
 import type { Logger } from "../index.js";
 
@@ -150,25 +152,21 @@ function findBootstrapSqlite(): string | null {
 }
 
 // ---------------------------------------------------------------------------
-// Zero-vector embedding provider — bootstrap source DB uses these
+// Bootstrap provider selection
+//
+// @decision DEC-1123-SEED-BGE-NATIVE-001 (supersedes DEC-V2-BOOTSTRAP-EMBEDDING-001)
+// The bootstrap corpus (bootstrap/yakcc.registry.sqlite) was re-embedded with
+// bge-small-en-v1.5 as part of issue #1017. registry_meta.embedding_model_id is
+// 'Xenova/bge-small-en-v1.5'. Opening with a null-zero provider triggers the
+// DEC-EMBED-REGISTRY-META-001 mismatch guard. The bootstrap read path uses
+// createLocalEmbeddingProvider() (imported above) so modelId matches.
+//
+// The old makeZeroEmbeddingProvider() function has been removed — it was the
+// single caller of the mismatching null-zero path. Deletion-first: no parallel
+// authorities. Tests that need offline isolation inject createOfflineEmbeddingProvider()
+// via opts.embeddings (which has a modelId that matches an offline/test registry,
+// not the real bootstrap db).
 // ---------------------------------------------------------------------------
-
-/**
- * Returns the embedding provider used when the bootstrap corpus was created.
- *
- * The bootstrap process stores atoms with a zero-vector embedding
- * (DEC-V2-BOOTSTRAP-EMBEDDING-001). When we open the bootstrap sqlite to READ
- * blocks from it, we must use the same zero provider so the registry's
- * embedding model ID matches the stored embeddings. The user's registry
- * receives real embeddings via the injected provider in storeBlock.
- */
-function makeZeroEmbeddingProvider(): RegistryOptions["embeddings"] {
-  return {
-    dimension: 384,
-    modelId: "bootstrap/null-zero",
-    embed: async (_text: string): Promise<Float32Array> => new Float32Array(384),
-  };
-}
 
 // ---------------------------------------------------------------------------
 // seedYakccCorpus — public command handler
@@ -231,13 +229,26 @@ export async function seedYakccCorpus(
 
   logger.log(`yakcc seed --yakcc: loading corpus from ${sqlitePath}`);
 
-  // Open the bootstrap sqlite as a READ source. Use the zero-vector provider —
-  // the bootstrap db was stored with that provider (DEC-V2-BOOTSTRAP-EMBEDDING-001).
-  // We only READ from this db; the user's registry is the write target.
+  // Open the bootstrap sqlite as a READ source.
+  //
+  // @decision DEC-1123-SEED-BGE-NATIVE-001 (supersedes DEC-V2-BOOTSTRAP-EMBEDDING-001)
+  // The bootstrap corpus was re-embedded with bge-small-en-v1.5 as part of issue #1017.
+  // registry_meta.embedding_model_id is 'Xenova/bge-small-en-v1.5' with embCount > 0.
+  // Opening with the old zero provider (modelId='bootstrap/null-zero') triggers the
+  // DEC-EMBED-REGISTRY-META-001/002 mismatch guard and throws embedding_model_mismatch.
+  // Fix: open with createLocalEmbeddingProvider() so modelId matches the stored value.
+  // null-zero is retained ONLY for :memory:/verify paths where no real embeddings exist.
+  //
+  // If the caller passed an explicit embeddings override (test injection seam), use it —
+  // tests that need offline isolation inject createOfflineEmbeddingProvider() via opts.embeddings.
+  // Production uses the real bge provider (may load model from cache on first call).
+  const bootstrapProvider: RegistryOptions["embeddings"] =
+    opts.embeddings ?? createLocalEmbeddingProvider();
+
   let sourceRegistry: Registry;
   try {
     sourceRegistry = await openRegistry(sqlitePath, {
-      embeddings: makeZeroEmbeddingProvider(),
+      embeddings: bootstrapProvider,
     });
   } catch (err) {
     throw new Error(

--- a/packages/contracts/src/embeddings.test.ts
+++ b/packages/contracts/src/embeddings.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createLocalEmbeddingProvider,
   createOfflineEmbeddingProvider,
@@ -457,5 +459,80 @@ describe("resolveEmbeddingProviderFromEnv", () => {
       if (prev !== undefined) process.env.YAKCC_EMBEDDING_PROVIDER = prev;
       else delete process.env.YAKCC_EMBEDDING_PROVIDER;
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createLocalEmbeddingProvider — conditional offline pin (DEC-1123-CONDITIONAL-OFFLINE-PIN-001)
+//
+// These tests verify the air-gap mode behavior WITHOUT making a real 25MB download.
+// Strategy:
+//   1. Pin-blocks-fetch test: redirects env.cacheDir to a fresh empty tmpdir so the
+//      model is guaranteed absent, then creates an airgapped provider and calls embed().
+//      Expects a throw containing "bge model not cached".
+//   2. Online-path-unaffected test: creates a provider with airgapped:false and asserts
+//      that env.allowRemoteModels is NOT forcibly set to false, proving the online dev
+//      first-run path is unaffected by the conditional pin.
+// ---------------------------------------------------------------------------
+
+describe("createLocalEmbeddingProvider — conditional offline pin (DEC-1123-CONDITIONAL-OFFLINE-PIN-001)", () => {
+  // Restore env after each test to avoid cross-contamination.
+  let savedCacheDir: string | undefined;
+  let savedAllowRemoteModels: boolean | undefined;
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    // Restore @xenova/transformers env state modified by these tests.
+    const mod = await import("@xenova/transformers");
+    if (savedCacheDir !== undefined) {
+      mod.env.cacheDir = savedCacheDir;
+      savedCacheDir = undefined;
+    }
+    if (savedAllowRemoteModels !== undefined) {
+      mod.env.allowRemoteModels = savedAllowRemoteModels;
+      savedAllowRemoteModels = undefined;
+    }
+    if (tempDir !== undefined) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  it(
+    "pin blocks fetch + fails loud: airgapped:true with empty cache dir throws 'bge model not cached'",
+    { timeout: 15_000 },
+    async () => {
+      // Redirect the xenova cache to a fresh empty directory so the model is absent.
+      const mod = await import("@xenova/transformers");
+      savedCacheDir = mod.env.cacheDir as string | undefined;
+      savedAllowRemoteModels = mod.env.allowRemoteModels as boolean | undefined;
+      tempDir = mkdtempSync(`${tmpdir()}/yakcc-test-airgap-`);
+      mod.env.cacheDir = tempDir;
+
+      // Create a provider with explicit airgapped:true.
+      // This uses a per-instance loader (NOT the module singleton) so the env pin
+      // is applied fresh inside this loader's pipeline call.
+      const provider = createLocalEmbeddingProvider(undefined, undefined, { airgapped: true });
+
+      // embed() must throw — model is absent under the pin.
+      await expect(provider.embed("test air-gap pin")).rejects.toThrow("bge model not cached");
+    },
+  );
+
+  it("online path unaffected: airgapped:false does NOT set allowRemoteModels=false", async () => {
+    const mod = await import("@xenova/transformers");
+    savedAllowRemoteModels = mod.env.allowRemoteModels as boolean | undefined;
+
+    // Reset to default (true) before the test.
+    mod.env.allowRemoteModels = true;
+
+    // Construct an online provider (airgapped:false). This should NOT touch
+    // allowRemoteModels. Note: the pipeline is lazy — it only fires on embed().
+    // We do NOT call embed() here (that would download the model in CI).
+    // Instead we assert that construction alone does not pin env.
+    createLocalEmbeddingProvider(undefined, undefined, { airgapped: false });
+
+    // allowRemoteModels should still be true — the pin was NOT applied.
+    expect(mod.env.allowRemoteModels).toBe(true);
   });
 });

--- a/packages/contracts/src/embeddings.ts
+++ b/packages/contracts/src/embeddings.ts
@@ -49,6 +49,24 @@ export interface EmbeddingProvider {
 // Local provider (transformers.js)
 // ---------------------------------------------------------------------------
 
+// @decision DEC-1123-CONDITIONAL-OFFLINE-PIN-001
+// @title Conditional allowRemoteModels=false for the shared embedder in air-gap mode
+// @status accepted (WI-1123)
+// @rationale The shared embedder is used by both online dev (legitimate first-run fetch)
+//   and air-gap scenarios (B6a). Pinning allowRemoteModels=false globally would break
+//   online dev; pinning conditionally behind YAKCC_AIRGAPPED=1 (existing env signal,
+//   also readable via an explicit `airgapped` option for programmatic callers) matches
+//   the DEC-MCP-RESOLVE-OFFLINE-GUARANTEE-001 pattern in resolve.ts without importing
+//   its unconditional semantics. The env var propagates to all spawned child CLI
+//   processes (the B6a harness sets it in spawnEnv), so every step is covered uniformly.
+//   Fail-loud on cache miss: when pinned and the model is absent, @xenova throws — we
+//   annotate the error message with "bge model not cached; provision it for air-gap"
+//   so operators understand the required provisioning step.
+//   Singleton caveat: the pin sets process-global env state; once a pipeline loads under
+//   air-gap mode the env stays pinned for the process lifetime (correct for an air-gap run).
+//   For mixed in-process tests, use the explicit airgapped option + a per-instance loader
+//   (see embeddings.test.ts restore pattern) to avoid cross-contamination.
+
 // @decision DEC-EMBED-MODEL-SELECTION-001
 // @title DISCOVERY_EMBED_MODEL env-var for D5 embedding-model experiment (#326)
 // @status accepted
@@ -124,26 +142,67 @@ export const LOCAL_KNOWN_MODELS: ReadonlyMap<string, number> = new Map([
 // module-level singleton to preserve DEC-EMBED-SINGLETON-CLOSURE-001 semantics for production.
 
 /**
+ * Returns true when the process is running in air-gap mode.
+ *
+ * Air-gap mode is signalled by `YAKCC_AIRGAPPED=1` — the same env var read by
+ * `resolve.ts` (`DEC-MCP-RESOLVE-OFFLINE-GUARANTEE-001`). This is the canonical
+ * single authority for the offline signal; we add a second reader here rather
+ * than introduce a new env var.
+ *
+ * @internal — used by makePipelineLoader and exposed as an option seam for tests.
+ */
+function isAirgapMode(): boolean {
+  return typeof process !== "undefined" && process.env.YAKCC_AIRGAPPED === "1";
+}
+
+/**
  * Create a lazy pipeline loader closure for the given model.
+ *
+ * When air-gap mode is active (YAKCC_AIRGAPPED=1 or the explicit `airgapped`
+ * option), sets `env.allowRemoteModels = false` and asserts
+ * `env.allowLocalModels = true` on the @xenova/transformers env before calling
+ * `pipeline()`. This mirrors DEC-MCP-RESOLVE-OFFLINE-GUARANTEE-001 in resolve.ts
+ * but conditionally, so online dev is unaffected.
+ *
+ * On cache miss with the pin active, @xenova throws — we surface a clear message
+ * containing "bge model not cached; provision it for air-gap" so operators know
+ * they need to provision the model before running air-gapped.
  *
  * @decision DEC-EMBED-LAZY-001: Dynamic import for lazy pipeline init.
  * Status: decided (WI-002)
  * Rationale: Static import triggers ONNX runtime at module load; dynamic defers to first use.
  */
-function makePipelineLoader(modelId: string): () => Promise<unknown> {
+function makePipelineLoader(modelId: string, airgapped?: boolean): () => Promise<unknown> {
   let pipelinePromise: Promise<unknown> | null = null;
   return (): Promise<unknown> => {
     if (pipelinePromise === null) {
-      pipelinePromise = import("@xenova/transformers").then((mod) =>
-        mod.pipeline("feature-extraction", modelId),
-      );
+      pipelinePromise = import("@xenova/transformers").then((mod) => {
+        // DEC-1123-CONDITIONAL-OFFLINE-PIN-001: apply offline pin only in air-gap mode.
+        const useAirgap = airgapped ?? isAirgapMode();
+        if (useAirgap) {
+          // Pin: no remote fetch allowed. allowLocalModels must be true (default, but assert).
+          mod.env.allowRemoteModels = false;
+          mod.env.allowLocalModels = true;
+        }
+        return mod.pipeline("feature-extraction", modelId).catch((err: unknown) => {
+          if (useAirgap) {
+            const msg = err instanceof Error ? err.message : String(err);
+            throw new Error(
+              `bge model not cached; provision it for air-gap operation. Original error: ${msg}`,
+            );
+          }
+          throw err;
+        });
+      });
     }
     return pipelinePromise;
   };
 }
 
-/** Module-level singleton pipeline for the default model (DEC-EMBED-SINGLETON-CLOSURE-001). */
-const getPipeline: () => Promise<unknown> = makePipelineLoader(LOCAL_MODEL_ID);
+/** Module-level singleton pipeline for the default model in online mode (DEC-EMBED-SINGLETON-CLOSURE-001).
+ * Air-gap mode gets a per-instance loader (see createLocalEmbeddingProvider) to avoid
+ * pinning process-global env for the online singleton. */
+const getPipeline: () => Promise<unknown> = makePipelineLoader(LOCAL_MODEL_ID, false);
 
 /**
  * The output shape from transformers.js feature-extraction pipeline.
@@ -171,7 +230,13 @@ interface TransformerOutput {
  *
  * Model selection when `modelId` is omitted (in priority order):
  *   1. `DISCOVERY_EMBED_MODEL` env var (experiment use)
- *   2. LOCAL_MODEL_ID default (`Xenova/all-MiniLM-L6-v2`)
+ *   2. LOCAL_MODEL_ID default (`Xenova/bge-small-en-v1.5`)
+ *
+ * Air-gap mode (DEC-1123-CONDITIONAL-OFFLINE-PIN-001):
+ *   Pass `options.airgapped = true` to force offline pin, or rely on the
+ *   `YAKCC_AIRGAPPED=1` env var. When pinned and the model is not cached,
+ *   the returned provider throws on the first embed() call with a message
+ *   containing "bge model not cached; provision it for air-gap".
  */
 export function createLocalEmbeddingProvider(
   modelId: string = (typeof process !== "undefined"
@@ -182,11 +247,18 @@ export function createLocalEmbeddingProvider(
       ? (process.env.DISCOVERY_EMBED_MODEL ?? LOCAL_MODEL_ID)
       : LOCAL_MODEL_ID,
   ) ?? LOCAL_DIMENSION,
+  options?: { airgapped?: boolean },
 ): EmbeddingProvider {
-  // Default model reuses the module-level singleton (DEC-EMBED-SINGLETON-CLOSURE-001).
-  // Custom models get a fresh per-instance closure so they don't share pipeline state.
+  // Effective air-gap mode: explicit option takes precedence over env var.
+  const useAirgap = options?.airgapped ?? isAirgapMode();
+
+  // Default model in online mode reuses the module-level singleton (DEC-EMBED-SINGLETON-CLOSURE-001).
+  // Air-gap mode always gets a per-instance loader so the pin does not contaminate
+  // the shared online singleton. Custom models also get per-instance loaders.
   const getLoader: () => Promise<unknown> =
-    modelId === LOCAL_MODEL_ID ? getPipeline : makePipelineLoader(modelId);
+    !useAirgap && modelId === LOCAL_MODEL_ID
+      ? getPipeline
+      : makePipelineLoader(modelId, useAirgap);
 
   return {
     dimension,


### PR DESCRIPTION
Supersedes #1127 (which was based on a stale pre-#1119 commit and conflicted with main's SeedResult). This branch is freshly based on current main (incl. #1119) and applies the verified-correct, reviewer-checked resolution.

## Problem
B6a (`pnpm bench:airgap`) was red on main:
- The seed/bootstrap **read** path used a null-zero embedding provider that mismatched the `bge-small-en-v1.5` bootstrap corpus (registry provider-consistency guard rejects it).
- The air-gap bench had **no offline pin**, so an uncached bge model fetched from HuggingFace (12 outbound connections in CI) on a cold runner.

## Fix (3 coordinated changes)
- **`packages/contracts/src/embeddings.ts`** — conditional offline pin: set `env.allowRemoteModels=false` **only** under air-gap (`YAKCC_AIRGAPPED=1` or the `{airgapped:true}` option), with a fail-loud `bge model not cached` error. Online callers (the cache-warm) are unaffected. `DEC-1123-CONDITIONAL-OFFLINE-PIN-001`.
- **`bench/B6-airgap/run.mjs`** — drop the offline stub injection; spawn children with `YAKCC_AIRGAPPED=1`; `warmBgeCache()` forces an online download via `createLocalEmbeddingProvider(..., { airgapped: false })` **before** the network interceptor installs, so the air-gap steps run against a warm cache.
- **`packages/cli/src/commands/seed-yakcc.ts`** — open the bootstrap with `createLocalEmbeddingProvider()` (bge-native), not the null-zero provider, so embeddings match the corpus provider-consistency guard. `DEC-1123-SEED-BGE-NATIVE-001`.

## Verification (local, full workspace)
- B6a: **7/7 steps, 0 outbound**, `BENCH RESULT: PASS`
- `@yakcc/contracts`: **384 passed** (incl. 2 new conditional-pin tests)
- `@yakcc/cli` seed/init: **90 passed**
- `pnpm -r build` + `pnpm lint` + `pnpm typecheck`: green (full workspace)

Closes #1123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)