### PR TITLE
feat(discovery): #1117 Slice 2 — export-atom-index CLI (atoms.json + embeddings index + model stamp)

### DIFF
--- a/packages/cli/src/commands/export-atom-index.test.ts
+++ b/packages/cli/src/commands/export-atom-index.test.ts
@@ -1,0 +1,789 @@
+// SPDX-License-Identifier: MIT
+//
+// export-atom-index.test.ts — T1–T6 integration tests for `yakcc export-atom-index`
+//
+// Production sequence exercised:
+//   1. Run exportAtomIndex() against the bootstrap corpus (via corpusPath override).
+//   2. Assert atoms.json exists with correct count, schema, and model stamp.
+//   3. Assert embeddings.json exists with correct count, dimension, alignment, and model stamp.
+//   4. Verify vector integrity and specHash alignment (index-aligned invariant).
+//   5. Verify Slice-1 fit: cosine self-match (mirrors rankCandidates) + determinism.
+//   6. Verify fail-loud: missing corpus → exit code 1, no silent output.
+//
+// T1–T3 and T6 use the real bootstrap corpus (skipped when absent, e.g. bare CI).
+// T4 and T5 fast paths use a small fixture registry (3 blocks) to keep CI fast.
+// T5 corpus smoke test (self-match on atom 0): gated on BOOTSTRAP_CORPUS_PATH.
+//
+// @decision DEC-1117-S2-TEST-001
+// @title T1–T6 vitest suite exercises the export-atom-index production sequence
+// @status decided (WI-1117 Slice 2)
+// @rationale
+//   The exporter's corpusPath injection seam lets us point at the real bootstrap
+//   corpus from any worktree path. Fast-path tests (T4, T5 fixture) use an in-
+//   memory registry with a deterministic mock provider to avoid ONNX loading.
+//   The corpus-backed tests confirm production output shape and counts without
+//   mocking internal state. T5 implements the Slice-1 fit check via an inline
+//   cosine rank helper (see rankCandidatesInline) that mirrors the production
+//   @yakcc/discovery-search rankCandidates contract:
+//     rankCandidates(queryVec: Float32Array, atomVectors: Float32Array[], topK?)
+//     → { ranked: RankedResult[], tier } where RankedResult = {index, score, band}
+//   This avoids a cross-package relative import that would violate the CLI
+//   tsconfig rootDir constraint (search.ts is outside packages/cli/src).
+//   The inline helper uses the same cosine formula and produces identical
+//   rankings on the fixture corpus — verified manually against the production impl.
+
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  type EmbeddingProvider,
+  type ProofManifest,
+  type SpecYak,
+  blockMerkleRoot,
+  canonicalize,
+  canonicalAstHash as deriveCanonicalAstHash,
+  specHash as deriveSpecHash,
+} from "@yakcc/contracts";
+import { type BlockTripletRow, openRegistry } from "@yakcc/registry";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CollectingLogger } from "../index.js";
+import { exportAtomIndex } from "./export-atom-index.js";
+
+// ---------------------------------------------------------------------------
+// Bootstrap corpus path resolution (same pattern as seed-yakcc.test.ts)
+// ---------------------------------------------------------------------------
+
+function resolveBootstrapCorpusPath(): string | null {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 30; i++) {
+    const candidate = join(dir, "bootstrap", "yakcc.registry.sqlite");
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+const BOOTSTRAP_CORPUS_PATH = resolveBootstrapCorpusPath();
+
+// ---------------------------------------------------------------------------
+// BGE-matching stub provider
+//
+// Matches the bootstrap corpus stored modelId (Xenova/bge-small-en-v1.5) without
+// loading the real ONNX model. The exporter reads stored vectors — it never calls
+// embed() on the source corpus; the provider is only required to satisfy the
+// openRegistry model-id check. Offline safe.
+// ---------------------------------------------------------------------------
+
+const bgeStubEmbeddings = {
+  modelId: "Xenova/bge-small-en-v1.5",
+  dimension: 384,
+  async embed(_text: string): Promise<Float32Array> {
+    return new Float32Array(384);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Mock embedding provider for fixture registries
+//
+// Deterministic 384-dim vectors from char-code hash. Used for T4/T5 fast paths
+// and T6 fixture. No ONNX loading.
+// ---------------------------------------------------------------------------
+
+function makeMockProvider(modelId = "mock/export-test"): EmbeddingProvider {
+  return {
+    dimension: 384,
+    modelId,
+    async embed(text: string): Promise<Float32Array> {
+      const vec = new Float32Array(384);
+      for (let i = 0; i < 384; i++) {
+        vec[i] = (text.charCodeAt(i % text.length) / 128 + i * 0.001) % 1;
+      }
+      return vec;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Inline cosine rank helper — mirrors @yakcc/discovery-search rankCandidates
+//
+// This is a test-local mirror of the production rankCandidates function from
+// packages/discovery-search/src/search.ts. It implements the same:
+//   - O(n) linear cosine scan
+//   - combinedScore formula: (1 + sim) / 2 (valid for unit-norm vectors)
+//   - sort descending by combinedScore
+//   - RankedResult shape: { index, score, band }
+//
+// Used in T5 to verify Slice-1 fit (cosine self-match invariant) without
+// introducing a cross-package relative import that violates CLI tsconfig rootDir.
+//
+// Mirror fidelity: the formula is equivalent to the production impl's
+//   cosineDistanceToCombinedScore(sqrt(2 - 2*sim)) = 1 - (2-2*sim)/4 = (1+sim)/2.
+//
+// @decision DEC-1117-S2-TEST-002
+// @title Inline cosine rank in test — avoids rootDir violation for Slice-1 fit check
+// @status decided (WI-1117 Slice 2)
+// @rationale
+//   @yakcc/discovery-search is not in CLI's tsconfig references. A relative import
+//   to discovery-search/src/search.ts violates rootDir and breaks pnpm -r build.
+//   Adding the dep+alias+reference is a non-trivial config change that widens
+//   CLI's dependency surface. The inline helper proves the same behavioral
+//   invariant (self-match under cosine similarity) with zero new production deps.
+// ---------------------------------------------------------------------------
+
+interface RankedResultInline {
+  readonly index: number;
+  readonly score: number;
+  readonly band: string;
+}
+
+/**
+ * Cosine-rank queryVec against atomVectors. Returns results sorted descending
+ * by combinedScore, which equals (1 + cosineSimilarity) / 2 for unit-norm vecs.
+ * Mirrors the contract of @yakcc/discovery-search rankCandidates.
+ */
+function rankCandidatesInline(
+  queryVec: Float32Array,
+  atomVectors: readonly Float32Array[],
+): { ranked: readonly RankedResultInline[] } {
+  const dim = queryVec.length;
+  const results: RankedResultInline[] = [];
+
+  for (let i = 0; i < atomVectors.length; i++) {
+    const vec = atomVectors[i];
+    if (vec === undefined || vec.length !== dim) continue;
+
+    let dot = 0;
+    let normQ = 0;
+    let normA = 0;
+    for (let j = 0; j < dim; j++) {
+      const q = queryVec[j] ?? 0;
+      const a = vec[j] ?? 0;
+      dot += q * a;
+      normQ += q * q;
+      normA += a * a;
+    }
+    const denom = Math.sqrt(normQ) * Math.sqrt(normA);
+    const sim = denom === 0 ? 0 : dot / denom;
+    // combinedScore = (1 + sim) / 2, same as cosineDistanceToCombinedScore(sqrt(2-2*sim))
+    const score = (1 + sim) / 2;
+    // band: mirrors production assignScoreBand from packages/discovery-search/src/score.ts
+    // (DEC-1117-S2-TEST-002): strong>=0.85, confident>=0.70, weak>=0.50, poor<0.50
+    const band =
+      score >= 0.85 ? "strong" : score >= 0.7 ? "confident" : score >= 0.5 ? "weak" : "poor";
+
+    results.push({ index: i, score, band });
+  }
+
+  results.sort((a, b) => b.score - a.score);
+  return { ranked: results };
+}
+
+// ---------------------------------------------------------------------------
+// Fixture factory — minimal BlockTripletRow (same pattern as export-embeddings.test.ts)
+// ---------------------------------------------------------------------------
+
+function makeSpec(name: string, behavior = `Compute ${name}`): SpecYak {
+  return {
+    name,
+    behavior,
+    inputs: [{ name: "x", type: "number" }],
+    outputs: [{ name: "result", type: "number" }],
+    preconditions: [],
+    postconditions: [],
+    invariants: [],
+    effects: [],
+    level: "L0",
+    nonFunctional: { purity: "pure", threadSafety: "safe" },
+  };
+}
+
+function makeRow(spec: SpecYak, implSuffix = ""): BlockTripletRow {
+  const manifest: ProofManifest = { artifacts: [] };
+  const artifacts = new Map<string, Uint8Array>();
+  const implSrc = `export function ${spec.name.replace(/-/g, "_")}(x: number): number { return x; }${implSuffix}`;
+  const bmr = blockMerkleRoot({ spec, implSource: implSrc, manifest, artifacts });
+  const sHash = deriveSpecHash(spec);
+  const specBytes = canonicalize(spec as Parameters<typeof canonicalize>[0]);
+  return {
+    blockMerkleRoot: bmr,
+    specHash: sHash,
+    specCanonicalBytes: specBytes,
+    implSource: implSrc,
+    proofManifestJson: JSON.stringify(manifest),
+    level: "L0",
+    createdAt: Date.now(),
+    canonicalAstHash: deriveCanonicalAstHash(implSrc),
+    parentBlockRoot: null,
+    artifacts,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Suite lifecycle — shared temp dir for test output
+// ---------------------------------------------------------------------------
+
+let suiteDir: string;
+
+beforeAll(() => {
+  suiteDir = mkdtempSync(join(tmpdir(), "yakcc-export-atom-index-test-"));
+});
+
+afterAll(() => {
+  try {
+    rmSync(suiteDir, { recursive: true, force: true });
+  } catch {
+    // Non-fatal cleanup.
+  }
+});
+
+// ---------------------------------------------------------------------------
+// T1 — outputs + counts (corpus-backed)
+//
+// Run exportAtomIndex against the bootstrap corpus. Assert:
+//   - atoms.json exists with .atoms.length === 4829
+//   - embeddings.json exists with .count === 4829 and .vectors.length === 4829
+// ---------------------------------------------------------------------------
+
+describe.skipIf(BOOTSTRAP_CORPUS_PATH === null)(
+  "T1 — outputs and counts (bootstrap corpus)",
+  () => {
+    let outDir: string;
+    let exitCode: number;
+
+    beforeAll(async () => {
+      outDir = join(suiteDir, "t1-out");
+      const logger = new CollectingLogger();
+      exitCode = await exportAtomIndex(["--out", outDir], logger, {
+        embeddings: bgeStubEmbeddings,
+        corpusPath: BOOTSTRAP_CORPUS_PATH as string,
+      });
+    }, 120_000);
+
+    it("handler exits with code 0", () => {
+      expect(exitCode).toBe(0);
+    });
+
+    it("atoms.json is written", () => {
+      expect(existsSync(join(outDir, "atoms.json"))).toBe(true);
+    });
+
+    it("embeddings.json is written", () => {
+      expect(existsSync(join(outDir, "embeddings.json"))).toBe(true);
+    });
+
+    it("atoms.json.atoms.length === 4829", () => {
+      const raw = readFileSync(join(outDir, "atoms.json"), "utf-8");
+      const parsed = JSON.parse(raw) as { atoms: unknown[] };
+      expect(parsed.atoms.length).toBe(4829);
+    });
+
+    it("embeddings.json.count === 4829 and .vectors.length === 4829", () => {
+      const raw = readFileSync(join(outDir, "embeddings.json"), "utf-8");
+      const parsed = JSON.parse(raw) as { count: number; vectors: unknown[] };
+      expect(parsed.count).toBe(4829);
+      expect(parsed.vectors.length).toBe(4829);
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
+// T2 — atom card schema (corpus-backed)
+//
+// Each atom has MUST fields with correct types. No license/root keys present.
+// ---------------------------------------------------------------------------
+
+describe.skipIf(BOOTSTRAP_CORPUS_PATH === null)("T2 — atom card schema (bootstrap corpus)", () => {
+  let outDir: string;
+  const VALID_LEVELS = new Set(["L0", "L1", "L2", "L3"]);
+
+  beforeAll(async () => {
+    outDir = join(suiteDir, "t2-out");
+    const logger = new CollectingLogger();
+    await exportAtomIndex(["--out", outDir], logger, {
+      embeddings: bgeStubEmbeddings,
+      corpusPath: BOOTSTRAP_CORPUS_PATH as string,
+    });
+  }, 120_000);
+
+  it("every atom has required string fields with correct types", () => {
+    const raw = readFileSync(join(outDir, "atoms.json"), "utf-8");
+    const parsed = JSON.parse(raw) as {
+      atoms: Array<{
+        specHash: unknown;
+        blockMerkleRoot: unknown;
+        name: unknown;
+        behavior: unknown;
+        level: unknown;
+        signature: { inputs: unknown[]; outputs: unknown[] };
+        nonFunctional: {
+          purity: unknown;
+          threadSafety: unknown;
+          time: unknown;
+          space: unknown;
+        };
+        source: { pkg: unknown; file: unknown };
+      }>;
+    };
+
+    for (const atom of parsed.atoms) {
+      // specHash
+      expect(typeof atom.specHash).toBe("string");
+      expect((atom.specHash as string).length).toBeGreaterThan(0);
+      // blockMerkleRoot
+      expect(typeof atom.blockMerkleRoot).toBe("string");
+      expect((atom.blockMerkleRoot as string).length).toBeGreaterThan(0);
+      // name
+      expect(typeof atom.name).toBe("string");
+      // behavior: string or null
+      expect(atom.behavior === null || typeof atom.behavior === "string").toBe(true);
+      // level
+      expect(VALID_LEVELS.has(atom.level as string)).toBe(true);
+      // signature.inputs / outputs — arrays of {name, type}
+      expect(Array.isArray(atom.signature.inputs)).toBe(true);
+      expect(Array.isArray(atom.signature.outputs)).toBe(true);
+      for (const p of [...atom.signature.inputs, ...atom.signature.outputs]) {
+        const param = p as { name: unknown; type: unknown };
+        expect(typeof param.name).toBe("string");
+        expect(typeof param.type).toBe("string");
+      }
+      // nonFunctional
+      expect(typeof atom.nonFunctional.purity).toBe("string");
+      expect(typeof atom.nonFunctional.threadSafety).toBe("string");
+      expect(atom.nonFunctional.time === null || typeof atom.nonFunctional.time === "string").toBe(
+        true,
+      );
+      expect(
+        atom.nonFunctional.space === null || typeof atom.nonFunctional.space === "string",
+      ).toBe(true);
+      // source
+      expect(atom.source.pkg === null || typeof atom.source.pkg === "string").toBe(true);
+      expect(atom.source.file === null || typeof atom.source.file === "string").toBe(true);
+    }
+  });
+
+  it("no atom has license or root keys", () => {
+    const raw = readFileSync(join(outDir, "atoms.json"), "utf-8");
+    const parsed = JSON.parse(raw) as { atoms: Array<Record<string, unknown>> };
+    for (const atom of parsed.atoms) {
+      expect(Object.prototype.hasOwnProperty.call(atom, "license")).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(atom, "root")).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T3 — model stamp (corpus-backed)
+//
+// atoms.json.model.id === embeddings.json.model.id === "Xenova/bge-small-en-v1.5"
+// Both dimension fields === 384.
+// ---------------------------------------------------------------------------
+
+describe.skipIf(BOOTSTRAP_CORPUS_PATH === null)("T3 — model stamp (bootstrap corpus)", () => {
+  let outDir: string;
+
+  beforeAll(async () => {
+    outDir = join(suiteDir, "t3-out");
+    const logger = new CollectingLogger();
+    await exportAtomIndex(["--out", outDir], logger, {
+      embeddings: bgeStubEmbeddings,
+      corpusPath: BOOTSTRAP_CORPUS_PATH as string,
+    });
+  }, 120_000);
+
+  it("atoms.json.model.id === Xenova/bge-small-en-v1.5", () => {
+    const raw = readFileSync(join(outDir, "atoms.json"), "utf-8");
+    const parsed = JSON.parse(raw) as { model: { id: string; dimension: number } };
+    expect(parsed.model.id).toBe("Xenova/bge-small-en-v1.5");
+  });
+
+  it("atoms.json.model.dimension === 384", () => {
+    const raw = readFileSync(join(outDir, "atoms.json"), "utf-8");
+    const parsed = JSON.parse(raw) as { model: { id: string; dimension: number } };
+    expect(parsed.model.dimension).toBe(384);
+  });
+
+  it("embeddings.json.model.id === Xenova/bge-small-en-v1.5", () => {
+    const raw = readFileSync(join(outDir, "embeddings.json"), "utf-8");
+    const parsed = JSON.parse(raw) as { model: { id: string; dimension: number } };
+    expect(parsed.model.id).toBe("Xenova/bge-small-en-v1.5");
+  });
+
+  it("embeddings.json.model.dimension === 384", () => {
+    const raw = readFileSync(join(outDir, "embeddings.json"), "utf-8");
+    const parsed = JSON.parse(raw) as { model: { id: string; dimension: number } };
+    expect(parsed.model.dimension).toBe(384);
+  });
+
+  it("atoms.json.model === embeddings.json.model (same id and dimension)", () => {
+    const atomsRaw = readFileSync(join(outDir, "atoms.json"), "utf-8");
+    const embeddingsRaw = readFileSync(join(outDir, "embeddings.json"), "utf-8");
+    const atomsParsed = JSON.parse(atomsRaw) as { model: { id: string; dimension: number } };
+    const embeddingsParsed = JSON.parse(embeddingsRaw) as {
+      model: { id: string; dimension: number };
+    };
+    expect(atomsParsed.model.id).toBe(embeddingsParsed.model.id);
+    expect(atomsParsed.model.dimension).toBe(embeddingsParsed.model.dimension);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T4 — vector integrity + alignment (fixture registry, fast path)
+//
+// Uses a small 3-block fixture registry with a mock provider.
+// Asserts:
+//   - every vector length === 384
+//   - atoms[i].specHash === vectors[i].specHash for all i (index-aligned)
+//   - Set(atoms.specHash) === Set(vectors.specHash) (no orphans)
+//   - both ASC by specHash
+// ---------------------------------------------------------------------------
+
+describe("T4 — vector integrity and alignment (fixture registry)", () => {
+  let outDir: string;
+  let fixtureDbPath: string;
+  let fixtureDir: string;
+
+  beforeAll(async () => {
+    fixtureDir = mkdtempSync(join(tmpdir(), "yakcc-export-fixture-"));
+    fixtureDbPath = join(fixtureDir, "fixture.sqlite");
+    outDir = join(fixtureDir, "t4-out");
+
+    // Build a 3-block fixture registry with mock provider
+    const provider = makeMockProvider();
+    const reg = await openRegistry(fixtureDbPath, { embeddings: provider });
+
+    const specs = [
+      makeSpec("alphaFn", "Compute alpha value"),
+      makeSpec("betaFn", "Compute beta value"),
+      makeSpec("gammaFn", "Compute gamma value"),
+    ];
+    for (const spec of specs) {
+      await reg.storeBlock(makeRow(spec));
+    }
+    await reg.close();
+
+    // Export using the fixture corpus and mock provider
+    const logger = new CollectingLogger();
+    await exportAtomIndex(["--out", outDir], logger, {
+      embeddings: provider,
+      corpusPath: fixtureDbPath,
+    });
+  }, 30_000);
+
+  afterAll(() => {
+    try {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    } catch {
+      // Non-fatal cleanup.
+    }
+  });
+
+  it("every vector has length === 384", () => {
+    const raw = readFileSync(join(outDir, "embeddings.json"), "utf-8");
+    const parsed = JSON.parse(raw) as {
+      vectors: Array<{ specHash: string; vector: number[] }>;
+    };
+    expect(parsed.vectors.length).toBeGreaterThan(0);
+    for (const entry of parsed.vectors) {
+      expect(entry.vector.length).toBe(384);
+    }
+  });
+
+  it("atoms and vectors are index-aligned: atoms[i].specHash === vectors[i].specHash", () => {
+    const atomsRaw = readFileSync(join(outDir, "atoms.json"), "utf-8");
+    const embeddingsRaw = readFileSync(join(outDir, "embeddings.json"), "utf-8");
+    const atoms = (JSON.parse(atomsRaw) as { atoms: Array<{ specHash: string }> }).atoms;
+    const vectors = (JSON.parse(embeddingsRaw) as { vectors: Array<{ specHash: string }> }).vectors;
+
+    expect(atoms.length).toBe(vectors.length);
+    for (let i = 0; i < atoms.length; i++) {
+      expect(atoms[i]?.specHash).toBe(vectors[i]?.specHash);
+    }
+  });
+
+  it("no orphan specHashes: Set(atoms.specHash) === Set(vectors.specHash)", () => {
+    const atomsRaw = readFileSync(join(outDir, "atoms.json"), "utf-8");
+    const embeddingsRaw = readFileSync(join(outDir, "embeddings.json"), "utf-8");
+    const atomHashes = new Set(
+      (JSON.parse(atomsRaw) as { atoms: Array<{ specHash: string }> }).atoms.map((a) => a.specHash),
+    );
+    const vectorHashes = new Set(
+      (JSON.parse(embeddingsRaw) as { vectors: Array<{ specHash: string }> }).vectors.map(
+        (v) => v.specHash,
+      ),
+    );
+
+    expect(atomHashes).toEqual(vectorHashes);
+  });
+
+  it("atoms are sorted ASC by specHash", () => {
+    const raw = readFileSync(join(outDir, "atoms.json"), "utf-8");
+    const atoms = (JSON.parse(raw) as { atoms: Array<{ specHash: string }> }).atoms;
+    for (let i = 1; i < atoms.length; i++) {
+      const prev = atoms[i - 1]?.specHash ?? "";
+      const curr = atoms[i]?.specHash ?? "";
+      expect(prev < curr).toBe(true);
+    }
+  });
+
+  it("vectors are sorted ASC by specHash", () => {
+    const raw = readFileSync(join(outDir, "embeddings.json"), "utf-8");
+    const vectors = (JSON.parse(raw) as { vectors: Array<{ specHash: string }> }).vectors;
+    for (let i = 1; i < vectors.length; i++) {
+      const prev = vectors[i - 1]?.specHash ?? "";
+      const curr = vectors[i]?.specHash ?? "";
+      expect(prev < curr).toBe(true);
+    }
+  });
+
+  it("fixture: 3 distinct specs → 3 atoms and 3 vectors", () => {
+    const atomsRaw = readFileSync(join(outDir, "atoms.json"), "utf-8");
+    const embeddingsRaw = readFileSync(join(outDir, "embeddings.json"), "utf-8");
+    const atoms = (JSON.parse(atomsRaw) as { atoms: unknown[] }).atoms;
+    const vectors = (JSON.parse(embeddingsRaw) as { count: number }).count;
+    expect(atoms.length).toBe(3);
+    expect(vectors).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T5 — Slice-1 fit + determinism (fixture registry, fast path)
+//
+// Uses a small 3-block fixture registry with a mock provider. No ONNX loading.
+//
+// Slice-1 fit check uses rankCandidatesInline (see top of file), which mirrors
+// the @yakcc/discovery-search rankCandidates contract. This avoids a cross-
+// package relative import that would violate CLI tsconfig rootDir (DEC-1117-S2-TEST-002).
+//
+// Assertions:
+//   - For each atom k, rankCandidatesInline(vectors[k], allVectors) top-1.index === k.
+//     (Self-match: the mock provider gives each spec a unique deterministic vector,
+//      so every atom's own vector is its nearest neighbor.)
+//   - RankedResult shape: {index: number, score: number, band: string}
+//   - Determinism: two runs produce byte-identical atoms.json AND embeddings.json.
+// ---------------------------------------------------------------------------
+
+describe("T5 — Slice-1 fit and determinism (fixture registry)", () => {
+  let outDir: string;
+  let outDir2: string;
+  let fixtureDbPath: string;
+  let fixtureDir: string;
+
+  beforeAll(async () => {
+    fixtureDir = mkdtempSync(join(tmpdir(), "yakcc-export-t5-fixture-"));
+    fixtureDbPath = join(fixtureDir, "fixture.sqlite");
+    outDir = join(fixtureDir, "t5-out-run1");
+    outDir2 = join(fixtureDir, "t5-out-run2");
+
+    // Build a 3-block fixture registry. The mock provider's deterministic
+    // per-text vectors make each atom's embedding unique so self-match holds.
+    const provider = makeMockProvider();
+    const reg = await openRegistry(fixtureDbPath, { embeddings: provider });
+
+    const specs = [
+      makeSpec("hashFn", "Compute BLAKE3 hash of binary input"),
+      makeSpec("sortFn", "Sort an array of integers in ascending order"),
+      makeSpec("parseFn", "Parse a decimal string into a number"),
+    ];
+    for (const spec of specs) {
+      await reg.storeBlock(makeRow(spec));
+    }
+    await reg.close();
+
+    // Run exporter twice for determinism check
+    const logger1 = new CollectingLogger();
+    await exportAtomIndex(["--out", outDir], logger1, {
+      embeddings: provider,
+      corpusPath: fixtureDbPath,
+    });
+
+    const logger2 = new CollectingLogger();
+    await exportAtomIndex(["--out", outDir2], logger2, {
+      embeddings: provider,
+      corpusPath: fixtureDbPath,
+    });
+  }, 30_000);
+
+  afterAll(() => {
+    try {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    } catch {
+      // Non-fatal cleanup.
+    }
+  });
+
+  it("Slice-1 fit: top-1 self-match for each atom k (cosine rank via rankCandidatesInline)", () => {
+    const raw = readFileSync(join(outDir, "embeddings.json"), "utf-8");
+    const parsed = JSON.parse(raw) as {
+      vectors: Array<{ specHash: string; vector: number[] }>;
+    };
+
+    // Build Float32Array[] — the same type @yakcc/discovery-search's rankCandidates expects
+    const atomVectors: Float32Array[] = parsed.vectors.map((v) => Float32Array.from(v.vector));
+
+    // Self-match: for each atom k, its own vector must be the top-1 result.
+    // This proves the exported vectors are consumable by cosine search (Slice-1 fit).
+    for (let k = 0; k < atomVectors.length; k++) {
+      const queryVec = atomVectors[k];
+      if (queryVec === undefined) continue;
+      const result = rankCandidatesInline(queryVec, atomVectors);
+      const top1Index = result.ranked[0]?.index;
+      expect(top1Index).toBe(k);
+    }
+  });
+
+  it("RankedResult shape: {index: number, score: number, band: string}", () => {
+    const raw = readFileSync(join(outDir, "embeddings.json"), "utf-8");
+    const parsed = JSON.parse(raw) as {
+      vectors: Array<{ specHash: string; vector: number[] }>;
+    };
+    const atomVectors = parsed.vectors.map((v) => Float32Array.from(v.vector));
+
+    if (atomVectors.length === 0) return;
+    const result = rankCandidatesInline(atomVectors[0] as Float32Array, atomVectors);
+
+    expect(result.ranked.length).toBeGreaterThan(0);
+    const top = result.ranked[0];
+    if (top !== undefined) {
+      expect(typeof top.index).toBe("number");
+      expect(typeof top.score).toBe("number");
+      expect(typeof top.band).toBe("string");
+    }
+  });
+
+  it("atoms[i].specHash maps back to the self-match atom's specHash via the exported index", () => {
+    // Cross-reference: the index returned by the rank function maps back to the
+    // correct atom in atoms.json via the index alignment invariant (T4).
+    const atomsRaw = readFileSync(join(outDir, "atoms.json"), "utf-8");
+    const embeddingsRaw = readFileSync(join(outDir, "embeddings.json"), "utf-8");
+    const atoms = (JSON.parse(atomsRaw) as { atoms: Array<{ specHash: string }> }).atoms;
+    const vectors = (
+      JSON.parse(embeddingsRaw) as { vectors: Array<{ specHash: string; vector: number[] }> }
+    ).vectors;
+
+    const atomVectors: Float32Array[] = vectors.map((v) => Float32Array.from(v.vector));
+
+    for (let k = 0; k < atomVectors.length; k++) {
+      const queryVec = atomVectors[k];
+      if (queryVec === undefined) continue;
+      const result = rankCandidatesInline(queryVec, atomVectors);
+      const top1Index = result.ranked[0]?.index;
+      if (top1Index === undefined) continue;
+      // The atom at the top-1 index must have the same specHash as the query vector's specHash
+      expect(atoms[top1Index]?.specHash).toBe(vectors[k]?.specHash);
+    }
+  });
+
+  it("determinism: two runs produce byte-identical atoms.json", () => {
+    const a1 = readFileSync(join(outDir, "atoms.json"), "utf-8");
+    const a2 = readFileSync(join(outDir2, "atoms.json"), "utf-8");
+    expect(a1).toBe(a2);
+  });
+
+  it("determinism: two runs produce byte-identical embeddings.json", () => {
+    const e1 = readFileSync(join(outDir, "embeddings.json"), "utf-8");
+    const e2 = readFileSync(join(outDir2, "embeddings.json"), "utf-8");
+    expect(e1).toBe(e2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T5 corpus smoke test (self-match on atom 0 from the real bootstrap corpus)
+//
+// Uses the bootstrap corpus + bgeStubEmbeddings. Only verifies that atom 0
+// maps back to itself under cosine similarity — proves Slice-1 fit on real data.
+// Uses rankCandidatesInline (same contract as production rankCandidates).
+// ---------------------------------------------------------------------------
+
+describe.skipIf(BOOTSTRAP_CORPUS_PATH === null)(
+  "T5 corpus smoke — Slice-1 self-match on atom 0 (bootstrap corpus)",
+  () => {
+    let outDir: string;
+
+    beforeAll(async () => {
+      outDir = join(suiteDir, "t5-corpus-out");
+      const logger = new CollectingLogger();
+      await exportAtomIndex(["--out", outDir], logger, {
+        embeddings: bgeStubEmbeddings,
+        corpusPath: BOOTSTRAP_CORPUS_PATH as string,
+      });
+    }, 180_000);
+
+    it("atom 0 maps to itself under cosine rank (Slice-1 self-match on bootstrap corpus)", () => {
+      const raw = readFileSync(join(outDir, "embeddings.json"), "utf-8");
+      const parsed = JSON.parse(raw) as {
+        vectors: Array<{ specHash: string; vector: number[] }>;
+      };
+
+      expect(parsed.vectors.length).toBeGreaterThan(0);
+
+      // Use atom 0 as the query; top-1 must map back to index 0.
+      // (The bgeStubEmbeddings fills stored vectors from the real BGE-embedded corpus;
+      //  atom 0's own vector must be its nearest neighbor.)
+      const atomVectors: Float32Array[] = parsed.vectors.map((v) => Float32Array.from(v.vector));
+      const query = atomVectors[0];
+      if (query === undefined) throw new Error("No vectors in corpus output");
+
+      const result = rankCandidatesInline(query, atomVectors);
+      const top1Index = result.ranked[0]?.index;
+      expect(top1Index).toBe(0);
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
+// T6 — fail-loud: missing corpus → exit code 1
+//
+// Missing corpus path (non-existent file via corpusPath injection) must:
+//   - return exit code 1
+//   - log an error message (never silent)
+//   - produce no output files (no silent empty output)
+// ---------------------------------------------------------------------------
+
+describe("T6 — fail-loud: missing corpus path", () => {
+  it("returns exit code 1 and logs error when corpusPath does not exist", async () => {
+    const outDir = join(suiteDir, "t6-out");
+    const logger = new CollectingLogger();
+
+    const exitCode = await exportAtomIndex(["--out", outDir], logger, {
+      embeddings: bgeStubEmbeddings,
+      corpusPath: join(suiteDir, "nonexistent-corpus.sqlite"),
+    });
+
+    expect(exitCode).toBe(1);
+    // At least one error line must have been emitted
+    expect(logger.errLines.length).toBeGreaterThan(0);
+    // No output files should have been written (no silent empty output)
+    expect(existsSync(join(outDir, "atoms.json"))).toBe(false);
+    expect(existsSync(join(outDir, "embeddings.json"))).toBe(false);
+  });
+
+  it("returns exit code 1 with informative error for a second distinct missing path", async () => {
+    // Belt-and-suspenders: verify the fail-loud contract with a different path.
+    const outDir = join(suiteDir, "t6-null-out");
+    const logger = new CollectingLogger();
+
+    const exitCode = await exportAtomIndex(["--out", outDir], logger, {
+      embeddings: bgeStubEmbeddings,
+      corpusPath: join(suiteDir, "definitely-missing.sqlite"),
+    });
+
+    expect(exitCode).toBe(1);
+  });
+
+  it("error output contains informative message with 'error:' prefix", async () => {
+    const outDir = join(suiteDir, "t6-msg-out");
+    const logger = new CollectingLogger();
+    await exportAtomIndex(["--out", outDir], logger, {
+      embeddings: bgeStubEmbeddings,
+      corpusPath: join(suiteDir, "missing-corpus.sqlite"),
+    });
+
+    const allErrors = logger.errLines.join("\n");
+    // The error message must reference the corpus path issue
+    expect(allErrors.length).toBeGreaterThan(0);
+    expect(allErrors).toContain("error:");
+  });
+});

--- a/packages/cli/src/commands/export-atom-index.ts
+++ b/packages/cli/src/commands/export-atom-index.ts
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: MIT
+//
+// export-atom-index.ts — handler for `yakcc export-atom-index`
+//
+// Emits two static JSON files from the bootstrap corpus:
+//   atoms.json    — one card per distinct spec_hash (4829 for the bootstrap corpus)
+//   embeddings.json — one 384-dim vector per spec_hash, index-aligned to atoms.json
+//
+// Both files carry a model stamp (Xenova/bge-small-en-v1.5, dimension 384) so
+// the browser-side consumer can verify it uses the same model for query embedding.
+//
+// The output is consumable by @yakcc/discovery-search's rankCandidates():
+//   rankCandidates(queryVec, vectors.map(v => Float32Array.from(v.vector)))
+//   → RankedResult.index → atoms[index]
+//
+// @decision DEC-1117-S2-EXPORTER-001
+// @title CLI command (not .mjs) for vitest-testability + corpus-path reuse
+// @status decided (WI-1117 Slice 2)
+// @rationale
+//   A CLI command is vitest-testable via runCli() / the command handler directly,
+//   consistent with seed-yakcc.ts, and reuses the proven corpus-resolution +
+//   registry-open path. A standalone .mjs script cannot be imported by vitest's
+//   module resolver in the same way and would require a separate test harness.
+//   The command shares findBootstrapSqlite() (copied here for isolation —
+//   acceptable for the first cut per the plan) and openRegistry with the
+//   local embedding provider (DEC-1123-SEED-BGE-NATIVE-001).
+
+// @decision DEC-1117-S2-EXPORTER-002
+// @title Two output files: atoms.json + embeddings.json with shared specHash ordering
+// @status decided (WI-1117 Slice 2)
+// @rationale
+//   Card metadata (small, human-diffable, frontend renders eagerly) and the vector
+//   index (large, ~4829×384 floats, frontend may lazy-load) have different size and
+//   lifecycle profiles. Splitting lets the explorer fetch cards first and vectors on
+//   demand. Both share the same ASC specHash ordering so the explorer can zip by index:
+//   atoms[i].specHash === vectors[i].specHash for all i (index-aligned invariant).
+
+// @decision DEC-1117-S2-CARD-001
+// @title MUST card fields from SpecYak+row; derived counts deferred behind --with-counts
+// @status decided (WI-1117 Slice 2)
+// @rationale
+//   First cut: MUST fields only — specHash, blockMerkleRoot, name, signature,
+//   behavior, level, nonFunctional, source. All are directly corpus-backed and
+//   verified. Derived counts (reuseCount, passingTestRuns, runtime exposure) require
+//   extra per-spec aggregation queries; gated behind --with-counts in a follow-up
+//   to keep the first cut tight and the exporter read-only without complex joins.
+
+// @decision DEC-1117-S2-CARD-002
+// @title license/root excluded — absent from registry schema; do not synthesize
+// @status decided (WI-1117 Slice 2)
+// @rationale
+//   Verification of the bootstrap corpus confirms: the blocks table has no
+//   license/root column; proof_manifest_json carries only artifacts. Including
+//   fabricated values would be a lie; omitting is the correct first cut.
+//   Recorded here as a NICE follow-up if a license/root authority is added.
+
+// @decision DEC-1117-S2-IDENTITY-001
+// @title Atom identity = spec_hash; representative block = lowest blockMerkleRoot
+// @status decided (WI-1117 Slice 2)
+// @rationale
+//   The corpus has 4904 blocks but only 4829 distinct spec_hashes — multiple
+//   implementations share one contract. The KNN read path (vec0 PK = spec_hash)
+//   already collapses to one embedding per spec. One card per spec_hash is the
+//   natural identity. For a spec with N blocks the lexicographically-lowest
+//   blockMerkleRoot is the representative (stable, content-addressed, deterministic).
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+import { createLocalEmbeddingProvider } from "@yakcc/contracts";
+import type { SpecYak } from "@yakcc/contracts";
+import { type RegistryOptions, openRegistry } from "@yakcc/registry";
+import type { Logger } from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Default output directory (repo tmp — Sacred Practice #3, never /tmp)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_OUT_DIR = "tmp/atom-index";
+
+// ---------------------------------------------------------------------------
+// findBootstrapSqlite — locate bootstrap/yakcc.registry.sqlite
+//
+// Copied from seed-yakcc.ts (acceptable for the first cut per plan §2 rationale).
+// Both walk from import.meta.url upward looking for bootstrap/yakcc.registry.sqlite.
+// This handles main checkout and git worktree layouts.
+// ---------------------------------------------------------------------------
+
+function findBootstrapSqlite(): string | null {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 30; i++) {
+    const candidate = join(dir, "bootstrap", "yakcc.registry.sqlite");
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Output schema types (internal; serialized to JSON)
+// ---------------------------------------------------------------------------
+
+/** One card in atoms.json.atoms. */
+interface AtomCard {
+  readonly specHash: string;
+  readonly blockMerkleRoot: string;
+  readonly name: string;
+  readonly signature: {
+    readonly inputs: ReadonlyArray<{ readonly name: string; readonly type: string }>;
+    readonly outputs: ReadonlyArray<{ readonly name: string; readonly type: string }>;
+  };
+  readonly behavior: string | null;
+  readonly level: "L0" | "L1" | "L2" | "L3";
+  readonly nonFunctional: {
+    readonly purity: string;
+    readonly threadSafety: string;
+    readonly time: string | null;
+    readonly space: string | null;
+  };
+  readonly source: {
+    readonly pkg: string | null;
+    readonly file: string | null;
+  };
+}
+
+/** atoms.json root shape. */
+interface AtomsJson {
+  readonly schemaVersion: 1;
+  readonly model: { readonly id: string; readonly dimension: number };
+  readonly corpus: { readonly atomCount: number; readonly source: string };
+  readonly atoms: readonly AtomCard[];
+}
+
+/** One entry in embeddings.json.vectors. */
+interface VectorEntry {
+  readonly specHash: string;
+  readonly vector: readonly number[];
+}
+
+/** embeddings.json root shape. */
+interface EmbeddingsJson {
+  readonly schemaVersion: 1;
+  readonly model: { readonly id: string; readonly dimension: number };
+  readonly count: number;
+  readonly vectors: readonly VectorEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Options interface
+// ---------------------------------------------------------------------------
+
+export interface ExportAtomIndexOptions {
+  /**
+   * Embedding provider override.
+   * Production: omit (uses createLocalEmbeddingProvider).
+   * Tests: pass bgeStubEmbeddings (matches stored modelId without loading ONNX).
+   */
+  embeddings?: RegistryOptions["embeddings"];
+  /**
+   * Override the corpus sqlite path.
+   * Production: omit (resolved by findBootstrapSqlite()).
+   * Tests (worktrees): pass the real path.
+   */
+  corpusPath?: string;
+}
+
+// ---------------------------------------------------------------------------
+// exportAtomIndex — main command handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handler for `yakcc export-atom-index [--out <dir>] [--corpus <path>]`.
+ *
+ * Opens the bootstrap corpus (read-only), reads all cards and embedding vectors,
+ * and emits atoms.json + embeddings.json to the output directory.
+ *
+ * Fail-loud contract:
+ *   - Missing corpus → non-zero exit, clear error message.
+ *   - Any vector dimension mismatch → throw (registry.exportAllEmbeddings tripwire).
+ *   - specHash set mismatch (orphan on either side) → throw (forbidden shortcut).
+ *   - No silent empty output.
+ *
+ * @param argv   - Remaining argv after `export-atom-index` has been consumed.
+ * @param logger - Output sink.
+ * @param opts   - Injection seams for tests (embeddings provider, corpus path).
+ * @returns Process exit code (0 success, 1 error).
+ */
+export async function exportAtomIndex(
+  argv: readonly string[],
+  logger: Logger,
+  opts?: ExportAtomIndexOptions,
+): Promise<number> {
+  // Parse arguments.
+  let parsedValues: {
+    out: string | undefined;
+    corpus: string | undefined;
+  };
+  try {
+    const { values } = parseArgs({
+      args: [...argv],
+      options: {
+        out: { type: "string" },
+        corpus: { type: "string" },
+      },
+      strict: true,
+      allowPositionals: false,
+    });
+    parsedValues = values as typeof parsedValues;
+  } catch (err) {
+    logger.error(`error: ${String(err)}`);
+    logger.error("Usage: yakcc export-atom-index [--out <dir>] [--corpus <path>]");
+    return 1;
+  }
+
+  const outDir = resolve(parsedValues.out ?? DEFAULT_OUT_DIR);
+
+  // Resolve corpus path. Fail loud if missing.
+  // opts.corpusPath is the injection seam for tests; production resolves automatically.
+  const corpusPath = opts?.corpusPath ?? parsedValues.corpus ?? findBootstrapSqlite();
+  if (corpusPath === null || !existsSync(corpusPath)) {
+    logger.error(
+      `error: bootstrap corpus not found at ${corpusPath ?? "(no path resolved)"}. Expected bootstrap/yakcc.registry.sqlite relative to the repo root. Use --corpus <path> to specify an alternative.`,
+    );
+    return 1;
+  }
+  const resolvedCorpus = resolve(corpusPath);
+
+  logger.log(`export-atom-index: opening corpus at ${resolvedCorpus}`);
+
+  // Open the corpus registry (read-only intent; openRegistry is always R/W but we don't mutate).
+  // Use the provided embeddings override or createLocalEmbeddingProvider() so the stored
+  // model ID matches (DEC-1123-SEED-BGE-NATIVE-001).
+  const embeddingsProvider = opts?.embeddings ?? createLocalEmbeddingProvider();
+
+  let registry: Awaited<ReturnType<typeof openRegistry>>;
+  try {
+    registry = await openRegistry(resolvedCorpus, { embeddings: embeddingsProvider });
+  } catch (err) {
+    logger.error(`error: failed to open corpus at ${resolvedCorpus}: ${String(err)}`);
+    return 1;
+  }
+
+  try {
+    // Read the model stamp from registry_meta — single authority (DEC-EMBED-REGISTRY-META-001).
+    const modelId = await registry.getStoredEmbeddingModelId();
+    const modelDimension = await registry.getStoredEmbeddingDimension();
+
+    if (modelId === null || modelDimension === null) {
+      logger.error(
+        "error: registry_meta has no embedding_model_id or embedding_dimension. The corpus may not have been embedded yet. Run `yakcc bootstrap` first.",
+      );
+      return 1;
+    }
+
+    logger.log(`export-atom-index: model=${modelId} dimension=${modelDimension}`);
+
+    // Read all embedding vectors via the registry authority (DEC-1117-S2-VECREAD-001).
+    // exportAllEmbeddings() returns ASC-by-spec_hash, length-validated entries.
+    logger.log("export-atom-index: reading embedding vectors...");
+    const embeddingRows = await registry.exportAllEmbeddings();
+    logger.log(`export-atom-index: ${embeddingRows.length} embedding vectors read`);
+
+    // Read all blocks via exportManifest → getBlock, collapsed to one card per spec_hash.
+    // Representative block = lexicographically-lowest blockMerkleRoot (DEC-1117-S2-IDENTITY-001).
+    logger.log("export-atom-index: reading block manifest...");
+    const manifest = await registry.exportManifest();
+    logger.log(`export-atom-index: ${manifest.length} block manifest entries`);
+
+    // Collapse blocks to one representative per spec_hash (lowest BMR).
+    // Map: specHash → { blockMerkleRoot, level, sourcePkg, sourceFile }
+    interface RepresentativeInfo {
+      blockMerkleRoot: string;
+      level: "L0" | "L1" | "L2" | "L3";
+      sourcePkg: string | null;
+      sourceFile: string | null;
+      specCanonicalBytes: Uint8Array;
+    }
+    const repBySpec = new Map<string, RepresentativeInfo>();
+
+    for (const entry of manifest) {
+      const existing = repBySpec.get(entry.specHash);
+      if (existing === undefined || entry.blockMerkleRoot < existing.blockMerkleRoot) {
+        // Hydrate the block to read level and source provenance.
+        const block = await registry.getBlock(
+          entry.blockMerkleRoot as import("@yakcc/contracts").BlockMerkleRoot,
+        );
+        if (block === null) {
+          // Fail loud — manifest entry without a corresponding block is corruption.
+          logger.error(
+            `error: manifest entry ${entry.blockMerkleRoot} not found in block table. The corpus may be corrupted.`,
+          );
+          return 1;
+        }
+        repBySpec.set(entry.specHash, {
+          blockMerkleRoot: entry.blockMerkleRoot,
+          level: block.level,
+          sourcePkg: block.sourcePkg ?? null,
+          sourceFile: block.sourceFile ?? null,
+          specCanonicalBytes: block.specCanonicalBytes,
+        });
+      }
+    }
+
+    logger.log(
+      `export-atom-index: collapsed to ${repBySpec.size} distinct spec_hashes (from ${manifest.length} blocks)`,
+    );
+
+    // Build the cards array — one per spec_hash, ASC by spec_hash.
+    // Sort the representative keys to guarantee deterministic ordering.
+    const sortedSpecHashes = Array.from(repBySpec.keys()).sort();
+
+    // Fail-loud join: assert every spec_hash in cards has an embedding and vice versa.
+    const embeddingSpecHashes = new Set(embeddingRows.map((e) => e.specHash));
+    const cardSpecHashes = new Set(sortedSpecHashes);
+
+    for (const sh of cardSpecHashes) {
+      if (!embeddingSpecHashes.has(sh as import("@yakcc/contracts").SpecHash)) {
+        logger.error(
+          `error: spec_hash ${sh} has a card but no embedding vector. The corpus is inconsistent. Run \`yakcc registry rebuild\` or \`yakcc bootstrap\`.`,
+        );
+        return 1;
+      }
+    }
+    for (const sh of embeddingSpecHashes) {
+      if (!cardSpecHashes.has(sh)) {
+        logger.error(
+          `error: spec_hash ${sh} has an embedding vector but no block. The corpus is inconsistent.`,
+        );
+        return 1;
+      }
+    }
+
+    // Verify counts are identical (belt-and-suspenders after the set checks above).
+    if (embeddingRows.length !== sortedSpecHashes.length) {
+      logger.error(
+        `error: embedding count (${embeddingRows.length}) !== card count (${sortedSpecHashes.length}). The corpus is inconsistent.`,
+      );
+      return 1;
+    }
+
+    // Build cards in ASC spec_hash order.
+    const cards: AtomCard[] = [];
+    for (const specHash of sortedSpecHashes) {
+      const rep = repBySpec.get(specHash);
+      if (rep === undefined) {
+        // Should never happen after the join above.
+        logger.error(`error: internal inconsistency: no representative for specHash=${specHash}`);
+        return 1;
+      }
+
+      // Parse the spec from stored canonical bytes.
+      // Precedent: storage.ts ~302 uses the same JSON.parse pattern.
+      const spec = JSON.parse(Buffer.from(rep.specCanonicalBytes).toString("utf-8")) as SpecYak;
+
+      cards.push({
+        specHash,
+        blockMerkleRoot: rep.blockMerkleRoot,
+        name: spec.name,
+        signature: {
+          inputs: (spec.inputs ?? []).map((p) => ({ name: p.name, type: p.type })),
+          outputs: (spec.outputs ?? []).map((p) => ({ name: p.name, type: p.type })),
+        },
+        behavior: spec.behavior ?? null,
+        level: rep.level,
+        nonFunctional: {
+          purity: spec.nonFunctional?.purity ?? "pure",
+          threadSafety: spec.nonFunctional?.threadSafety ?? "safe",
+          time: spec.nonFunctional?.time ?? null,
+          space: spec.nonFunctional?.space ?? null,
+        },
+        source: {
+          pkg: rep.sourcePkg,
+          file: rep.sourceFile,
+        },
+      });
+    }
+
+    // Build vectors array — ASC by spec_hash (embeddingRows is already sorted ASC
+    // by spec_hash via exportAllEmbeddings ORDER BY spec_hash ASC).
+    // We must emit them in the same sorted order as cards for index-alignment.
+    const vectorMap = new Map(embeddingRows.map((e) => [e.specHash, e.vector]));
+    const vectors: VectorEntry[] = sortedSpecHashes.map((specHash) => ({
+      specHash,
+      vector: vectorMap.get(specHash as import("@yakcc/contracts").SpecHash) ?? [],
+    }));
+
+    // Assemble output objects with fixed key order for deterministic JSON.stringify.
+    const model = { id: modelId, dimension: modelDimension };
+    const corpusRelative = resolvedCorpus.includes("bootstrap")
+      ? "bootstrap/yakcc.registry.sqlite"
+      : resolvedCorpus;
+
+    const atomsJson: AtomsJson = {
+      schemaVersion: 1,
+      model,
+      corpus: { atomCount: cards.length, source: corpusRelative },
+      atoms: cards,
+    };
+
+    const embeddingsJson: EmbeddingsJson = {
+      schemaVersion: 1,
+      model,
+      count: vectors.length,
+      vectors,
+    };
+
+    // Write output files.
+    mkdirSync(outDir, { recursive: true });
+
+    const atomsPath = join(outDir, "atoms.json");
+    const embeddingsPath = join(outDir, "embeddings.json");
+
+    writeFileSync(atomsPath, `${JSON.stringify(atomsJson, null, 2)}\n`, "utf-8");
+    writeFileSync(embeddingsPath, `${JSON.stringify(embeddingsJson, null, 2)}\n`, "utf-8");
+
+    logger.log(`export-atom-index: wrote ${cards.length} atoms → ${atomsPath}`);
+    logger.log(`export-atom-index: wrote ${vectors.length} vectors → ${embeddingsPath}`);
+    logger.log("export-atom-index: done");
+
+    return 0;
+  } finally {
+    await registry.close();
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -41,6 +41,7 @@ import { build } from "./commands/build.js";
 import { compileSelf } from "./commands/compile-self.js";
 import { compile } from "./commands/compile.js";
 import { emitAtom } from "./commands/emit-atom.js";
+import { exportAtomIndex } from "./commands/export-atom-index.js";
 import { runFederation } from "./commands/federation.js";
 import { hookIntercept } from "./commands/hook-intercept.js";
 import { hooksAiderInstall } from "./commands/hooks-aider-install.js";
@@ -341,6 +342,15 @@ export async function runCli(
     case "propose": {
       const proposeArgv = subcommand !== undefined ? [subcommand, ...rest] : rest;
       return propose(proposeArgv, logger, { embeddings: opts?.embeddings });
+    }
+
+    case "export-atom-index": {
+      // `yakcc export-atom-index [--out <dir>] [--corpus <path>]`
+      // Emits atoms.json + embeddings.json from the bootstrap corpus.
+      // Consumer: yakforge atom-explorer frontend (separate repo).
+      // DEC-1117-S2-EXPORTER-001: CLI command for vitest-testability + corpus-path reuse.
+      const exportArgv = subcommand !== undefined ? [subcommand, ...rest] : rest;
+      return exportAtomIndex(exportArgv, logger, { embeddings: opts?.embeddings });
     }
 
     case "emit-atom": {

--- a/packages/compile/src/manifest.test.ts
+++ b/packages/compile/src/manifest.test.ts
@@ -243,6 +243,15 @@ function makeRegistryMock(rows: Map<BlockMerkleRoot, MockRowMeta>): Registry {
       _blockMerkleRoot: BlockMerkleRoot,
       _submittedAt: number,
     ): Promise<void> {},
+    // DEC-1117-S2-VECREAD-001: new read-back surface; not used by this mock.
+    async exportAllEmbeddings(): Promise<
+      ReadonlyArray<{
+        readonly specHash: import("@yakcc/contracts").SpecHash;
+        readonly vector: number[];
+      }>
+    > {
+      return [];
+    },
     async close(): Promise<void> {},
   };
 }

--- a/packages/hooks-base/test/index.test.ts
+++ b/packages/hooks-base/test/index.test.ts
@@ -384,6 +384,9 @@ describe("executeRegistryQuery — passthrough (error) path", () => {
       recreateEmbeddingsTable: registry.recreateEmbeddingsTable.bind(registry),
       listUnsubmittedBlocks: registry.listUnsubmittedBlocks.bind(registry),
       markBlockSubmitted: registry.markBlockSubmitted.bind(registry),
+      // Added: exportAllEmbeddings() added to Registry interface in WI-1117 Slice 2.
+      // Delegate to the real registry so the mock remains valid as the interface grows.
+      exportAllEmbeddings: registry.exportAllEmbeddings.bind(registry),
     };
 
     const ctx: EmissionContext = { intent: "some emission intent" };

--- a/packages/hooks-claude-code/test/adapter-telemetry.test.ts
+++ b/packages/hooks-claude-code/test/adapter-telemetry.test.ts
@@ -303,6 +303,8 @@ describe("T2: observe-don't-mutate — response unchanged under all 3 outcomes",
       recreateEmbeddingsTable: registry.recreateEmbeddingsTable.bind(registry),
       listUnsubmittedBlocks: registry.listUnsubmittedBlocks.bind(registry),
       markBlockSubmitted: registry.markBlockSubmitted.bind(registry),
+      // Added: exportAllEmbeddings() added to Registry interface in WI-1117 Slice 2.
+      exportAllEmbeddings: registry.exportAllEmbeddings.bind(registry),
     };
 
     const hook = createHook(brokenRegistry, {

--- a/packages/hooks-claude-code/test/index.test.ts
+++ b/packages/hooks-claude-code/test/index.test.ts
@@ -300,6 +300,8 @@ describe("onCodeEmissionIntent — passthrough (error) path", () => {
       recreateEmbeddingsTable: registry.recreateEmbeddingsTable.bind(registry),
       listUnsubmittedBlocks: registry.listUnsubmittedBlocks.bind(registry),
       markBlockSubmitted: registry.markBlockSubmitted.bind(registry),
+      // Added: exportAllEmbeddings() added to Registry interface in WI-1117 Slice 2.
+      exportAllEmbeddings: registry.exportAllEmbeddings.bind(registry),
     };
 
     const hook = createHook(brokenRegistry, { telemetryDir: testTelemetryDir });

--- a/packages/hooks-cline/test/adapter-telemetry.test.ts
+++ b/packages/hooks-cline/test/adapter-telemetry.test.ts
@@ -290,6 +290,8 @@ describe("T2: observe-don't-mutate — response unchanged under all 3 outcomes",
         recreateEmbeddingsTable: registry.recreateEmbeddingsTable.bind(registry),
         listUnsubmittedBlocks: registry.listUnsubmittedBlocks.bind(registry),
         markBlockSubmitted: registry.markBlockSubmitted.bind(registry),
+        // Added: exportAllEmbeddings() added to Registry interface in WI-1117 Slice 2.
+        exportAllEmbeddings: registry.exportAllEmbeddings.bind(registry),
     };
 
     const hook = createHook(brokenRegistry, {

--- a/packages/hooks-cline/test/index.test.ts
+++ b/packages/hooks-cline/test/index.test.ts
@@ -296,6 +296,8 @@ describe("onCodeEmissionIntent — passthrough (error) path", () => {
       recreateEmbeddingsTable: registry.recreateEmbeddingsTable.bind(registry),
       listUnsubmittedBlocks: registry.listUnsubmittedBlocks.bind(registry),
       markBlockSubmitted: registry.markBlockSubmitted.bind(registry),
+      // Added: exportAllEmbeddings() added to Registry interface in WI-1117 Slice 2.
+      exportAllEmbeddings: registry.exportAllEmbeddings.bind(registry),
     };
 
     const hook = createHook(brokenRegistry, { telemetryDir: TEST_TELEMETRY_DIR });

--- a/packages/hooks-codex/test/index.test.ts
+++ b/packages/hooks-codex/test/index.test.ts
@@ -289,6 +289,8 @@ describe("onCodeEmissionIntent — passthrough (error) path", () => {
       recreateEmbeddingsTable: registry.recreateEmbeddingsTable.bind(registry),
       listUnsubmittedBlocks: registry.listUnsubmittedBlocks.bind(registry),
       markBlockSubmitted: registry.markBlockSubmitted.bind(registry),
+      // Added: exportAllEmbeddings() added to Registry interface in WI-1117 Slice 2.
+      exportAllEmbeddings: registry.exportAllEmbeddings.bind(registry),
     };
 
     const hook = createHook(brokenRegistry);

--- a/packages/hooks-cursor/test/adapter-telemetry.test.ts
+++ b/packages/hooks-cursor/test/adapter-telemetry.test.ts
@@ -287,6 +287,8 @@ describe("T2: observe-don't-mutate — response unchanged under all 3 outcomes",
       recreateEmbeddingsTable: registry.recreateEmbeddingsTable.bind(registry),
       listUnsubmittedBlocks: registry.listUnsubmittedBlocks.bind(registry),
       markBlockSubmitted: registry.markBlockSubmitted.bind(registry),
+      // Added: exportAllEmbeddings() added to Registry interface in WI-1117 Slice 2.
+      exportAllEmbeddings: registry.exportAllEmbeddings.bind(registry),
     };
 
     const hook = createHook(brokenRegistry, {

--- a/packages/hooks-cursor/test/index.test.ts
+++ b/packages/hooks-cursor/test/index.test.ts
@@ -295,6 +295,8 @@ describe("onCodeEmissionIntent — passthrough (error) path", () => {
       recreateEmbeddingsTable: registry.recreateEmbeddingsTable.bind(registry),
       listUnsubmittedBlocks: registry.listUnsubmittedBlocks.bind(registry),
       markBlockSubmitted: registry.markBlockSubmitted.bind(registry),
+      // Added: exportAllEmbeddings() added to Registry interface in WI-1117 Slice 2.
+      exportAllEmbeddings: registry.exportAllEmbeddings.bind(registry),
     };
 
     const hook = createHook(brokenRegistry, { telemetryDir: TEST_TELEMETRY_DIR });

--- a/packages/registry/src/export-embeddings.test.ts
+++ b/packages/registry/src/export-embeddings.test.ts
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: MIT
+//
+// export-embeddings.test.ts — Registry invariant tests for exportAllEmbeddings()
+//
+// Production sequence exercised:
+//   openRegistry → storeBlock (N specs) → exportAllEmbeddings()
+//     → assert rowcount == SELECT count(*) FROM contract_embeddings
+//     → assert every vector.length == embedding dimension
+//     → assert ordering strictly ASC by specHash
+//
+// Also tested: dimension mismatch corruption tripwire (fail loud).
+//
+// @decision DEC-1117-S2-VECREAD-001
+// @title exportAllEmbeddings invariant test — architecture-bundle obligation
+// @status decided (WI-1117 Slice 2)
+// @rationale
+//   CLAUDE.md architecture-bundle rule: any authority-surface change ships
+//   with invariant test coverage in the same change. exportAllEmbeddings() is
+//   a new read-back surface on the Registry interface; these tests verify:
+//   (1) rowcount == contract_embeddings count, (2) every vector length ==
+//   stored dimension, (3) ordering ASC by specHash. The mock embedding
+//   provider keeps the tests offline and fast (Sacred Practice #5).
+
+import {
+  type EmbeddingProvider,
+  type ProofManifest,
+  type SpecYak,
+  blockMerkleRoot,
+  canonicalize,
+  canonicalAstHash as deriveCanonicalAstHash,
+  specHash as deriveSpecHash,
+} from "@yakcc/contracts";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { BlockTripletRow, Registry, SpecHash } from "./index.js";
+import { openRegistry } from "./storage.js";
+
+// ---------------------------------------------------------------------------
+// Mock embedding provider
+// ---------------------------------------------------------------------------
+
+/**
+ * Deterministic 384-dim mock provider. Different text → different vectors via
+ * a simple char-code hash. Vectors are NOT L2-normalised here — we only need
+ * dimension correctness for these invariant tests, not cosine semantics.
+ */
+function mockProvider(modelId = "mock/export-embeddings-test"): EmbeddingProvider {
+  return {
+    dimension: 384,
+    modelId,
+    async embed(text: string): Promise<Float32Array> {
+      const vec = new Float32Array(384);
+      for (let i = 0; i < 384; i++) {
+        vec[i] = text.charCodeAt(i % text.length) / 128 + i * 0.001;
+      }
+      return vec;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixture factory — minimal valid BlockTripletRow
+// ---------------------------------------------------------------------------
+
+function makeSpec(name: string): SpecYak {
+  return {
+    name,
+    inputs: [{ name: "x", type: "number" }],
+    outputs: [{ name: "result", type: "number" }],
+    preconditions: [],
+    postconditions: [],
+    invariants: [],
+    effects: [],
+    level: "L0",
+    nonFunctional: { purity: "pure", threadSafety: "safe" },
+  };
+}
+
+function makeManifest(): ProofManifest {
+  return { artifacts: [] };
+}
+
+function makeRow(spec: SpecYak, implSuffix = ""): BlockTripletRow {
+  const manifest = makeManifest();
+  const artifacts = new Map<string, Uint8Array>();
+  const implSrc = `export function ${spec.name}(x: number): number { return x; }${implSuffix}`;
+  const bmr = blockMerkleRoot({ spec, implSource: implSrc, manifest, artifacts });
+  const sHash = deriveSpecHash(spec);
+  const specBytes = canonicalize(spec as Parameters<typeof canonicalize>[0]);
+  return {
+    blockMerkleRoot: bmr,
+    specHash: sHash as SpecHash,
+    specCanonicalBytes: specBytes,
+    implSource: implSrc,
+    proofManifestJson: JSON.stringify(manifest),
+    level: "L0",
+    createdAt: Date.now(),
+    canonicalAstHash: deriveCanonicalAstHash(implSrc),
+    parentBlockRoot: null,
+    artifacts,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Suite lifecycle
+// ---------------------------------------------------------------------------
+
+let registry: Registry;
+
+beforeEach(async () => {
+  registry = await openRegistry(":memory:", { embeddings: mockProvider() });
+});
+
+afterEach(async () => {
+  await registry.close();
+});
+
+// ---------------------------------------------------------------------------
+// Invariant I1: empty registry returns empty array
+// ---------------------------------------------------------------------------
+
+describe("exportAllEmbeddings — empty registry", () => {
+  it("returns an empty array when no blocks are stored", async () => {
+    const result = await registry.exportAllEmbeddings();
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invariant I2: rowcount == contract_embeddings count
+// ---------------------------------------------------------------------------
+
+describe("exportAllEmbeddings — rowcount invariant", () => {
+  it("returns exactly one entry per distinct spec_hash (not per block)", async () => {
+    // Store 3 distinct specs → 3 embedding rows expected
+    const specs = ["alpha", "beta", "gamma"].map(makeSpec);
+    for (const spec of specs) {
+      const row = makeRow(spec);
+      await registry.storeBlock(row);
+    }
+
+    const result = await registry.exportAllEmbeddings();
+    expect(result).toHaveLength(3);
+  });
+
+  it("returns one entry when two blocks share the same spec_hash (two impls, one spec)", async () => {
+    // Same spec → same spec_hash. vec0 upserts on spec_hash PK so only one
+    // embedding row exists regardless of how many blocks share that spec.
+    const spec = makeSpec("sharedSpec");
+    const rowA = makeRow(spec, "// impl A");
+    const rowB = makeRow(spec, "// impl B");
+    await registry.storeBlock(rowA);
+    await registry.storeBlock(rowB);
+
+    const result = await registry.exportAllEmbeddings();
+    // One embedding per spec_hash — the two blocks collapsed to one vec0 row.
+    expect(result).toHaveLength(1);
+    expect(result[0]?.specHash).toBe(rowA.specHash);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invariant I3: every vector.length == stored dimension (384)
+// ---------------------------------------------------------------------------
+
+describe("exportAllEmbeddings — vector dimension invariant", () => {
+  it("every returned vector has length == 384 (the provider dimension)", async () => {
+    const specs = ["dimCheck1", "dimCheck2"].map(makeSpec);
+    for (const spec of specs) {
+      const row = makeRow(spec);
+      await registry.storeBlock(row);
+    }
+
+    const result = await registry.exportAllEmbeddings();
+    expect(result.length).toBeGreaterThan(0);
+    for (const entry of result) {
+      expect(entry.vector).toHaveLength(384);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invariant I4: ordering strictly ASC by specHash
+// ---------------------------------------------------------------------------
+
+describe("exportAllEmbeddings — ASC ordering invariant", () => {
+  it("returned entries are sorted strictly ASC by specHash", async () => {
+    // Store specs whose names produce different spec_hashes (content-addressed).
+    const specs = ["zeta", "alpha", "mu", "delta"].map(makeSpec);
+    for (const spec of specs) {
+      const row = makeRow(spec);
+      await registry.storeBlock(row);
+    }
+
+    const result = await registry.exportAllEmbeddings();
+    expect(result.length).toBe(4);
+
+    // Verify strict ascending order
+    for (let i = 1; i < result.length; i++) {
+      const prev = result[i - 1]?.specHash ?? "";
+      const curr = result[i]?.specHash ?? "";
+      expect(prev < curr).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invariant I5: specHash values match what was stored
+// ---------------------------------------------------------------------------
+
+describe("exportAllEmbeddings — specHash identity invariant", () => {
+  it("every returned specHash matches the stored block's specHash", async () => {
+    const specs = ["iota", "kappa", "lambda"].map(makeSpec);
+    const storedHashes = new Set<string>();
+
+    for (const spec of specs) {
+      const row = makeRow(spec);
+      storedHashes.add(row.specHash);
+      await registry.storeBlock(row);
+    }
+
+    const result = await registry.exportAllEmbeddings();
+    const returnedHashes = new Set(result.map((e) => e.specHash));
+
+    // Every returned specHash must have been stored, and vice versa.
+    expect(returnedHashes).toEqual(storedHashes);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compound integration: the full production read-back sequence
+//
+// This is the Compound-Interaction Test required by CLAUDE.md §"Write Tests That
+// Prove Production Works". It exercises the real production sequence end-to-end:
+// openRegistry → storeBlock (multiple specs) → exportAllEmbeddings →
+// verify all invariants together (count, dimension, ordering, identity).
+// ---------------------------------------------------------------------------
+
+describe("exportAllEmbeddings — compound production sequence", () => {
+  it("full sequence: store N specs, export, verify all invariants simultaneously", async () => {
+    const specNames = ["compound1", "compound2", "compound3", "compound4", "compound5"];
+    const specs = specNames.map(makeSpec);
+    const expectedHashes = new Set<string>();
+
+    for (const spec of specs) {
+      const row = makeRow(spec);
+      expectedHashes.add(row.specHash);
+      await registry.storeBlock(row);
+    }
+
+    const result = await registry.exportAllEmbeddings();
+
+    // I2: rowcount
+    expect(result).toHaveLength(5);
+
+    // I3: every vector has correct dimension
+    for (const entry of result) {
+      expect(entry.vector).toHaveLength(384);
+      // Every element must be a finite number
+      for (const v of entry.vector) {
+        expect(Number.isFinite(v)).toBe(true);
+      }
+    }
+
+    // I4: strict ASC ordering
+    for (let i = 1; i < result.length; i++) {
+      const prev = result[i - 1]?.specHash ?? "";
+      const curr = result[i]?.specHash ?? "";
+      expect(prev < curr).toBe(true);
+    }
+
+    // I5: identity — every exported specHash was stored
+    const returnedHashes = new Set(result.map((e) => e.specHash));
+    expect(returnedHashes).toEqual(expectedHashes);
+
+    // Determinism: call again and compare
+    const result2 = await registry.exportAllEmbeddings();
+    expect(result2).toEqual(result);
+  }, 15_000);
+});

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -1214,6 +1214,41 @@ export interface Registry {
    * @decision DEC-COMMONS-SUBMIT-LOCAL-QUEUE-001 (issue #794)
    */
   markBlockSubmitted(blockMerkleRoot: BlockMerkleRoot, submittedAt: number): Promise<void>;
+
+  // @decision DEC-1117-S2-VECREAD-001
+  // title: exportAllEmbeddings() via vec_to_json — registry-owned read-back, not a CLI-side second sqlite handle
+  // status: decided (WI-1117 Slice 2)
+  // rationale:
+  //   serializeEmbedding (the write-side vector codec) already lives in storage.ts;
+  //   its read-side inverse belongs in the same authority — Single Source of Truth
+  //   (Sacred Practice #12). A second better-sqlite3/sqlite-vec handle in the CLI
+  //   would create a parallel embedding-read authority that can silently diverge from
+  //   the registry's open path (model-stamp guard, vec0 load order). The raw db handle
+  //   + loaded sqlite-vec already exist inside RegistryImpl; exposing a typed accessor
+  //   is the minimal, encapsulated surface. The exporter needs zero direct sqlite/vec0
+  //   knowledge.
+  /**
+   * Export all stored embedding vectors ordered strictly ASC by spec_hash.
+   *
+   * Returns one entry per spec_hash present in `contract_embeddings`.
+   * Row count MUST equal `SELECT COUNT(*) FROM contract_embeddings` — every
+   * spec that has a stored embedding is included; none are silently dropped.
+   * Every vector length MUST equal the stored embedding dimension (384 for
+   * the bootstrap corpus with bge-small-en-v1.5).
+   *
+   * Primary consumer: `yakcc export-atom-index` (Slice 2), which emits a
+   * static embeddings.json bundle consumable by the browser-side
+   * `@yakcc/discovery-search` kit.
+   *
+   * Fail loud on corruption: if any vector's length does not match the
+   * dimension stored in `registry_meta.embedding_dimension`, throws
+   * immediately with a descriptive error (no silent truncation/drop).
+   *
+   * @decision DEC-1117-S2-VECREAD-001 — vec_to_json read-back; registry-owned.
+   */
+  exportAllEmbeddings(): Promise<
+    ReadonlyArray<{ readonly specHash: SpecHash; readonly vector: number[] }>
+  >;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/registry/src/storage.ts
+++ b/packages/registry/src/storage.ts
@@ -2000,7 +2000,7 @@ class SqliteRegistry implements Registry {
       .prepare<[string], { value: string }>("SELECT value FROM registry_meta WHERE key = ?")
       .get("embedding_dimension");
     if (row === undefined) return null;
-    const n = parseInt(row.value, 10);
+    const n = Number.parseInt(row.value, 10);
     return Number.isNaN(n) ? null : n;
   }
 
@@ -2036,10 +2036,7 @@ class SqliteRegistry implements Registry {
     return rows.map((r) => r.block_merkle_root as BlockMerkleRoot);
   }
 
-  async markBlockSubmitted(
-    blockMerkleRoot: BlockMerkleRoot,
-    submittedAt: number,
-  ): Promise<void> {
+  async markBlockSubmitted(blockMerkleRoot: BlockMerkleRoot, submittedAt: number): Promise<void> {
     this.assertOpen();
     if (!Number.isFinite(submittedAt) || submittedAt < 0) {
       throw new Error(
@@ -2049,6 +2046,72 @@ class SqliteRegistry implements Registry {
     this.db
       .prepare("UPDATE blocks SET submitted_at = ? WHERE block_merkle_root = ?")
       .run(submittedAt, blockMerkleRoot);
+  }
+
+  // -------------------------------------------------------------------------
+  // exportAllEmbeddings — bulk vector read-back (DEC-1117-S2-VECREAD-001)
+  //
+  // @decision DEC-1117-S2-VECREAD-001
+  // @title exportAllEmbeddings() via vec_to_json — registry-owned read-back
+  // @status decided (WI-1117 Slice 2)
+  // @rationale
+  //   serializeEmbedding (the write-side vector codec) already lives here.
+  //   The read-side inverse belongs in the same module — Single Source of Truth
+  //   (Sacred Practice #12). A second better-sqlite3/sqlite-vec handle in the
+  //   CLI would create a parallel embedding-read authority that can silently
+  //   diverge from the registry's open path (model-stamp guard, vec0 load
+  //   order). The raw db handle + already-loaded sqlite-vec are reused here;
+  //   the exporter needs zero direct sqlite/vec0 knowledge.
+  //   vec_to_json is provided by sqlite-vec (already loaded by openRegistry
+  //   via sqliteVec.load(db) at ~2268) and returns a JSON array of floats.
+  //   Verified on the bootstrap corpus: all 4829 rows return length-384
+  //   arrays, deterministic across runs.
+  //   Architecture-bundle obligation (CLAUDE.md): this is a net-new read-back
+  //   surface (no old path is superseded). Ships in one bundle with the
+  //   Registry interface update and the registry invariant test.
+  // -------------------------------------------------------------------------
+
+  async exportAllEmbeddings(): Promise<
+    ReadonlyArray<{ readonly specHash: SpecHash; readonly vector: number[] }>
+  > {
+    this.assertOpen();
+
+    // Read the stored dimension so we can validate every returned vector.
+    // getStoredEmbeddingDimension() is on the same Registry — no second DB open.
+    const storedDimension = await this.getStoredEmbeddingDimension();
+
+    interface EmbeddingExportRow {
+      spec_hash: string;
+      j: string; // JSON array of floats from vec_to_json()
+    }
+
+    const rows = this.db
+      .prepare<[], EmbeddingExportRow>(
+        "SELECT spec_hash, vec_to_json(embedding) AS j FROM contract_embeddings ORDER BY spec_hash ASC",
+      )
+      .all();
+
+    const results: Array<{ readonly specHash: SpecHash; readonly vector: number[] }> = [];
+
+    for (const row of rows) {
+      const vector: number[] = JSON.parse(row.j) as number[];
+
+      // Fail loud on dimension mismatch — corruption tripwire.
+      // If storedDimension is null (fresh registry, no meta yet), skip the
+      // check; the table will be empty anyway and this loop won't execute.
+      if (storedDimension !== null && vector.length !== storedDimension) {
+        throw Object.assign(
+          new Error(
+            `exportAllEmbeddings: vector for spec_hash=${row.spec_hash} has length ${vector.length}, expected ${storedDimension} (stored dimension). The contract_embeddings table may be corrupt. Run \`yakcc registry rebuild\` to re-embed.`,
+          ),
+          { reason: "embedding_dimension_mismatch", specHash: row.spec_hash },
+        );
+      }
+
+      results.push({ specHash: row.spec_hash as SpecHash, vector });
+    }
+
+    return results;
   }
 
   // close
@@ -2342,27 +2405,21 @@ export async function openRegistry(path: string, options?: RegistryOptions): Pro
   if (storedModelId !== null && storedModelId !== embeddingProvider.modelId) {
     // Check whether any embeddings actually exist — if the registry is empty,
     // there's nothing to mismatch and we can just update the metadata.
-    const embCount = (
-      db.prepare<[], { n: number }>("SELECT COUNT(*) as n FROM contract_embeddings").get() as
-        | { n: number }
-        | undefined
-    )?.n ?? 0;
+    const embCount =
+      (
+        db.prepare<[], { n: number }>("SELECT COUNT(*) as n FROM contract_embeddings").get() as
+          | { n: number }
+          | undefined
+      )?.n ?? 0;
 
     // @decision DEC-EMBED-REGISTRY-META-001: autoRebuild bypasses mismatch throw.
     // When autoRebuild is true (explicit opt-in), the caller is about to rebuild
     // anyway (e.g. `yakcc registry rebuild`). Suppress the throw so the registry
     // opens successfully; rebuildRegistry will fix the vectors immediately after.
-    if (
-      embCount > 0 &&
-      !(options?.autoRebuild ?? false) &&
-      callerSetExplicitProvider
-    ) {
+    if (embCount > 0 && !(options?.autoRebuild ?? false) && callerSetExplicitProvider) {
       throw Object.assign(
         new Error(
-          `Registry was embedded with model "${storedModelId}", but the current ` +
-            `provider uses "${embeddingProvider.modelId}". ` +
-            `Run \`yakcc registry rebuild\` to re-embed with the current provider, ` +
-            `or set YAKCC_EMBEDDING_PROVIDER and model env vars to match the stored model.`,
+          `Registry was embedded with model "${storedModelId}", but the current provider uses "${embeddingProvider.modelId}". Run \`yakcc registry rebuild\` to re-embed with the current provider, or set YAKCC_EMBEDDING_PROVIDER and model env vars to match the stored model.`,
         ),
         { reason: "embedding_model_mismatch" },
       );

--- a/plans/wi-1117-slice2-atom-index-exporter.md
+++ b/plans/wi-1117-slice2-atom-index-exporter.md
@@ -1,0 +1,197 @@
+# WI-1117 Slice 2 — `export-atom-index` CLI (atoms.json + embeddings index + model stamp)
+
+**Workflow:** `1117-slice2-atom-exporter` · branch `feature/1117-slice2-atom-exporter` (base main `47ba986`, includes #1119 + #1129)
+**Issue:** #1117 — *feat(discovery): browser-consumable semantic-search kit + atom-index/embeddings exporter* (Slice 1 = `@yakcc/discovery-search`, landed #1121/#1129; this is Slice 2)
+**Consumer:** yakforge atom-explorer frontend (SEPARATE repo). yakcc ships the exporter + tests only — NOT a website build step.
+
+---
+
+## 1. Problem
+
+The atom-explorer must run the *same* semantic search the LLM uses: embed a query with `bge-small-en-v1.5` (384-dim) client-side and cosine-rank against atom contract embeddings, in the browser, via the Slice-1 kit (`rankCandidates`). To do that without shipping `better-sqlite3`/`sqlite-vec`/`ts-morph` to the browser, yakcc must emit a **static, dependency-free data bundle** from the registry corpus:
+
+- a per-atom **card** (atoms.json) the explorer renders, and
+- an **embeddings index** (raw 384-dim vectors) the explorer cosine-ranks.
+
+Both must carry a **model-id/provider stamp** so the client provably embeds queries with the same model id the index was built with (honors `DEC-V3-IMPL-QUERY-002` / provider-consistency guard). Fail loud, no silent skips, deterministic output.
+
+### Challenge to the requirement (scope correction)
+
+The issue lists card fields "name, signature, behavior, level, purity/thread-safety/complexity, deps/reuse counts, license, root." Verification of the bootstrap corpus (`bootstrap/yakcc.registry.sqlite`, schema-confirmed) shows:
+
+- **`license` and `root` do not exist** in the registry schema. The `blocks` table has no license/root column; `proof_manifest_json` carries only `artifacts`. → **Excluded from the first cut** (DEC-1117-S2-CARD-002). Not inventing data the corpus doesn't hold. Recorded as a NICE follow-up if a license/root authority is later added to the registry.
+- **The atom unit of identity is the spec, not the block.** Embeddings are keyed by `spec_hash` (vec0 PK). The corpus has **4904 blocks but 4829 distinct `spec_hash`** — multiple implementations share one contract. The KNN read path (`storage.ts` ~678) already returns `spec_hash`. **0 specs lack an embedding.** → atoms.json is **one card per `spec_hash`** (4829 cards), embeddings index is keyed by `spec_hash`, vector count == card count == 4829. This matches the registry's own search identity and the Slice-1 kit (which ranks a flat vector array and maps `index → atom`).
+
+### Goals (measurable)
+
+- A node-only `yakcc export-atom-index --out <dir>` command emits, from the bootstrap corpus by default:
+  - `atoms.json` — exactly 4829 cards (one per distinct `spec_hash`), schema in §4.
+  - `embeddings.json` — exactly 4829 vectors, each `number[384]`, aligned to atoms.json order, keyed by `spec_hash`; carries the model stamp.
+- Model stamp present and equal to the stored `registry_meta.embedding_model_id` (`Xenova/bge-small-en-v1.5`) and `embedding_dimension` (`384`).
+- Deterministic: two runs over the same corpus produce byte-identical files; stable ordering = `ORDER BY spec_hash` (ASC).
+- Pure-Node vitest tests green on the bootstrap corpus + a minimal fixture; full-workspace `pnpm -r build` + `pnpm lint` + `pnpm typecheck` green; no node-dep leak into the browser path.
+
+### Non-goals
+
+- No yakforge frontend code; no website build wiring (consumer is a separate repo).
+- No `license`/`root` fields (not in corpus — DEC-1117-S2-CARD-002).
+- No new browser-path exports to `@yakcc/discovery-search` (its node-dep-isolation invariant must stay green). If a pure re-export is genuinely needed it is the only allowed touch, and must remain browser-safe.
+- No re-embedding, no registry mutation: exporter is **read-only** over the corpus.
+
+### Dominant constraints
+
+- `better-sqlite3`/`sqlite-vec` are node-only and pnpm-isolated to `@yakcc/registry`. The exporter is node-only (fine); its JSON output is dependency-free.
+- vec0 stores vectors opaquely; raw read-back is the key technical risk (resolved in §3).
+
+---
+
+## 2. Architecture — exporter as a CLI command
+
+**Chosen:** a CLI command `packages/cli/src/commands/export-atom-index.ts` exposing `export async function exportAtomIndex(argv, logger): Promise<number>`, registered in the `packages/cli/src/index.ts` dispatch switch as top-level command `export-atom-index` (sibling of `seed`, `emit-atom`, `stats`). Rejected an `.mjs` script: a CLI command is vitest-testable, consistent with `seed-yakcc.ts`, and reuses the proven corpus-resolution + registry-open path. (DEC-1117-S2-EXPORTER-001)
+
+**Two output files, not one bundle** (`atoms.json` + `embeddings.json`): the card metadata (small, human-diffable, frontend renders eagerly) and the vector index (large, ~4829×384 floats, frontend may lazy-load/stream) have different size/lifecycle profiles; splitting lets the explorer fetch cards first and vectors on demand. Both share the same `specHash` ordering so the explorer zips them by index. (DEC-1117-S2-EXPORTER-002)
+
+**Default `--out`:** `tmp/atom-index/` (repo-tmp per Sacred Practice #3; never `/tmp`). `--corpus <path>` overrides the source registry (defaults to `findBootstrapSqlite()`); `--out <dir>` overrides destination. `mkdirSync(out, { recursive: true })`; fail loud if corpus missing (mirror `seed-yakcc` ENOENT handling and `generate-benchmark-svgs.mjs` fail-loud precedent).
+
+**Corpus open path (reuse, do not re-derive):**
+- `findBootstrapSqlite()` — copy the walk-up resolver pattern from `seed-yakcc.ts` (~141) (or factor a shared helper; copying is acceptable for the first cut to avoid touching seed-yakcc's scope).
+- `openRegistry(path, { embeddings: createLocalEmbeddingProvider() })` — open with the local provider so the stored model id matches and the `DEC-EMBED-REGISTRY-META-001` mismatch guard passes (precedent DEC-1123-SEED-BGE-NATIVE-001).
+- `registry.getStoredEmbeddingModelId()` / `getStoredEmbeddingDimension()` — read the stamp.
+- `registry.exportManifest()` → `getBlock(blockMerkleRoot)` — hydrate blocks; **collapse to one card per `spec_hash`** picking the first block per spec under a deterministic tie-break (lowest `blockMerkleRoot` lexicographically), so a spec with multiple impls yields one stable card.
+- New `registry.exportAllEmbeddings()` (see §3) → `{ specHash, vector: number[384] }[]`, joined to cards by `specHash`. Assert every card's `specHash` has exactly one vector and vice versa (fail loud on any mismatch — forbidden shortcut: silent drop).
+
+### State-Authority Map (integration surfaces)
+
+| Domain | Canonical authority | Exporter relationship |
+|---|---|---|
+| Block triplets / card fields | `blocks` table via `RegistryImpl.exportManifest` + `getBlock` (`storage.ts`) | read-only |
+| Spec card fields | `JSON.parse(block.specCanonicalBytes) as SpecYak` (precedent storage.ts ~270/302) | read-only parse |
+| Embedding vectors | `contract_embeddings` vec0 table; read-back via **new** `exportAllEmbeddings()` | read-only, new authority method |
+| Model stamp | `registry_meta` via `getStoredEmbeddingModelId/Dimension` | read-only |
+| Reuse / test / runtime counts | `block_occurrences`, `test_history`, `runtime_exposure` tables | read-only (NICE, §4) |
+| Output artifacts | `--out` dir (default `tmp/atom-index/`) | write-only, exporter-owned |
+| Browser scoring contract | `@yakcc/discovery-search` `rankCandidates(Float32Array[])` | output must slot in; NOT imported by exporter |
+
+No parallel authority is created: card fields, vectors, and stamp all flow from the single `Registry` opened once.
+
+---
+
+## 3. RESOLVED — vec0 raw vector read-back (the key technical risk)
+
+**Verified on the live bootstrap DB** (node + the registry's own `better-sqlite3`/`sqlite-vec`):
+```
+SELECT spec_hash, vec_to_json(embedding) AS j FROM contract_embeddings ORDER BY spec_hash
+```
+returns `j` = a JSON array of **384 floats** for **all 4829 rows**, deterministic across runs. No shadow-table (`*_vector_chunks00`) parsing is required. `vec_to_json` is provided by `sqlite-vec`, which `openRegistry` already loads via `sqliteVec.load(db)` (storage.ts ~2268).
+
+**Authority decision — DEC-1117-S2-VECREAD-001 (chosen: option a, add a registry method).**
+Add to `RegistryImpl` (`packages/registry/src/storage.ts`) and the `Registry` interface (`packages/registry/src/index.ts`):
+```ts
+exportAllEmbeddings(): Promise<ReadonlyArray<{ specHash: SpecHash; vector: number[] }>>;
+```
+Implementation: `assertOpen()`, then `this.db.prepare("SELECT spec_hash, vec_to_json(embedding) AS j FROM contract_embeddings ORDER BY spec_hash").all()`, `JSON.parse` each `j`, assert `vector.length === LOCAL_DIMENSION` per row (fail loud otherwise — corruption tripwire, do not weaken). Returns ASC-by-spec_hash for stable ordering.
+
+**Why a registry method, not a second sqlite handle in the CLI (rejected option b):**
+- `serializeEmbedding` (the write-side vector codec) already lives in `storage.ts`; its read-side inverse belongs in the same authority — Single Source of Truth (Sacred Practice #12). Option (b) would open a *second* `better-sqlite3` handle and re-call `sqliteVec.load` in the CLI, creating a parallel embedding-read authority that can silently diverge from the registry's open path (model-stamp guard, vec0 load order).
+- The raw `db` handle + loaded `sqlite-vec` already exist inside `RegistryImpl`; exposing a typed accessor is the minimal, encapsulated surface. The exporter then needs **zero** direct sqlite/vec0 knowledge.
+
+**Architecture-bundle obligation (CLAUDE.md):** this is an authority-surface change, so it ships in one bundle: (1) the `storage.ts` method + `index.ts` interface line, (2) an invariant test asserting count == `contract_embeddings` rowcount, every vector length == 384, and ordering == ASC `spec_hash` (added in registry's test suite), (3) this plan doc as the decision record. No old path is superseded (this is net-new read-back), so there is nothing to delete — noted explicitly.
+
+---
+
+## 4. atoms.json + embeddings.json schema (exact)
+
+### `atoms.json`
+```jsonc
+{
+  "schemaVersion": 1,
+  "model": { "id": "Xenova/bge-small-en-v1.5", "dimension": 384 },  // == stored registry_meta
+  "corpus": { "atomCount": 4829, "source": "bootstrap/yakcc.registry.sqlite" },
+  "atoms": [
+    {
+      "specHash": "string",            // identity key; ASC-sorted; matches embeddings.json
+      "blockMerkleRoot": "string",     // representative block (lowest BMR for the spec)
+      "name": "string",                // SpecYak.name
+      "signature": {                   // SpecYak.inputs/outputs
+        "inputs":  [{ "name": "string", "type": "string" }],
+        "outputs": [{ "name": "string", "type": "string" }]
+      },
+      "behavior": "string | null",     // SpecYak.behavior (optional in SpecYak)
+      "level": "L0|L1|L2|L3",          // blocks.level
+      "nonFunctional": {               // SpecYak.nonFunctional
+        "purity": "pure|io|stateful|nondeterministic",
+        "threadSafety": "safe|unsafe|sequential",
+        "time":  "string | null",
+        "space": "string | null"
+      },
+      "source": { "pkg": "string | null", "file": "string | null" }  // blocks.source_pkg/source_file
+    }
+  ]
+}
+```
+**MUST fields (first cut, all corpus-backed & verified):** `specHash`, `blockMerkleRoot`, `name`, `signature`, `behavior`, `level`, `nonFunctional.{purity,threadSafety,time,space}`, `source.{pkg,file}`.
+
+**NICE (deferred, DEC-1117-S2-CARD-001):** derived counts — `reuseCount` (`block_occurrences` rows for the spec's blocks), `passingTestRuns` (`test_history`), `runtime.{requestsSeen,lastSeen}` (`runtime_exposure`). These require extra per-spec aggregation queries; gated behind `--with-counts` in a follow-up to keep the first cut tight. If added, they are additive object fields (schemaVersion stays 1 if optional, bumps to 2 if always-present).
+
+**EXCLUDED (DEC-1117-S2-CARD-002):** `license`, `root` — not present in the registry schema. Do not synthesize.
+
+`behavior` is `SpecYak.behavior` which is `string | undefined` — emit `null` when absent (never drop the key; stable shape).
+
+### `embeddings.json`
+```jsonc
+{
+  "schemaVersion": 1,
+  "model": { "id": "Xenova/bge-small-en-v1.5", "dimension": 384 },
+  "count": 4829,
+  "vectors": [
+    { "specHash": "string", "vector": [/* 384 floats */] }
+  ]
+}
+```
+**Vector format & Slice-1 fit:** `vector` is a plain `number[384]` JSON array (dependency-free; the explorer constructs `Float32Array` per the kit). `vectors` is ASC-sorted by `specHash`, **identical order to `atoms.json.atoms`**, so the explorer zips by index: `rankCandidates(queryVec, vectors.map(v => Float32Array.from(v.vector)))` returns `RankedResult.index` → `atoms[index]`. Vectors are bge-small L2-normalized (kit's `(1+sim)/2` simplification holds). The kit does NOT vec0 — it linear-scans, so raw per-atom vectors keyed by identity are exactly what's needed.
+
+---
+
+## 5. Determinism guarantee
+
+- Ordering: every emitted list is `ORDER BY spec_hash ASC`. Cards and vectors share this order → index-aligned.
+- Representative-block tie-break: for a spec with N blocks, pick the lexicographically-lowest `blockMerkleRoot` (stable, content-addressed).
+- JSON serialization: `JSON.stringify(obj, null, 2)` with object keys constructed in fixed declaration order (TS object literal order is preserved). Numbers come straight from `vec_to_json` (no re-rounding).
+- No timestamps, no run-ids, no map-iteration-order dependence in output.
+- Test asserts byte-identity across two runs (§6 T3).
+
+---
+
+## 6. Test plan (pure-Node vitest, no network)
+
+Test file `packages/cli/src/commands/export-atom-index.test.ts` (mirror `seed-yakcc.test.ts` / `bootstrap.bge-roundtrip.test.ts`):
+
+- **T1 (bootstrap corpus shape):** run exporter against `findBootstrapSqlite()` into a tmp dir; assert `atoms.json.atoms.length === embeddings.json.count === 4829`; every card has all MUST fields with correct types; `level ∈ {L0..L3}`; `nonFunctional.purity/threadSafety` in their enums.
+- **T2 (model stamp):** `atoms.json.model.id === embeddings.json.model.id === await registry.getStoredEmbeddingModelId()` (`Xenova/bge-small-en-v1.5`); `dimension === 384 === getStoredEmbeddingDimension()`.
+- **T3 (dims + determinism):** every `vectors[i].vector.length === 384`; run exporter twice → both `atoms.json` and `embeddings.json` byte-identical (`readFileSync` string equality).
+- **T4 (alignment):** for all i, `atoms[i].specHash === vectors[i].specHash`; set of specHashes in atoms == set in embeddings (no orphan either way) — fail-loud join verified.
+- **T5 (Slice-1 fit, kit consumed read-only in test):** uses a test-local `rankCandidatesInline` (DEC-1117-S2-TEST-002) whose score formula `(1+sim)/2` is algebraically identical to the production path in `@yakcc/discovery-search`, and whose band labels/thresholds mirror production `assignScoreBand` verbatim (strong/confident/weak/poor at 0.85/0.70/0.50). Importing `rankCandidates` directly from `@yakcc/discovery-search` is deliberately avoided to keep the node-only CLI test free of browser-side package coupling. A dedicated cross-package slot-in test importing the real `rankCandidates` is a future enhancement. Assert `ranked[0].index` maps back to its own `specHash` (self-match top-1) and `RankedResult` shape is honored.
+- **T6 (fixture / fail-loud):** a minimal fixture registry (offline provider) with a couple atoms — assert exporter emits the right count; and assert it throws loudly (non-zero exit) when `--corpus` points at a missing file (no silent empty output).
+
+Registry invariant test (in `packages/registry`, bundle for DEC-1117-S2-VECREAD-001): `exportAllEmbeddings()` returns rowcount == `SELECT count(*) FROM contract_embeddings`, every vector length 384, ordering strictly ASC by specHash.
+
+---
+
+## 7. @decision annotations to emit in code
+
+- `DEC-1117-S2-EXPORTER-001` — CLI command (not .mjs) for vitest-testability + corpus-path reuse.
+- `DEC-1117-S2-EXPORTER-002` — two files (atoms.json + embeddings.json), shared specHash ordering.
+- `DEC-1117-S2-VECREAD-001` — `registry.exportAllEmbeddings()` via `vec_to_json`; registry-owned read-back, not a CLI-side second sqlite handle (Single Source of Truth + architecture-bundle).
+- `DEC-1117-S2-CARD-001` — MUST card fields from SpecYak+row; derived counts deferred behind `--with-counts`.
+- `DEC-1117-S2-CARD-002` — `license`/`root` excluded (absent from registry schema; do not synthesize).
+- `DEC-1117-S2-IDENTITY-001` — atom unit = `spec_hash` (4829), representative block = lowest BMR; matches vec0/KNN identity.
+
+---
+
+## 8. Waves
+
+Single implementer slice (all items are one tightly-coupled change; no internal parallelism needed):
+1. **W1 (M):** add `exportAllEmbeddings()` to `storage.ts` + `Registry` interface in `index.ts` + registry invariant test. Gate: none (auto-verified by tests). Deps: none.
+2. **W2 (M):** `export-atom-index.ts` command + register in CLI `index.ts` + `export-atom-index.test.ts`. Gate: review. Deps: W1.
+
+Critical path W1 → W2. Max width 1. Both land in the same PR (#1117 Slice 2).


### PR DESCRIPTION
Completes **#1117**. Slice 1 (the browser-importable `@yakcc/discovery-search` kit) landed in #1121; this adds the build-time **index exporter** that feeds it — the last yakcc-side piece of the Atom Explorer initiative (umbrella: cneckar/yakforge).

## What
`yakcc export-atom-index [--out <dir>] [--corpus <path>]` reads a registry corpus (default `bootstrap/yakcc.registry.sqlite`) **read-only** and emits two static, dependency-free JSON files for the yakforge atom-explorer frontend to cosine-search client-side:

- **`atoms.json`** — one card per distinct `spec_hash` (4829 for the bootstrap corpus): `specHash`, `blockMerkleRoot`, `name`, `signature{inputs,outputs}`, `behavior`, `level`, `nonFunctional{purity,threadSafety,time,space}`, `source{pkg,file}`. `license`/`root` are absent from the registry schema and are **not synthesized**.
- **`embeddings.json`** — 4829 × 384-dim vectors, `spec_hash`-aligned (both arrays strictly ASC by `spec_hash`, index-aligned), plus a **model stamp** (`Xenova/bge-small-en-v1.5` / 384) read from `registry_meta` so the client embeds with the same model the index was built with.

## How
Vector read-back is **registry-owned**, not a second sqlite handle in the CLI: new `Registry.exportAllEmbeddings()` (DEC-1117-S2-VECREAD-001) reads vec0 vectors via `vec_to_json`, length-validated and ASC by `spec_hash`, with an invariant test asserting `rowcount === count(*) contract_embeddings`. Adding the method to the `Registry` interface propagates conformance stubs to the compile + hooks test mocks (real `.bind(registry)` delegation, no behavioral change).

Output is consumable by Slice-1 `rankCandidates` (`Float32Array[384]`); a fixture + corpus test proves self-match top-1 and **byte-identical determinism** across runs.

## Verification (local, full workspace)
- Real run over bootstrap corpus: 4829 atoms + 4829 vectors (len 384), model stamp matches stored `registry_meta`, 0 index-misalignments, 0 ASC violations, deterministic.
- CLI `export-atom-index` **27** tests (T1–T6); registry `exportAllEmbeddings` invariant **7**; compile **11**; discovery-search node-isolation green.
- `pnpm -r build` + `pnpm lint` (27) + `pnpm typecheck` (72): green.
- Reviewer verdict: **ready_for_guardian** (one non-blocking concern — misleading inline band-label comment — fixed before landing).

Closes #1117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)